### PR TITLE
Check that jar attributes are present before accessing them

### DIFF
--- a/aspect/intellij_info_impl.bzl
+++ b/aspect/intellij_info_impl.bzl
@@ -525,13 +525,13 @@ def build_filtered_gen_jar(ctx, target, java, gen_java_sources, srcjars):
   jar_artifacts = []
   source_jar_artifacts = []
   for jar in java.outputs.jars:
-    if jar.ijar:
+    if hasattr(jar, "ijar") and jar.ijar:
       jar_artifacts.append(jar.ijar)
-    elif jar.class_jar:
+    elif hasattr(jar, "class_jar") and jar.class_jar:
       jar_artifacts.append(jar.class_jar)
-    if jar.source_jars:
+    if hasattr(jar, "source_jars") and jar.source_jars:
       source_jar_artifacts.extend(jar.source_jars)
-    elif jar.source_jar:
+    elif hasattr(jar, "source_jar") and jar.source_jar:
       source_jar_artifacts.append(jar.source_jar)
 
   filtered_jar = ctx.new_file(target.label.name + "-filtered-gen.jar")


### PR DESCRIPTION
Hi everyone! I ran into an issue importing some of our `scala_binary` targets using the IntelliJ plugin, so I modified the plugin to successfully import those projects.

I'm not very familiar with the IntelliJ plugin, so I hope this change is alright. If it's not, I'm happy to do something else.

When importing the WORKSPACE, I encountered this error on two targets:
```
ERROR: /home/james/lucid/main/foo-service/BUILD:119:1: in @intellij_aspect//:intellij_info_bundled.bzl%intellij_info_aspect aspect on scala_binary rule //foo-service:foo-service: 
Traceback (most recent call last):
    File "/home/james/lucid/main/foo-service/BUILD", line 119
        @intellij_aspect//:intellij_info_bundled.bzl%intellij_info_aspect(...)
    File "/home/james/.cache/bazel/_bazel_james/b380b3446fcd8bc5dde6a5e5af5d8825/external/intellij_aspect/intellij_info_bundled.bzl", line 36, in _aspect_impl
        intellij_info_aspect_impl(target, ctx, semantics)
    File "/home/james/.cache/bazel/_bazel_james/b380b3446fcd8bc5dde6a5e5af5d8825/external/intellij_aspect/intellij_info_impl.bzl", line 737, in intellij_info_aspect_impl
        collect_java_info(target, ctx, semantics, ide_info, <2 more arguments>)
    File "/home/james/.cache/bazel/_bazel_james/b380b3446fcd8bc5dde6a5e5af5d8825/external/intellij_aspect/intellij_info_impl.bzl", line 465, in collect_java_info
        build_filtered_gen_jar(ctx, target, java, gen_java_sources, src...)
    File "/home/james/.cache/bazel/_bazel_james/b380b3446fcd8bc5dde6a5e5af5d8825/external/intellij_aspect/intellij_info_impl.bzl", line 532, in build_filtered_gen_jar
        jar.source_jars
'struct' object has no attribute 'source_jars'
Available attributes: class_jar, ijar.
```

The error could be reproduced by running
```
bazel build --tool_tag=ijwb:IDEA:community --keep_going --experimental_build_event_binary_file=/tmp/intellij-bep-8d3853aa-0199-4e07-8bb6-51ae8b5b9fa5 --noexperimental_build_event_binary_file_path_conversion --curses=no --color=yes --experimental_ui=no --progress_in_terminal_title=no --aspects=@intellij_aspect//:intellij_info_bundled.bzl%intellij_info_aspect --override_repository=intellij_aspect=/home/james/.IdeaIC2017.3/config/plugins/ijwb/aspect --output_groups=intellij-resolve-java -- //foo-service
```
I'm not sure what caused the issue for those two targets, but this change did enable the targets to import.