### PR TITLE
Allow more characters in labels

### DIFF
--- a/base/src/com/google/idea/blaze/base/model/primitives/TargetName.java
+++ b/base/src/com/google/idea/blaze/base/model/primitives/TargetName.java
@@ -30,7 +30,8 @@ public final class TargetName {
   // Rule names must be alpha-numeric or consist of the following allowed chars:
   // (note, rule names can also contain '/'; we handle that case separately)
   private static final ImmutableSet<Character> ALLOWED_META =
-      ImmutableSet.of('+', '_', ',', '=', '-', '.', '@', '~', '#', ' ', '(', ')', '$');
+      ImmutableSet.of('+', '_', ',', '=', '-', '.', '@', '~', '#', ' ', '(', ')', '$', '%', '\'',
+                      '"', '&', '*', ';', '<', '>', '?', '[', ']', '{', '|', '}', '!', '^', '`');
 
   private final String name;
 


### PR DESCRIPTION
Bazel's LabelValidator class was updated in [c4f2d80](https://github.com/bazelbuild/bazel/commit/c4f2d80270f1ce947fcf7fb0a4e5f0afb3a7062d) to allow more characters in labels.

This PR updates TargetName validation to reflect those changes (specifically, it adds the following as valid characters: ``%'"&*;<>?[]{|}!`^``).

