### PR TITLE
Don't test on Ubuntu 14.04

### DIFF
--- a/.bazelci/android-studio.yml
+++ b/.bazelci/android-studio.yml
@@ -1,6 +1,6 @@
 ---
 platforms:
-  ubuntu1404:
+  ubuntu1604:
     build_flags:
     - --define=ij_product=android-studio-beta
     build_targets:
@@ -10,7 +10,7 @@ platforms:
     - --test_output=errors
     test_targets:
     - //:aswb_tests
-  ubuntu1604:
+  ubuntu1804:
     build_flags:
     - --define=ij_product=android-studio-beta
     build_targets:

--- a/.bazelci/aspect.yml
+++ b/.bazelci/aspect.yml
@@ -1,13 +1,13 @@
 ---
 platforms:
-  ubuntu1404:
+  ubuntu1604:
     build_targets:
     - //aspect:aspect_files
     test_flags:
     - --test_output=errors
     test_targets:
     - //aspect/testing/...
-  ubuntu1604:
+  ubuntu1804:
     build_targets:
     - //aspect:aspect_files
     test_flags:

--- a/.bazelci/clion.yml
+++ b/.bazelci/clion.yml
@@ -1,6 +1,6 @@
 ---
 platforms:
-  ubuntu1404:
+  ubuntu1604:
     build_flags:
     - --define=ij_product=clion-beta
     build_targets:
@@ -10,7 +10,7 @@ platforms:
     - --test_output=errors
     test_targets:
     - //:clwb_tests
-  ubuntu1604:
+  ubuntu1804:
     build_flags:
     - --define=ij_product=clion-beta
     build_targets:

--- a/.bazelci/intellij.yml
+++ b/.bazelci/intellij.yml
@@ -1,6 +1,6 @@
 ---
 platforms:
-  ubuntu1404:
+  ubuntu1604:
     build_flags:
     - --define=ij_product=intellij-beta
     build_targets:
@@ -10,7 +10,7 @@ platforms:
     - --test_output=errors
     test_targets:
     - //:ijwb_tests
-  ubuntu1604:
+  ubuntu1804:
     build_flags:
     - --define=ij_product=intellij-beta
     build_targets:


### PR DESCRIPTION
Ubuntu 14.04 is about to be end-of-life and Bazel CI will stop supporting it shortly afterwards.

Context: https://groups.google.com/d/msg/bazel-dev/_D6XzfNkQQE/8TNKiNmsCAAJ
