### PR TITLE
README: Inform how to build for CLion

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,19 @@ Detailed docs are available [here](http://ij.bazel.build).
 
 ## Building the plugin
 
-Install Bazel, then run
+Install Bazel, then build the target `*:*_bazel_zip` for your desired product:
 
-```bazel build //ijwb:ijwb_bazel_zip --define=ij_product=intellij-latest```
+* `bazel build //ijwb:ijwb_bazel_zip --define=ij_product=intellij-latest`
+* `bazel build //clwb:clwb_bazel_zip --define=ij_product=clion-latest`
+* `bazel build //aswb:aswb_bazel_zip --define=ij_product=android-studio-latest`
 
 from the project root. This will create a plugin zip file at
-`bazel-bin/ijwb/ijwb_bazel.zip`, which can be installed directly
-from the IDE.
+`bazel-bin/<PRODUCT>/<PRODUCT>_bazel.zip`, which can be installed directly
+from the IDE. `<PRODUCT>` can be one of `ijwb, clwb, aswb`.
+
+If the IDE refuses to load the plugin because of version issues, specify
+`ij_product` manually. A mapping of product `latest` to direct versions can be
+found in `intellij_platform_sdk/build_defs.bzl`.
 
 ## Contributions
 


### PR DESCRIPTION
The README was missing some info on how to build the plugin for CLion.
Secondly, keeping `ij_product` as `clion-latest` would result in the
plugin not loading on the latest CLion (2018.1.5). So, this PR also
informs the developer how to debug that.