### PR TITLE
Skip project data subdir

### DIFF
--- a/base/src/com/google/idea/blaze/base/sync/BuildTargetFinder.java
+++ b/base/src/com/google/idea/blaze/base/sync/BuildTargetFinder.java
@@ -50,6 +50,15 @@ public class BuildTargetFinder {
     }
 
     final File directory = file;
+    boolean excluded = importRoots
+            .excludeDirectories()
+            .stream()
+            .map(workspaceRoot::fileForPath)
+            .anyMatch(potentialExclude -> FileUtil.isAncestor(potentialExclude, directory, false));
+    if (excluded) {
+      return null;
+    }
+
     File root =
         importRoots
             .rootDirectories()

--- a/base/src/com/google/idea/blaze/base/sync/projectview/ImportRoots.java
+++ b/base/src/com/google/idea/blaze/base/sync/projectview/ImportRoots.java
@@ -29,6 +29,7 @@ import com.google.idea.blaze.base.projectview.section.sections.DirectoryEntry;
 import com.google.idea.blaze.base.projectview.section.sections.DirectorySection;
 import com.google.idea.blaze.base.settings.Blaze;
 import com.google.idea.blaze.base.settings.BuildSystem;
+import com.google.idea.blaze.base.sync.data.BlazeDataStorage;
 import com.google.idea.blaze.base.util.WorkspacePathUtil;
 import com.intellij.openapi.project.Project;
 import java.nio.file.FileSystems;
@@ -91,6 +92,7 @@ public final class ImportRoots {
       if (buildSystem == BuildSystem.Bazel && hasWorkspaceRoot(rootDirectories)) {
         excludeBuildSystemArtifacts();
       }
+      excludeProjectDataSubDirectory();
       ImmutableSet<WorkspacePath> minimalExcludes =
           WorkspacePathUtil.calculateMinimalWorkspacePaths(excludeDirectoriesBuilder.build());
 
@@ -107,6 +109,10 @@ public final class ImportRoots {
               .buildArtifactDirectories(workspaceRoot)) {
         excludeDirectoriesBuilder.add(new WorkspacePath(dir));
       }
+    }
+
+    private void excludeProjectDataSubDirectory() {
+      excludeDirectoriesBuilder.add(new WorkspacePath(BlazeDataStorage.PROJECT_DATA_SUBDIRECTORY));
     }
 
     private static boolean hasWorkspaceRoot(ImmutableCollection<WorkspacePath> rootDirectories) {


### PR DESCRIPTION
Current behavior:
When you import the plugin IDE creates project data subdir and a bunch of files in it (e.g. `.ijwb`). If `addWorkingSet` is `true` it leads to the situation when such files are determined as edited and the target for these files is determined `//:all`
So the sync command looks like
```
bazel build --tool_tag=ijwb:IDEA:ultimate ... --output_groups=intellij-info-generic,intellij-info-java -- //ijwb:ijwb_bazel_dev //ijwb:ijwb_lib //:ijwb_tests //:ijwb_ue_tests //:all
```
which leads to building some `awsb` stuff (as it is referenced from BUILD file in the root of the project)

Expected behavior:
target `//:all` should not be added to the build command


This change solves the issue https://github.com/bazelbuild/intellij/issues/441


This PR is based on top of https://github.com/bazelbuild/intellij/pull/497 (it includes the changes from it) so that adding the project subdir to the exclude list leads to the target not being added any more.