### PR TITLE
java_binary should line up with kotlin run markers.

### DIFF
--- a/kotlin/src/com/google/idea/blaze/kotlin/run/producers/BlazeKotlinRunConfigurationProducer.java
+++ b/kotlin/src/com/google/idea/blaze/kotlin/run/producers/BlazeKotlinRunConfigurationProducer.java
@@ -152,6 +152,6 @@ public class BlazeKotlinRunConfigurationProducer
         project,
         projectData.artifactLocationDecoder,
         projectData.targetMap,
-        (target) -> target.kind == Kind.KT_JVM_BINARY && target.isPlainTarget());
+        (target) -> (target.kind == Kind.KT_JVM_BINARY || target.kind == Kind.JAVA_BINARY) && target.isPlainTarget());
   }
 }


### PR DESCRIPTION
Simple fix for #387 -- this regressed or it was never included from my kotlin-v3 work.