### PR TITLE
Update error message to use "Bazel"

### DIFF
--- a/python/src/com/google/idea/blaze/python/run/BlazePyRunConfigurationRunner.java
+++ b/python/src/com/google/idea/blaze/python/run/BlazePyRunConfigurationRunner.java
@@ -310,7 +310,7 @@ public class BlazePyRunConfigurationRunner implements BlazeCommandRunConfigurati
       try {
         BuildResult result = buildOperation.get();
         if (result.status != BuildResult.Status.SUCCESS) {
-          throw new ExecutionException("Blaze failure building debug binary");
+          throw new ExecutionException("Bazel failure building debug binary");
         }
       } catch (InterruptedException | CancellationException e) {
         buildOperation.cancel(true);


### PR DESCRIPTION
Changing error message to use "Bazel" rather than "Blaze" (which is not the external name).

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #802 

# Description of this change

Changes the error message from "Blaze" to "Bazel".