### PR TITLE
Add support for building Intellij 2018.2 targets (CE and UE)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -96,6 +96,20 @@ new_http_archive(
     url = "https://plugins.jetbrains.com/files/7322/44945/python-ce-2018.1.181.4445.78.zip",
 )
 
+# Python plugin for IntelliJ CE 2018.2. Required at compile-time for python-specific features.
+new_http_archive(
+    name = "python_2018_2",
+    build_file_content = "\n".join([
+        "java_import(",
+        "    name = 'python',",
+        "    jars = ['python-ce/lib/python-ce.jar'],",
+        "    visibility = ['//visibility:public'],",
+        ")",
+    ]),
+    sha256 = "5a54c3823fc591ae65ea4fdf1e6e6a1c2704025b3c052e9d2a1695f5cf6f0e0b",
+    url = "https://plugins.jetbrains.com/files/7322/48089/python-ce-2018.2.182.3684.101.zip",
+)
+
 # Go plugin for IntelliJ UE. Required at compile-time for Bazel integration.
 new_http_archive(
     name = "go_2018_1",
@@ -108,6 +122,20 @@ new_http_archive(
     ]),
     sha256 = "de69ac9f8b81119c4a136860b66730d1e0dd89f713ac182bd8d5fdce801a60e5",
     url = "https://plugins.jetbrains.com/files/9568/44888/intellij-go-181.4445.53.182.zip",
+)
+
+# Go plugin for IntelliJ UE. Required at compile-time for Bazel integration.
+new_http_archive(
+    name = "go_2018_2",
+    build_file_content = "\n".join([
+        "java_import(",
+        "    name = 'go',",
+        "    jars = glob(['intellij-go/lib/*.jar']),",
+        "    visibility = ['//visibility:public'],",
+        ")",
+    ]),
+    sha256 = "7e974ae50372dd81e3fae3f5cb5256fedee158502ab785dd77882807b56d2bda",
+    url = "https://plugins.jetbrains.com/files/9568/48153/intellij-go-182.3684.111.849.zip",
 )
 
 # Scala plugin for IntelliJ CE 2018.1. Required at compile-time for scala-specific features.

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -9,7 +9,9 @@ java_library(
     visibility = ["//visibility:private"],
     exports = select_for_plugin_api({
         "intellij-2018.1": ["@go_2018_1//:go"],
+        "intellij-2018.2": ["@go_2018_2//:go"],
         "intellij-ue-2018.1": ["@go_2018_1//:go"],
+        "intellij-ue-2018.2": ["@go_2018_2//:go"],
         "default": [],
     }),
 )

--- a/third_party/python/BUILD
+++ b/third_party/python/BUILD
@@ -9,7 +9,9 @@ java_library(
     visibility = ["//visibility:private"],
     exports = select_for_plugin_api({
         "intellij-2018.1": ["@python_2018_1//:python"],
+        "intellij-2018.2": ["@python_2018_2//:python"],
         "intellij-ue-2018.1": ["@python_2018_1//:python"],
+        "intellij-ue-2018.2": ["@python_2018_2//:python"],
         "clion-2018.1": ["@clion_2018_1//:python"],
         "clion-2018.2": ["@clion_2018_2//:python"],
         "android-studio-3.0": ["@python_2017_1_4249//:python"],

--- a/third_party/scala/BUILD
+++ b/third_party/scala/BUILD
@@ -10,6 +10,8 @@ java_library(
     exports = select_for_plugin_api({
         "intellij-2018.1": ["@scala_2018_1//:scala"],
         "intellij-2018.2": ["@scala_2018_2//:scala"],
+        "intellij-ue-2018.1": ["@scala_2018_1//:scala"],
+        "intellij-ue-2018.2": ["@scala_2018_2//:scala"],
     }),
 )
 


### PR DESCRIPTION
I have not thoroughly tested this, but I ran into the 2018.2 incompatibility that has been discussed in https://github.com/bazelbuild/intellij/issues/375

This patch fixes the build for the following targets:
bazel build //ijwb:ijwb_bazel_zip --define=ij_product=intellij-2018.2
bazel build //ijwb:ijwb_bazel_zip --define=ij_product=intellij-ue-2018.2

The resulting build seems to load and work in Intellij 2018.2, though as I freely admit, my testing is cursory.