### PR TITLE
Add fallback runfiles path for setting debug CWD.

### DIFF
--- a/python/src/com/google/idea/blaze/python/run/BlazePyRunConfigurationRunner.java
+++ b/python/src/com/google/idea/blaze/python/run/BlazePyRunConfigurationRunner.java
@@ -267,6 +267,11 @@ public class BlazePyRunConfigurationRunner implements BlazeCommandRunConfigurati
     if (FileOperationProvider.getInstance().exists(expectedPath)) {
       return expectedPath.getPath();
     }
+    // Default workspace name used when none specified in WORKSPACE file.
+    File fallbackPath = new File(executable.getPath() + ".runfiles/__main__");
+    if (FileOperationProvider.getInstance().exists(fallbackPath)) {
+      return fallbackPath.getPath();
+    }
     return null;
   }
 


### PR DESCRIPTION
There is a default workspace name `__main__` that is used when none is
declared in a WORKSPACE file. This commit adds this as a fallback path
since the expected path derives the workspace name from the root
directory.

See Bazel change log at: https://github.com/bazelbuild/bazel/blob/master/CHANGELOG.md#release-023-2016-05-10