### PR TITLE
Custom buildifier and buildozer for build file generation / modification

### DIFF
--- a/base/src/com/google/idea/blaze/base/buildmodifier/BazelBuildifierBinaryProvider.java
+++ b/base/src/com/google/idea/blaze/base/buildmodifier/BazelBuildifierBinaryProvider.java
@@ -15,6 +15,7 @@
  */
 package com.google.idea.blaze.base.buildmodifier;
 
+import com.google.idea.blaze.base.settings.BlazeUserSettings;
 import com.google.idea.common.binaryhelper.HelperBinaryUtil;
 import java.io.File;
 import javax.annotation.Nullable;
@@ -29,6 +30,10 @@ public class BazelBuildifierBinaryProvider implements BuildifierBinaryProvider {
   @Nullable
   @Override
   public File getBuildifierBinary() {
-    return HelperBinaryUtil.getHelperBinary(BUILDIFIER_BINARY_PATH);
+    BlazeUserSettings settings = BlazeUserSettings.getInstance();
+    if (settings.getUseBuiltInBuildifier())
+      return HelperBinaryUtil.getHelperBinary(BUILDIFIER_BINARY_PATH);
+    else
+      return new File(settings.getBuildifierBinaryPath());
   }
 }

--- a/base/src/com/google/idea/blaze/base/lang/buildfile/actions/BuildFileModifierImpl.java
+++ b/base/src/com/google/idea/blaze/base/lang/buildfile/actions/BuildFileModifierImpl.java
@@ -17,6 +17,7 @@ package com.google.idea.blaze.base.lang.buildfile.actions;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
+import com.google.common.io.CharStreams;
 import com.google.idea.blaze.base.buildmodifier.BuildFileModifier;
 import com.google.idea.blaze.base.lang.buildfile.psi.BuildFile;
 import com.google.idea.blaze.base.lang.buildfile.psi.Expression;
@@ -25,11 +26,16 @@ import com.google.idea.blaze.base.lang.buildfile.psi.util.BuildElementGenerator;
 import com.google.idea.blaze.base.lang.buildfile.references.BuildReferenceManager;
 import com.google.idea.blaze.base.model.primitives.Kind;
 import com.google.idea.blaze.base.model.primitives.Label;
