### PR TITLE
Propagate intellij aspect along the 'embed' attr

### DIFF
--- a/aspect/intellij_info_impl.bzl
+++ b/aspect/intellij_info_impl.bzl
@@ -37,6 +37,7 @@ DEPS = [
     "instruments",  # android_instrumentation_test
     "library",  # From go_test
     "tests",  # From test_suite
+    "embed", # From go_library
 ]
 
 # Run-time dependency attributes, grouped by type.


### PR DESCRIPTION
The bazel rules_go use the 'embed' attr for other go rules (particularly go_proto_library). This PR, along with [rules_go#1827](https://github.com/bazelbuild/rules_go/pull/1827) will resolve #194.