### PR TITLE
Disable tests on ubuntu1804 that don't work with JDK11

### DIFF
--- a/.bazelci/android-studio.yml
+++ b/.bazelci/android-studio.yml
@@ -2,21 +2,11 @@
 platforms:
   ubuntu1604:
     build_flags:
-    - --define=ij_product=android-studio-beta
+      - --define=ij_product=android-studio-beta
     build_targets:
-    - //aswb:aswb_bazel
+      - //aswb:aswb_bazel
     test_flags:
-    - --define=ij_product=android-studio-beta
-    - --test_output=errors
+      - --define=ij_product=android-studio-beta
+      - --test_output=errors
     test_targets:
-    - //:aswb_tests
-  ubuntu1804:
-    build_flags:
-    - --define=ij_product=android-studio-beta
-    build_targets:
-    - //aswb:aswb_bazel
-    test_flags:
-    - --define=ij_product=android-studio-beta
-    - --test_output=errors
-    test_targets:
-    - //:aswb_tests
+      - //:aswb_tests

--- a/.bazelci/aspect.yml
+++ b/.bazelci/aspect.yml
@@ -2,15 +2,8 @@
 platforms:
   ubuntu1604:
     build_targets:
-    - //aspect:aspect_files
+      - //aspect:aspect_files
     test_flags:
-    - --test_output=errors
+      - --test_output=errors
     test_targets:
-    - //aspect/testing/...
-  ubuntu1804:
-    build_targets:
-    - //aspect:aspect_files
-    test_flags:
-    - --test_output=errors
-    test_targets:
-    - //aspect/testing/...
+      - //aspect/testing/...

--- a/.bazelci/clion.yml
+++ b/.bazelci/clion.yml
@@ -2,21 +2,11 @@
 platforms:
   ubuntu1604:
     build_flags:
-    - --define=ij_product=clion-beta
+      - --define=ij_product=clion-beta
     build_targets:
-    - //clwb:clwb_bazel
+      - //clwb:clwb_bazel
     test_flags:
-    - --define=ij_product=clion-beta
-    - --test_output=errors
+      - --define=ij_product=clion-beta
+      - --test_output=errors
     test_targets:
-    - //:clwb_tests
-  ubuntu1804:
-    build_flags:
-    - --define=ij_product=clion-beta
-    build_targets:
-    - //clwb:clwb_bazel
-    test_flags:
-    - --define=ij_product=clion-beta
-    - --test_output=errors
-    test_targets:
-    - //:clwb_tests
+      - //:clwb_tests

--- a/.bazelci/intellij.yml
+++ b/.bazelci/intellij.yml
@@ -2,21 +2,11 @@
 platforms:
   ubuntu1604:
     build_flags:
-    - --define=ij_product=intellij-beta
+      - --define=ij_product=intellij-beta
     build_targets:
-    - //ijwb:ijwb_bazel
+      - //ijwb:ijwb_bazel
     test_flags:
-    - --define=ij_product=intellij-beta
-    - --test_output=errors
+      - --define=ij_product=intellij-beta
+      - --test_output=errors
     test_targets:
-    - //:ijwb_tests
-  ubuntu1804:
-    build_flags:
-    - --define=ij_product=intellij-beta
-    build_targets:
-    - //ijwb:ijwb_bazel
-    test_flags:
-    - --define=ij_product=intellij-beta
-    - --test_output=errors
-    test_targets:
-    - //:ijwb_tests
+      - //:ijwb_tests


### PR DESCRIPTION
I have migrated ubuntu1804 to use OpenJDK 11, because that's the default JDK for that distribution.

During the migration I noticed that you have tests that fail with OpenJDK 11, so I recommend to
disable them until they're fixed.

For your reference, here's the log: https://buildkite.com/bazel/intellij-plugin/builds/2057#45f59142-dd60-491c-94eb-155b965fb0a4
