### PR TITLE
Add tests for scrooge_scala_library target type

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -225,7 +225,8 @@ http_archive(
 # LICENSE: The Apache Software License, Version 2.0
 git_repository(
     name = "io_bazel_rules_scala",
-    commit = "40151843d9be877048f187fd2f627c1eccfb3b5c",
+    commit = "57661fa1ebbdc1359147d573e0ba4306dc6b9b98", # Fixed on this commit (unmerged branch: https://github.com/bazelbuild/rules_scala/pull/562)
+#    commit = "64faf06a4932a9a1d3378b6ba1a6d77479cefef3", # Broken on this commit (master)
     remote = "https://github.com/bazelbuild/rules_scala.git",
 )
 
@@ -233,6 +234,8 @@ load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repositories")
 scala_repositories()
 load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_toolchains")
 scala_register_toolchains()
+load("@io_bazel_rules_scala//twitter_scrooge:twitter_scrooge.bzl", "twitter_scrooge")
+twitter_scrooge()
 # END-EXTERNAL-SCALA
 
 # BEGIN-EXTERNAL-KOTLIN

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/scala/scroogescalalibrary/BUILD
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/scala/scroogescalalibrary/BUILD
@@ -1,0 +1,36 @@
+licenses(["notice"])  # Apache 2.0
+
+load(
+    "//aspect/testing/rules:intellij_aspect_test_fixture.bzl",
+    "intellij_aspect_test_fixture",
+)
+load(
+    "@io_bazel_rules_scala//twitter_scrooge:twitter_scrooge.bzl",
+    "scrooge_scala_library",
+)
+
+scrooge_scala_library(
+    name = "simple",
+    visibility = ["//visibility:public"],
+    deps = ["//aspect/testing/tests/src/com/google/idea/blaze/aspect/scala/scroogescalalibrary/thrift:thrift"],
+)
+
+intellij_aspect_test_fixture(
+    name = "simple_fixture",
+    deps = [":simple"],
+)
+
+java_test(
+    name = "ScroogeScalaLibraryTest",
+    srcs = ["ScroogeScalaLibraryTest.java"],
+    data = [":simple_fixture"],
+    deps = [
+        "//aspect/testing:BazelIntellijAspectTest",
+        "//aspect/testing/rules:IntellijAspectTest",
+        "//aspect/testing/rules:intellij_aspect_test_fixture_java_proto",
+        "//proto:intellij_ide_info_java_proto",
+        "@junit//jar",
+        "@truth//jar",
+        ":simple",
+    ],
+)

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/scala/scroogescalalibrary/ScroogeScalaLibraryTest.java
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/scala/scroogescalalibrary/ScroogeScalaLibraryTest.java
@@ -1,0 +1,50 @@
+package com.google.idea.blaze.aspect.scala.scroogescalalibrary;
+
+import com.google.devtools.intellij.IntellijAspectTestFixtureOuterClass;
+import com.google.devtools.intellij.ideinfo.IntellijIdeInfo;
+import com.google.idea.blaze.BazelIntellijAspectTest;
+import com.google.idea.blaze.aspect.IntellijAspectTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.stream.Collectors;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@RunWith(JUnit4.class)
+public class ScroogeScalaLibraryTest extends BazelIntellijAspectTest {
+    @Test
+    public void testScroogeScalaLibrary() throws Exception {
+        IntellijAspectTestFixtureOuterClass.IntellijAspectTestFixture testFixture = loadTestFixture(":simple_fixture");
+        IntellijIdeInfo.TargetIdeInfo target = findTarget(testFixture, ":simple");
+        assertThat(target.getKindString()).isEqualTo("scrooge_scala_library");
+        assertThat(target.hasJavaIdeInfo()).isTrue();
+        assertThat(target.hasCIdeInfo()).isFalse();
+        assertThat(target.hasAndroidIdeInfo()).isFalse();
+        assertThat(target.hasPyIdeInfo()).isFalse();
+
+        assertThat(relativePathsForArtifacts(target.getJavaIdeInfo().getSourcesList()))
+                .isEmpty();
+        assertThat(
+                target
+                        .getJavaIdeInfo()
+                        .getJarsList()
+                        .stream()
+                        .map(IntellijAspectTest::libraryArtifactToString)
+                        .collect(Collectors.toList()))
+                .containsExactly(jarString(testRelative("thrift/thrift_scrooge.jar"), null, null));
+
+        assertThat(getOutputGroupFiles(testFixture, "intellij-resolve-java"))
+                .containsExactly(testRelative("thrift/thrift_scrooge.jar"));
+
+        assertThat(getOutputGroupFiles(testFixture, "intellij-info-java"))
+                .containsExactly(testRelative("simple.intellij-info.txt"));
+        assertThat(getOutputGroupFiles(testFixture, "intellij-compile-java"))
+                .containsExactly(testRelative("thrift/thrift_scrooge.jar"));
+        assertThat(getOutputGroupFiles(testFixture, "intellij-info-generic"))
+                .containsExactly(testRelative("thrift/thrift.intellij-info.txt"));
+
+        assertThat(target.getJavaIdeInfo().getMainClass()).isEmpty();
+    }
+}

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/scala/scroogescalalibrary/thrift/BUILD
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/scala/scroogescalalibrary/thrift/BUILD
@@ -1,0 +1,7 @@
+load("@io_bazel_rules_scala//thrift:thrift.bzl", "thrift_library")
+
+thrift_library(
+    name = "thrift",
+    srcs = ["Thrift.thrift"],
+    visibility = ["//visibility:public"],
+)

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/scala/scroogescalalibrary/thrift/Thrift.thrift
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/scala/scroogescalalibrary/thrift/Thrift.thrift
@@ -1,0 +1,5 @@
+namespace java scalarules.test.twitter_scrooge.thrift
+
+struct Struct1 {
+  1: i32 integer
+}


### PR DESCRIPTION
# Overview

The `scrooge_scala_library` target type (part of the rules_scala project) recently experienced an IJ support regression. This PR adds a test which will catch this regression in the future. In short, the issue was that a new implementation of the scrooge_scala_library rule stopped returning output jars. This test checks the proper output jars are returned.

**This is WIP PR.** It cannot land until this PR in rules_scala lands: https://github.com/bazelbuild/rules_scala/pull/562. At that point the rules_scala SHA in the WORKSPACE file can point at master (it's currently pointing at a branch with my fix).

# Testing

`bazel test aspect/...` passes