### PR TITLE
Make Python scripts in build_defs compatible with Python 3.

### DIFF
--- a/build_defs/api_version_txt.py
+++ b/build_defs/api_version_txt.py
@@ -58,7 +58,7 @@ def main():
     build_element = build_elements[0]
 
     attrs = build_element.attributes
-    if attrs.has_key("apiVersion"):
+    if "apiVersion" in attrs:
       api_version_attr = attrs.get("apiVersion")
     else:
       api_version_attr = attrs.get("number")
@@ -67,7 +67,7 @@ def main():
     raise ValueError("Could not find api version in application info")
 
   api_version = _parse_build_number(api_version_attr.value)
-  print api_version
+  print(api_version)
 
 
 if __name__ == "__main__":

--- a/build_defs/api_version_txt.py
+++ b/build_defs/api_version_txt.py
@@ -58,10 +58,10 @@ def main():
     build_element = build_elements[0]
 
     attrs = build_element.attributes
-    if "apiVersion" in attrs:
-      api_version_attr = attrs.get("apiVersion")
-    else:
-      api_version_attr = attrs.get("number")
+    try:
+      api_version_attr = attrs["apiVersion"]
+    except KeyError:
+      api_version_attr = attrs["number"]
 
   if not api_version_attr:
     raise ValueError("Could not find api version in application info")

--- a/build_defs/append_optional_xml_elements.py
+++ b/build_defs/append_optional_xml_elements.py
@@ -2,7 +2,11 @@
 """
 
 import argparse
-from itertools import izip
+try:
+  from itertools import izip as zip
+except ImportError:
+  # Python 3.x already has a built-in `zip` that takes `izip`'s place.
+  pass
 from xml.dom.minidom import parse
 
 parser = argparse.ArgumentParser()
@@ -18,7 +22,7 @@ parser.add_argument(
 
 def pairwise(t):
   it = iter(t)
-  return izip(it, it)
+  return zip(it, it)
 
 
 def main():
@@ -36,10 +40,10 @@ def main():
     plugin_xml.appendChild(depends_element)
 
   if args.output:
-    with file(args.output, "w") as f:
+    with open(args.output, "wb") as f:
       f.write(dom.toxml(encoding="utf-8"))
   else:
-    print dom.toxml(encoding="utf-8")
+    print(dom.toxml(encoding="utf-8"))
 
 
 if __name__ == "__main__":

--- a/build_defs/merge_xml.py
+++ b/build_defs/merge_xml.py
@@ -52,7 +52,7 @@ if __name__ == "__main__":
     AppendFileToTree(filename, dom)
 
   if args.output:
-    with file(args.output, "w") as f:
+    with open(args.output, "wb") as f:
       f.write(dom.toxml(encoding="utf-8"))
   else:
-    print dom.toxml()
+    print(dom.toxml())

--- a/build_defs/package_meta_inf_files.py
+++ b/build_defs/package_meta_inf_files.py
@@ -2,7 +2,11 @@
 """
 
 import argparse
-from itertools import izip
+try:
+  from itertools import izip as zip
+except ImportError:
+  # Python 3.x already has a built-in `zip` that takes `izip`'s place.
+  pass
 import shutil
 import zipfile
 
@@ -27,7 +31,7 @@ parser.add_argument(
 
 def pairwise(t):
   it = iter(t)
-  return izip(it, it)
+  return zip(it, it)
 
 
 def main():
@@ -36,7 +40,7 @@ def main():
   shutil.copyfile(args.deploy_jar, args.output)
   output_jar = zipfile.ZipFile(args.output, "a")
   for meta_inf_file, name in pairwise(args.meta_inf_files):
-    with file(meta_inf_file) as f:
+    with open(meta_inf_file, "r") as f:
       zip_info = zipfile.ZipInfo("META-INF/" + name, ZIP_DATE)
       output_jar.writestr(zip_info, f.read())
 

--- a/build_defs/stamp_plugin_xml.py
+++ b/build_defs/stamp_plugin_xml.py
@@ -203,7 +203,7 @@ def main():
   for new_element in new_elements:
     idea_plugin.appendChild(new_element)
 
-  print dom.toxml(encoding="utf-8")
+  print(dom.toxml())
 
 
 if __name__ == "__main__":

--- a/build_defs/stamp_plugin_xml.py
+++ b/build_defs/stamp_plugin_xml.py
@@ -203,7 +203,7 @@ def main():
   for new_element in new_elements:
     idea_plugin.appendChild(new_element)
 
-  print(dom.toxml())
+  print(dom.toxml(encoding="utf-8").decode("utf-8"))
 
 
 if __name__ == "__main__":

--- a/build_defs/zip_plugin_files.py
+++ b/build_defs/zip_plugin_files.py
@@ -1,7 +1,11 @@
 """Packages plugin files into a zip archive."""
 
 import argparse
-from itertools import izip
+try:
+  from itertools import izip as zip
+except ImportError:
+  # Python 3.x already has a built-in `zip` that takes `izip`'s place.
+  pass
 import time
 import zipfile
 
@@ -14,7 +18,7 @@ parser.add_argument(
 
 def pairwise(t):
   it = iter(t)
-  return izip(it, it)
+  return zip(it, it)
 
 
 def main():


### PR DESCRIPTION
Some distributions like Arch Linux no longer ship Python 2 by default
and /usr/bin/python on these systems is a Python 3.x version, which
causes Bazel to try to run them with Python 3.x as part of the build.

With these changes, I was able to successfully build the plug-in on my
Arch Linux machine. I made sure that the changes are backwards
compatible with Python 2.x.