### PR TITLE
Fix compare for empty test results on prematurely-terminated test run

### DIFF
--- a/base/src/com/google/idea/blaze/base/run/testlogs/BlazeTestResults.java
+++ b/base/src/com/google/idea/blaze/base/run/testlogs/BlazeTestResults.java
@@ -35,4 +35,19 @@ public class BlazeTestResults {
   private BlazeTestResults(ImmutableMultimap<Label, BlazeTestResult> perTargetResults) {
     this.perTargetResults = perTargetResults;
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    BlazeTestResults that = (BlazeTestResults) o;
+
+    return perTargetResults.equals(that.perTargetResults);
+  }
+
+  @Override
+  public int hashCode() {
+    return perTargetResults.hashCode();
+  }
 }


### PR DESCRIPTION
This is a complement to #472. Seems that if test run terminated prematurely, BUT there exists a bep file without any tests, it will create an unpopulated (empty) `BlazeTestResults` object. It will fail comparison with `BlazeTestResults.NO_RESULTS`, and report the wrong status:
![image](https://user-images.githubusercontent.com/601206/52561773-0a0f4d80-2e05-11e9-9f27-8bad54e5ec40.png)

This PR adds an `.equals` implementation, which makes the comparison check for actual contents. This fixes the 