### PR TITLE
Add explicit depset to list conversions

### DIFF
--- a/aspect/artifacts.bzl
+++ b/aspect/artifacts.bzl
@@ -14,7 +14,7 @@ def artifacts_from_target_list_attr(ctx, attr_name):
     return [
         artifact_location(f)
         for target in getattr(ctx.rule.attr, attr_name, [])
-        for f in target.files
+        for f in target.files.to_list()
     ]
 
 def artifact_location(f):

--- a/aspect/fast_build_info.bzl
+++ b/aspect/fast_build_info.bzl
@@ -62,7 +62,7 @@ def _fast_build_info_impl(target, ctx):
             java_info["annotation_processor_class_names"] = annotation_processing.processor_classnames
             java_info["annotation_processor_classpath"] = [
                 artifact_location(t)
-                for t in annotation_processing.processor_classpath
+                for t in annotation_processing.processor_classpath.to_list()
             ]
         info["java_info"] = struct_omit_none(**java_info)
     if hasattr(target, "android"):

--- a/aspect/intellij_info_impl.bzl
+++ b/aspect/intellij_info_impl.bzl
@@ -679,7 +679,7 @@ def divide_java_sources(ctx):
     if hasattr(ctx.rule.attr, "srcs"):
         srcs = ctx.rule.attr.srcs
         for src in srcs:
-            for f in src.files:
+            for f in src.files.to_list():
                 if f.basename.endswith(".java"):
                     if f.is_source:
                         java_sources.append(f)
@@ -818,7 +818,10 @@ def intellij_info_aspect_impl(target, ctx, semantics):
     export_deps = []
     if JavaInfo in target:
         transitive_exports = target[JavaInfo].transitive_exports
-        export_deps = [make_dep_from_label(label, COMPILE_TIME) for label in transitive_exports]
+        export_deps = [
+            make_dep_from_label(label, COMPILE_TIME)
+            for label in transitive_exports.to_list()
+        ]
 
         # Empty android libraries export all their dependencies.
         if ctx.rule.kind == "android_library":


### PR DESCRIPTION
Add explicit depset to list conversions

Implicit conversions will be forbidden with upcoming
incompatible_depset_is_not_iterable change in Bazel.