### PR TITLE
Prefetch project files when base CL changes.

### DIFF
--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -419,7 +419,7 @@
     <extensionPoint qualifiedName="com.google.idea.blaze.BinaryContextProvider" interface="com.google.idea.blaze.base.run.producers.BinaryContextProvider"/>
     <extensionPoint qualifiedName="com.google.idea.blaze.HeuristicTestIdentifier" interface="com.google.idea.blaze.base.run.producers.HeuristicTestIdentifier"/>
     <extensionPoint qualifiedName="com.google.idea.blaze.RemoteOutputsCacheProvider" interface="com.google.idea.blaze.base.filecache.RemoteOutputsCache$OutputsProvider"/>
-    <extensionPoint qualifiedName="com.google.idea.blaze.VcsStateListener" interface="com.google.idea.blaze.base.vcs.VcsSyncListener"/>
+    <extensionPoint qualifiedName="com.google.idea.blaze.VcsSyncListener" interface="com.google.idea.blaze.base.vcs.VcsSyncListener"/>
   </extensionPoints>
 
   <extensions defaultExtensionNs="com.google.idea.blaze">
@@ -471,6 +471,7 @@
     <TestContextProvider implementation="com.google.idea.blaze.base.run.producers.OutsideProjectTestContextProvider"/>
     <OutputArtifactParser implementation="com.google.idea.blaze.base.command.buildresult.OutputArtifactParser$LocalFileParser"/>
     <BuildBatchingService implementation="com.google.idea.blaze.base.sync.sharding.BlazeBuildTargetSharder$LexicographicTargetSharder" order="last"/>
+    <VcsSyncListener implementation="com.google.idea.blaze.base.prefetch.PrefetchVcsSyncListener"/>
     <SettingsUiContributor implementation="com.google.idea.blaze.base.settings.ui.BlazeUserSettingsConfigurable$UiContributor" order="first" id="base"/>
   </extensions>
 

--- a/base/src/com/google/idea/blaze/base/prefetch/PrefetchService.java
+++ b/base/src/com/google/idea/blaze/base/prefetch/PrefetchService.java
@@ -43,4 +43,10 @@ public interface PrefetchService {
 
   ListenableFuture<?> prefetchProjectFiles(
       Project project, ProjectViewSet projectViewSet, @Nullable BlazeProjectData blazeProjectData);
+
+  /**
+   * If this prefetch service ignores recently-prefetched files, this instructs it to clear that
+   * 'time since last prefetch' cache.
+   */
+  void clearPrefetchCache();
 }

--- a/base/src/com/google/idea/blaze/base/prefetch/PrefetchServiceImpl.java
+++ b/base/src/com/google/idea/blaze/base/prefetch/PrefetchServiceImpl.java
@@ -57,6 +57,11 @@ public class PrefetchServiceImpl implements PrefetchService {
   }
 
   @Override
+  public void clearPrefetchCache() {
+    fileToLastFetchTimeMillis.clear();
+  }
+
+  @Override
   public ListenableFuture<?> prefetchFiles(
       Collection<File> files, boolean refetchCachedFiles, boolean fetchFileTypes) {
     return prefetchFiles(ImmutableSet.of(), files, refetchCachedFiles, fetchFileTypes);

--- a/base/src/com/google/idea/blaze/base/prefetch/PrefetchVcsSyncListener.java
+++ b/base/src/com/google/idea/blaze/base/prefetch/PrefetchVcsSyncListener.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.prefetch;
+
+import com.google.idea.blaze.base.model.BlazeProjectData;
+import com.google.idea.blaze.base.projectview.ProjectViewManager;
+import com.google.idea.blaze.base.projectview.ProjectViewSet;
+import com.google.idea.blaze.base.settings.Blaze;
+import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
+import com.google.idea.blaze.base.vcs.VcsSyncListener;
+import com.google.idea.common.experiments.BoolExperiment;
+import com.intellij.openapi.project.Project;
+
+/** Kicks off a prefetch task when the base VCS revision/commit/CL/whatever changes. */
+class PrefetchVcsSyncListener implements VcsSyncListener {
+
+  private static final BoolExperiment enabled = new BoolExperiment("prefetch.on.vcs.sync", true);
+
+  @Override
+  public void onVcsSync(Project project) {
+    if (!Blaze.isBlazeProject(project) || !enabled.getValue()) {
+      return;
+    }
+    BlazeProjectData projectData =
+        BlazeProjectDataManager.getInstance(project).getBlazeProjectData();
+    ProjectViewSet projectViewSet = ProjectViewManager.getInstance(project).getProjectViewSet();
+    if (projectViewSet == null) {
+      return;
+    }
+    PrefetchService.getInstance().clearPrefetchCache();
+    PrefetchIndexingTask.submitPrefetchingTask(
+        project,
+        PrefetchService.getInstance().prefetchProjectFiles(project, projectViewSet, projectData),
+        "Prefetching on VCS state change");
+  }
+}

--- a/base/tests/utils/unit/com/google/idea/blaze/base/prefetch/MockPrefetchService.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/prefetch/MockPrefetchService.java
@@ -38,4 +38,7 @@ public class MockPrefetchService implements PrefetchService {
       Project project, ProjectViewSet projectViewSet, @Nullable BlazeProjectData blazeProjectData) {
     return Futures.immediateFuture(null);
   }
+
+  @Override
+  public void clearPrefetchCache() {}
 }


### PR DESCRIPTION
Prefetch project files when base CL changes.

These days I'm commonly seeing code analysis blocked for minutes after syncing, while the IDE is busy refreshing all project files.