### PR TITLE
Adapting to rules scala src jar gen change

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -260,7 +260,7 @@ http_archive(
 # LICENSE: The Apache Software License, Version 2.0
 git_repository(
     name = "io_bazel_rules_scala",
-    commit = "8359fc6781cf3102e918c84cb1638a1b1e050ce0",
+    commit = "c3e0b6f4096ea891a85abd696b3ea70c27a97e88",
     remote = "https://github.com/bazelbuild/rules_scala.git",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -260,7 +260,7 @@ http_archive(
 # LICENSE: The Apache Software License, Version 2.0
 git_repository(
     name = "io_bazel_rules_scala",
-    commit = "c3e0b6f4096ea891a85abd696b3ea70c27a97e88",
+    commit = "fc024b11e662b7ca5b0f746458706a4461371392",
     remote = "https://github.com/bazelbuild/rules_scala.git",
 )
 

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/scala/scalabinary/ScalaBinaryTest.java
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/scala/scalabinary/ScalaBinaryTest.java
@@ -46,7 +46,7 @@ public class ScalaBinaryTest extends BazelIntellijAspectTest {
                 .stream()
                 .map(IntellijAspectTest::libraryArtifactToString)
                 .collect(Collectors.toList()))
-        .containsExactly(jarString(testRelative("foo.jar"), null, null));
+        .containsExactly(jarString(testRelative("foo.jar"), null, testRelative("foo-src.jar")));
 
     assertThat(binaryInfo.getJavaIdeInfo().getMainClass()).isEqualTo("com.google.MyMainClass");
 

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/scala/scalalibrary/ScalaLibraryTest.java
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/scala/scalalibrary/ScalaLibraryTest.java
@@ -48,7 +48,7 @@ public class ScalaLibraryTest extends BazelIntellijAspectTest {
                 .stream()
                 .map(IntellijAspectTest::libraryArtifactToString)
                 .collect(Collectors.toList()))
-        .containsExactly(jarString(testRelative("simple.jar"), null, null));
+        .containsExactly(jarString(testRelative("simple.jar"), null, testRelative("simple-src.jar")));
     // Also contains ijars for scala-library.
     // Also contains jars + srcjars for liblibrary.
     assertThat(getOutputGroupFiles(testFixture, "intellij-resolve-java"))

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/scala/scalamacrolibrary/ScalaMacroLibraryTest.java
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/scala/scalamacrolibrary/ScalaMacroLibraryTest.java
@@ -44,7 +44,7 @@ public class ScalaMacroLibraryTest extends BazelIntellijAspectTest {
                 .stream()
                 .map(IntellijAspectTest::libraryArtifactToString)
                 .collect(Collectors.toList()))
-        .containsExactly(jarString(testRelative("simple.jar"), null, null));
+        .containsExactly(jarString(testRelative("simple.jar"), null, testRelative("simple-src.jar")));
 
     // Also contains ijars for scala-library.
     // Also contains jars + srcjars for liblibrary.

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/scala/scalatest/ScalaTestTest.java
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/scala/scalatest/ScalaTestTest.java
@@ -44,7 +44,7 @@ public class ScalaTestTest extends BazelIntellijAspectTest {
                 .stream()
                 .map(IntellijAspectTest::libraryArtifactToString)
                 .collect(Collectors.toList()))
-        .containsExactly(jarString(testRelative("FooTest.jar"), null, null));
+        .containsExactly(jarString(testRelative("FooTest.jar"), null, testRelative("FooTest-src.jar")));
 
     assertThat(getOutputGroupFiles(testFixture, "intellij-info-java"))
         .contains(testRelative(intellijInfoFileName("FooTest")));


### PR DESCRIPTION
This PR adapts Scala rules tests to changes in `rules_scala`. In short, `rules_scala` will soon generate source-jars for Scala targets and their corresponding tests currently assume no source-jars.

(details here: https://github.com/bazelbuild/rules_scala/pull/633)

Thanks!