+import com.google.idea.blaze.base.settings.BlazeUserSettings;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.LocalFileSystem;
-import com.intellij.psi.PsiElement;
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /** Implementation of BuildFileModifier. Modifies the PSI tree directly. */
 public class BuildFileModifierImpl implements BuildFileModifier {
@@ -53,9 +59,46 @@ public class BuildFileModifierImpl implements BuildFileModifier {
     return true;
   }
 
+  private static String run(String[] command) throws IOException, InterruptedException {
+    return run(command, "");
+  }
+
+  private static String run(String[] command, String input) throws IOException, InterruptedException {
+    ProcessBuilder builder = new ProcessBuilder(command);
+    Process process = builder.start();
+    process.getOutputStream().write(input.getBytes(UTF_8));
+    process.getOutputStream().close();
+    String result = CharStreams.toString(new BufferedReader(new InputStreamReader(process.getInputStream(), UTF_8)));
+    String errors = CharStreams.toString(new BufferedReader(new InputStreamReader(process.getErrorStream(), UTF_8)));
+    process.waitFor();
+    if (errors.length() > 0) {
+      String message = Joiner.on(' ').join(command, errors);
+      if (result.length() == 0) {
+        throw new IOException(message);
+      } else {
+        logger.warn(message);
+      }
+    }
+    return result;
+  }
+
   private PsiElement createRule(Project project, Kind ruleKind, String ruleName) {
-    String text =
-        Joiner.on("\n").join(ruleKind.toString() + "(", "    name = \"" + ruleName + "\"", ")");
+    String command = Joiner.on(" ").join("new", ruleKind.toString(), ruleName);
+    String text = ruleKind.toString() + "(name = \"" + ruleName + "\")";
+    BlazeUserSettings settings = BlazeUserSettings.getInstance();
+    try {
+      text = run(new String[] { settings.getBuildozerBinaryPath(), command, "-:*" });
+    } catch (IOException|InterruptedException ec) {
+      try {
+        if (!settings.isBuildozerDefault()) {
+          text = run(new String[] { settings.getDefaultBuildozerPath(), command, "-:*" });
+        } else {
+          throw ec;
+        }
+      } catch (IOException|InterruptedException ed) {
+        logger.warn("Unable to invoke buildozer, falling back to string concatenation", ed);
+      }
+    }
     Expression expr = BuildElementGenerator.getInstance(project).createExpressionFromText(text);
     assert (expr instanceof FuncallExpression);
     return expr;

--- a/base/src/com/google/idea/blaze/base/lang/buildfile/actions/BuildFileModifierImpl.java
+++ b/base/src/com/google/idea/blaze/base/lang/buildfile/actions/BuildFileModifierImpl.java
@@ -17,7 +17,6 @@ package com.google.idea.blaze.base.lang.buildfile.actions;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
-import com.google.common.io.CharStreams;
 import com.google.idea.blaze.base.buildmodifier.BuildFileModifier;
 import com.google.idea.blaze.base.lang.buildfile.psi.BuildFile;
 import com.google.idea.blaze.base.lang.buildfile.psi.Expression;
@@ -27,13 +26,15 @@ import com.google.idea.blaze.base.lang.buildfile.references.BuildReferenceManage
 import com.google.idea.blaze.base.model.primitives.Kind;
 import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.settings.BlazeUserSettings;
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.OutputListener;
+import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.execution.process.OSProcessHandler;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.LocalFileSystem;
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStreamReader;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -58,28 +59,30 @@ public class BuildFileModifierImpl implements BuildFileModifier {
     buildFile.add(createRule(project, ruleKind, newRule.targetName().toString()));
     return true;
   }
-
-  private static String run(String[] command) throws IOException, InterruptedException {
+  
+  private static String run(String[] command) throws IOException, ExecutionException {
     return run(command, "");
   }
 
-  private static String run(String[] command, String input) throws IOException, InterruptedException {
-    ProcessBuilder builder = new ProcessBuilder(command);
-    Process process = builder.start();
-    process.getOutputStream().write(input.getBytes(UTF_8));
-    process.getOutputStream().close();
-    String result = CharStreams.toString(new BufferedReader(new InputStreamReader(process.getInputStream(), UTF_8)));
-    String errors = CharStreams.toString(new BufferedReader(new InputStreamReader(process.getErrorStream(), UTF_8)));
-    process.waitFor();
-    if (errors.length() > 0) {
-      String message = Joiner.on(' ').join(command, errors);
-      if (result.length() == 0) {
+  private static String run(String[] command, String input) throws IOException, ExecutionException {
+    GeneralCommandLine commandLine = new GeneralCommandLine(command);
+    OSProcessHandler process = new OSProcessHandler(commandLine.createProcess(), commandLine.getCommandLineString());
+    OutputListener outputListener = new OutputListener();
+    process.addProcessListener(outputListener);
+    process.getProcessInput().write(input.getBytes(UTF_8));
+    process.getProcessInput().flush();
+    process.startNotify();
+    process.waitFor(1000);
+    if(outputListener.getOutput().getExitCode() != 0){
+      String message = Joiner.on(' ').join(command, outputListener.getOutput().getStderr());
+      if (outputListener.getOutput().getStdout().length() == 0) {
         throw new IOException(message);
       } else {
         logger.warn(message);
       }
     }
-    return result;
+
+    return outputListener.getOutput().getStdout();
   }
 
   private PsiElement createRule(Project project, Kind ruleKind, String ruleName) {
@@ -88,14 +91,14 @@ public class BuildFileModifierImpl implements BuildFileModifier {
     BlazeUserSettings settings = BlazeUserSettings.getInstance();
     try {
       text = run(new String[] { settings.getBuildozerBinaryPath(), command, "-:*" });
-    } catch (IOException|InterruptedException ec) {
+    } catch (IOException|ExecutionException ec) {
       try {
         if (!settings.isBuildozerDefault()) {
           text = run(new String[] { settings.getDefaultBuildozerPath(), command, "-:*" });
         } else {
           throw ec;
         }
-      } catch (IOException|InterruptedException ed) {
+      } catch (IOException|ExecutionException ed) {
         logger.warn("Unable to invoke buildozer, falling back to string concatenation", ed);
       }
     }

--- a/base/src/com/google/idea/blaze/base/lang/buildfile/actions/BuildFileModifierImpl.java
+++ b/base/src/com/google/idea/blaze/base/lang/buildfile/actions/BuildFileModifierImpl.java
@@ -33,6 +33,7 @@ import com.intellij.execution.process.OSProcessHandler;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.psi.PsiElement;
 import java.io.File;
 import java.io.IOException;
 

--- a/base/src/com/google/idea/blaze/base/settings/BlazeUserSettings.java
+++ b/base/src/com/google/idea/blaze/base/settings/BlazeUserSettings.java
@@ -62,6 +62,8 @@ public class BlazeUserSettings implements PersistentStateComponent<BlazeUserSett
   private static final String DEFAULT_BLAZE_PATH =
       SystemInfo.isMac ? "/usr/local/bin/blaze" : "/usr/bin/blaze";
   private static final String DEFAULT_BAZEL_PATH = "bazel";
+  private static final String DEFAULT_BUILDIFIER_PATH = "buildifier";
+  private static final String DEFAULT_BUILDOZER_PATH = "buildozer";
 
   private FocusBehavior showBlazeConsoleOnSync = FocusBehavior.ALWAYS;
   private FocusBehavior showBlazeProblemsViewOnSync = FocusBehavior.ALWAYS;
@@ -81,6 +83,9 @@ public class BlazeUserSettings implements PersistentStateComponent<BlazeUserSett
   private boolean showAddFileToProjectNotification = true;
   private String blazeBinaryPath = DEFAULT_BLAZE_PATH;
   private String bazelBinaryPath = DEFAULT_BAZEL_PATH;
+  private String buildifierBinaryPath = DEFAULT_BUILDIFIER_PATH;
+  private boolean useBuiltInBuildifier = true;
+  private String buildozerBinaryPath = DEFAULT_BUILDOZER_PATH;
 
   public static BlazeUserSettings getInstance() {
     return ServiceManager.getService(BlazeUserSettings.class);
@@ -239,6 +244,38 @@ public class BlazeUserSettings implements PersistentStateComponent<BlazeUserSett
     this.bazelBinaryPath = StringUtil.defaultIfEmpty(bazelBinaryPath, DEFAULT_BAZEL_PATH).trim();
   }
 
+  public boolean getUseBuiltInBuildifier() {
+    return this.useBuiltInBuildifier;
+  }
+
+  public void setUseBuiltInBuildifier(boolean useBuiltInBuildifier) {
+    this.useBuiltInBuildifier = useBuiltInBuildifier;
+  }
+
+  public String getBuildifierBinaryPath() {
+    return StringUtil.defaultIfEmpty(buildifierBinaryPath, DEFAULT_BUILDIFIER_PATH).trim();
+  }
+
+  public void setBuildifierBinaryPath(String buildifierBinaryPath) {
+    this.buildifierBinaryPath = StringUtil.defaultIfEmpty(buildifierBinaryPath, DEFAULT_BUILDIFIER_PATH).trim();;
+  }
+
+  public String getBuildozerBinaryPath() {
+    return StringUtil.defaultIfEmpty(buildozerBinaryPath, DEFAULT_BUILDOZER_PATH).trim();
+  }
+
+  public void setBuildozerBinaryPath(String buildozerBinaryPath) {
+    this.buildozerBinaryPath = StringUtil.defaultIfEmpty(buildozerBinaryPath, DEFAULT_BUILDOZER_PATH).trim();;
+  }
+
+  public boolean isBuildozerDefault() {
+    return DEFAULT_BUILDOZER_PATH.equals(buildifierBinaryPath);
+  }
+
+  public String getDefaultBuildozerPath() {
+    return DEFAULT_BUILDOZER_PATH;
+  }
+
   public boolean getCollapseProjectView() {
     return collapseProjectView;
   }
@@ -294,6 +331,8 @@ public class BlazeUserSettings implements PersistentStateComponent<BlazeUserSett
           Boolean.toString(settings.showAddFileToProjectNotification));
       builder.put("blazeBinaryPath", settings.blazeBinaryPath);
       builder.put("bazelBinaryPath", settings.bazelBinaryPath);
+      builder.put("buildifierBinaryPath", settings.buildifierBinaryPath);
+      builder.put("buildozerBinaryPath", settings.buildozerBinaryPath);
       return builder.build();
     }
   }

--- a/base/src/com/google/idea/blaze/base/settings/BlazeUserSettings.java
+++ b/base/src/com/google/idea/blaze/base/settings/BlazeUserSettings.java
@@ -257,7 +257,7 @@ public class BlazeUserSettings implements PersistentStateComponent<BlazeUserSett
   }
 
   public void setBuildifierBinaryPath(String buildifierBinaryPath) {
-    this.buildifierBinaryPath = StringUtil.defaultIfEmpty(buildifierBinaryPath, DEFAULT_BUILDIFIER_PATH).trim();;
+    this.buildifierBinaryPath = StringUtil.defaultIfEmpty(buildifierBinaryPath, DEFAULT_BUILDIFIER_PATH).trim();
   }
 
   public String getBuildozerBinaryPath() {
@@ -265,7 +265,7 @@ public class BlazeUserSettings implements PersistentStateComponent<BlazeUserSett
   }
 
   public void setBuildozerBinaryPath(String buildozerBinaryPath) {
-    this.buildozerBinaryPath = StringUtil.defaultIfEmpty(buildozerBinaryPath, DEFAULT_BUILDOZER_PATH).trim();;
+    this.buildozerBinaryPath = StringUtil.defaultIfEmpty(buildozerBinaryPath, DEFAULT_BUILDOZER_PATH).trim();
   }
 
   public boolean isBuildozerDefault() {

--- a/base/src/com/google/idea/blaze/base/settings/ui/BlazeUserSettingsConfigurable.java
+++ b/base/src/com/google/idea/blaze/base/settings/ui/BlazeUserSettingsConfigurable.java
@@ -210,7 +210,7 @@ public class BlazeUserSettingsConfigurable extends BaseConfigurable
       contributorRowCount += contributor.getRowCount();
     }
 
-    final int totalRowSize = 12 + contributorRowCount;
+    final int totalRowSize = 13 + contributorRowCount;
     int rowi = 0;
 
     SearchableOptionsHelper helper = new SearchableOptionsHelper(this);

--- a/base/src/com/google/idea/blaze/base/settings/ui/BlazeUserSettingsConfigurable.java
+++ b/base/src/com/google/idea/blaze/base/settings/ui/BlazeUserSettingsConfigurable.java
@@ -50,6 +50,8 @@ public class BlazeUserSettingsConfigurable extends BaseConfigurable
 
   private static final String BLAZE_BINARY_PATH_KEY = "blaze.binary.path";
   public static final String BAZEL_BINARY_PATH_KEY = "bazel.binary.path";
+  public static final String BUILDIFIER_BINARY_PATH_KEY = "buildifier.binary.path";
+  public static final String BUILDOZER_BINARY_PATH_KEY = "buildozer.binary.path";
   public static final String ID = "blaze.view";
   public static final String SHOW_ADD_FILE_TO_PROJECT_LABEL_TEXT =
       "Show 'Add source to project' editor notifications";
@@ -74,6 +76,9 @@ public class BlazeUserSettingsConfigurable extends BaseConfigurable
   private JCheckBox showAddFileToProjectNotification;
   private FileSelectorWithStoredHistory blazeBinaryPathField;
   private FileSelectorWithStoredHistory bazelBinaryPathField;
+  private JCheckBox useBuildInBuildifier;
+  private FileSelectorWithStoredHistory buildifierBinaryPathField;
+  private FileSelectorWithStoredHistory buildozerBinaryPathField;
 
   public BlazeUserSettingsConfigurable() {
     this.defaultBuildSystem = Blaze.defaultBuildSystem();
@@ -112,6 +117,9 @@ public class BlazeUserSettingsConfigurable extends BaseConfigurable
     settings.setShowAddFileToProjectNotification(showAddFileToProjectNotification.isSelected());
     settings.setBlazeBinaryPath(Strings.nullToEmpty(blazeBinaryPathField.getText()));
     settings.setBazelBinaryPath(Strings.nullToEmpty(bazelBinaryPathField.getText()));
+    settings.setBuildifierBinaryPath(Strings.nullToEmpty(buildifierBinaryPathField.getText()));
+    settings.setUseBuiltInBuildifier(useBuildInBuildifier.isSelected());
+    settings.setBuildozerBinaryPath(buildozerBinaryPathField.getText());
 
     for (BlazeUserSettingsContributor settingsContributor : settingsContributors) {
       settingsContributor.apply();
@@ -132,6 +140,9 @@ public class BlazeUserSettingsConfigurable extends BaseConfigurable
     showAddFileToProjectNotification.setSelected(settings.getShowAddFileToProjectNotification());
     blazeBinaryPathField.setTextWithHistory(settings.getBlazeBinaryPath());
     bazelBinaryPathField.setTextWithHistory(settings.getBazelBinaryPath());
+    buildifierBinaryPathField.setTextWithHistory(settings.getBuildifierBinaryPath());
+    useBuildInBuildifier.setSelected(settings.getUseBuiltInBuildifier());
+    buildozerBinaryPathField.setTextWithHistory(settings.getBuildozerBinaryPath());
 
     for (BlazeUserSettingsContributor settingsContributor : settingsContributors) {
       settingsContributor.reset();
@@ -163,7 +174,14 @@ public class BlazeUserSettingsConfigurable extends BaseConfigurable
                 Strings.nullToEmpty(settings.getBlazeBinaryPath()))
             || !Objects.equal(
                 Strings.nullToEmpty(bazelBinaryPathField.getText()).trim(),
-                Strings.nullToEmpty(settings.getBazelBinaryPath()));
+                Strings.nullToEmpty(settings.getBazelBinaryPath()))
+            || !Objects.equal(
+                Strings.nullToEmpty(buildifierBinaryPathField.getText()).trim(),
+                Strings.nullToEmpty(settings.getBuildifierBinaryPath()))
+            || useBuildInBuildifier.isSelected() != settings.getUseBuiltInBuildifier()
+            || !Objects.equal(
+                Strings.nullToEmpty(buildozerBinaryPathField.getText()).trim(),
+                Strings.nullToEmpty(settings.getBuildozerBinaryPath()));
 
     for (BlazeUserSettingsContributor settingsContributor : settingsContributors) {
       isModified |= settingsContributor.isModified();
@@ -192,7 +210,7 @@ public class BlazeUserSettingsConfigurable extends BaseConfigurable
       contributorRowCount += contributor.getRowCount();
     }
 
-    final int totalRowSize = 10 + contributorRowCount;
+    final int totalRowSize = 12 + contributorRowCount;
     int rowi = 0;
 
     SearchableOptionsHelper helper = new SearchableOptionsHelper(this);
@@ -323,6 +341,18 @@ public class BlazeUserSettingsConfigurable extends BaseConfigurable
         FileSelectorWithStoredHistory.create(
             BAZEL_BINARY_PATH_KEY, "Specify the bazel binary path");
 
+    useBuildInBuildifier = helper.createSearchableCheckBox("Use built-in buildifier binary", true);
+    useBuildInBuildifier.addActionListener(e -> buildifierBinaryPathField.setEnabled(!((JCheckBox)e.getSource()).isSelected()));
+
+    buildifierBinaryPathField =
+        FileSelectorWithStoredHistory.create(
+            BUILDIFIER_BINARY_PATH_KEY, "Specify the buildifier binary path");
+    buildifierBinaryPathField.setEnabled(!BlazeUserSettings.getInstance().getUseBuiltInBuildifier());
+
+    buildozerBinaryPathField =
+        FileSelectorWithStoredHistory.create(
+            BUILDOZER_BINARY_PATH_KEY, "Specify the buildozer binary path");
+
     if (BuildSystemProvider.isBuildSystemAvailable(BuildSystem.Blaze)) {
       addBinaryLocationSetting(
           helper.createSearchableLabel("Blaze binary location", true),
@@ -335,6 +365,36 @@ public class BlazeUserSettingsConfigurable extends BaseConfigurable
           bazelBinaryPathField,
           rowi++);
     }
+    if (BuildSystemProvider.isBuildSystemAvailable(BuildSystem.Bazel) || BuildSystemProvider.isBuildSystemAvailable(BuildSystem.Blaze)) {
+      mainPanel.add(
+        useBuildInBuildifier,
+        new GridConstraints(
+              rowi++,
+              0,
+              1,
+              2,
+              GridConstraints.ANCHOR_NORTHWEST,
+              GridConstraints.FILL_NONE,
+              GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW,
+              GridConstraints.SIZEPOLICY_FIXED,
+              null,
+              null,
+              null,
+              0,
+              false));
+      addBinaryLocationSetting(
+          helper.createSearchableLabel("Buildifier binary location", true),
+          buildifierBinaryPathField,
+          rowi++);
+    }
+
+    if (BuildSystemProvider.isBuildSystemAvailable(BuildSystem.Bazel)) {
+      addBinaryLocationSetting(
+              helper.createSearchableLabel("Buildozer binary location", true),
+              buildozerBinaryPathField,
+              rowi++);
+    }
+
 
     mainPanel.add(
         new Spacer(),

--- a/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/actions/BuildFileModifierTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/actions/BuildFileModifierTest.java
@@ -47,8 +47,6 @@ public class BuildFileModifierTest extends BuildFileIntegrationTestCase {
     assertFileContents(
         buildFile,
         "java_library(name = 'existing')",
-        "proto_library(",
-        "    name = \"new_target\"",
-        ")");
+        "proto_library(name = \"new_target\")");
   }
 }


### PR DESCRIPTION
Buildozer and buildifier paths are made configurable using Settings dialog box. Defaults are set to simply `buildozer` and `buildifier` so that system would pick up the one that is found anywhere in the PATH, it it is available.

Fallback scheme for `buildozer`:
- Attempt to invoke the configured one
- If configured one fails and it is not the same as default (not found, etc.) invoke the default one in path (`buildozer`)
- If default one fails, use string concatenation to generate build file
The advantage of `buildozer` over string manipulation is that `buildozer` has already implemented this and in a more thorough way, also it provides way more features thus allowing plugin to become easily extendable.

At the moment there is no fallback scheme for buildifier yet. Fallback scheme for buildifier would require design change (rewrite of `getBuildifierBinary`) at least and how it is invoked.

Note: this PR comes a bit late and branch has been created from slightly older commit, because most recent code dump made this whole feature implementation obsolete. However, it might still be a useful contribution to consider should build file modification would be deemed desirable.