### PR TITLE
Run main with deployable jars

### DIFF
--- a/scala/src/META-INF/scala-contents.xml
+++ b/scala/src/META-INF/scala-contents.xml
@@ -43,7 +43,7 @@
         language="Scala"
         order="first"/>
     <stepsBeforeRunProvider
-        implementation="com.google.idea.blaze.scala.run.producers.GenerateExecutableDeployableJarProviderTaskProvider"/>
+        implementation="com.google.idea.blaze.scala.run.producers.GenerateDeployableJarTaskProvider"/>
   </extensions>
 
   <project-components>

--- a/scala/src/com/google/idea/blaze/scala/run/producers/DeployableJarRunConfigurationProducer.java
+++ b/scala/src/com/google/idea/blaze/scala/run/producers/DeployableJarRunConfigurationProducer.java
@@ -15,29 +15,33 @@
  */
 package com.google.idea.blaze.scala.run.producers;
 
-import static com.google.idea.blaze.scala.run.producers.BlazeScalaMainClassRunConfigurationProducer.getMainObject;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import com.google.idea.blaze.base.dependencies.TargetInfo;
 import com.google.idea.blaze.base.ideinfo.TargetIdeInfo;
-import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.primitives.Label;
+import com.google.idea.blaze.base.model.primitives.RuleType;
+import com.google.idea.blaze.base.run.SourceToTargetFinder;
 import com.google.idea.blaze.base.run.producers.BlazeRunConfigurationProducer;
-import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
 import com.google.idea.blaze.java.run.RunUtil;
 import com.intellij.execution.RunManagerEx;
 import com.intellij.execution.actions.ConfigurationContext;
 import com.intellij.execution.application.ApplicationConfiguration;
 import com.intellij.execution.application.ApplicationConfigurationType;
+import com.intellij.execution.configurations.RunConfigurationBase;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.Ref;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiElement;
+import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.ScObject;
+
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Collection;
-import javax.annotation.Nullable;
-import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.ScObject;
+import java.util.Optional;
+
+import static com.google.idea.blaze.scala.run.producers.BlazeScalaMainClassRunConfigurationProducer.getMainObject;
 
 class DeployableJarRunConfigurationProducer
     extends BlazeRunConfigurationProducer<ApplicationConfiguration> {
@@ -57,22 +61,14 @@ class DeployableJarRunConfigurationProducer
     if (mainObject == null) {
       return false;
     }
-    TargetIdeInfo target = findTarget(context.getProject(), mainObject);
+    TargetInfo target = findTarget(context.getProject(), mainObject);
     if (target == null) {
       return false;
     }
 
-    Label label = target.key.label;
-    File jarFile = getDeployJarFile(label, context.getProject());
-    if (jarFile == null) {
-      return false;
-    }
-
-    configuration.setVMParameters("-cp " + jarFile.getPath());
-    configuration.setMainClassName(mainObject.getTruncedQualifiedName());
+    configuration.putUserData(TARGET_LABEL, target.label);
     configuration.setModule(context.getModule());
-
-    configuration.putUserData(TARGET_LABEL, label);
+    configuration.setMainClassName(mainObject.getTruncedQualifiedName());
     configuration.setName(mainObject.name());
     configuration.setNameChangedByUser(true); // don't revert to generated name
 
@@ -95,46 +91,34 @@ class DeployableJarRunConfigurationProducer
     if (mainObject == null) {
       return false;
     }
-    TargetIdeInfo target = findTarget(context.getProject(), mainObject);
+    TargetInfo target = findTarget(context.getProject(), mainObject);
     if (target == null) {
       return false;
     }
-    Label label = target.key.label;
-    File jarFile = getDeployJarFile(label, context.getProject());
-    if (jarFile == null) {
-      return false;
-    }
+
     return mainClass.getQualifiedName().equals(mainObject.getTruncedQualifiedName())
-        && configuration.getVMParameters().contains("-cp " + jarFile.getPath());
+        && configuration.getVMParameters().endsWith(
+                String.format("%s_deploy.jar", target.label.targetName()));
   }
 
   @Nullable
