### PR TITLE
Clion 2019.1 fixes

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -20,8 +20,8 @@ http_archive(
 http_archive(
     name = "intellij_ce_2019_1",
     build_file = "@//intellij_platform_sdk:BUILD.idea",
-    sha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-    url = "https://www.jetbrains.com/intellij-repository/releases/com/jetbrains/intellij/idea/ideaIC/191.6014.8/ideaIC-191.6014.8.zip",
+    sha256 = "8bd7ff641f482c68cfa30564bd5bb42cf75b521f5298d3a8189dcc147188c66a",
+    url = "https://www.jetbrains.com/intellij-repository/releases/com/jetbrains/intellij/idea/ideaIC/191.6183.87/ideaIC-191.6183.87.zip",
 )
 
 # The plugin api for IntelliJ UE 2018.3. This is required to run UE-specific
@@ -38,8 +38,8 @@ http_archive(
 http_archive(
     name = "intellij_ue_2019_1",
     build_file = "@//intellij_platform_sdk:BUILD.ue",
-    sha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-    url = "https://www.jetbrains.com/intellij-repository/releases/com/jetbrains/intellij/idea/ideaIU/191.6014.8/ideaIU-191.6014.8.zip",
+    sha256 = "f0f34e7d3f4e60b4649babe3d9cce7385d075d91254ce3db68c46c2dfb4c9531",
+    url = "https://www.jetbrains.com/intellij-repository/releases/com/jetbrains/intellij/idea/ideaIU/191.6183.87/ideaIU-191.6183.87.zip",
 )
 
 # The plugin api for CLion 2018.3. This is required to build CLwB,
@@ -50,6 +50,8 @@ http_archive(
     sha256 = "963fb343272e5903ac7dc944cc64ea9541ab4c150cc4ea796dcb0fb613bff4fd",
     url = "https://download.jetbrains.com/cpp/CLion-2018.3.4.tar.gz",
 )
+
+# https://www.jetbrains.com/intellij-repository/releases/com/jetbrains/intellij/clion/clion/2019.1/clion-2019.1.zip
 
 # The plugin api for CLion 2019.1. This is required to build CLwB,
 # and run integration tests.

--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrLauncher.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrLauncher.java
@@ -66,7 +66,7 @@ import com.intellij.openapi.util.SystemInfo;
 import com.intellij.util.PathUtil;
 import com.intellij.xdebugger.XDebugSession;
 import com.jetbrains.cidr.cpp.execution.CLionRunParameters;
-import com.jetbrains.cidr.cpp.execution.debugger.backend.GDBDriverConfiguration;
+import com.jetbrains.cidr.cpp.execution.debugger.backend.CLionGDBDriverConfiguration;
 import com.jetbrains.cidr.cpp.toolchains.CPPDebugger;
 import com.jetbrains.cidr.cpp.toolchains.CPPToolSet;
 import com.jetbrains.cidr.cpp.toolchains.CPPToolSetWithHome;
@@ -367,7 +367,7 @@ public final class BlazeCidrLauncher extends CidrLauncher {
     ToolchainUtils.setDebuggerToDefault(toolchainForDebugger);
 
     DebuggerDriverConfiguration debuggerDriverConfiguration =
-        new GDBDriverConfiguration(project, toolchainForDebugger);
+        new CLionGDBDriverConfiguration(project, toolchainForDebugger);
 
     return new BlazeCidrRemoteDebugProcess(
         targetProcess, debuggerDriverConfiguration, parameters, session, state.getConsoleBuilder());
@@ -379,7 +379,8 @@ public final class BlazeCidrLauncher extends CidrLauncher {
    * launches. See https://youtrack.jetbrains.com/issue/CPP-8362
    */
   private static class BlazeToolSet extends CPPToolSetWithHome {
-    private static final char[] separators = {'/'};
+    // private static final char[] separators = {'/'};
+    private static final String separators = "/";
 
     private BlazeToolSet(File workingDirectory) {
       super(Kind.MINGW, workingDirectory);
@@ -396,7 +397,7 @@ public final class BlazeCidrLauncher extends CidrLauncher {
     }
 
     @Override
-    public char[] getSupportedFileSeparators() {
+    public String getSupportedFileSeparators() {
       return separators;
     }
 

--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeGDBDriverConfiguration.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeGDBDriverConfiguration.java
@@ -25,13 +25,13 @@ import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.io.FileUtil;
-import com.jetbrains.cidr.cpp.execution.debugger.backend.GDBDriverConfiguration;
+import com.jetbrains.cidr.cpp.execution.debugger.backend.CLionGDBDriverConfiguration;
 import com.jetbrains.cidr.execution.debugger.backend.DebuggerDriver;
 import java.io.File;
 import java.io.IOException;
 import javax.annotation.Nullable;
 
-final class BlazeGDBDriverConfiguration extends GDBDriverConfiguration {
+final class BlazeGDBDriverConfiguration extends CLionGDBDriverConfiguration {
   private static final Logger LOG = Logger.getInstance(BlazeGDBDriverConfiguration.class);
 
   private final ImmutableList<String> startupCommands;

--- a/clwb/src/com/google/idea/blaze/plugin/CMakeNotificationFilter.java
+++ b/clwb/src/com/google/idea/blaze/plugin/CMakeNotificationFilter.java
@@ -17,6 +17,7 @@ package com.google.idea.blaze.plugin;
 
 import com.google.idea.blaze.base.settings.Blaze;
 import com.intellij.openapi.extensions.ExtensionPoint;
+import com.intellij.openapi.extensions.ExtensionPointName;
 import com.intellij.openapi.extensions.Extensions;
 import com.intellij.openapi.fileEditor.FileEditor;
 import com.intellij.openapi.project.DumbAware;
@@ -52,7 +53,7 @@ public class CMakeNotificationFilter extends EditorNotifications.Provider<JCompo
 
   public static void overrideProjectExtension(Project project) {
     ExtensionPoint<EditorNotifications.Provider> ep =
-        Extensions.getArea(project).getExtensionPoint(EditorNotifications.EXTENSION_POINT_NAME);
+        Extensions.getArea(project).getExtensionPoint(new ExtensionPointName<EditorNotifications.Provider>("com.intellij.editorNotificationProvider"));
     for (EditorNotifications.Provider<?> editorNotificationsProvider : ep.getExtensions()) {
       if (editorNotificationsProvider instanceof CMakeNotificationProvider) {
         ep.unregisterExtension(editorNotificationsProvider);

--- a/intellij_platform_sdk/build_defs.bzl
+++ b/intellij_platform_sdk/build_defs.bzl
@@ -2,7 +2,7 @@
 
 # The current indirect ij_product mapping (eg. "intellij-latest")
 INDIRECT_IJ_PRODUCTS = {
-    "intellij-latest": "intellij-2018.3",
+    "intellij-latest": "intellij-2019.1",
     "intellij-beta": "intellij-2018.3",
     "intellij-ue-latest": "intellij-ue-2018.3",
     "intellij-ue-beta": "intellij-ue-2018.3",
@@ -10,7 +10,7 @@ INDIRECT_IJ_PRODUCTS = {
     "android-studio-beta": "android-studio-3.4",
     "android-studio-beta-mac": "android-studio-3.4-mac",
     "android-studio-canary": "android-studio-3.5",
-    "clion-latest": "clion-2018.3",
+    "clion-latest": "clion-2019.1",
     "clion-beta": "clion-2018.3",
 }
 

--- a/intellij_platform_sdk/build_defs.bzl
+++ b/intellij_platform_sdk/build_defs.bzl
@@ -3,15 +3,15 @@
 # The current indirect ij_product mapping (eg. "intellij-latest")
 INDIRECT_IJ_PRODUCTS = {
     "intellij-latest": "intellij-2019.1",
-    "intellij-beta": "intellij-2018.3",
-    "intellij-ue-latest": "intellij-ue-2018.3",
-    "intellij-ue-beta": "intellij-ue-2018.3",
+    "intellij-beta": "intellij-2019.1",
+    "intellij-ue-latest": "intellij-ue-2019.1",
+    "intellij-ue-beta": "intellij-ue-2019.1",
     "android-studio-latest": "android-studio-3.3",
     "android-studio-beta": "android-studio-3.4",
     "android-studio-beta-mac": "android-studio-3.4-mac",
     "android-studio-canary": "android-studio-3.5",
     "clion-latest": "clion-2019.1",
-    "clion-beta": "clion-2018.3",
+    "clion-beta": "clion-2019.1",
 }
 
 DIRECT_IJ_PRODUCTS = {

--- a/python/src/com/google/idea/blaze/python/run/BlazePyPositionConverter.java
+++ b/python/src/com/google/idea/blaze/python/run/BlazePyPositionConverter.java
@@ -42,9 +42,19 @@ public class BlazePyPositionConverter implements PyPositionConverter {
 
   private static final Logger logger = Logger.getInstance(BlazePyPositionConverter.class);
 
-  @Override
+  // @Override
   public PySourcePosition create(String filePath, int line) {
     return new PySourcePosition(convertFilePath(filePath), line) {};
+  }
+
+  @Override
+  public PySourcePosition convertPythonToFrame(final String file, final int line) {
+    return create(file, line);
+  }
+
+  @Override
+  public PySourcePosition convertFrameToPython(PySourcePosition position) {
+    return position;
   }
 
   @Override

--- a/python/src/com/google/idea/blaze/python/run/BlazePyPositionConverter.java
+++ b/python/src/com/google/idea/blaze/python/run/BlazePyPositionConverter.java
@@ -42,17 +42,17 @@ public class BlazePyPositionConverter implements PyPositionConverter {
 
   private static final Logger logger = Logger.getInstance(BlazePyPositionConverter.class);
 
-  // @Override
+  @SuppressWarnings("MissingOverride") // required for idea, not in clion
   public PySourcePosition create(String filePath, int line) {
     return new PySourcePosition(convertFilePath(filePath), line) {};
   }
 
-  @Override
+  @SuppressWarnings("MissingOverride") // required for clion, not in idea
   public PySourcePosition convertPythonToFrame(final String file, final int line) {
     return create(file, line);
   }
 
-  @Override
+  @SuppressWarnings("MissingOverride") // required for clion, not in idea
   public PySourcePosition convertFrameToPython(PySourcePosition position) {
     return position;
   }


### PR DESCRIPTION
Didn't build for me as-is, seems like a few things in the sdk have changed.

Changes here allowed me to build the plugin and load into CLion 2019.1. 

I "fixed" the IntelliJ urls as the ones there aren't in the repo anymore, though I'm not using bazel there to know if that works ok.

I saw the blurb about contribution difficulties, feel free to take if this is useful or close if not.