### PR TITLE
kotlin v3 changes

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -11,3 +11,4 @@
 
 Brendan Douglas <brendandouglas@google.com>
 Tom Lundell <tomlu@google.com>
+Hassan Syed <h.a.syed@gmail.com>

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -277,10 +277,10 @@ scala_repositories()
 # LICENSE: The Apache Software License, Version 2.0
 git_repository(
     name = "io_bazel_rules_kotlin",
-    commit = "6d8dcd4d6000d0cf3321eb8580d8fc67f8731f8e",
+    commit = "2ab126808329700c6c23df5d571762e77fbd9efc",
     remote = "https://github.com/bazelbuild/rules_kotlin.git",
 )
 
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories")
-
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories","kt_register_toolchains")
+kt_register_toolchains()
 kotlin_repositories()

--- a/aspect/intellij_info_impl.bzl
+++ b/aspect/intellij_info_impl.bzl
@@ -22,6 +22,7 @@ DEPS = [
     "_android_sdk",  # from android rules
     "aidl_lib",  # from android_sdk
     "_scala_toolchain",  # From scala rules
+    "_kotlin_toolchain", # From kotlin rules
     "test_app",  # android_instrumentation_test
     "instruments",  # android_instrumentation_test
 ]
@@ -334,6 +335,24 @@ def collect_c_toolchain_info(target, ctx, semantics, ide_info, ide_info_file, ou
     )
     ide_info["c_toolchain_ide_info"] = c_toolchain_info
     update_set_in_dict(output_groups, "intellij-info-cpp", depset([ide_info_file]))
+    return True
+
+def collect_kt_toolchain_info(target, ctx, ide_info, ide_info_file, output_groups):
+    if ctx.rule.kind != "kt_toolchain_ide_info":
+        return False
+
+    fl=target.files.to_list()
+    if len(fl) != 1:
+        print("the kt_toolchain_ide_info did not contain the kt_toolchain_ide_info.json file")
+        return True
+
+    kt_toolchain_ide_info = struct_omit_none(
+        json_info_file = artifact_location(fl[0])
+    )
+
+    ide_info["kt_toolchain_ide_info"] = kt_toolchain_ide_info
+    update_set_in_dict(output_groups, "intellij-info-kt", depset([ide_info_file]))
+    update_set_in_dict(output_groups, "intellij-resolve-kt", target.files)
     return True
 
 def get_java_provider(target):
@@ -699,6 +718,7 @@ def intellij_info_aspect_impl(target, ctx, semantics):
     handled = collect_android_info(target, ctx, semantics, ide_info, ide_info_file, output_groups) or handled
     handled = collect_android_sdk_info(ctx, ide_info, ide_info_file, output_groups) or handled
     handled = collect_aar_import_info(ctx, ide_info, ide_info_file, output_groups) or handled
+    handled = collect_kt_toolchain_info(target, ctx, ide_info, ide_info_file, output_groups) or handled
 
     # Any extra ide info
     if hasattr(semantics, "extra_ide_info"):

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/kotlin/kotlinlibrary/BUILD
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/kotlin/kotlinlibrary/BUILD
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load(
+    "//aspect/testing/rules:intellij_aspect_test_fixture.bzl",
+    "intellij_aspect_test_fixture",
+)
+
+kt_jvm_library(
+    name = "simple",
+    srcs = [":Foo.kt"]
+)
+
+intellij_aspect_test_fixture(
+    name = "simple_fixture",
+    deps = [":simple"]
+)
+
+java_test(
+    name = "KotlinLibraryTest",
+    srcs = ["KotlinLibraryTest.java"],
+    data = [":simple_fixture"],
+    deps = [
+        "//aspect/testing:BazelIntellijAspectTest",
+        "//aspect/testing/rules:IntellijAspectTest",
+        "//aspect/testing/rules:intellij_aspect_test_fixture_java_proto",
+        "//proto:intellij_ide_info_java_proto",
+        "@junit//jar",
+        "@truth//jar",
+    ],
+)

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/kotlin/kotlinlibrary/Foo.kt
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/kotlin/kotlinlibrary/Foo.kt
@@ -1,0 +1,7 @@
+package com.google.idea.blaze.aspect.kotlin.kotlinlibrary;
+
+class Foo {
+
+
+
+}

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/kotlin/kotlinlibrary/KotlinLibraryTest.java
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/kotlin/kotlinlibrary/KotlinLibraryTest.java
@@ -1,0 +1,23 @@
+package com.google.idea.blaze.aspect.kotlin.kotlinlibrary;
+
+import com.google.devtools.intellij.IntellijAspectTestFixtureOuterClass.IntellijAspectTestFixture;
+import com.google.devtools.intellij.ideinfo.IntellijIdeInfo.TargetIdeInfo;
+import com.google.idea.blaze.BazelIntellijAspectTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.IOException;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@RunWith(JUnit4.class)
+public class KotlinLibraryTest extends BazelIntellijAspectTest {
+  @Test
+  public void testKotlinLibrary() throws IOException {
+    IntellijAspectTestFixture testFixture = loadTestFixture(":simple_fixture");
+
+    TargetIdeInfo target = findTarget(testFixture, ":simple");
+    assertThat(target.getKindString()).isEqualTo("kt_jvm_library");
+  }
+}

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/kotlin/toolchainideinfo/BUILD
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/kotlin/toolchainideinfo/BUILD
@@ -1,0 +1,32 @@
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load(
+    "//aspect/testing/rules:intellij_aspect_test_fixture.bzl",
+    "intellij_aspect_test_fixture",
+)
+
+kt_jvm_library(
+    name = "simple",
+    srcs = [":Foo.kt"]
+)
+
+intellij_aspect_test_fixture(
+    name = "global_toolchain_fixture",
+    deps = [":simple"]
+)
+
+java_test(
+    name = "KotlinGlobalToolchainTest",
+    srcs = ["KotlinGlobalToolchainTest.java"],
+    data = [
+        ":global_toolchain_fixture",
+        "@io_bazel_rules_kotlin//kotlin:kt_toolchain_ide_info.json"
+    ],
+    deps = [
+        "//aspect/testing:BazelIntellijAspectTest",
+        "//aspect/testing/rules:IntellijAspectTest",
+        "//aspect/testing/rules:intellij_aspect_test_fixture_java_proto",
+        "//proto:intellij_ide_info_java_proto",
+        "@junit//jar",
+        "@truth//jar",
+    ],
+)

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/kotlin/toolchainideinfo/Foo.kt
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/kotlin/toolchainideinfo/Foo.kt
@@ -1,0 +1,7 @@
+package com.google.idea.blaze.aspect.kotlin.toolchainideinfo;
+
+class Foo {
+
+
+
+}

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/kotlin/toolchainideinfo/KotlinGlobalToolchainTest.java
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/kotlin/toolchainideinfo/KotlinGlobalToolchainTest.java
@@ -1,0 +1,42 @@
+package com.google.idea.blaze.aspect.kotlin.toolchainideinfo;
+
+import com.google.devtools.intellij.IntellijAspectTestFixtureOuterClass.IntellijAspectTestFixture;
+import com.google.devtools.intellij.ideinfo.IntellijIdeInfo;
+import com.google.idea.blaze.BazelIntellijAspectTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+@RunWith(JUnit4.class)
+public class KotlinGlobalToolchainTest extends BazelIntellijAspectTest {
+  @Test
+  public void testGlobalToolchainInfo() throws IOException {
+    IntellijAspectTestFixture testFixture = loadTestFixture(":global_toolchain_fixture");
+    IntellijIdeInfo.TargetIdeInfo ideInfo =
+        testFixture
+            .getTargetsList()
+            .stream()
+            .filter(
+                t ->
+                    t.getKey()
+                        .getLabel()
+                        .equals("@io_bazel_rules_kotlin//kotlin:kt_toolchain_ide_info"))
+            .findFirst()
+            .orElse(null);
+
+    assertThat(ideInfo).isNotNull();
+    assertThat(ideInfo.getKindString()).isEqualTo("kt_toolchain_ide_info");
+    assertThat(ideInfo.hasKtToolchainIdeInfo()).isTrue();
+    assertThat(ideInfo.getKtToolchainIdeInfo().getJsonInfoFile()).isNotNull();
+
+    File toolchainFile = Paths.get("external", "io_bazel_rules_kotlin", "kotlin", "kt_toolchain_ide_info.json").toFile();
+    assertWithMessage("the workspace should expose a toolchain info file").that(toolchainFile.exists()).isTrue();
+  }
+}