-  private static TargetIdeInfo findTarget(Project project, ScObject mainObject) {
+  private static TargetInfo findTarget(Project project, ScObject mainObject) {
     File mainObjectFile = RunUtil.getFileForClass(mainObject);
     if (mainObjectFile == null) {
       return null;
     }
 
-    Collection<TargetIdeInfo> targets =
-        BlazeScalaMainClassRunConfigurationProducer.findScalaBinaryTargets(project, mainObjectFile);
+    Collection<TargetInfo> targets =
+            SourceToTargetFinder.findTargetsForSourceFile(
+                    project, mainObjectFile, Optional.of(RuleType.LIBRARY));
+
     return Iterables.getFirst(targets, null);
   }
 
-  private void setDeployableJarGeneratorTask(ApplicationConfiguration config) {
+  private void setDeployableJarGeneratorTask(RunConfigurationBase config) {
     Project project = config.getProject();
     RunManagerEx runManager = RunManagerEx.getInstanceEx(project);
     runManager.setBeforeRunTasks(
         config, ImmutableList.of(new GenerateExecutableDeployableJarProviderTaskProvider.Task()));
-  }
-
-  @Nullable
-  private File getDeployJarFile(Label target, Project project) {
-    BlazeProjectData projectData =
-        BlazeProjectDataManager.getInstance(project).getBlazeProjectData();
-    if (projectData == null) {
-      return null;
-    }
-    File blazeBin = projectData.blazeInfo.getBlazeBinDirectory();
-    return new File(blazeBin, String.format("%s_deploy.jar", target.targetName()));
   }
 }

--- a/scala/src/com/google/idea/blaze/scala/run/producers/DeployableJarRunConfigurationProducer.java
+++ b/scala/src/com/google/idea/blaze/scala/run/producers/DeployableJarRunConfigurationProducer.java
@@ -18,7 +18,6 @@ package com.google.idea.blaze.scala.run.producers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.idea.blaze.base.dependencies.TargetInfo;
-import com.google.idea.blaze.base.ideinfo.TargetIdeInfo;
 import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.model.primitives.RuleType;
 import com.google.idea.blaze.base.run.SourceToTargetFinder;
@@ -119,6 +118,6 @@ class DeployableJarRunConfigurationProducer
     Project project = config.getProject();
     RunManagerEx runManager = RunManagerEx.getInstanceEx(project);
     runManager.setBeforeRunTasks(
-        config, ImmutableList.of(new GenerateExecutableDeployableJarProviderTaskProvider.Task()));
+        config, ImmutableList.of(new GenerateDeployableJarTaskProvider.Task()));
   }
 }

--- a/scala/src/com/google/idea/blaze/scala/run/producers/GenerateDeployableJarTaskProvider.java
+++ b/scala/src/com/google/idea/blaze/scala/run/producers/GenerateDeployableJarTaskProvider.java
@@ -56,10 +56,10 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
 
