### PR TITLE
intellij_ide_info.proto update for Kotlin (please patch proto_deps.jar)

### DIFF
--- a/proto/intellij_ide_info.proto
+++ b/proto/intellij_ide_info.proto
@@ -172,7 +172,12 @@ message Dependency {
   DependencyType dependency_type = 2;
 }
 
-// Next Available: 30
+// Contains the location of a Json encoded file containing Kotlin Toolchain Info..
+message KtToolchainIdeInfo {
+  ArtifactLocation location = 1;
+}
+
+// Next Available: 31
 message TargetIdeInfo {
   string label = 1 [deprecated = true];
   repeated string dependencies = 4 [deprecated = true];
@@ -215,4 +220,5 @@ message TargetIdeInfo {
   DartIdeInfo dart_ide_info = 28;
 
   AndroidAarIdeInfo android_aar_ide_info = 29;
+  KtToolchainIdeInfo kt_toolchain_ide_info = 30;
 }


### PR DESCRIPTION
@brendandouglas I could really do with an update to the `proto_deps.jar` I have been blocked on this for a long time.

I need to update `IdeInfoFromProtobuf` and I can't find a way to include the updated generated proto classes. 

I tried adding `//proto:intellij_ide_info_java_proto` above `//proto:proto_deps` but this causes other problems.  This was I think what you suggested (placing the updated package jar higher up in classpath)?