### PR TITLE
Ensure windows paths are converted to the correct format for blaze

### DIFF
--- a/base/src/com/google/idea/blaze/base/model/primitives/WorkspacePath.java
+++ b/base/src/com/google/idea/blaze/base/model/primitives/WorkspacePath.java
@@ -48,6 +48,7 @@ public class WorkspacePath implements ProtoWrapper<String>, Serializable {
    * @throws IllegalArgumentException if the path is invalid
    */
   public WorkspacePath(String relativePath) {
+    relativePath = replaceFileSeperator(relativePath);
     String error = validate(relativePath);
     if (error != null) {
       throw new IllegalArgumentException(
@@ -138,5 +139,10 @@ public class WorkspacePath implements ProtoWrapper<String>, Serializable {
   @Override
   public String toProto() {
     return relativePath;
+  }
+
+  /** Parse targetPattern to use the correct fileSeperator expected by Blaze - needed for windows */
+  private String replaceFileSeperator(String targetPattern) {
+    return targetPattern.replace('\\', BLAZE_COMPONENT_SEPARATOR);
   }
 }


### PR DESCRIPTION
I was having issues using this on Windows. It seems to simply append the relative target path to the workspace - which works fine on Linux and MacOS but on Windows due to the different file separators means the target paths are invalid.

This takes any windows file path separators in the targetPattern and replaces it with the blaze separator.

The error I was seeing without this fix:
```
ERROR: Skipping '//main\java\example\example:all': Invalid package name 'main\java\example\example:all': package names may contain A-Z, a-z, 0-9, or any of ' !"#$%&'()*+,-./;<=>?[]^_`{|}~' (most 127-bit ascii characters except 0-31, 127, ':', or '\').
WARNING: Target pattern parsing failed.
``` 