### PR TITLE
add default flags section for single test class run configuration

### DIFF
--- a/base/src/com/google/idea/blaze/base/projectview/section/sections/Sections.java
+++ b/base/src/com/google/idea/blaze/base/projectview/section/sections/Sections.java
@@ -41,7 +41,8 @@ public class Sections {
           RunConfigurationsSection.PARSER,
           ShardBlazeBuildsSection.PARSER,
           TargetShardSizeSection.PARSER,
-          BazelBinarySection.PARSER);
+          BazelBinarySection.PARSER,
+          SingleTestFlagsSection.PARSER);
 
   public static List<SectionParser> getParsers() {
     List<SectionParser> parsers = Lists.newArrayList(PARSERS);

--- a/base/src/com/google/idea/blaze/base/projectview/section/sections/SingleTestFlagsSection.java
+++ b/base/src/com/google/idea/blaze/base/projectview/section/sections/SingleTestFlagsSection.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.projectview.section.sections;
+
+import com.google.idea.blaze.base.projectview.parser.ParseContext;
+import com.google.idea.blaze.base.projectview.parser.ProjectViewParser;
+import com.google.idea.blaze.base.projectview.section.ListSection;
+import com.google.idea.blaze.base.projectview.section.ListSectionParser;
+import com.google.idea.blaze.base.projectview.section.SectionKey;
+import com.google.idea.blaze.base.projectview.section.SectionParser;
+
+import javax.annotation.Nullable;
+
+public class SingleTestFlagsSection {
+  public static final SectionKey<String, ListSection<String>> KEY = SectionKey.of("single_test_flags");
+  public static final SectionParser PARSER = new SingleTestFlagsSectionParser();
+
+  static class SingleTestFlagsSectionParser extends ListSectionParser<String> {
+    SingleTestFlagsSectionParser() {
+      super(KEY);
+    }
+
+    @Nullable
+    @Override
+    protected String parseItem(ProjectViewParser parser, ParseContext parseContext) {
+      return parseContext.current().text;
+    }
+
+    @Override
+    protected void printItem(String item, StringBuilder sb) {
+      sb.append(item);
+    }
+
+    @Override
+    public ItemType getItemType() {
+      return ItemType.Other;
+    }
+
+    @Override
+    public String quickDocs() {
+      return "flags that should be added to single test run configurations";
+    }
+  }
+}

--- a/base/tests/unittests/com/google/idea/blaze/base/projectview/ProjectViewSetTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/projectview/ProjectViewSetTest.java
@@ -42,6 +42,7 @@ import com.google.idea.blaze.base.projectview.section.sections.ImportTargetOutpu
 import com.google.idea.blaze.base.projectview.section.sections.RunConfigurationsSection;
 import com.google.idea.blaze.base.projectview.section.sections.Sections;
 import com.google.idea.blaze.base.projectview.section.sections.ShardBlazeBuildsSection;
+import com.google.idea.blaze.base.projectview.section.sections.SingleTestFlagsSection;
 import com.google.idea.blaze.base.projectview.section.sections.SyncFlagsSection;
 import com.google.idea.blaze.base.projectview.section.sections.TargetSection;
 import com.google.idea.blaze.base.projectview.section.sections.TargetShardSizeSection;
@@ -105,6 +106,9 @@ public class ProjectViewSetTest extends BlazeTestCase {
                     .add(
                         ScalarSection.builder(BazelBinarySection.KEY)
                             .set(new File("/bazel/path/override")))
+                    .add(
+                      ListSection.builder(SingleTestFlagsSection.KEY)
+                        .add("someFlag"))
                     .build())
             .build();
 

--- a/base/tests/utils/integration/com/google/idea/blaze/base/run/producer/BlazeRunConfigurationProducerTestCase.java
+++ b/base/tests/utils/integration/com/google/idea/blaze/base/run/producer/BlazeRunConfigurationProducerTestCase.java
@@ -42,9 +42,15 @@ import com.intellij.psi.PsiFile;
 import com.intellij.testFramework.MapDataContext;
 import java.util.Arrays;
 import javax.annotation.Nullable;
+
 import org.junit.Before;
 
-/** Run configuration producer integration test base */
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Run configuration producer integration test base
+ */
 public class BlazeRunConfigurationProducerTestCase extends BlazeIntegrationTestCase {
 
   protected EditorTestHelper editorTest;
@@ -89,6 +95,12 @@ public class BlazeRunConfigurationProducerTestCase extends BlazeIntegrationTestC
     BlazeCommandRunConfigurationCommonState handlerState =
         config.getHandlerStateIfType(BlazeCommandRunConfigurationCommonState.class);
     return handlerState != null ? handlerState.getTestFilterFlag() : null;
+  }
+
+  protected static List<String> getRunConfigurationFlags(BlazeCommandRunConfiguration config) {
+    BlazeCommandRunConfigurationCommonState handlerState =
+            config.getHandlerStateIfType(BlazeCommandRunConfigurationCommonState.class);
+    return handlerState == null ? Collections.emptyList() : handlerState.getBlazeFlagsState().getRawFlags();
   }
 
   @Nullable

--- a/base/tests/utils/integration/com/google/idea/blaze/base/sync/BlazeSyncIntegrationTestCase.java
+++ b/base/tests/utils/integration/com/google/idea/blaze/base/sync/BlazeSyncIntegrationTestCase.java
@@ -82,13 +82,10 @@ public abstract class BlazeSyncIntegrationTestCase extends BlazeIntegrationTestC
       OUTPUT_PATH + "/gcc-4.X.Y-crosstool-v17-hybrid-grtev3-k8-fastbuild/testlogs";
 
   private Disposable thisClassDisposable; // disposed prior to calling parent class's @After methods
-  private MockProjectViewManager projectViewManager;
   private MockBlazeInfoRunner blazeInfoData;
   private MockBlazeIdeInterface blazeIdeInterface;
   private MockEventLoggingService eventLogger;
   @Nullable private ProjectModuleMocker moduleMocker; // this will be null for heavy test cases
-
-  protected ErrorCollector errorCollector;
 
   @Before
   public void doSetup() throws Exception {
@@ -152,23 +149,6 @@ public abstract class BlazeSyncIntegrationTestCase extends BlazeIntegrationTestC
 
   protected static ArtifactLocation sourceRoot(String relativePath) {
     return ArtifactLocation.builder().setRelativePath(relativePath).setIsSource(true).build();
-  }
-
-  protected void setProjectView(String... contents) {
-    BlazeContext context = new BlazeContext();
-    context.addOutputSink(IssueOutput.class, errorCollector);
-    ProjectViewParser projectViewParser =
-        new ProjectViewParser(context, new WorkspacePathResolverImpl(workspaceRoot));
-    projectViewParser.parseProjectView(Joiner.on("\n").join(contents));
-
-    ProjectViewSet result = projectViewParser.getResult();
-    assertThat(result.getProjectViewFiles()).isNotEmpty();
-    errorCollector.assertNoIssues();
-    setProjectViewSet(result);
-  }
-
-  protected void setProjectViewSet(ProjectViewSet projectViewSet) {
-    projectViewManager.setProjectView(projectViewSet);
   }
 
   protected void setTargetMap(TargetMap targetMap) {

--- a/java/src/com/google/idea/blaze/java/run/producers/JavaTestContextProvider.java
+++ b/java/src/com/google/idea/blaze/java/run/producers/JavaTestContextProvider.java
@@ -28,6 +28,7 @@ import com.google.idea.blaze.base.run.producers.TestContextProvider;
 import com.intellij.execution.JavaExecutionUtil;
 import com.intellij.execution.Location;
 import com.intellij.execution.actions.ConfigurationContext;
+import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiMethod;
 import com.intellij.psi.PsiModifier;
@@ -86,6 +87,7 @@ class JavaTestContextProvider implements TestContextProvider {
         .setTarget(target)
         .setSourceElement(testClass)
         .setTestFilter(testFilter)
+        .setSingleTestFlags(testClass.getProject())
         .setDescription(testClass.getName())
         .build();
   }

--- a/scala/src/com/google/idea/blaze/scala/run/producers/ScalaSpecs2TestContextProvider.java
+++ b/scala/src/com/google/idea/blaze/scala/run/producers/ScalaSpecs2TestContextProvider.java
@@ -59,6 +59,7 @@ class ScalaSpecs2TestContextProvider implements TestContextProvider {
         .setTarget(target)
         .setSourceElement(testCase)
         .setTestFilter(testFilter)
+        .setSingleTestFlags(context.getProject())
         .setDescription(description)
         .build();
   }


### PR DESCRIPTION
Adding a section in .bazelproject files `single_test_flags`, listing all default flags needed for a single test run.