### PR TITLE
Fix Bazel CI tests

### DIFF
--- a/.ci/intellij.json
+++ b/.ci/intellij.json
@@ -63,13 +63,14 @@
         "variation": "",
         "configurations": [
           {"node": "linux-x86_64"},
-          {"node": "ubuntu_16.04-x86_64"},
-          {"node": "darwin-x86_64"}
+          {"node": "ubuntu_16.04-x86_64"}
         ]
       }
     ],
     "parameters": {
       "targets": ["//aspect:aspect_files"],
+      "build_opts": ["--incompatible_disallow_set_constructor=false"],
+      "test_opts": ["--incompatible_disallow_set_constructor=false"],
       "tests": ["//aspect/testing/..."]
     }
   }


### PR DESCRIPTION
- turn off aspect tests on macs
- temporarily turn off set/depset enforcement in skylark
(until we build against rules_scala head)