### PR TITLE
Support IntelliJ IDEA 2019.1

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -20,8 +20,8 @@ http_archive(
 http_archive(
     name = "intellij_ce_2019_1",
     build_file = "@//intellij_platform_sdk:BUILD.idea",
-    sha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-    url = "https://www.jetbrains.com/intellij-repository/releases/com/jetbrains/intellij/idea/ideaIC/191.6014.8/ideaIC-191.6014.8.zip",
+    sha256 = "f0f34e7d3f4e60b4649babe3d9cce7385d075d91254ce3db68c46c2dfb4c9531",
+    url = "https://www.jetbrains.com/intellij-repository/releases/com/jetbrains/intellij/idea/ideaIC/191.6183.87/ideaIC-191.6183.87.zip",
 )
 
 # The plugin api for IntelliJ UE 2018.3. This is required to run UE-specific
@@ -38,8 +38,8 @@ http_archive(
 http_archive(
     name = "intellij_ue_2019_1",
     build_file = "@//intellij_platform_sdk:BUILD.ue",
-    sha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-    url = "https://www.jetbrains.com/intellij-repository/releases/com/jetbrains/intellij/idea/ideaIU/191.6014.8/ideaIU-191.6014.8.zip",
+    sha256 = "f0f34e7d3f4e60b4649babe3d9cce7385d075d91254ce3db68c46c2dfb4c9531",
+    url = "https://www.jetbrains.com/intellij-repository/releases/com/jetbrains/intellij/idea/ideaIU/191.6183.87/ideaIU-191.6183.87.zip",
 )
 
 # The plugin api for CLion 2018.3. This is required to build CLwB,

--- a/aspect/BUILD
+++ b/aspect/BUILD
@@ -4,10 +4,7 @@
 
 licenses(["notice"])  # Apache 2.0
 
-load(
-    ":intellij_info_impl.bzl",
-    "define_flag_hack",
-)
+# load(":intellij_info_impl.bzl")
 
 # Files needed at runtime for blaze-invoking integration tests
 filegroup(
@@ -64,8 +61,6 @@ genrule(
     srcs = ["intellij_info.bzl"],
     outs = ["intellij_info_bundled.bzl"],
     cmd = "cat $(SRCS) >$@ && " +
-          "sed -i -e 's,//%s/tools:\" + tool_name,//:\" + tool_name + \"_bin\",g' $@ && " % _dev_aspect_path +
-          "sed -i -e 's,//%s:flag_hack,//:flag_hack,g' $@" % _dev_aspect_path,
+          "sed -i -e 's,//%s/tools:\" + tool_name,//:\" + tool_name + \"_bin\",g' $@ " % _dev_aspect_path
 )
 
-define_flag_hack()

--- a/aspect/BUILD.aspect
+++ b/aspect/BUILD.aspect
@@ -5,8 +5,7 @@
 
 licenses(["notice"])  # Apache 2.0
 
-load(":intellij_info_impl.bzl",
-     "define_flag_hack")
+# load(":intellij_info_impl.bzl")
 
 java_binary(
     name = "JarFilter_bin",
@@ -32,4 +31,3 @@ java_import(
     jars = ["tools/PackageParser_deploy.jar"],
 )
 
-define_flag_hack()

--- a/aspect/intellij_info.bzl
+++ b/aspect/intellij_info.bzl
@@ -46,8 +46,7 @@ semantics = struct(
     ),
     py = struct(
         get_launcher = get_py_launcher,
-    ),
-    flag_hack_label = "//aspect:flag_hack",
+    )
 )
 
 def _aspect_impl(target, ctx):

--- a/intellij_platform_sdk/build_defs.bzl
+++ b/intellij_platform_sdk/build_defs.bzl
@@ -2,10 +2,10 @@
 
 # The current indirect ij_product mapping (eg. "intellij-latest")
 INDIRECT_IJ_PRODUCTS = {
-    "intellij-latest": "intellij-2018.3",
-    "intellij-beta": "intellij-2018.3",
-    "intellij-ue-latest": "intellij-ue-2018.3",
-    "intellij-ue-beta": "intellij-ue-2018.3",
+    "intellij-latest": "intellij-2019.1",
+    "intellij-beta": "intellij-2019.1",
+    "intellij-ue-latest": "intellij-ue-2019.1",
+    "intellij-ue-beta": "intellij-ue-2019.1",
     "android-studio-latest": "android-studio-3.3",
     "android-studio-beta": "android-studio-3.4",
     "android-studio-beta-mac": "android-studio-3.4-mac",


### PR DESCRIPTION
Tested by building a local plugin and loading it into IDEA 2019.1 against a reasonably large codebase.

$ bazel version
Build label: 0.23.2-homebrew
Build target: bazel-out/darwin-opt/bin/src/main/java/com/google/devtools/build/lib/bazel/BazelServer_deploy.jar
Build time: Tue Mar 12 06:12:54 2019 (1552371174)
Build timestamp: 1552371174
Build timestamp as int: 1552371174

Please note that I have not signed the Google CLA (would require me to go through legal). 
This is provided as-is for reference - you may choose to not merge. 
