### PR TITLE
Updating docs to reference ijwb_bazel_zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,6 @@ Detailed docs are available [here](http://ij.bazel.build).
 
 ## Building the plugin
 
-Install Bazel, then run `bazel build //ijwb:ijwb_bazel --define=ij_product=intellij-latest`
-from the project root. This will create a plugin jar in
-`bazel-genfiles/ijwb/ijwb_bazel.jar`.
+Install Bazel, then run `bazel build //ijwb:ijwb_bazel_zip --define=ij_product=intellij-latest`
+from the project root. This will create a plugin zip in
+`bazel-bin/ijwb/ijwb_bazel.zip`.


### PR DESCRIPTION
The docs currently refer to using the jar as the plugin, however, it appears that we need to use the zip now which contains both the jar and the aspect. Using the current instructions to build/run the plugin do not work, however, using the zip does.

Also, it seems that the output is in `bazel-bin`, not `bazel-genfiles`