### PR TITLE
skip excluded dir

### DIFF
--- a/base/src/com/google/idea/blaze/base/sync/BuildTargetFinder.java
+++ b/base/src/com/google/idea/blaze/base/sync/BuildTargetFinder.java
@@ -50,6 +50,15 @@ public class BuildTargetFinder {
     }
 
     final File directory = file;
+    boolean excluded = importRoots
+            .excludeDirectories()
+            .stream()
+            .map(workspaceRoot::fileForPath)
+            .anyMatch(potentialExclude -> FileUtil.isAncestor(potentialExclude, directory, false));
+    if (excluded) {
+      return null;
+    }
+
     File root =
         importRoots
             .rootDirectories()


### PR DESCRIPTION
**Current behavior:**
If `syncParam.addWorkingSet` is `true` and you somehow edited the file in the dir that should be excluded this target will be added to the command during sync.

Example:
though `cpp` dir is excluded in `.bazelproject` if you edit any file in `cpp` dir the sync command will be 
```
bazel build --tool_tag=ijwb:IDEA:ultimate ... --output_groups=intellij-info-generic,intellij-info-java -- //ijwb:ijwb_bazel_dev //ijwb:ijwb_lib //:ijwb_tests //:ijwb_ue_tests //cpp:all
```

**Expected behavior:**
excluded dir should be skipped