### PR TITLE
Update OLDEST_SUPPORTED_VERSION to 0.23.0+

### DIFF
--- a/base/src/com/google/idea/blaze/base/plugin/BazelVersionChecker.java
+++ b/base/src/com/google/idea/blaze/base/plugin/BazelVersionChecker.java
@@ -24,8 +24,9 @@ import com.google.idea.blaze.base.settings.BuildSystem;
 /** Verifies that the available Bazel version is supported by this plugin. */
 public class BazelVersionChecker implements BuildSystemVersionChecker {
 
-  // version 0.18 introduced a backwards-incompatible change to the depset API
-  private static final BazelVersion OLDEST_SUPPORTED_VERSION = new BazelVersion(0, 18, 0);
+  // version 0.23 introduced a backwards-incompatible change to the Py struct
+  // providers. See: https://github.com/bazelbuild/bazel/issues/7298
+  private static final BazelVersion OLDEST_SUPPORTED_VERSION = new BazelVersion(0, 23, 0);
 
   @Override
   public boolean versionSupported(BlazeContext context, BlazeVersionData version) {


### PR DESCRIPTION
Given the swap to using [PyInfo](https://github.com/bazelbuild/bazel/blob/ddfc430e54ac2b2d9eebb5adf672cbf1318175f2/src/main/java/com/google/devtools/build/lib/rules/python/PyInfo.java) in place of the legacy python provider (see: https://github.com/bazelbuild/bazel/issues/7298), this plugin no longer supports Bazel Versions < 0.23.

This updates the OLDEST_SUPPORTED_VERSION to `0.23.0`