### PR TITLE
README: Mention to configure Bazel binary location

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,11 @@ JetBrains' plugin repository.
 
 ## Installation
 
-You can find our plugin in the Jetbrains plugin repository by going to
+1. You can find our plugin in the Jetbrains plugin repository by going to
 `Settings -> Browse Repositories`, and searching for `Bazel`.
+2. Optional: Choose the right Bazel binary by going to 
+`Settings -> Other Settings -> Bazel Settings` and select the location
+of your Bazel binary.
 
 ## Usage
 


### PR DESCRIPTION
README: Mention to configure Bazel binary location

When first using the Intelij plugin, it immediately crashed. In the
below linked issue, the solution was to configure the location of the
bazel binary in the settings. I think this should be mentioned in the
README.

https://github.com/bazelbuild/intellij/issues/361