### PR TITLE
Remove confusion with indefinite "Updating in-memory state".

### DIFF
--- a/base/src/com/google/idea/blaze/base/sync/SyncPhaseCoordinator.java
+++ b/base/src/com/google/idea/blaze/base/sync/SyncPhaseCoordinator.java
@@ -354,6 +354,7 @@ final class SyncPhaseCoordinator {
           .setStartTime(startTime)
           .setTotalClockTime(Duration.between(startTime, Instant.now()));
       EventLoggingService.getInstance().log(stats.build());
+      context.output(new StatusOutput("Sync finished"));
       outputTimingSummary(context, stats.getCurrentTimedEvents());
 
     } catch (Throwable e) {


### PR DESCRIPTION
Remove confusion with indefinite "Updating in-memory state".

outputTimingSummary emits nothing if sync happened too quickly,
the last line ends up being
"Updating in-memory state..."
that makes people think it is still ongoing.