-class GenerateExecutableDeployableJarProviderTaskProvider
-    extends BeforeRunTaskProvider<GenerateExecutableDeployableJarProviderTaskProvider.Task> {
-  private static final Key<GenerateExecutableDeployableJarProviderTaskProvider.Task> ID =
-      Key.create("CreateTempScalaBinaryTarget");
+class GenerateDeployableJarTaskProvider
+    extends BeforeRunTaskProvider<GenerateDeployableJarTaskProvider.Task> {
+  private static final Key<GenerateDeployableJarTaskProvider.Task> ID =
+      Key.create("GenerateDeployableJarTarget");
 
   static class Task extends BeforeRunTask<Task> {
     Task() {
@@ -70,7 +70,7 @@ class GenerateExecutableDeployableJarProviderTaskProvider
 
   private final Project project;
 
-  GenerateExecutableDeployableJarProviderTaskProvider(Project project) {
+  GenerateDeployableJarTaskProvider(Project project) {
     this.project = project;
   }
 
@@ -85,7 +85,7 @@ class GenerateExecutableDeployableJarProviderTaskProvider
   }
 
   @Override
-  public Icon getTaskIcon(GenerateExecutableDeployableJarProviderTaskProvider.Task task) {
+  public Icon getTaskIcon(GenerateDeployableJarTaskProvider.Task task) {
     return BlazeIcons.Blaze;
   }
 
@@ -97,7 +97,7 @@ class GenerateExecutableDeployableJarProviderTaskProvider
   @Override
   public final boolean canExecuteTask(
       RunConfiguration configuration,
-      GenerateExecutableDeployableJarProviderTaskProvider.Task task) {
+      GenerateDeployableJarTaskProvider.Task task) {
     return isValidConfiguration(configuration);
   }
 

--- a/scala/tests/integrationtests/com/google/idea/blaze/scala/run/producers/DeployableJarRunConfigurationProducerTest.java
+++ b/scala/tests/integrationtests/com/google/idea/blaze/scala/run/producers/DeployableJarRunConfigurationProducerTest.java
@@ -1,0 +1,63 @@
+package com.google.idea.blaze.scala.run.producers;
+
+import com.google.idea.blaze.base.ideinfo.TargetIdeInfo;
+import com.google.idea.blaze.base.ideinfo.TargetMapBuilder;
+import com.google.idea.blaze.base.model.MockBlazeProjectDataBuilder;
+import com.google.idea.blaze.base.model.MockBlazeProjectDataManager;
+import com.google.idea.blaze.base.model.primitives.TargetExpression;
+import com.google.idea.blaze.base.model.primitives.WorkspacePath;
+import com.google.idea.blaze.base.run.producer.BlazeRunConfigurationProducerTestCase;
+import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
+import com.intellij.execution.application.ApplicationConfiguration;
+import com.intellij.execution.configurations.RunConfiguration;
+import com.intellij.psi.PsiFile;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/** Integration tests for {@link DeployableJarRunConfigurationProducerTest}. */
+@RunWith(JUnit4.class)
+public class DeployableJarRunConfigurationProducerTest
+    extends BlazeRunConfigurationProducerTestCase {
+
+    @Test
+    public void testCorrectMainAppAndTargetChosen() {
+        MockBlazeProjectDataBuilder builder = MockBlazeProjectDataBuilder.builder(workspaceRoot);
+        builder.setTargetMap(
+            TargetMapBuilder.builder()
+                .addTarget(
+                    TargetIdeInfo.builder()
+                        .setKind("scala_library")
+                        .setLabel("//com/google/library:SomeLibrary")
+                        .addSource(sourceRoot("com/google/library/SomeLibrary.scala"))
+                        .build())
+                    .build());
+        registerProjectService(
+                BlazeProjectDataManager.class, new MockBlazeProjectDataManager(builder.build()));
+
+        PsiFile scalaFile =
+            createAndIndexFile(
+                WorkspacePath.createIfValid("com/google/library/SomeLibrary.scala"),
+                "package com.google.library {",
+                "  object Foo {",
+                "    def main(args: Array[String]) {}",
+                "  }",
+                "}",
+                "package scala { final class Array[T] {} }",
+                "package java.lang { public final class String {} }");
+
+        RunConfiguration config = createConfigurationFromLocation(scalaFile);
+
+        assertThat(config).isInstanceOf(ApplicationConfiguration.class);
+        ApplicationConfiguration appConfig = (ApplicationConfiguration) config;
+        assertThat(appConfig).isNotNull();
+        assertThat(appConfig.getMainClass().getQualifiedName())
+                .isEqualTo("com.google.library.Foo");
+        assertThat(appConfig.getUserData(DeployableJarRunConfigurationProducer.TARGET_LABEL)).isNotNull();
+        assertThat(appConfig.getUserData(DeployableJarRunConfigurationProducer.TARGET_LABEL))
+                .isEqualTo(TargetExpression.fromStringSafe("//com/google/library:SomeLibrary"));
+    }
+
+}


### PR DESCRIPTION
This pr fixes #288, the original goal was to create a deployable jar based on the current `scala_library`, and run it with a specified classpath main.
Seems the original PR got changed when it was merged upstream, breaking the pr (it looked up binary targets instead)
This PR restores the functionality with a few tweaks.

Please review