### PR TITLE
treating library files with extension '.srcjar' as jar files

### DIFF
--- a/base/src/com/google/idea/blaze/base/model/BlazeLibrary.java
+++ b/base/src/com/google/idea/blaze/base/model/BlazeLibrary.java
@@ -75,7 +75,9 @@ public abstract class BlazeLibrary implements ProtoWrapper<ProjectData.BlazeLibr
   protected static String pathToUrl(File path) {
     String name = path.getName();
     boolean isJarFile =
-        FileUtilRt.extensionEquals(name, "jar") || FileUtilRt.extensionEquals(name, "zip");
+        FileUtilRt.extensionEquals(name, "jar")
+                || FileUtilRt.extensionEquals(name, "srcjar")
+                || FileUtilRt.extensionEquals(name, "zip");
     // .jar files require an URL with "jar" protocol.
     String protocol =
         isJarFile


### PR DESCRIPTION
This PR fixes the library URLs generates for files with extension `.srcjar`, so that intelliJ treats them as jar files.
This is a part of a wider change that started in `rules_scala` and discussed here: https://github.com/bazelbuild/rules_scala/pull/633. Specifically, this PR is related to source attachment of `.srcjar` files generated for Scala proto libraries.

Thanks.