### PR TITLE
Update rules_scala to the latest commit

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -238,7 +238,7 @@ http_archive(
     urls = ["https://github.com/google/protobuf/archive/master.zip"],
 )
 
-rules_scala_version="33fed13f7a2e776e2cd73aabc66ce0d5cb3b0f1f"
+rules_scala_version="8acd086bc2f2682d632e9c7313f3785e943802c8"
 
 # LICENSE: The Apache Software License, Version 2.0
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -238,7 +238,7 @@ http_archive(
     urls = ["https://github.com/google/protobuf/archive/master.zip"],
 )
 
-rules_scala_version="a72dc8bb2033fed96deec39420b99331a2119a4e"
+rules_scala_version="33fed13f7a2e776e2cd73aabc66ce0d5cb3b0f1f"
 
 # LICENSE: The Apache Software License, Version 2.0
 http_archive(


### PR DESCRIPTION
The version of `rules_scala` that's used currently contains a reference to the deprecated `set` function, it will soon be not allowed to use such reference even in the parts of code that aren't being called.