### PR TITLE
Respect user's package view settings

### DIFF
--- a/base/src/com/google/idea/blaze/base/treeview/BlazeTreeStructureProvider.java
+++ b/base/src/com/google/idea/blaze/base/treeview/BlazeTreeStructureProvider.java
@@ -122,11 +122,17 @@ public class BlazeTreeStructureProvider implements TreeStructureProvider, DumbAw
 
       @Override
       public boolean isFlattenPackages() {
+        if (original instanceof ProjectViewSettings) {
+          return ((ProjectViewSettings) original).isFlattenPackages();
+        }
         return false;
       }
 
       @Override
       public boolean isAbbreviatePackageNames() {
+        if (original instanceof ProjectViewSettings) {
+          return ((ProjectViewSettings) original).isAbbreviatePackageNames();
+        }
         return false;
       }
 


### PR DESCRIPTION
This PR preserves the user's package settings in the project view (namely, the 'Flatten Packages' and 'Abbreviate Qualified Package Names' options).