### PR TITLE
Replace use of replaceAll with replace to fix Pattern.compile error

### DIFF
--- a/java/src/com/google/idea/blaze/java/sync/projectstructure/JavaSourceFolderProvider.java
+++ b/java/src/com/google/idea/blaze/java/sync/projectstructure/JavaSourceFolderProvider.java
@@ -105,7 +105,7 @@ public class JavaSourceFolderProvider implements SourceFolderProvider {
     if (Strings.isNullOrEmpty(relativePath)) {
       return parentPackagePrefix;
     }
-    relativePath = relativePath.replaceAll(File.separator, ".");
+    relativePath = relativePath.replace(File.separator, ".");
     return Strings.isNullOrEmpty(parentPackagePrefix)
         ? relativePath
         : parentPackagePrefix + "." + relativePath;


### PR DESCRIPTION
String.replace is like String.replaceAll except it doesn't use regex, it
still replaces all the occurrences but this doesn't throw when
File.separator is `\` (an invalid regex pattern).