### PR TITLE
Fixing Scala Test Events Handler to actually process Scala files

### DIFF
--- a/scala/src/com/google/idea/blaze/scala/run/smrunner/BlazeScalaTestEventsHandler.java
+++ b/scala/src/com/google/idea/blaze/scala/run/smrunner/BlazeScalaTestEventsHandler.java
@@ -39,7 +39,7 @@ public class BlazeScalaTestEventsHandler implements BlazeTestEventsHandler {
   @Override
   public boolean handlesKind(@Nullable Kind kind) {
     return kind != null
-        && kind.getLanguageClass().equals(LanguageClass.KOTLIN)
+        && kind.getLanguageClass().equals(LanguageClass.SCALA)
         && kind.getRuleType().equals(RuleType.TEST);
   }
 


### PR DESCRIPTION
There is a mistake in the handler, which makes it check for incorrect language kind (Kotlin, instead of Scala)

This one fix solves several issues, most notable of which are restoring the ability to navigate to tests (and other context menu actions), and fixes trimming the `::` character from test names (which explains why this started happening again in the first place.)