### PR TITLE
[wip] kotlin v3

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -277,10 +277,10 @@ scala_repositories()
 # LICENSE: The Apache Software License, Version 2.0
 git_repository(
     name = "io_bazel_rules_kotlin",
-    commit = "6d8dcd4d6000d0cf3321eb8580d8fc67f8731f8e",
+    commit = "c7e19236f0936626c6ac141e531993720079df44",
     remote = "https://github.com/bazelbuild/rules_kotlin.git",
 )
 
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories")
-
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories","kt_register_toolchains")
+kt_register_toolchains()
 kotlin_repositories()

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/kotlin/kotlinlibrary/BUILD
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/kotlin/kotlinlibrary/BUILD
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load(
+    "//aspect/testing/rules:intellij_aspect_test_fixture.bzl",
+    "intellij_aspect_test_fixture",
+)
+
+kt_jvm_library(
+    name = "simple",
+    srcs = [":Foo.kt"]
+)
+
+intellij_aspect_test_fixture(
+    name = "simple_fixture",
+    deps = [":simple"]
+)
+
+java_test(
+    name = "KotlinLibraryTest",
+    srcs = ["KotlinLibraryTest.java"],
+    data = [":simple_fixture"],
+    deps = [
+        "//aspect/testing:BazelIntellijAspectTest",
+        "//aspect/testing/rules:IntellijAspectTest",
+        "//aspect/testing/rules:intellij_aspect_test_fixture_java_proto",
+        "//proto:intellij_ide_info_java_proto",
+        "@junit//jar",
+        "@truth//jar",
+    ],
+)

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/kotlin/kotlinlibrary/Foo.kt
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/kotlin/kotlinlibrary/Foo.kt
@@ -1,0 +1,7 @@
+package com.google.idea.blaze.aspect.kotlin.kotlinlibrary;
+
+class Foo {
+
+
+
+}

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/kotlin/kotlinlibrary/KotlinLibraryTest.java
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/kotlin/kotlinlibrary/KotlinLibraryTest.java
@@ -1,0 +1,45 @@
+package com.google.idea.blaze.aspect.kotlin.kotlinlibrary;
+
+import com.google.devtools.intellij.IntellijAspectTestFixtureOuterClass.IntellijAspectTestFixture;
+import com.google.devtools.intellij.ideinfo.IntellijIdeInfo.TargetIdeInfo;
+import com.google.idea.blaze.BazelIntellijAspectTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.IOException;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@RunWith(JUnit4.class)
+public class KotlinLibraryTest extends BazelIntellijAspectTest {
+  @Test
+  public void testKotlinLibrary() throws IOException {
+    IntellijAspectTestFixture testFixture = loadTestFixture(":simple_fixture");
+
+    TargetIdeInfo target = findTarget(testFixture, ":simple");
+    assertThat(target.getKindString()).isEqualTo("kt_jvm_library");
+    assertThat(target.hasJavaIdeInfo()).isTrue();
+
+    TargetIdeInfo ideInfo =
+        testFixture
+            .getTargetsList()
+            .stream()
+            .filter(
+                t ->
+                    t.getKey()
+                        .getLabel()
+                        .equals("@io_bazel_rules_kotlin//kotlin:kt_toolchain_ide_info"))
+            .findFirst()
+            .orElse(null);
+
+    assertThat(ideInfo).isNotNull();
+    assertThat(ideInfo.getKindString()).isEqualTo("kt_toolchain_ide_info");
+    assertThat(ideInfo.hasKtToolchainIdeInfo()).isTrue();
+    assertThat(ideInfo.getKtToolchainIdeInfo().getLocation()).isNotNull();
+
+    // TODO remove this block
+    assertThat(ideInfo.getJavaIdeInfo()).isNotNull();
+    assertThat(ideInfo.getJavaIdeInfo().getSourcesList()).hasSize(1);
+  }
+}

--- a/base/src/com/google/idea/blaze/base/ideinfo/KtToolchainIdeInfo.java
+++ b/base/src/com/google/idea/blaze/base/ideinfo/KtToolchainIdeInfo.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.ideinfo;
+
+public class KtToolchainIdeInfo {
+  private static final long serialVersionUID = 1L;
+
+  public final ArtifactLocation location;
+
+  public KtToolchainIdeInfo(ArtifactLocation ideInfoLocation) {
+    this.location = ideInfoLocation;
+  }
+
+  public static class Builder {
+    ArtifactLocation location;
+
+    public Builder setLocation(ArtifactLocation location) {
+      this.location = location;
+      return this;
+    }
+
+    public KtToolchainIdeInfo build() {
+      return new KtToolchainIdeInfo(location);
+    }
+  }
+}

