### PR TITLE
Sync status contributor for Scala

### DIFF
--- a/scala/src/META-INF/scala-contents.xml
+++ b/scala/src/META-INF/scala-contents.xml
@@ -27,6 +27,7 @@
         implementation="com.google.idea.blaze.scala.run.producers.ScalaSpecs2TestContextProvider"
         order="before JavaTestContextProvider"/>
     <BinaryContextProvider implementation="com.google.idea.blaze.scala.run.producers.ScalaBinaryContextProvider"/>
+    <SyncStatusContributor implementation="com.google.idea.blaze.scala.syncstatus.ScalaSyncStatusContributor"/>
   </extensions>
 
   <extensions defaultExtensionNs="com.intellij">

--- a/scala/src/com/google/idea/blaze/scala/syncstatus/ScalaSyncStatusContributor.java
+++ b/scala/src/com/google/idea/blaze/scala/syncstatus/ScalaSyncStatusContributor.java
@@ -1,0 +1,35 @@
+package com.google.idea.blaze.scala.syncstatus;
+
+import com.google.idea.blaze.base.model.BlazeProjectData;
+import com.google.idea.blaze.base.model.primitives.LanguageClass;
+import com.google.idea.blaze.base.syncstatus.SyncStatusContributor;
+import com.intellij.ide.projectView.ProjectViewNode;
+import com.intellij.ide.projectView.impl.nodes.ClassTreeNode;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiFile;
+
+import javax.annotation.Nullable;
+
+public class ScalaSyncStatusContributor implements SyncStatusContributor {
+
+    @Nullable
+    @Override
+    public PsiFileAndName toPsiFileAndName(BlazeProjectData projectData, ProjectViewNode<?> node) {
+        if (!(node instanceof ClassTreeNode)) {
+            return null;
+        }
+        PsiClass psiClass = ((ClassTreeNode) node).getPsiClass();
+        if (psiClass == null) {
+            return null;
+        }
+        PsiFile file = psiClass.getContainingFile();
+        return file != null ? new PsiFileAndName(file, psiClass.getName()) : null;
+    }
+
+    @Override
+    public boolean handlesFile(BlazeProjectData projectData, VirtualFile file) {
+        return projectData.getWorkspaceLanguageSettings().isLanguageActive(LanguageClass.SCALA)
+                && (file.getName().endsWith(".scala") || file.getName().endsWith(".sc"));
+    }
+}


### PR DESCRIPTION
This add a (missing?) status contributor for Scala, allowing newly added files to correctly appear `(unsynced)`.
The method `toPsiFileAndName` duplicates the JavaSyncStatusContributor implementation, but I couldn't find a good place to put it, without making it more visible.