--- a/base/src/com/google/idea/blaze/base/ideinfo/KtToolchainIdeInfo.java
+++ b/base/src/com/google/idea/blaze/base/ideinfo/KtToolchainIdeInfo.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.ideinfo;
+
+import java.io.Serializable;
+
+public class KtToolchainIdeInfo implements Serializable {
+  public static final long serialVersionUID = 1L;
+
+  public final ArtifactLocation location;
+
+  KtToolchainIdeInfo(ArtifactLocation ideInfoLocation) {
+    this.location = ideInfoLocation;
+  }
+
+  public static class Builder {
+    ArtifactLocation location;
+
+    public Builder location(ArtifactLocation location) {
+      this.location = location;
+      return this;
+    }
+
+    public KtToolchainIdeInfo build() {
+      return new KtToolchainIdeInfo(location);
+    }
+  }
+
+  public static Builder builder() {
+    return new KtToolchainIdeInfo.Builder();
+  }
+}

--- a/base/src/com/google/idea/blaze/base/ideinfo/TargetIdeInfo.java
+++ b/base/src/com/google/idea/blaze/base/ideinfo/TargetIdeInfo.java
@@ -52,6 +52,7 @@ public final class TargetIdeInfo implements Serializable {
   @Nullable public final DartIdeInfo dartIdeInfo;
   @Nullable public final TestIdeInfo testIdeInfo;
   @Nullable public final JavaToolchainIdeInfo javaToolchainIdeInfo;
+  @Nullable public final KtToolchainIdeInfo ktToolchainIdeInfo;
 
   public TargetIdeInfo(
       TargetKey key,
@@ -72,7 +73,8 @@ public final class TargetIdeInfo implements Serializable {
       @Nullable TsIdeInfo tsIdeInfo,
       @Nullable DartIdeInfo dartIdeInfo,
       @Nullable TestIdeInfo testIdeInfo,
-      @Nullable JavaToolchainIdeInfo javaToolchainIdeInfo) {
+      @Nullable JavaToolchainIdeInfo javaToolchainIdeInfo,
+      @Nullable KtToolchainIdeInfo ktToolchainIdeInfo) {
     this.key = key;
     this.kind = kind;
     this.buildFile = buildFile;
@@ -92,6 +94,7 @@ public final class TargetIdeInfo implements Serializable {
     this.dartIdeInfo = dartIdeInfo;
     this.testIdeInfo = testIdeInfo;
     this.javaToolchainIdeInfo = javaToolchainIdeInfo;
+    this.ktToolchainIdeInfo = ktToolchainIdeInfo;
   }
 
   public TargetInfo toTargetInfo() {
@@ -147,6 +150,7 @@ public final class TargetIdeInfo implements Serializable {
     private DartIdeInfo dartIdeInfo;
     private TestIdeInfo testIdeInfo;
     private JavaToolchainIdeInfo javaToolchainIdeInfo;
+    private KtToolchainIdeInfo ktToolchainIdeInfo;
 
     public Builder setLabel(String label) {
       return setLabel(Label.create(label));
@@ -245,6 +249,11 @@ public final class TargetIdeInfo implements Serializable {
       return this;
     }
 
+    public Builder setKtToolchainIdeInfo(KtToolchainIdeInfo.Builder ktToolchainIdeInfo) {
+      this.ktToolchainIdeInfo = ktToolchainIdeInfo.build();
+      return this;
+    }
+
     public Builder addTag(String s) {
       this.tags.add(s);
       return this;
@@ -290,7 +299,8 @@ public final class TargetIdeInfo implements Serializable {
           tsIdeInfo,
           dartIdeInfo,
           testIdeInfo,
-          javaToolchainIdeInfo);
+          javaToolchainIdeInfo,
+          ktToolchainIdeInfo);
     }
   }
 }

--- a/base/src/com/google/idea/blaze/base/model/primitives/Kind.java
+++ b/base/src/com/google/idea/blaze/base/model/primitives/Kind.java
@@ -96,6 +96,7 @@ public enum Kind {
   KT_JVM_BINARY("kt_jvm_binary", LanguageClass.KOTLIN, RuleType.BINARY),
   KT_JVM_TEST("kt_jvm_test", LanguageClass.KOTLIN, RuleType.TEST),
   KT_JVM_IMPORT("kt_jvm_import", LanguageClass.KOTLIN, RuleType.UNKNOWN),
+  KT_TOOLCHAIN_IDE_INFO("kt_toolchain_ide_info", LanguageClass.KOTLIN, RuleType.UNKNOWN),
   KOTLIN_STDLIB("kotlin_stdlib", LanguageClass.KOTLIN, RuleType.UNKNOWN),
 
   // any rule exposing java_common.provider which isn't specifically recognized

--- a/base/src/com/google/idea/blaze/base/sync/aspects/IdeInfoFromProtobuf.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/IdeInfoFromProtobuf.java
@@ -44,6 +44,7 @@ import com.google.idea.blaze.base.ideinfo.TargetIdeInfo;
 import com.google.idea.blaze.base.ideinfo.TargetKey;
 import com.google.idea.blaze.base.ideinfo.TestIdeInfo;
 import com.google.idea.blaze.base.ideinfo.TsIdeInfo;
+import com.google.idea.blaze.base.ideinfo.KtToolchainIdeInfo;
 import com.google.idea.blaze.base.model.primitives.ExecutionRootPath;
 import com.google.idea.blaze.base.model.primitives.Kind;
 import com.google.idea.blaze.base.model.primitives.Label;
@@ -145,6 +146,10 @@ public class IdeInfoFromProtobuf {
     if (message.hasJavaToolchainIdeInfo()) {
       javaToolchainIdeInfo = makeJavaToolchainIdeInfo(message.getJavaToolchainIdeInfo());
     }
+    KtToolchainIdeInfo ktToolchainIdeInfo = null;
+    if (message.hasKtToolchainIdeInfo()) {
+      ktToolchainIdeInfo = makeKotlinToolchainIdeInfo(message.getKtToolchainIdeInfo());
+    }
 
     return new TargetIdeInfo(
         key,
@@ -165,7 +170,15 @@ public class IdeInfoFromProtobuf {
         tsIdeInfo,
         dartIdeInfo,
         testIdeInfo,
-        javaToolchainIdeInfo);
+        javaToolchainIdeInfo,
+        ktToolchainIdeInfo);
+  }
+
+  private static KtToolchainIdeInfo makeKotlinToolchainIdeInfo(
+      IntellijIdeInfo.KotlinToolchainIdeInfo info) {
+    return KtToolchainIdeInfo.builder()
+        .location(makeArtifactLocation(info.getJsonInfoFile()))
+        .build();
   }
 
   private static Collection<Dependency> makeDependencyListFromLabelList(

--- a/base/src/com/google/idea/blaze/base/sync/aspects/strategy/LanguageOutputGroup.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/strategy/LanguageOutputGroup.java
@@ -16,6 +16,7 @@
 package com.google.idea.blaze.base.sync.aspects.strategy;
 
 import com.google.idea.blaze.base.model.primitives.LanguageClass;
+
 import javax.annotation.Nullable;
 
 /** Enumerates the sets of aspect output groups corresponding to each language */
@@ -27,7 +28,8 @@ public enum LanguageOutputGroup {
   GO(LanguageClass.GO, "go"),
   JAVASCRIPT(LanguageClass.JAVASCRIPT, "js"),
   TYPESCRIPT(LanguageClass.TYPESCRIPT, "ts"),
-  DART(LanguageClass.DART, "dart");
+  DART(LanguageClass.DART, "dart"),
+  KOTLIN(LanguageClass.KOTLIN, "kt");
 
   public final LanguageClass languageClass;
   public final String suffix;

--- a/base/tests/unittests/com/google/idea/blaze/base/sync/aspects/strategy/AspectStrategyTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/sync/aspects/strategy/AspectStrategyTest.java
@@ -86,7 +86,8 @@ public class AspectStrategyTest extends BlazeTestCase {
             "intellij-info-go",
             "intellij-info-js",
             "intellij-info-ts",
-            "intellij-info-dart");
+            "intellij-info-dart",
+            "intellij-info-kt");
 
     builder = emptyBuilder();
     strategy.addAspectAndOutputGroups(builder, OutputGroup.RESOLVE, activeLanguages);
@@ -99,7 +100,8 @@ public class AspectStrategyTest extends BlazeTestCase {
             "intellij-resolve-go",
             "intellij-resolve-js",
             "intellij-resolve-ts",
-            "intellij-resolve-dart");
+            "intellij-resolve-dart",
+            "intellij-resolve-kt");
 
     builder = emptyBuilder();
     strategy.addAspectAndOutputGroups(builder, OutputGroup.COMPILE, activeLanguages);
@@ -112,7 +114,8 @@ public class AspectStrategyTest extends BlazeTestCase {
             "intellij-compile-go",
             "intellij-compile-js",
             "intellij-compile-ts",
-            "intellij-compile-dart");
+            "intellij-compile-dart",
+            "intellij-compile-kt");
   }
 
   private static BlazeCommand.Builder emptyBuilder() {

--- a/kotlin/src/com/google/idea/blaze/kotlin/sync/BlazeKotlinLanguageVersionSection.java
+++ b/kotlin/src/com/google/idea/blaze/kotlin/sync/BlazeKotlinLanguageVersionSection.java
@@ -23,14 +23,19 @@ import com.google.idea.blaze.base.projectview.section.ScalarSection;
 import com.google.idea.blaze.base.projectview.section.ScalarSectionParser;
 import com.google.idea.blaze.base.projectview.section.SectionKey;
 import com.google.idea.blaze.base.projectview.section.SectionParser;
-import javax.annotation.Nullable;
 import org.jetbrains.kotlin.config.LanguageVersion;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Optional;
 
 /** Project view sections for Kotlin. */
 public final class BlazeKotlinLanguageVersionSection {
   private static final SectionKey<LanguageVersion, ScalarSection<LanguageVersion>>
       LANGUAGE_VERSION = new SectionKey<>("kotlin_language_version");
 
+  // hsyed: This is not needed any longer. With newer version of the rules the intellij configuration is picked up
+  // from the toolchain info file. I can remove this now or in the next update.
   private static final ScalarSectionParser<LanguageVersion> LANGUAGE_VERSION_PARSER =
       new ScalarSectionParser<LanguageVersion>(LANGUAGE_VERSION, ':') {
         @Nullable
@@ -46,6 +51,13 @@ public final class BlazeKotlinLanguageVersionSection {
           }
         }
 
+        // the language version is now derived from the toolchain info
+        @Override
+        public boolean isDeprecated() {
+          return true;
+        }
+
+        @Nonnull
         @Override
         public String quickDocs() {
           return "The kotlin language and api version.";
@@ -64,7 +76,7 @@ public final class BlazeKotlinLanguageVersionSection {
 
   static final ImmutableList<SectionParser> PARSERS = ImmutableList.of(LANGUAGE_VERSION_PARSER);
 
-  public static LanguageVersion getLanguageLevel(ProjectViewSet projectViewSet) {
-    return projectViewSet.getScalarValue(LANGUAGE_VERSION).orElse(LanguageVersion.LATEST_STABLE);
+  public static Optional<LanguageVersion> getLanguageLevel(ProjectViewSet projectViewSet) {
+    return projectViewSet.getScalarValue(LANGUAGE_VERSION);
   }
 }

--- a/kotlin/src/com/google/idea/blaze/kotlin/sync/BlazeKotlinSyncPlugin.java
+++ b/kotlin/src/com/google/idea/blaze/kotlin/sync/BlazeKotlinSyncPlugin.java
@@ -35,7 +35,6 @@ import com.google.idea.blaze.base.projectview.ProjectViewSet;
 import com.google.idea.blaze.base.projectview.section.SectionParser;
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.scope.Scope;
-import com.google.idea.blaze.base.scope.output.IssueOutput;
 import com.google.idea.blaze.base.scope.scopes.TimingScope;
 import com.google.idea.blaze.base.sync.BlazeSyncPlugin;
 import com.google.idea.blaze.base.sync.libraries.LibrarySource;
@@ -186,23 +185,16 @@ public class BlazeKotlinSyncPlugin implements BlazeSyncPlugin {
     }
 
     KotlinSettingsUpdater updater = KotlinSettingsUpdater.create(project);
-    Optional<LanguageVersion> languageLevelFromViewSet =
-        BlazeKotlinLanguageVersionSection.getLanguageLevel(projectViewSet);
 
     if (toolchainIdeInfo != null) {
-      if (languageLevelFromViewSet.isPresent()) {
-        IssueOutput.issue(
-                IssueOutput.Category.INFORMATION,
-                "The Kotlin rules configure all of the project settings, \"kotlin_language_version\" is ignored")
-            .submit(context);
-      }
       updater.languageVersion(toolchainIdeInfo.common.languageVersion);
       updater.apiVersion(toolchainIdeInfo.common.apiVersion);
       updater.coroutineState(toolchainIdeInfo.common.coroutines);
       updater.jvmTarget(toolchainIdeInfo.jvm.jvmTarget);
     } else {
       LanguageVersion languageVersion =
-          languageLevelFromViewSet.orElse(LanguageVersion.LATEST_STABLE);
+          BlazeKotlinLanguageVersionSection.getLanguageLevel(projectViewSet)
+              .orElse(LanguageVersion.LATEST_STABLE);
       updater.languageVersion(languageVersion.getVersionString());
       updater.apiVersion(languageVersion.getVersionString());
     }
@@ -228,9 +220,9 @@ public class BlazeKotlinSyncPlugin implements BlazeSyncPlugin {
       return;
     }
     // This is validated and the user is given the option to setup the plugin in the validate
-    // method, it's rechecked here for race conditions that occur when syncing a fresh project. Later updates to the
-    // plugin and rules will pick up the libraries via aspect processing -- this should make it unnecessary to
-    // examine the workspace files.
+    // method, it's rechecked here for race conditions that occur when syncing a fresh project.
+    // Later updates to the plugin and rules will pick up the libraries via aspect processing --
+    // this should make it unnecessary to examine the workspace files.
     if (KotlinUtils.compilerRepoAbsentFromWorkspace(project)) {
       return;
     }

--- a/kotlin/src/com/google/idea/blaze/kotlin/sync/KotlinSettingsUpdater.java
+++ b/kotlin/src/com/google/idea/blaze/kotlin/sync/KotlinSettingsUpdater.java
@@ -46,7 +46,7 @@ final class KotlinSettingsUpdater {
                 .unfrozen();
   }
 
-  public static KotlinSettingsUpdater create(Project project) {
+  static KotlinSettingsUpdater create(Project project) {
     return new KotlinSettingsUpdater(project);
   }
 
@@ -54,7 +54,7 @@ final class KotlinSettingsUpdater {
     return this.commonArguments.getApiVersion();
   }
 
-  public void apiVersion(String apiVersion) {
+  void apiVersion(String apiVersion) {
     commonSetting(apiVersion, this::apiVersion, commonArguments::setApiVersion);
   }
 
@@ -62,7 +62,7 @@ final class KotlinSettingsUpdater {
     return this.commonArguments.getLanguageVersion();
   }
 
-  public void languageVersion(String languageVersion) {
+  void languageVersion(String languageVersion) {
     commonSetting(languageVersion, this::languageVersion, commonArguments::setLanguageVersion);
   }
 
@@ -70,7 +70,7 @@ final class KotlinSettingsUpdater {
     return this.commonArguments.getCoroutinesState();
   }
 
-  public void coroutineState(String coroutines) {
+  void coroutineState(String coroutines) {
     commonSetting(coroutines, this::coroutineState, commonArguments::setCoroutinesState);
   }
 
@@ -78,13 +78,13 @@ final class KotlinSettingsUpdater {
     return this.jvmCompilerArguments.getJvmTarget();
   }
 
-  public void jvmTarget(String jvmTarget) {
+  void jvmTarget(String jvmTarget) {
     jvmSetting(jvmTarget, this::jvmTarget, jvmCompilerArguments::setJvmTarget);
   }
 
   private <T> void commonSetting(T value, Supplier<T> settingProvider, Consumer<T> updater) {
     T current = settingProvider.get();
-    if(current == null || !current.equals(value)) {
+    if (current == null || !current.equals(value)) {
       commonUpdated = true;
       updater.accept(value);
     }
@@ -92,13 +92,13 @@ final class KotlinSettingsUpdater {
 
   private <T> void jvmSetting(T value, Supplier<T> settingProvider, Consumer<T> updater) {
     T current = settingProvider.get();
-    if(current == null || !current.equals(value)) {
+    if (current == null || !current.equals(value)) {
       jvmUpdated = true;
       updater.accept(value);
     }
   }
 
-  public void commit() {
+  void commit() {
     if (commonUpdated) {
       KotlinCommonCompilerArgumentsHolder.Companion.getInstance(project)
           .setSettings(commonArguments);

--- a/kotlin/src/com/google/idea/blaze/kotlin/sync/KotlinSettingsUpdater.java
+++ b/kotlin/src/com/google/idea/blaze/kotlin/sync/KotlinSettingsUpdater.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2018 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.kotlin.sync;
+
+import com.intellij.openapi.project.Project;
+import org.jetbrains.kotlin.cli.common.arguments.CommonCompilerArguments;
+import org.jetbrains.kotlin.cli.common.arguments.K2JVMCompilerArguments;
+import org.jetbrains.kotlin.idea.compiler.configuration.Kotlin2JvmCompilerArgumentsHolder;
+import org.jetbrains.kotlin.idea.compiler.configuration.KotlinCommonCompilerArgumentsHolder;
+
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+@SuppressWarnings("WeakerAccess")
+final class KotlinSettingsUpdater {
+  private boolean commonUpdated = false;
+  private boolean jvmUpdated = false;
+  private final Project project;
+  private final CommonCompilerArguments commonArguments;
+  private final K2JVMCompilerArguments jvmCompilerArguments;
+
+  private KotlinSettingsUpdater(Project project) {
+    this.project = project;
+    commonArguments =
+        (CommonCompilerArguments)
+            KotlinCommonCompilerArgumentsHolder.Companion.getInstance(project)
+                .getSettings()
+                .unfrozen();
+    jvmCompilerArguments =
+        (K2JVMCompilerArguments)
+            Kotlin2JvmCompilerArgumentsHolder.Companion.getInstance(project)
+                .getSettings()
+                .unfrozen();
+  }
+
+  public static KotlinSettingsUpdater create(Project project) {
+    return new KotlinSettingsUpdater(project);
+  }
+
+  String apiVersion() {
+    return this.commonArguments.getApiVersion();
+  }
+
+  public void apiVersion(String apiVersion) {
+    commonSetting(apiVersion, this::apiVersion, commonArguments::setApiVersion);
+  }
+
+  String languageVersion() {
+    return this.commonArguments.getLanguageVersion();
+  }
+
+  public void languageVersion(String languageVersion) {
+    commonSetting(languageVersion, this::languageVersion, commonArguments::setLanguageVersion);
+  }
+
+  String coroutineState() {
+    return this.commonArguments.getCoroutinesState();
+  }
+
+  public void coroutineState(String coroutines) {
+    commonSetting(coroutines, this::coroutineState, commonArguments::setCoroutinesState);
+  }
+
+  String jvmTarget() {
+    return this.jvmCompilerArguments.getJvmTarget();
+  }
+
+  public void jvmTarget(String jvmTarget) {
+    jvmSetting(jvmTarget, this::jvmTarget, jvmCompilerArguments::setJvmTarget);
+  }
+
+  private <T> void commonSetting(T value, Supplier<T> settingProvider, Consumer<T> updater) {
+    T current = settingProvider.get();
+    if(current == null || !current.equals(value)) {
+      commonUpdated = true;
+      updater.accept(value);
+    }
+  }
+
+  private <T> void jvmSetting(T value, Supplier<T> settingProvider, Consumer<T> updater) {
+    T current = settingProvider.get();
+    if(current == null || !current.equals(value)) {
+      jvmUpdated = true;
+      updater.accept(value);
+    }
+  }
+
+  public void commit() {
+    if (commonUpdated) {
+      KotlinCommonCompilerArgumentsHolder.Companion.getInstance(project)
+          .setSettings(commonArguments);
+    }
+    if (jvmUpdated) {
+      Kotlin2JvmCompilerArgumentsHolder.Companion.getInstance(project)
+          .setSettings(jvmCompilerArguments);
+    }
+  }
+}

--- a/kotlin/src/com/google/idea/blaze/kotlin/sync/KotlinUtils.java
+++ b/kotlin/src/com/google/idea/blaze/kotlin/sync/KotlinUtils.java
@@ -16,13 +16,18 @@
 package com.google.idea.blaze.kotlin.sync;
 
 import com.google.idea.blaze.base.model.primitives.LanguageClass;
+import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
 import com.google.idea.blaze.base.model.primitives.WorkspaceType;
+import com.google.idea.blaze.base.scope.BlazeContext;
+import com.google.idea.blaze.base.scope.output.IssueOutput;
 import com.google.idea.blaze.base.settings.Blaze;
 import com.google.idea.blaze.base.settings.BuildSystem;
+import com.google.idea.blaze.base.sync.workspace.WorkspaceHelper;
 import com.google.idea.common.experiments.BoolExperiment;
+import com.intellij.openapi.project.Project;
 import com.intellij.util.PlatformUtils;
 
-class KotlinUtils {
+final class KotlinUtils {
 
   // whether kotlin language support is enabled for internal users
   private static final BoolExperiment blazeKotlinSupport =
@@ -36,5 +41,35 @@ class KotlinUtils {
     return Blaze.defaultBuildSystem().equals(BuildSystem.Bazel)
         || (blazeKotlinSupport.getValue()
             && PlatformUtils.getPlatformPrefix().equals("AndroidStudio"));
+  }
+
+  private static final String
+      RULES_REPO_PROJECT_PAGE = "https://github.com/bazelbuild/rules_kotlin",
+      COMPILER_WORKSPACE_NAME = "com_github_jetbrains_kotlin";
+
+  /**
+   * The presence of the kotlin compiler repo is validated. See {@link
+   * BlazeKotlinSyncPlugin#updateProjectStructure} for more details.
+   */
+  static boolean compilerRepoAbsentFromWorkspace(Project project) {
+    WorkspaceRoot workspaceRoot =
+        WorkspaceHelper.resolveExternalWorkspace(project, COMPILER_WORKSPACE_NAME);
+    return workspaceRoot == null || !workspaceRoot.directory().exists();
+  }
+
+  static void issueUpdateRulesWarning(
+      BlazeContext context, @SuppressWarnings("SameParameterValue") String because) {
+    IssueOutput.issue(
+            IssueOutput.Category.WARNING,
+            because + ". Please update the rules by visiting " + RULES_REPO_PROJECT_PAGE + ".")
+        .submit(context);
+  }
+
+  static void issueRulesMissingWarning(BlazeContext context) {
+    IssueOutput.warn(
+            "The Kotlin workspace has not been setup in this workspace. Visit "
+                + RULES_REPO_PROJECT_PAGE
+                + " , or remove the Kotlin language from the project view.")
+        .submit(context);
   }
 }

--- a/kotlin/src/com/google/idea/blaze/kotlin/sync/KotlinUtils.java
+++ b/kotlin/src/com/google/idea/blaze/kotlin/sync/KotlinUtils.java
@@ -48,7 +48,7 @@ final class KotlinUtils {
       COMPILER_WORKSPACE_NAME = "com_github_jetbrains_kotlin";
 
   /**
-   * The presence of the kotlin compiler repo is validated. See {@link
+   * This validates the presence of the kotlin compiler repo in the workspace. See {@link
    * BlazeKotlinSyncPlugin#updateProjectStructure} for more details.
    */
   static boolean compilerRepoAbsentFromWorkspace(Project project) {

--- a/kotlin/src/com/google/idea/blaze/kotlin/sync/importer/BlazeKotlinWorkspaceImporter.java
+++ b/kotlin/src/com/google/idea/blaze/kotlin/sync/importer/BlazeKotlinWorkspaceImporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 The Bazel Authors. All rights reserved.
+ * Copyright 2018 The Bazel Authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kotlin/src/com/google/idea/blaze/kotlin/sync/importer/BlazeKotlinWorkspaceImporter.java
+++ b/kotlin/src/com/google/idea/blaze/kotlin/sync/importer/BlazeKotlinWorkspaceImporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The Bazel Authors. All rights reserved.
+ * Copyright 2017 The Bazel Authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,54 +15,93 @@
  */
 package com.google.idea.blaze.kotlin.sync.importer;
 
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.idea.blaze.base.ideinfo.TargetIdeInfo;
 import com.google.idea.blaze.base.ideinfo.TargetMap;
 import com.google.idea.blaze.base.model.LibraryKey;
+import com.google.idea.blaze.base.model.primitives.Kind;
 import com.google.idea.blaze.base.model.primitives.LanguageClass;
 import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
 import com.google.idea.blaze.base.projectview.ProjectViewSet;
+import com.google.idea.blaze.base.scope.BlazeContext;
+import com.google.idea.blaze.base.scope.output.IssueOutput;
 import com.google.idea.blaze.base.sync.projectview.ProjectViewTargetImportFilter;
+import com.google.idea.blaze.base.sync.workspace.ArtifactLocationDecoder;
 import com.google.idea.blaze.base.targetmaps.TransitiveDependencyMap;
 import com.google.idea.blaze.java.sync.model.BlazeJarLibrary;
 import com.google.idea.blaze.kotlin.sync.model.BlazeKotlinImportResult;
+import com.google.idea.blaze.kotlin.sync.model.BlazeKotlinToolchainIdeInfo;
 import com.intellij.openapi.project.Project;
+
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.stream.Stream;
 
 /** Computes Kotlin-specific project sync data. */
 public class BlazeKotlinWorkspaceImporter {
+  private static final Gson gson =
+      new GsonBuilder()
+          .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+          .create();
+
   private final TargetMap targetMap;
+  private final BlazeContext context;
   private final ProjectViewTargetImportFilter importFilter;
+  private final ArtifactLocationDecoder artifactLocationDecoder;
 
   public BlazeKotlinWorkspaceImporter(
       Project project,
       WorkspaceRoot workspaceRoot,
       ProjectViewSet projectViewSet,
-      TargetMap targetMap) {
+      TargetMap targetMap,
+      ArtifactLocationDecoder artifactLocationDecoder,
+      BlazeContext context) {
     this.targetMap = targetMap;
+    this.context = context;
     importFilter = new ProjectViewTargetImportFilter(project, workspaceRoot, projectViewSet);
+    this.artifactLocationDecoder = artifactLocationDecoder;
   }
 
   public BlazeKotlinImportResult importWorkspace() {
     HashMap<LibraryKey, BlazeJarLibrary> libraries = new HashMap<>();
     HashMap<TargetIdeInfo, ImmutableList<BlazeJarLibrary>> targetLibraryMap = new HashMap<>();
+    HashSet<TargetIdeInfo> toolchainTargetIdeInfos = new HashSet<>();
 
-    collectTransitiveLibsFromKotlinSourceTargets(libraries, targetLibraryMap);
+    calculateWorkspaceImports(libraries, targetLibraryMap, toolchainTargetIdeInfos);
 
     return new BlazeKotlinImportResult(
-        ImmutableList.copyOf(libraries.values()), ImmutableMap.copyOf(targetLibraryMap));
+        ImmutableList.copyOf(libraries.values()),
+        ImmutableMap.copyOf(targetLibraryMap),
+        renderToolchainInfo(context, toolchainTargetIdeInfos));
   }
 
-  private void collectTransitiveLibsFromKotlinSourceTargets(
+  private void calculateWorkspaceImports(
       HashMap<LibraryKey, BlazeJarLibrary> libraries,
-      HashMap<TargetIdeInfo, ImmutableList<BlazeJarLibrary>> targetLibraryMap) {
-    transitiveKotlinTargets()
+      HashMap<TargetIdeInfo, ImmutableList<BlazeJarLibrary>> targetLibraryMap,
+      HashSet<TargetIdeInfo> toolchainInfos) {
+    targetMap
+        .targets()
+        .stream()
+        .filter(target -> target.kind.languageClass.equals(LanguageClass.KOTLIN))
+        .peek(
+            target -> {
+              if (target.kind.equals(Kind.KT_TOOLCHAIN_IDE_INFO)) toolchainInfos.add(target);
+            })
+        .filter(importFilter::isSourceTarget)
+        .flatMap(this::expandWithKotlinTargets)
         .forEach(
             depIdeInfo -> {
-              // noinspection ConstantConditions
+              //noinspection ConstantConditions
               BlazeJarLibrary[] transitiveLibraries =
                   depIdeInfo
                       .javaIdeInfo
@@ -75,15 +114,6 @@ public class BlazeKotlinWorkspaceImporter {
             });
   }
 
-  private Stream<TargetIdeInfo> transitiveKotlinTargets() {
-    return targetMap
-        .targets()
-        .stream()
-        .filter(target -> target.kind.languageClass.equals(LanguageClass.KOTLIN))
-        .filter(importFilter::isSourceTarget)
-        .flatMap(this::expandWithKotlinTargets);
-  }
-
   private Stream<TargetIdeInfo> expandWithKotlinTargets(TargetIdeInfo target) {
     return Stream.concat(
         Stream.of(target),
@@ -94,5 +124,39 @@ public class BlazeKotlinWorkspaceImporter {
             .filter(Objects::nonNull)
             .filter(info -> info.javaIdeInfo != null)
             .filter(depIdeInfo -> depIdeInfo.kind.languageClass == LanguageClass.KOTLIN));
+  }
+
+  @Nullable
+  private BlazeKotlinToolchainIdeInfo renderToolchainInfo(
+      BlazeContext context, HashSet<TargetIdeInfo> targetIdeInfos) {
+    switch (targetIdeInfos.size()) {
+      case 0:
+        return null;
+      case 1:
+        File location =
+            artifactLocationDecoder.decode(
+                Objects.requireNonNull(targetIdeInfos.iterator().next().ktToolchainIdeInfo)
+                    .location);
+        try (InputStreamReader reader = new InputStreamReader(new FileInputStream(location))) {
+          return gson.fromJson(reader, BlazeKotlinToolchainIdeInfo.class);
+        } catch (Exception e) {
+          issueToolchainRenderingError(context, Throwables.getRootCause(e).getMessage());
+          return null;
+        }
+      default:
+        // A toolchain ide info should be a singleton. It is currently populated from the singleton
+        // rule kt_toolchain_ide_info. The toolchain Ide info is
+        // used to configure the project -- this is global. Whilst it is conceivable for the
+        // workspace to have multiple compiler configurations active
+        // for Kotlin for now it is an error for multiple configurations to enter the sync model, at
+        // least configurations generated from the
+        // kt_toolchain_ide_info rule.
+        issueToolchainRenderingError(context, "Multiple kt_toolchain_ide_info rules in repo");
+        return null;
+    }
+  }
+
+  private static void issueToolchainRenderingError(BlazeContext context, String because) {
+    IssueOutput.error("Could not render ide info json file, error: " + because).submit(context);
   }
 }

--- a/kotlin/src/com/google/idea/blaze/kotlin/sync/model/BlazeKotlinImportResult.java
+++ b/kotlin/src/com/google/idea/blaze/kotlin/sync/model/BlazeKotlinImportResult.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.idea.blaze.base.ideinfo.TargetIdeInfo;
 import com.google.idea.blaze.java.sync.model.BlazeJarLibrary;
 import java.io.Serializable;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /** The result of a blaze import operation. */
@@ -29,11 +30,15 @@ public class BlazeKotlinImportResult implements Serializable {
 
   public final ImmutableList<BlazeJarLibrary> libraries;
   public final ImmutableMap<TargetIdeInfo, ImmutableList<BlazeJarLibrary>> kotlinTargetToLibraryMap;
+  @Nullable
+  public final BlazeKotlinToolchainIdeInfo toolchainIdeInfo;
 
   public BlazeKotlinImportResult(
       ImmutableList<BlazeJarLibrary> libraries,
-      ImmutableMap<TargetIdeInfo, ImmutableList<BlazeJarLibrary>> targetToLibraryMap) {
+      ImmutableMap<TargetIdeInfo, ImmutableList<BlazeJarLibrary>> targetToLibraryMap,
+      @Nullable BlazeKotlinToolchainIdeInfo toolchainIdeInfo) {
     this.libraries = libraries;
     this.kotlinTargetToLibraryMap = targetToLibraryMap;
+    this.toolchainIdeInfo = toolchainIdeInfo;
   }
 }

--- a/kotlin/src/com/google/idea/blaze/kotlin/sync/model/BlazeKotlinToolchainIdeInfo.java
+++ b/kotlin/src/com/google/idea/blaze/kotlin/sync/model/BlazeKotlinToolchainIdeInfo.java
@@ -16,9 +16,12 @@
 package com.google.idea.blaze.kotlin.sync.model;
 
 import javax.annotation.Nonnull;
+import java.io.Serializable;
 import java.util.Objects;
 
-public final class BlazeKotlinToolchainIdeInfo {
+public final class BlazeKotlinToolchainIdeInfo implements Serializable {
+  public static final long serialVersionUID = 2L;
+
   @Nonnull public final String label;
   @Nonnull public final CommonInfo common;
   @Nonnull public final JvmInfo jvm;
@@ -30,7 +33,9 @@ public final class BlazeKotlinToolchainIdeInfo {
     this.jvm = Objects.requireNonNull(jvm);
   }
 
-  public static final class CommonInfo {
+  public static final class CommonInfo implements Serializable {
+    public static final long serialVersionUID = 2L;
+
     @Nonnull public final String languageVersion;
     @Nonnull public final String apiVersion;
     @Nonnull public final String coroutines;
@@ -43,7 +48,9 @@ public final class BlazeKotlinToolchainIdeInfo {
     }
   }
 
-  public static final class JvmInfo {
+  public static final class JvmInfo implements Serializable {
+    public static final long serialVersionUID = 2L;
+
     @Nonnull public final String jvmTarget;
 
     JvmInfo(@Nonnull String jvmTarget) {

--- a/kotlin/src/com/google/idea/blaze/kotlin/sync/model/BlazeKotlinToolchainIdeInfo.java
+++ b/kotlin/src/com/google/idea/blaze/kotlin/sync/model/BlazeKotlinToolchainIdeInfo.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.kotlin.sync.model;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
+
+public final class BlazeKotlinToolchainIdeInfo {
+  @Nonnull public final String label;
+  @Nonnull public final CommonInfo common;
+  @Nonnull public final JvmInfo jvm;
+
+  BlazeKotlinToolchainIdeInfo(
+      @Nonnull String label, @Nonnull CommonInfo common, @Nonnull JvmInfo jvm) {
+    this.label = Objects.requireNonNull(label);
+    this.common = Objects.requireNonNull(common);
+    this.jvm = Objects.requireNonNull(jvm);
+  }
+
+  public static final class CommonInfo {
+    @Nonnull public final String languageVersion;
+    @Nonnull public final String apiVersion;
+    @Nonnull public final String coroutines;
+
+    CommonInfo(
+        @Nonnull String languageVersion, @Nonnull String apiVersion, @Nonnull String coroutines) {
+      this.languageVersion = Objects.requireNonNull(languageVersion);
+      this.apiVersion = Objects.requireNonNull(apiVersion);
+      this.coroutines = Objects.requireNonNull(coroutines);
+    }
+  }
+
+  public static final class JvmInfo {
+    @Nonnull public final String jvmTarget;
+
+    JvmInfo(@Nonnull String jvmTarget) {
+      this.jvmTarget = Objects.requireNonNull(jvmTarget);
+    }
+  }
+}

--- a/kotlin/tests/integrationtests/com/google/idea/blaze/kotlin/sync/KotlinSyncTest.java
+++ b/kotlin/tests/integrationtests/com/google/idea/blaze/kotlin/sync/KotlinSyncTest.java
@@ -13,9 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.idea.blaze.kotlin;
-
-import static com.google.common.truth.Truth.assertThat;
+package com.google.idea.blaze.kotlin.sync;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.idea.blaze.base.ideinfo.JavaIdeInfo;
@@ -35,15 +33,15 @@ import com.google.idea.blaze.base.sync.projectview.WorkspaceLanguageSettings;
 import com.google.idea.blaze.java.sync.model.BlazeContentEntry;
 import com.google.idea.blaze.java.sync.model.BlazeJavaSyncData;
 import com.google.idea.blaze.java.sync.model.BlazeSourceDirectory;
-import com.google.idea.blaze.kotlin.sync.BlazeKotlinLanguageVersionSection;
-import com.google.idea.sdkcompat.kotlin.CommonCompilerArgumentsCompatUtils;
-import java.util.List;
-import org.jetbrains.kotlin.cli.common.arguments.CommonCompilerArguments;
 import org.jetbrains.kotlin.config.LanguageVersion;
-import org.jetbrains.kotlin.idea.compiler.configuration.KotlinCommonCompilerArgumentsHolder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.truth.Truth.assertThat;
 
 /** Kotlin-specific sync integration tests. */
 @RunWith(JUnit4.class)
@@ -176,7 +174,7 @@ public class KotlinSyncTest extends BlazeSyncIntegrationTestCase {
   public void testDefaultSectionParsing() {
     setProjectView("additional_languages:", "  kotlin");
 
-    assertViewConfigState(LanguageVersion.LATEST_STABLE);
+    assertViewConfigState(Optional.empty());
   }
 
   @Test
@@ -185,28 +183,32 @@ public class KotlinSyncTest extends BlazeSyncIntegrationTestCase {
         "kotlin_language_version: " + LanguageVersion.KOTLIN_1_1.getVersionString(),
         "additional_languages:",
         "  kotlin");
-
-    assertViewConfigState(LanguageVersion.KOTLIN_1_1);
+    workspace.createDirectory(new WorkspacePath("external/com_github_jetbrains_kotlin"));
+    assertViewConfigState(Optional.of(LanguageVersion.KOTLIN_1_1));
   }
 
-  private void assertViewConfigState(LanguageVersion languageVersion) {
+  private void assertViewConfigState(Optional<LanguageVersion> languageVersion) {
     runBlazeSync(
         new BlazeSyncParams.Builder("Sync", BlazeSyncParams.SyncMode.INCREMENTAL)
             .addProjectViewTargets(true)
             .build());
 
+    errorCollector.assertIssueContaining("The Kotlin workspace has not been setup in this workspace");
+
     ProjectViewSet projectViewSet =
         ProjectViewManager.getInstance(getProject()).getProjectViewSet();
     assert projectViewSet != null;
-    assertThat(BlazeKotlinLanguageVersionSection.getLanguageLevel(projectViewSet))
-        .isEqualTo(languageVersion);
+    if (languageVersion.isPresent()) {
+      assertThat(BlazeKotlinLanguageVersionSection.getLanguageLevel(projectViewSet).get())
+          .isEqualTo(languageVersion.get());
 
-    // test the compiler reflect the project view.
-    CommonCompilerArguments settings =
-        KotlinCommonCompilerArgumentsHolder.Companion.getInstance(getProject()).getSettings();
-    assertThat(CommonCompilerArgumentsCompatUtils.getApiVersion(settings))
-        .isEqualTo(languageVersion.getVersionString());
-    assertThat(CommonCompilerArgumentsCompatUtils.getLanguageVersion(settings))
-        .isEqualTo(languageVersion.getVersionString());
+      // test the compiler reflect the project view.
+      KotlinSettingsUpdater updater =
+          KotlinSettingsUpdater.create(getProject());
+      assertThat(updater.apiVersion()).isEqualTo(languageVersion.get().getVersionString());
+      assertThat(updater.languageVersion()).isEqualTo(languageVersion.get().getVersionString());
+    } else {
+      assertThat(BlazeKotlinLanguageVersionSection.getLanguageLevel(projectViewSet).isPresent()).isFalse();
+    }
   }
 }

--- a/kotlin/tests/unittests/com/google/idea/blaze/kotlin/sync/model/KotlinModelTest.java
+++ b/kotlin/tests/unittests/com/google/idea/blaze/kotlin/sync/model/KotlinModelTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.kotlin.sync.model;
+
+import com.google.idea.blaze.base.TestUtils;
+import org.junit.Test;
+
+public class KotlinModelTest {
+
+    @Test
+    public void testBlazeKotlinToolchainIdeInfoIsSerializable() {
+        TestUtils.assertIsSerializable(
+                new BlazeKotlinToolchainIdeInfo(
+                        "//monkey",
+                        new BlazeKotlinToolchainIdeInfo.CommonInfo("1.1", "1.2", "enabled"),
+                        new BlazeKotlinToolchainIdeInfo.JvmInfo("1.8")));
+    }
+}


### PR DESCRIPTION
* KtToolchainIdeInfo from Kotlin rules to relay the Kotlin plugin configuration from the workspace.
* Aspect processing for Kotlin rules (currently the KtToolchainIdeInfo is coming in via this but I will update this to inject the stdlibs from here as well, currently these are hard coded and discovered by the plugin).
* Attach srcjar jars to targets for code generated code.
* configure plugin elements found in KtToolchainIdeInfo (this deprecates the config section -- I will remove it outright in v4).
* a start to some aspect integration tests.

The code has been in use in our production repo for quite a while, so it's quite well tested.