### PR TITLE
Fixing an NPE if test runner finished with error.

### DIFF
--- a/base/src/com/google/idea/blaze/base/run/smrunner/BlazeXmlSchema.java
+++ b/base/src/com/google/idea/blaze/base/run/smrunner/BlazeXmlSchema.java
@@ -18,6 +18,8 @@ package com.google.idea.blaze.base.run.smrunner;
 import static java.util.stream.Collectors.joining;
 
 import com.google.common.collect.Lists;
+import org.jetbrains.annotations.Nullable;
+
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
@@ -160,7 +162,11 @@ public class BlazeXmlSchema {
     public ErrorOrFailureOrSkipped skipped;
   }
 
+  @Nullable
   static String getErrorContent(ErrorOrFailureOrSkipped err) {
+    if (err.content == null)
+      return err.message;
+
     return err.content.stream()
         .filter(Objects::nonNull)
         .map(Object::toString)

--- a/base/tests/unittests/com/google/idea/blaze/base/run/smrunner/BlazeXmlSchemaTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/run/smrunner/BlazeXmlSchemaTest.java
@@ -117,6 +117,23 @@ public class BlazeXmlSchemaTest {
   }
 
   @Test
+  public void testTestRunnerTerminatedWithError() {
+    TestSuite parsed =
+        parseXml(
+            "<?xml version='1.0' encoding='UTF-8'?>",
+            "<testsuites>",
+            "  <testsuite name='com.google.ConfigTest' tests='1' failures='0' errors='1'>",
+            "    <testcase name='testCase1' status='run' duration='55' time='55'>",
+                    "<error message='exited with error code 1'></error>",
+            "    </testcase>",
+            "  </testsuite>",
+            "</testsuites>");
+
+    TestCase testCase = parsed.testSuites.get(0).testCases.get(0);
+    assertThat(BlazeXmlSchema.getErrorContent(testCase.errors.get(0))).isEqualTo("exited with error code 1");
+  }
+
+  @Test
   public void testMergeShardedTests() {
     TestSuite shard1 =
         parseXml(


### PR DESCRIPTION
Fixes the test runner spinning indefinitely, caused by an NPE while reading the test.xml of a run that finished with an error. Fixes #732.
