### PR TITLE
don't use deprecated Futures.get method from guava library

### DIFF
--- a/plugin_dev/src/com/google/idea/blaze/plugin/run/BuildPluginBeforeRunTaskProvider.java
+++ b/plugin_dev/src/com/google/idea/blaze/plugin/run/BuildPluginBeforeRunTaskProvider.java
@@ -259,7 +259,7 @@ public final class BuildPluginBeforeRunTaskProvider
                   .submitTaskWithResult(buildTask);
 
           try {
-            Futures.get(buildFuture, ExecutionException.class);
+            Futures.getChecked(buildFuture, ExecutionException.class);
           } catch (ExecutionException e) {
             context.setHasError();
           } catch (CancellationException e) {


### PR DESCRIPTION
Futures.get method was deprecated in Guava long time ago and it's even removed from modern Guava versions. This change is needed to avoid compatibility problems with IntelliJ IDEA 2018.1 where a new version of Guava is bundled.