--- a/base/src/com/google/idea/blaze/base/ideinfo/KtToolchainIdeInfo.java
+++ b/base/src/com/google/idea/blaze/base/ideinfo/KtToolchainIdeInfo.java
@@ -27,7 +27,7 @@ public class KtToolchainIdeInfo {
   public static class Builder {
     ArtifactLocation location;
 
-    public Builder setLocation(ArtifactLocation location) {
+    public Builder location(ArtifactLocation location) {
       this.location = location;
       return this;
     }

--- a/base/src/com/google/idea/blaze/base/ideinfo/TargetIdeInfo.java
+++ b/base/src/com/google/idea/blaze/base/ideinfo/TargetIdeInfo.java
@@ -23,11 +23,12 @@ import com.google.idea.blaze.base.dependencies.TargetInfo;
 import com.google.idea.blaze.base.ideinfo.Dependency.DependencyType;
 import com.google.idea.blaze.base.model.primitives.Kind;
 import com.google.idea.blaze.base.model.primitives.Label;
+
+import javax.annotation.Nullable;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import javax.annotation.Nullable;
 
 /** Simple implementation of TargetIdeInfo. */
 public final class TargetIdeInfo implements Serializable {
@@ -53,6 +54,7 @@ public final class TargetIdeInfo implements Serializable {
   @Nullable public final TestIdeInfo testIdeInfo;
   @Nullable public final ProtoLibraryLegacyInfo protoLibraryLegacyInfo;
   @Nullable public final JavaToolchainIdeInfo javaToolchainIdeInfo;
+  @Nullable public final KtToolchainIdeInfo ktToolchainIdeInfo;
 
   public TargetIdeInfo(
       TargetKey key,
@@ -74,7 +76,8 @@ public final class TargetIdeInfo implements Serializable {
       @Nullable DartIdeInfo dartIdeInfo,
       @Nullable TestIdeInfo testIdeInfo,
       @Nullable ProtoLibraryLegacyInfo protoLibraryLegacyInfo,
-      @Nullable JavaToolchainIdeInfo javaToolchainIdeInfo) {
+      @Nullable JavaToolchainIdeInfo javaToolchainIdeInfo,
+      @Nullable KtToolchainIdeInfo ktToolchainIdeInfo) {
     this.key = key;
     this.kind = kind;
     this.buildFile = buildFile;
@@ -95,6 +98,7 @@ public final class TargetIdeInfo implements Serializable {
     this.testIdeInfo = testIdeInfo;
     this.protoLibraryLegacyInfo = protoLibraryLegacyInfo;
     this.javaToolchainIdeInfo = javaToolchainIdeInfo;
+    this.ktToolchainIdeInfo = ktToolchainIdeInfo;
   }
 
   public TargetInfo toTargetInfo() {
@@ -151,6 +155,7 @@ public final class TargetIdeInfo implements Serializable {
     private TestIdeInfo testIdeInfo;
     private ProtoLibraryLegacyInfo protoLibraryLegacyInfo;
     private JavaToolchainIdeInfo javaToolchainIdeInfo;
+    private KtToolchainIdeInfo ktToolchainIdeInfo;
 
     public Builder setLabel(String label) {
       return setLabel(Label.create(label));
@@ -255,6 +260,11 @@ public final class TargetIdeInfo implements Serializable {
       return this;
     }
 
+    public Builder setKtToolchainIdeInfo(KtToolchainIdeInfo.Builder ktToolchainIdeInfo) {
+      this.ktToolchainIdeInfo = ktToolchainIdeInfo.build();
+      return this;
+    }
+
     public Builder addTag(String s) {
       this.tags.add(s);
       return this;
@@ -301,7 +311,8 @@ public final class TargetIdeInfo implements Serializable {
           dartIdeInfo,
           testIdeInfo,
           protoLibraryLegacyInfo,
-          javaToolchainIdeInfo);
+          javaToolchainIdeInfo,
+          ktToolchainIdeInfo);
     }
   }
 }

--- a/base/src/com/google/idea/blaze/base/model/primitives/Kind.java
+++ b/base/src/com/google/idea/blaze/base/model/primitives/Kind.java
@@ -19,9 +19,10 @@ import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
+
+import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Collection;
-import javax.annotation.Nullable;
 
 /** Wrapper around a string for a blaze kind (android_library, android_test...) */
 public enum Kind {
@@ -96,8 +97,8 @@ public enum Kind {
   KT_JVM_BINARY("kt_jvm_binary", LanguageClass.KOTLIN, RuleType.BINARY),
   KT_JVM_TEST("kt_jvm_test", LanguageClass.KOTLIN, RuleType.TEST),
   KT_JVM_IMPORT("kt_jvm_import", LanguageClass.KOTLIN, RuleType.UNKNOWN),
+  KT_TOOLCHAIN_IDE_INFO("kt_toolchain_ide_info", LanguageClass.KOTLIN, RuleType.UNKNOWN),
   KOTLIN_STDLIB("kotlin_stdlib", LanguageClass.KOTLIN, RuleType.UNKNOWN),
-
   // any rule exposing java_common.provider which isn't specifically recognized
   GENERIC_JAVA_PROVIDER("generic_java", LanguageClass.JAVA, RuleType.UNKNOWN),
   ;

--- a/base/src/com/google/idea/blaze/base/sync/aspects/IdeInfoFromProtobuf.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/IdeInfoFromProtobuf.java
@@ -29,6 +29,7 @@ import com.google.idea.blaze.base.model.primitives.ExecutionRootPath;
 import com.google.idea.blaze.base.model.primitives.Kind;
 import com.google.idea.blaze.base.model.primitives.Label;
 
+import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/base/src/com/google/idea/blaze/base/sync/aspects/IdeInfoFromProtobuf.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/IdeInfoFromProtobuf.java
@@ -170,9 +170,10 @@ public class IdeInfoFromProtobuf {
     if (message.getJavaIdeInfo() == null || message.getJavaIdeInfo().getSourcesCount() == 0) {
       return null;
     } else {
-      realKtIdeInfoLocation = makeArtifactLocation(message.getJavaIdeInfo().getSources(0));
+      ArtifactLocation artifactLocation =
+          makeArtifactLocation(message.getJavaIdeInfo().getSources(0));
+      return new KtToolchainIdeInfo.Builder().location(artifactLocation).build();
     }
-    return new KtToolchainIdeInfo.Builder().setLocation(realKtIdeInfoLocation).build();
   }
 
   private static Collection<Dependency> makeDependencyListFromLabelList(

--- a/base/src/com/google/idea/blaze/base/sync/aspects/strategy/LanguageOutputGroup.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/strategy/LanguageOutputGroup.java
@@ -16,6 +16,7 @@
 package com.google.idea.blaze.base.sync.aspects.strategy;
 
 import com.google.idea.blaze.base.model.primitives.LanguageClass;
+
 import javax.annotation.Nullable;
 
 /** Enumerates the sets of aspect output groups corresponding to each language */
@@ -27,7 +28,8 @@ public enum LanguageOutputGroup {
   GO(LanguageClass.GO, "go"),
   JAVASCRIPT(LanguageClass.JAVASCRIPT, "js"),
   TYPESCRIPT(LanguageClass.TYPESCRIPT, "ts"),
-  DART(LanguageClass.DART, "dart");
+  DART(LanguageClass.DART, "dart"),
+  KOTLIN(LanguageClass.KOTLIN, "kt");
 
   public final LanguageClass languageClass;
   public final String suffix;

--- a/base/tests/unittests/com/google/idea/blaze/base/sync/aspects/strategy/AspectStrategyTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/sync/aspects/strategy/AspectStrategyTest.java
@@ -86,7 +86,8 @@ public class AspectStrategyTest extends BlazeTestCase {
             "intellij-info-go",
             "intellij-info-js",
             "intellij-info-ts",
-            "intellij-info-dart");
+            "intellij-info-dart",
+            "intellij-info-kt");
 
     builder = emptyBuilder();
     strategy.addAspectAndOutputGroups(builder, OutputGroup.RESOLVE, activeLanguages);
@@ -99,7 +100,8 @@ public class AspectStrategyTest extends BlazeTestCase {
             "intellij-resolve-go",
             "intellij-resolve-js",
             "intellij-resolve-ts",
-            "intellij-resolve-dart");
+            "intellij-resolve-dart",
+            "intellij-resolve-kt");
 
     builder = emptyBuilder();
     strategy.addAspectAndOutputGroups(builder, OutputGroup.COMPILE, activeLanguages);
@@ -112,7 +114,8 @@ public class AspectStrategyTest extends BlazeTestCase {
             "intellij-compile-go",
             "intellij-compile-js",
             "intellij-compile-ts",
-            "intellij-compile-dart");
+            "intellij-compile-dart",
+            "intellij-compile-kt");
   }
 
   private static BlazeCommand.Builder emptyBuilder() {

--- a/kotlin/src/com/google/idea/blaze/kotlin/BlazeKotlin.java
+++ b/kotlin/src/com/google/idea/blaze/kotlin/BlazeKotlin.java
@@ -1,0 +1,37 @@
+package com.google.idea.blaze.kotlin;
+
+import org.jetbrains.kotlin.config.LanguageVersion;
+import org.jetbrains.kotlin.idea.KotlinPluginUtil;
+
+import java.util.function.Function;
+
+/** Contains constants for the Kotlin plugin. */
+public final class BlazeKotlin {
+  /** The language level to use if the user has not provided one in the workspace. */
+  public static final LanguageVersion DEFAULT_LANGUAGE_VERSION = LanguageVersion.LATEST_STABLE;
+
+  public static final String
+      /*
+       The name of the workspace in which to find the Kotlin compiler. This is setup by the rules.
+      */
+      COMPILER_WORKSPACE_NAME = "com_github_jetbrains_kotlin",
+      KOTLIN_RULES_WORKSPACE_NAME = "io_bazel_rules_kotlin",
+      PLUGIN_ID = KotlinPluginUtil.KOTLIN_PLUGIN_ID.getIdString(),
+      RULES_REPO = "https://github.com/bazelbuild/rules_kotlin";
+
+  public static class Issues {
+    public static final String
+        RULES_ABSENT_FROM_WORKSPACE =
+            "The Kotlin workspace has not been setup. Visit "
+                + RULES_REPO
+                + " , or remove the Kotlin language.",
+        MULTIPLE_KT_TOOLCHAIN_IDE_INFO = "Multiple kt_toolchain_ide_info rules in repo",
+        LANGUAGE_VERSION_SECTION_IGNORED =
+            "The Kotlin rules configure all of the project settings, \"kotlin_language_version\" is ignored";
+    public static final Function<String, String>
+        UPDATE_RULES_WARNING =
+            (because) -> because + ". Please update the rules by visiting " + RULES_REPO + ".",
+        ERROR_RENDERING_KT_TOOLCHAIN_IDE_INFO =
+            (because) -> "Could not render ide info json file, error: " + because;
+  }
+}

--- a/kotlin/src/com/google/idea/blaze/kotlin/run/producers/BlazeKotlinRunConfigurationProducer.java
+++ b/kotlin/src/com/google/idea/blaze/kotlin/run/producers/BlazeKotlinRunConfigurationProducer.java
@@ -34,12 +34,13 @@ import com.intellij.openapi.util.Ref;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
+import org.jetbrains.kotlin.idea.run.KotlinRunConfigurationProducer;
+import org.jetbrains.kotlin.psi.KtDeclarationContainer;
+
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Collection;
 import java.util.Objects;
-import javax.annotation.Nullable;
-import org.jetbrains.kotlin.idea.run.KotlinRunConfigurationProducer;
-import org.jetbrains.kotlin.psi.KtDeclarationContainer;
 
 /** Creates run configurations for Kotlin main methods. */
 public class BlazeKotlinRunConfigurationProducer
@@ -48,44 +49,6 @@ public class BlazeKotlinRunConfigurationProducer
 
   public BlazeKotlinRunConfigurationProducer() {
     super(BlazeCommandRunConfigurationType.getInstance());
-  }
-
-  @Override
-  protected boolean doSetupConfigFromContext(
-      BlazeCommandRunConfiguration configuration,
-      ConfigurationContext context,
-      Ref<PsiElement> sourceElement) {
-    Location<?> location = context.getLocation();
-    if (location == null) {
-      return false;
-    }
-    sourceElement.set(location.getPsiElement());
-    TargetIdeInfo target = getTargetIdeInfo(context);
-    if (target == null) {
-      return false;
-    }
-    BlazeCommandRunConfigurationCommonState handlerState =
-        configuration.getHandlerStateIfType(BlazeCommandRunConfigurationCommonState.class);
-    if (handlerState == null) {
-      return false;
-    }
-    handlerState.getCommandState().setCommand(BlazeCommandName.RUN);
-    configuration.setTargetInfo(target.toTargetInfo());
-    configuration.setGeneratedName();
-    return true;
-  }
-
-  @Override
-  protected boolean doIsConfigFromContext(
-      BlazeCommandRunConfiguration configuration, ConfigurationContext context) {
-    TargetIdeInfo target = getTargetIdeInfo(context);
-    BlazeCommandRunConfigurationCommonState handlerState =
-        configuration.getHandlerStateIfType(BlazeCommandRunConfigurationCommonState.class);
-    return target != null
-        && handlerState != null
-        && Objects.equals(handlerState.getCommandState().getCommand(), BlazeCommandName.RUN)
-        && configuration.getTarget() != null
-        && Objects.equals(configuration.getTarget(), target.key.label);
   }
 
   @Nullable
@@ -153,5 +116,43 @@ public class BlazeKotlinRunConfigurationProducer
         projectData.artifactLocationDecoder,
         projectData.targetMap,
         (target) -> target.kind == Kind.KT_JVM_BINARY && target.isPlainTarget());
+  }
+
+  @Override
+  protected boolean doSetupConfigFromContext(
+      BlazeCommandRunConfiguration configuration,
+      ConfigurationContext context,
+      Ref<PsiElement> sourceElement) {
+    Location<?> location = context.getLocation();
+    if (location == null) {
+      return false;
+    }
+    sourceElement.set(location.getPsiElement());
+    TargetIdeInfo target = getTargetIdeInfo(context);
+    if (target == null) {
+      return false;
+    }
+    BlazeCommandRunConfigurationCommonState handlerState =
+        configuration.getHandlerStateIfType(BlazeCommandRunConfigurationCommonState.class);
+    if (handlerState == null) {
+      return false;
+    }
+    handlerState.getCommandState().setCommand(BlazeCommandName.RUN);
+    configuration.setTargetInfo(target.toTargetInfo());
+    configuration.setGeneratedName();
+    return true;
+  }
+
+  @Override
+  protected boolean doIsConfigFromContext(
+      BlazeCommandRunConfiguration configuration, ConfigurationContext context) {
+    TargetIdeInfo target = getTargetIdeInfo(context);
+    BlazeCommandRunConfigurationCommonState handlerState =
+        configuration.getHandlerStateIfType(BlazeCommandRunConfigurationCommonState.class);
+    return target != null
+        && handlerState != null
+        && Objects.equals(handlerState.getCommandState().getCommand(), BlazeCommandName.RUN)
+        && configuration.getTarget() != null
+        && Objects.equals(configuration.getTarget(), target.key.label);
   }
 }

--- a/kotlin/src/com/google/idea/blaze/kotlin/run/producers/BlazeKotlinTestClassConfigurationProducer.java
+++ b/kotlin/src/com/google/idea/blaze/kotlin/run/producers/BlazeKotlinTestClassConfigurationProducer.java
@@ -32,15 +32,16 @@ import com.intellij.execution.actions.ConfigurationContext;
 import com.intellij.openapi.util.Ref;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.psi.PsiElement;
+import org.jetbrains.kotlin.name.FqName;
+import org.jetbrains.kotlin.psi.KtClass;
+import org.jetbrains.kotlin.psi.KtNamedFunction;
+
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import javax.annotation.Nullable;
-import org.jetbrains.kotlin.name.FqName;
-import org.jetbrains.kotlin.psi.KtClass;
-import org.jetbrains.kotlin.psi.KtNamedFunction;
 
 /** Creates run configurations for Kotlin tests. */
 public class BlazeKotlinTestClassConfigurationProducer
@@ -103,6 +104,11 @@ public class BlazeKotlinTestClassConfigurationProducer
     final KtClass testClass;
     @Nullable final KtNamedFunction testMethod;
 
+    private TestLocation(@Nullable KtNamedFunction testMethod, KtClass testClass) {
+      this.testMethod = testMethod;
+      this.testClass = testClass;
+    }
+
     @Nullable
     static TestLocation from(ConfigurationContext context) {
       Location<?> location = context.getLocation();
@@ -116,11 +122,6 @@ public class BlazeKotlinTestClassConfigurationProducer
         return null;
       }
       return new TestLocation(testMethod, testClass);
-    }
-
-    private TestLocation(@Nullable KtNamedFunction testMethod, KtClass testClass) {
-      this.testMethod = testMethod;
-      this.testClass = testClass;
     }
 
     PsiElement getSourceElement() {

--- a/kotlin/src/com/google/idea/blaze/kotlin/sync/AlwaysPresentKotlinSyncPlugin.java
+++ b/kotlin/src/com/google/idea/blaze/kotlin/sync/AlwaysPresentKotlinSyncPlugin.java
@@ -26,9 +26,10 @@ import com.google.idea.blaze.base.scope.output.IssueOutput;
 import com.google.idea.blaze.base.sync.BlazeSyncPlugin;
 import com.google.idea.blaze.base.sync.projectview.WorkspaceLanguageSettings;
 import com.intellij.openapi.project.Project;
+
+import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Set;
-import javax.annotation.Nullable;
 
 /**
  * Unlike most of the Kotlin-specific code, will be run even if the JetBrains Kotlin plugin isn't

--- a/kotlin/src/com/google/idea/blaze/kotlin/sync/AlwaysPresentKotlinSyncPlugin.java
+++ b/kotlin/src/com/google/idea/blaze/kotlin/sync/AlwaysPresentKotlinSyncPlugin.java
@@ -26,10 +26,9 @@ import com.google.idea.blaze.base.scope.output.IssueOutput;
 import com.google.idea.blaze.base.sync.BlazeSyncPlugin;
 import com.google.idea.blaze.base.sync.projectview.WorkspaceLanguageSettings;
 import com.intellij.openapi.project.Project;
-
-import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * Unlike most of the Kotlin-specific code, will be run even if the JetBrains Kotlin plugin isn't

--- a/kotlin/src/com/google/idea/blaze/kotlin/sync/BlazeKotlinSections.java
+++ b/kotlin/src/com/google/idea/blaze/kotlin/sync/BlazeKotlinSections.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2018 The Bazel Authors. All rights reserved.
+ * Copyright 2017 The Bazel Authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,11 +23,13 @@ import com.google.idea.blaze.base.projectview.section.ScalarSection;
 import com.google.idea.blaze.base.projectview.section.ScalarSectionParser;
 import com.google.idea.blaze.base.projectview.section.SectionKey;
 import com.google.idea.blaze.base.projectview.section.SectionParser;
-import javax.annotation.Nullable;
 import org.jetbrains.kotlin.config.LanguageVersion;
 
-/** Project view sections for Kotlin. */
-public final class BlazeKotlinLanguageVersionSection {
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Optional;
+
+public final class BlazeKotlinSections {
   private static final SectionKey<LanguageVersion, ScalarSection<LanguageVersion>>
       LANGUAGE_VERSION = new SectionKey<>("kotlin_language_version");
 
@@ -46,6 +48,13 @@ public final class BlazeKotlinLanguageVersionSection {
           }
         }
 
+        // the language version is now derived from the toolchain info
+        @Override
+        public boolean isDeprecated() {
+          return true;
+        }
+
+        @Nonnull
         @Override
         public String quickDocs() {
           return "The kotlin language and api version.";
@@ -64,7 +73,7 @@ public final class BlazeKotlinLanguageVersionSection {
 
   static final ImmutableList<SectionParser> PARSERS = ImmutableList.of(LANGUAGE_VERSION_PARSER);
 
-  public static LanguageVersion getLanguageLevel(ProjectViewSet projectViewSet) {
-    return projectViewSet.getScalarValue(LANGUAGE_VERSION).orElse(LanguageVersion.LATEST_STABLE);
+  public static Optional<LanguageVersion> getLanguageLevel(ProjectViewSet projectViewSet) {
+    return projectViewSet.getScalarValue(LANGUAGE_VERSION);
   }
 }

--- a/kotlin/src/com/google/idea/blaze/kotlin/sync/BlazeKotlinStdLib.java
+++ b/kotlin/src/com/google/idea/blaze/kotlin/sync/BlazeKotlinStdLib.java
@@ -19,13 +19,14 @@ import com.google.common.collect.ImmutableList;
 import com.google.idea.blaze.base.ideinfo.ArtifactLocation;
 import com.google.idea.blaze.base.ideinfo.LibraryArtifact;
 import com.google.idea.blaze.java.sync.model.BlazeJarLibrary;
+
+import javax.annotation.Nullable;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import javax.annotation.Nullable;
 
 /** Kotlin standard library. */
 public enum BlazeKotlinStdLib {
@@ -35,8 +36,13 @@ public enum BlazeKotlinStdLib {
   REFLECT("kotlin-reflect", false),
   TEST("kotlin-test", false);
 
+  public static final List<BlazeKotlinStdLib> MANDATORY_STDLIBS =
+      Arrays.stream(BlazeKotlinStdLib.values())
+          .filter(lib -> lib.mandatory)
+          .collect(Collectors.toList());
+  static final String COMPILER_WORKSPACE_PATH =
+      Paths.get("external", "com_github_jetbrains_kotlin").toString();
   public final String id;
-
   /** Mandatory libraries are those that should always be present. */
   public final boolean mandatory;
 
@@ -44,26 +50,6 @@ public enum BlazeKotlinStdLib {
     this.id = id;
     this.mandatory = mandatory;
   }
-
-  String getClassJarFileName() {
-    return id + ".jar";
-  }
-
-  String getSourceJarFileName() {
-    return id + "-sources.jar";
-  }
-
-  String externalWorkspaceRelativeLibPath(Supplier<String> jarName) {
-    return Paths.get("lib", jarName.get()).toString();
-  }
-
-  static final String COMPILER_WORKSPACE_PATH =
-      Paths.get("external", "com_github_jetbrains_kotlin").toString();
-
-  public static final List<BlazeKotlinStdLib> MANDATORY_STDLIBS =
-      Arrays.stream(BlazeKotlinStdLib.values())
-          .filter(lib -> lib.mandatory)
-          .collect(Collectors.toList());
 
   private static ArtifactLocation.Builder createExternalArtifactBuilder(
       String rootExecutionPathFragment) {
@@ -98,5 +84,17 @@ public enum BlazeKotlinStdLib {
               return new BlazeJarLibrary(libBuilder.build());
             })
         .collect(Collectors.toList());
+  }
+
+  String getClassJarFileName() {
+    return id + ".jar";
+  }
+
+  String getSourceJarFileName() {
+    return id + "-sources.jar";
+  }
+
+  String externalWorkspaceRelativeLibPath(Supplier<String> jarName) {
+    return Paths.get("lib", jarName.get()).toString();
   }
 }

--- a/kotlin/src/com/google/idea/blaze/kotlin/sync/importer/BlazeKotlinWorkspaceImporter.java
+++ b/kotlin/src/com/google/idea/blaze/kotlin/sync/importer/BlazeKotlinWorkspaceImporter.java
@@ -39,7 +39,6 @@ import com.google.idea.blaze.kotlin.sync.model.BlazeKotlinImportResult;
 import com.google.idea.blaze.kotlin.sync.model.BlazeKotlinToolchainIdeInfo;
 import com.intellij.openapi.project.Project;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.File;
 import java.io.FileInputStream;
@@ -54,6 +53,7 @@ public class BlazeKotlinWorkspaceImporter {
       new GsonBuilder()
           .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
           .create();
+
   private final TargetMap targetMap;
   private final ProjectViewTargetImportFilter importFilter;
   private final ArtifactLocationDecoder artifactLocationDecoder;
@@ -115,7 +115,6 @@ public class BlazeKotlinWorkspaceImporter {
             });
   }
 
-  @Nonnull
   private Stream<TargetIdeInfo> expandWithKotlinTargets(TargetIdeInfo target) {
     return Stream.concat(
         Stream.of(target),

--- a/kotlin/src/com/google/idea/blaze/kotlin/sync/importer/BlazeKotlinWorkspaceImporter.java
+++ b/kotlin/src/com/google/idea/blaze/kotlin/sync/importer/BlazeKotlinWorkspaceImporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The Bazel Authors. All rights reserved.
+ * Copyright 2017 The Bazel Authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,54 +15,94 @@
  */
 package com.google.idea.blaze.kotlin.sync.importer;
 
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.idea.blaze.base.ideinfo.TargetIdeInfo;
 import com.google.idea.blaze.base.ideinfo.TargetMap;
 import com.google.idea.blaze.base.model.LibraryKey;
+import com.google.idea.blaze.base.model.primitives.Kind;
 import com.google.idea.blaze.base.model.primitives.LanguageClass;
 import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
 import com.google.idea.blaze.base.projectview.ProjectViewSet;
+import com.google.idea.blaze.base.scope.BlazeContext;
+import com.google.idea.blaze.base.scope.output.IssueOutput;
 import com.google.idea.blaze.base.sync.projectview.ProjectViewTargetImportFilter;
+import com.google.idea.blaze.base.sync.workspace.ArtifactLocationDecoder;
 import com.google.idea.blaze.base.targetmaps.TransitiveDependencyMap;
 import com.google.idea.blaze.java.sync.model.BlazeJarLibrary;
+import com.google.idea.blaze.kotlin.BlazeKotlin;
 import com.google.idea.blaze.kotlin.sync.model.BlazeKotlinImportResult;
+import com.google.idea.blaze.kotlin.sync.model.BlazeKotlinToolchainIdeInfo;
 import com.intellij.openapi.project.Project;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.stream.Stream;
 
-/** Computes Kotlin-specific project sync data. */
 public class BlazeKotlinWorkspaceImporter {
+  private static final Gson gson =
+      new GsonBuilder()
+          .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+          .create();
   private final TargetMap targetMap;
   private final ProjectViewTargetImportFilter importFilter;
+  private final ArtifactLocationDecoder artifactLocationDecoder;
+  private final BlazeContext context;
 
   public BlazeKotlinWorkspaceImporter(
       Project project,
       WorkspaceRoot workspaceRoot,
       ProjectViewSet projectViewSet,
-      TargetMap targetMap) {
+      TargetMap targetMap,
+      BlazeContext context,
+      ArtifactLocationDecoder artifactLocationDecoder) {
     this.targetMap = targetMap;
     importFilter = new ProjectViewTargetImportFilter(project, workspaceRoot, projectViewSet);
+    this.context = context;
+    this.artifactLocationDecoder = artifactLocationDecoder;
   }
 
   public BlazeKotlinImportResult importWorkspace() {
     HashMap<LibraryKey, BlazeJarLibrary> libraries = new HashMap<>();
     HashMap<TargetIdeInfo, ImmutableList<BlazeJarLibrary>> targetLibraryMap = new HashMap<>();
+    HashSet<TargetIdeInfo> toolchainTargetIdeInfos = new HashSet<>();
 
-    collectTransitiveLibsFromKotlinSourceTargets(libraries, targetLibraryMap);
+    collectTransitiveLibsFromKotlinSourceTargets(
+        libraries, targetLibraryMap, toolchainTargetIdeInfos);
 
     return new BlazeKotlinImportResult(
-        ImmutableList.copyOf(libraries.values()), ImmutableMap.copyOf(targetLibraryMap));
+        ImmutableList.copyOf(libraries.values()),
+        ImmutableMap.copyOf(targetLibraryMap),
+        renderToolchainInfo(toolchainTargetIdeInfos));
   }
 
   private void collectTransitiveLibsFromKotlinSourceTargets(
       HashMap<LibraryKey, BlazeJarLibrary> libraries,
-      HashMap<TargetIdeInfo, ImmutableList<BlazeJarLibrary>> targetLibraryMap) {
-    transitiveKotlinTargets()
+      HashMap<TargetIdeInfo, ImmutableList<BlazeJarLibrary>> targetLibraryMap,
+      HashSet<TargetIdeInfo> toolchainInfos) {
+    targetMap
+        .targets()
+        .stream()
+        .filter(target -> target.kind.languageClass.equals(LanguageClass.KOTLIN))
+        .peek(
+            target -> {
+              if (target.kind.equals(Kind.KT_TOOLCHAIN_IDE_INFO)) toolchainInfos.add(target);
+            })
+        .filter(importFilter::isSourceTarget)
+        .flatMap(this::expandWithKotlinTargets)
         .forEach(
             depIdeInfo -> {
-              // noinspection ConstantConditions
+              //noinspection ConstantConditions
               BlazeJarLibrary[] transitiveLibraries =
                   depIdeInfo
                       .javaIdeInfo
@@ -75,15 +115,7 @@ public class BlazeKotlinWorkspaceImporter {
             });
   }
 
-  private Stream<TargetIdeInfo> transitiveKotlinTargets() {
-    return targetMap
-        .targets()
-        .stream()
-        .filter(target -> target.kind.languageClass.equals(LanguageClass.KOTLIN))
-        .filter(importFilter::isSourceTarget)
-        .flatMap(this::expandWithKotlinTargets);
-  }
-
+  @Nonnull
   private Stream<TargetIdeInfo> expandWithKotlinTargets(TargetIdeInfo target) {
     return Stream.concat(
         Stream.of(target),
@@ -94,5 +126,37 @@ public class BlazeKotlinWorkspaceImporter {
             .filter(Objects::nonNull)
             .filter(info -> info.javaIdeInfo != null)
             .filter(depIdeInfo -> depIdeInfo.kind.languageClass == LanguageClass.KOTLIN));
+  }
+
+  @Nullable
+  private BlazeKotlinToolchainIdeInfo renderToolchainInfo(HashSet<TargetIdeInfo> targetIdeInfos) {
+    switch (targetIdeInfos.size()) {
+      case 0:
+        return null;
+      case 1:
+        File location =
+            artifactLocationDecoder.decode(
+                Objects.requireNonNull(targetIdeInfos.iterator().next().ktToolchainIdeInfo)
+                    .location);
+        try (InputStreamReader reader = new InputStreamReader(new FileInputStream(location))) {
+          return gson.fromJson(reader, BlazeKotlinToolchainIdeInfo.class);
+        } catch (Exception e) {
+          IssueOutput.error(
+                  BlazeKotlin.Issues.ERROR_RENDERING_KT_TOOLCHAIN_IDE_INFO.apply(
+                      Throwables.getRootCause(e).getMessage()))
+              .submit(context);
+          return null;
+        }
+      default:
+        // A toolchain ide info should be a singleton. It is currently populated from the singleton
+        // rule kt_toolchain_ide_info. The toolchain Ide info is
+        // used to configure the project -- this is global. Whilst it is conceivable for the
+        // workspace to have multiple compiler configurations active
+        // for Kotlin for now it is an error for multiple configurations to enter the sync model, at
+        // least configurations generated from the
+        // kt_toolchain_ide_info rule.
+        IssueOutput.error(BlazeKotlin.Issues.MULTIPLE_KT_TOOLCHAIN_IDE_INFO).submit(context);
+        return null;
+    }
   }
 }

--- a/kotlin/src/com/google/idea/blaze/kotlin/sync/model/BlazeKotlinImportResult.java
+++ b/kotlin/src/com/google/idea/blaze/kotlin/sync/model/BlazeKotlinImportResult.java
@@ -19,21 +19,26 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.idea.blaze.base.ideinfo.TargetIdeInfo;
 import com.google.idea.blaze.java.sync.model.BlazeJarLibrary;
-import java.io.Serializable;
+
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
+import java.io.Serializable;
 
 /** The result of a blaze import operation. */
 @Immutable
 public class BlazeKotlinImportResult implements Serializable {
-  private static final long serialVersionUID = 2L;
+  private static final long serialVersionUID = 1L;
 
   public final ImmutableList<BlazeJarLibrary> libraries;
   public final ImmutableMap<TargetIdeInfo, ImmutableList<BlazeJarLibrary>> kotlinTargetToLibraryMap;
+  @Nullable public final BlazeKotlinToolchainIdeInfo toolchainIdeInfo;
 
   public BlazeKotlinImportResult(
       ImmutableList<BlazeJarLibrary> libraries,
-      ImmutableMap<TargetIdeInfo, ImmutableList<BlazeJarLibrary>> targetToLibraryMap) {
+      ImmutableMap<TargetIdeInfo, ImmutableList<BlazeJarLibrary>> targetToLibraryMap,
+      @Nullable BlazeKotlinToolchainIdeInfo toolchainIdeInfo) {
     this.libraries = libraries;
     this.kotlinTargetToLibraryMap = targetToLibraryMap;
+    this.toolchainIdeInfo = toolchainIdeInfo;
   }
 }

--- a/kotlin/src/com/google/idea/blaze/kotlin/sync/model/BlazeKotlinSyncData.java
+++ b/kotlin/src/com/google/idea/blaze/kotlin/sync/model/BlazeKotlinSyncData.java
@@ -15,8 +15,9 @@
 package com.google.idea.blaze.kotlin.sync.model;
 
 import com.google.idea.blaze.base.model.BlazeProjectData;
-import java.io.Serializable;
+
 import javax.annotation.concurrent.Immutable;
+import java.io.Serializable;
 
 /** Sync data for the kotlin plugin. */
 @Immutable

--- a/kotlin/src/com/google/idea/blaze/kotlin/sync/model/BlazeKotlinToolchainIdeInfo.java
+++ b/kotlin/src/com/google/idea/blaze/kotlin/sync/model/BlazeKotlinToolchainIdeInfo.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.kotlin.sync.model;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
+
+public final class BlazeKotlinToolchainIdeInfo {
+  @Nonnull public final String label;
+  @Nonnull public final CommonInfo common;
+  @Nonnull public final JvmInfo jvm;
+
+  BlazeKotlinToolchainIdeInfo(
+      @Nonnull String label, @Nonnull CommonInfo common, @Nonnull JvmInfo jvm) {
+    this.label = Objects.requireNonNull(label);
+    this.common = Objects.requireNonNull(common);
+    this.jvm = Objects.requireNonNull(jvm);
+  }
+
+  public static final class CommonInfo {
+    @Nonnull public final String languageVersion;
+    @Nonnull public final String apiVersion;
+    @Nonnull public final String coroutines;
+
+    CommonInfo(
+        @Nonnull String languageVersion, @Nonnull String apiVersion, @Nonnull String coroutines) {
+      this.languageVersion = Objects.requireNonNull(languageVersion);
+      this.apiVersion = Objects.requireNonNull(apiVersion);
+      this.coroutines = Objects.requireNonNull(coroutines);
+    }
+  }
+
+  public static final class JvmInfo {
+    @Nonnull public final String jvmTarget;
+
+    JvmInfo(@Nonnull String jvmTarget) {
+      this.jvmTarget = Objects.requireNonNull(jvmTarget);
+    }
+  }
+}

--- a/kotlin/tests/integrationtests/com/google/idea/blaze/kotlin/run/producers/BlazeKotlinRunConfigureProducerTest.java
+++ b/kotlin/tests/integrationtests/com/google/idea/blaze/kotlin/run/producers/BlazeKotlinRunConfigureProducerTest.java
@@ -15,8 +15,6 @@
  */
 package com.google.idea.blaze.kotlin.run.producers;
 
-import static com.google.common.truth.Truth.assertThat;
-
 import com.google.idea.blaze.base.ideinfo.JavaIdeInfo;
 import com.google.idea.blaze.base.ideinfo.TargetIdeInfo;
 import com.google.idea.blaze.base.ideinfo.TargetMapBuilder;
@@ -31,6 +29,8 @@ import com.intellij.psi.PsiFile;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+
+import static com.google.common.truth.Truth.assertThat;
 
 /** Integration tests for {@link BlazeKotlinRunConfigurationProducer}. */
 @RunWith(JUnit4.class)

--- a/kotlin/tests/unittests/com/google/idea/blaze/kotlin/sync/BlazeKotlinSyncPluginTest.java
+++ b/kotlin/tests/unittests/com/google/idea/blaze/kotlin/sync/BlazeKotlinSyncPluginTest.java
@@ -15,8 +15,6 @@
  */
 package com.google.idea.blaze.kotlin.sync;
 
-import static com.google.common.truth.Truth.assertThat;
-
 import com.google.common.collect.ImmutableSet;
 import com.google.idea.blaze.base.BlazeTestCase;
 import com.google.idea.blaze.base.bazel.BazelBuildSystemProvider;
@@ -41,6 +39,8 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+
+import static com.google.common.truth.Truth.assertThat;
 
 /** Unit tests for {@link BlazeKotlinSyncPlugin} */
 @RunWith(JUnit4.class)

--- a/proto/intellij_ide_info.proto
+++ b/proto/intellij_ide_info.proto
@@ -158,7 +158,11 @@ message Dependency {
   DependencyType dependency_type = 2;
 }
 
-// Next Available: 30
+// Next Available: 31
+message KtToolchainIdeInfo {
+  ArtifactLocation location = 1;
+}
+
 message TargetIdeInfo {
   string label = 1 [deprecated = true];
   repeated string dependencies = 4 [deprecated = true];
@@ -201,4 +205,5 @@ message TargetIdeInfo {
   DartIdeInfo dart_ide_info = 28;
 
   AndroidAarIdeInfo android_aar_ide_info = 29;
+  KtToolchainIdeInfo kt_toolchain_ide_info = 30;
 }

--- a/proto/intellij_ide_info.proto
+++ b/proto/intellij_ide_info.proto
@@ -158,11 +158,11 @@ message Dependency {
   DependencyType dependency_type = 2;
 }
 
-// Next Available: 31
 message KtToolchainIdeInfo {
   ArtifactLocation location = 1;
 }
 
+// Next Available: 31
 message TargetIdeInfo {
   string label = 1 [deprecated = true];
   repeated string dependencies = 4 [deprecated = true];

--- a/sdkcompat/v172/com/google/idea/sdkcompat/kotlin/BlazeKotlinCompilerArgumentsUpdaterCompat.java
+++ b/sdkcompat/v172/com/google/idea/sdkcompat/kotlin/BlazeKotlinCompilerArgumentsUpdaterCompat.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2018 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.sdkcompat.kotlin;
+
+import com.intellij.openapi.project.Project;
+import org.jetbrains.kotlin.cli.common.arguments.CommonCompilerArguments;
+import org.jetbrains.kotlin.cli.common.arguments.K2JVMCompilerArguments;
+import org.jetbrains.kotlin.idea.compiler.configuration.Kotlin2JvmCompilerArgumentsHolder;
+import org.jetbrains.kotlin.idea.compiler.configuration.KotlinCommonCompilerArgumentsHolder;
+
+public final class BlazeKotlinCompilerArgumentsUpdaterCompat {
+  private boolean commonUpdated = false;
+  private boolean jvmUpdated = false;
+  private final Project project;
+  private final CommonCompilerArguments commonArguments;
+  private final K2JVMCompilerArguments jvmCompilerArguments;
+
+  private BlazeKotlinCompilerArgumentsUpdaterCompat(Project project) {
+    this.project = project;
+    commonArguments =
+        KotlinCommonCompilerArgumentsHolder.Companion.getInstance(project).getSettings();
+    jvmCompilerArguments =
+        Kotlin2JvmCompilerArgumentsHolder.Companion.getInstance(project).getSettings();
+  }
+
+  public static BlazeKotlinCompilerArgumentsUpdaterCompat build(Project project) {
+    return new BlazeKotlinCompilerArgumentsUpdaterCompat(project);
+  }
+
+  public String getApiVersion() {
+    return this.commonArguments.apiVersion;
+  }
+
+  public String getLanguageVersion() {
+    return this.commonArguments.languageVersion;
+  }
+
+  public String getCoroutineState() {
+    return this.commonArguments.coroutinesState;
+  }
+
+  public String getJvmTarget() {
+    return this.jvmCompilerArguments.jvmTarget;
+  }
+
+  public void updateApiVersion(String apiVersion) {
+    if (getApiVersion() == null || !getApiVersion().equals(apiVersion)) {
+      commonUpdated = true;
+      commonArguments.apiVersion = apiVersion;
+    }
+  }
+
+  public void updateLanguageVersion(String languageVersion) {
+    if (getLanguageVersion() == null || !getLanguageVersion().equals(languageVersion)) {
+      commonUpdated = true;
+      commonArguments.languageVersion = languageVersion;
+    }
+  }
+
+  public void updateCoroutineState(String coroutines) {
+    if (getCoroutineState() == null || !getCoroutineState().equals(coroutines)) {
+      commonUpdated = true;
+      commonArguments.coroutinesState = coroutines;
+    }
+  }
+
+  public void updateJvmTarget(String jvmTarget) {
+    if (getJvmTarget() == null || !getJvmTarget().equals(jvmTarget)) {
+      jvmUpdated = true;
+      jvmCompilerArguments.jvmTarget = jvmTarget;
+    }
+  }
+
+  public void commit() {
+    if (commonUpdated) {
+      KotlinCommonCompilerArgumentsHolder.Companion.getInstance(project)
+          .setSettings(commonArguments);
+    }
+    if (jvmUpdated) {
+      Kotlin2JvmCompilerArgumentsHolder.Companion.getInstance(project)
+          .setSettings(jvmCompilerArguments);
+    }
+  }
+}

--- a/sdkcompat/v173/com/google/idea/sdkcompat/kotlin/BlazeKotlinCompilerArgumentsUpdaterCompat.java
+++ b/sdkcompat/v173/com/google/idea/sdkcompat/kotlin/BlazeKotlinCompilerArgumentsUpdaterCompat.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2018 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.sdkcompat.kotlin;
+
+import com.intellij.openapi.project.Project;
+import org.jetbrains.kotlin.cli.common.arguments.CommonCompilerArguments;
+import org.jetbrains.kotlin.cli.common.arguments.K2JVMCompilerArguments;
+import org.jetbrains.kotlin.idea.compiler.configuration.Kotlin2JvmCompilerArgumentsHolder;
+import org.jetbrains.kotlin.idea.compiler.configuration.KotlinCommonCompilerArgumentsHolder;
+
+public final class BlazeKotlinCompilerArgumentsUpdaterCompat {
+  private boolean commonUpdated = false;
+  private boolean jvmUpdated = false;
+  private final Project project;
+  private final CommonCompilerArguments commonArguments;
+  private final K2JVMCompilerArguments jvmCompilerArguments;
+
+  private BlazeKotlinCompilerArgumentsUpdaterCompat(Project project) {
+    this.project = project;
+    commonArguments =
+        (CommonCompilerArguments)
+            KotlinCommonCompilerArgumentsHolder.Companion.getInstance(project)
+                .getSettings()
+                .unfrozen();
+    jvmCompilerArguments =
+        (K2JVMCompilerArguments)
+            Kotlin2JvmCompilerArgumentsHolder.Companion.getInstance(project)
+                .getSettings()
+                .unfrozen();
+  }
+
+  public static BlazeKotlinCompilerArgumentsUpdaterCompat build(Project project) {
+    return new BlazeKotlinCompilerArgumentsUpdaterCompat(project);
+  }
+
+  public String getApiVersion() {
+    return this.commonArguments.getApiVersion();
+  }
+
+  public String getLanguageVersion() {
+    return this.commonArguments.getLanguageVersion();
+  }
+
+  public String getCoroutineState() {
+    return this.commonArguments.getCoroutinesState();
+  }
+
+  public String getJvmTarget() {
+    return this.jvmCompilerArguments.getJvmTarget();
+  }
+
+  public void updateApiVersion(String apiVersion) {
+    if (getApiVersion() == null || !getApiVersion().equals(apiVersion)) {
+      commonUpdated = true;
+      commonArguments.setApiVersion(apiVersion);
+    }
+  }
+
+  public void updateLanguageVersion(String languageVersion) {
+    if (getLanguageVersion() == null || !getLanguageVersion().equals(languageVersion)) {
+      commonUpdated = true;
+      commonArguments.setLanguageVersion(languageVersion);
+    }
+  }
+
+  public void updateCoroutineState(String coroutines) {
+    if (getCoroutineState() == null || !getCoroutineState().equals(coroutines)) {
+      commonUpdated = true;
+      commonArguments.setCoroutinesState(coroutines);
+    }
+  }
+
+  public void updateJvmTarget(String jvmTarget) {
+    if (getJvmTarget() == null || !getJvmTarget().equals(jvmTarget)) {
+      jvmUpdated = true;
+      jvmCompilerArguments.setJvmTarget(jvmTarget);
+    }
+  }
+
+  public void commit() {
+    if (commonUpdated) {
+      KotlinCommonCompilerArgumentsHolder.Companion.getInstance(project)
+          .setSettings(commonArguments);
+    }
+    if (jvmUpdated) {
+      Kotlin2JvmCompilerArgumentsHolder.Companion.getInstance(project)
+          .setSettings(jvmCompilerArguments);
+    }
+  }
+}


### PR DESCRIPTION
This is the version we using internally for our mono repo.

* KtToolchainIdeInfo from Kotlin rules to relay the Kotlin plugin configuration from the workspace. 
* Aspect processing for Kotlin rules (currently the KtToolchainIdeInfo is coming in via this but I will update this to inject the stdlibs from here as well, currently these are hard coded and discovered by the plugin).
* Attach srcgen jars to targets which contain generated code.
* configure plugin elements found in `KtToolchainIdeInfo` (this deprecates the config sections -- I could remove them outright).
* a start to some aspect integration tests.

I'd like to draw a line under this one and get it merged in. Currently the `KtToolchainIdeInfo` is piggy backing off [`JavaIdeInfo` location field](https://github.com/hsyed/intellij/blob/6d19beaa968042b2ca9f4aa10c631f3557e19774/base/src/com/google/idea/blaze/base/sync/aspects/IdeInfoFromProtobuf.java#L163-L178) I'm waiting for a solution to #291 that doesn't involve me temporarily hacking files in `//base`. 