### PR TITLE
Make the plugin work on IntelliJ 2016.3. Fixes #32.

### DIFF
--- a/base/src/com/google/idea/blaze/base/async/AsyncUtil.java
+++ b/base/src/com/google/idea/blaze/base/async/AsyncUtil.java
@@ -16,6 +16,7 @@
 package com.google.idea.blaze.base.async;
 
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
 import com.intellij.util.ui.UIUtil;
 import org.jetbrains.annotations.NotNull;
 
@@ -52,7 +53,7 @@ public class AsyncUtil {
     if (ApplicationManager.getApplication().isDispatchThread()) {
       task.run();
     } else {
-      UIUtil.invokeAndWaitIfNeeded(task);
+      ApplicationManager.getApplication().invokeAndWait(task, ModalityState.NON_MODAL);
     }
   }
 }

--- a/base/src/com/google/idea/blaze/base/run/BlazeRunConfigurationSyncListener.java
+++ b/base/src/com/google/idea/blaze/base/run/BlazeRunConfigurationSyncListener.java
@@ -28,6 +28,8 @@ import com.google.idea.blaze.base.sync.SyncListener;
 import com.intellij.execution.RunManager;
 import com.intellij.execution.RunnerAndConfigurationSettings;
 import com.intellij.execution.configurations.RunConfiguration;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.project.Project;
 import com.intellij.util.ui.UIUtil;
 import java.util.List;
@@ -46,22 +48,22 @@ public class BlazeRunConfigurationSyncListener extends SyncListener.Adapter {
       SyncMode syncMode,
       SyncResult syncResult) {
 
-    UIUtil.invokeAndWaitIfNeeded(
-        (Runnable)
-            () -> {
-              Set<Label> labelsWithConfigs = labelsWithConfigs(project);
-              Set<TargetExpression> targetExpressions =
-                  Sets.newHashSet(projectViewSet.listItems(TargetSection.KEY));
-              // We only auto-generate configurations for rules listed in the project view.
-              for (TargetExpression target : targetExpressions) {
-                if (!(target instanceof Label) || labelsWithConfigs.contains(target)) {
-                  continue;
-                }
-                Label label = (Label) target;
-                labelsWithConfigs.add(label);
-                maybeAddRunConfiguration(project, blazeProjectData, label);
-              }
-            });
+    ApplicationManager.getApplication().invokeAndWait(
+            (Runnable)
+                    () -> {
+                      Set<Label> labelsWithConfigs = labelsWithConfigs(project);
+                      Set<TargetExpression> targetExpressions =
+                              Sets.newHashSet(projectViewSet.listItems(TargetSection.KEY));
+                      // We only auto-generate configurations for rules listed in the project view.
+                      for (TargetExpression target : targetExpressions) {
+                        if (!(target instanceof Label) || labelsWithConfigs.contains(target)) {
+                          continue;
+                        }
+                        Label label = (Label) target;
+                        labelsWithConfigs.add(label);
+                        maybeAddRunConfiguration(project, blazeProjectData, label);
+                      }
+                    }, ModalityState.NON_MODAL);
   }
 
   /** Collects a set of all the Blaze labels that have an associated run configuration. */

--- a/base/src/com/google/idea/blaze/base/util/SaveUtil.java
+++ b/base/src/com/google/idea/blaze/base/util/SaveUtil.java
@@ -15,18 +15,19 @@
  */
 package com.google.idea.blaze.base.util;
 
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.util.ui.UIUtil;
 
 /** Utility for saving all files. */
 public class SaveUtil {
   public static void saveAllFiles() {
-    UIUtil.invokeAndWaitIfNeeded(
-        new Runnable() {
-          @Override
-          public void run() {
-            FileDocumentManager.getInstance().saveAllDocuments();
-          }
-        });
+    ApplicationManager.getApplication().invokeAndWait(new Runnable() {
+      @Override
+      public void run() {
+        FileDocumentManager.getInstance().saveAllDocuments();
+      }
+    }, ModalityState.NON_MODAL);
   }
 }

--- a/clwb/src/com/google/idea/blaze/clwb/problemsview/BlazeProblemsViewConsole.java
+++ b/clwb/src/com/google/idea/blaze/clwb/problemsview/BlazeProblemsViewConsole.java
@@ -22,6 +22,7 @@ import com.intellij.ide.errorTreeView.ErrorTreeElement;
 import com.intellij.ide.errorTreeView.ErrorTreeElementKind;
 import com.intellij.ide.errorTreeView.ErrorViewStructure;
 import com.intellij.ide.errorTreeView.GroupingElement;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.fileEditor.OpenFileDescriptor;
@@ -222,7 +223,7 @@ public class BlazeProblemsViewConsole implements BlazeProblemsView {
   }
 
   private void updateIcon() {
-    UIUtil.invokeLaterIfNeeded(
+    ApplicationManager.getApplication().invokeLater(
         () -> {
           if (!myProject.isDisposed()) {
             final ToolWindow tw =

--- a/clwb/src/com/google/idea/blaze/clwb/wizard2/BlazeCProjectCreator.java
+++ b/clwb/src/com/google/idea/blaze/clwb/wizard2/BlazeCProjectCreator.java
@@ -58,7 +58,7 @@ class BlazeCProjectCreator {
     try {
       return doCreate();
     } catch (final IOException e) {
-      UIUtil.invokeLaterIfNeeded(
+      ApplicationManager.getApplication().invokeLater(
           () -> Messages.showErrorDialog(e.getMessage(), "Project Initialization Failed"));
       return null;
     }

--- a/java/src/com/google/idea/blaze/java/libraries/BlazeAttachSourceProvider.java
+++ b/java/src/com/google/idea/blaze/java/libraries/BlazeAttachSourceProvider.java
@@ -85,7 +85,7 @@ public class BlazeAttachSourceProvider implements AttachSourcesProvider {
      * corresponding user setting is active.
      */
     if (BlazeJavaUserSettings.getInstance().getAttachSourcesOnDemand()) {
-      UIUtil.invokeLaterIfNeeded(
+      ApplicationManager.getApplication().invokeLater(
           () -> {
             attachSources(project, blazeProjectData, librariesToAttachSourceTo);
           });


### PR DESCRIPTION
The files in this commit were misusing UIUtil.invokeLater and
invokeAndWait. UIUtil's Javadoc explains that you shouldn't use
UIUtil, but instead use Application.invokeLater and .invokeAndWait,
so that's what this commit does.