### PR TITLE
Prefer SystemProperties.getUsername() or StandardSystemProperty.USER_NAME.value()

### DIFF
--- a/common/experiments/src/com/google/idea/common/experiments/ExperimentUsernameProvider.java
+++ b/common/experiments/src/com/google/idea/common/experiments/ExperimentUsernameProvider.java
@@ -15,7 +15,7 @@
  */
 package com.google.idea.common.experiments;
 
-import com.google.common.base.StandardSystemProperty;
+import com.intellij.util.SystemProperties;
 import javax.annotation.Nullable;
 
 /**
@@ -33,7 +33,7 @@ final class ExperimentUsernameProvider {
   @Nullable
   static String getUsername() {
     String override = usernameOverride.getValue();
-    return override != null ? override : StandardSystemProperty.USER_NAME.value();
+    return override != null ? override : SystemProperties.getUserName();
   }
 
   static boolean isUsernameOverridden() {

--- a/common/experiments/tests/unittests/com/google/idea/common/experiments/FeatureRolloutExperimentTest.java
+++ b/common/experiments/tests/unittests/com/google/idea/common/experiments/FeatureRolloutExperimentTest.java
@@ -18,8 +18,8 @@ package com.google.idea.common.experiments;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 
-import com.google.common.base.StandardSystemProperty;
 import com.google.idea.testing.IntellijRule;
+import com.intellij.util.SystemProperties;
 import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
@@ -35,17 +35,13 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class FeatureRolloutExperimentTest {
 
-  private static final String USERNAME_PROPERTY = StandardSystemProperty.USER_NAME.key();
-
   @Rule public IntellijRule intellij = new IntellijRule();
 
-  private String initialUserName;
   private MockExperimentService experimentService;
   private FeatureRolloutExperiment rolloutExperiment;
 
   @Before
   public void setUp() {
-    initialUserName = System.getProperty(USERNAME_PROPERTY);
     InternalDevFlag.markUserAsInternalDev(false);
 
     experimentService = new MockExperimentService();
@@ -56,11 +52,7 @@ public class FeatureRolloutExperimentTest {
 
   @After
   public void tearDown() {
-    if (initialUserName != null) {
-      System.setProperty(USERNAME_PROPERTY, initialUserName);
-    } else {
-      System.clearProperty(USERNAME_PROPERTY);
-    }
+    SystemProperties.setTestUserName(null); // Reset to real username
   }
 
   private void setFeatureRolloutPercentage(int percentage) {
@@ -218,7 +210,7 @@ public class FeatureRolloutExperimentTest {
   }
 
   private boolean isEnabled(String userName) {
-    System.setProperty(USERNAME_PROPERTY, userName);
+    SystemProperties.setTestUserName(userName);
     return rolloutExperiment.isEnabled();
   }
 

--- a/testing/src/com/google/idea/testing/BlazeTestSystemPropertiesRule.java
+++ b/testing/src/com/google/idea/testing/BlazeTestSystemPropertiesRule.java
@@ -16,6 +16,7 @@
 package com.google.idea.testing;
 
 import com.google.common.base.Joiner;
+import com.google.common.base.StandardSystemProperty;
 import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 import com.intellij.ide.plugins.PluginManagerCore;
@@ -186,7 +187,7 @@ public class BlazeTestSystemPropertiesRule extends ExternalResource {
       tmpDir = new File(baseTmpDir).getAbsoluteFile();
 
       // .. Add username
-      String username = System.getProperty("user.name");
+      String username = StandardSystemProperty.USER_NAME.value();
       username = username.replace('/', '_');
       username = username.replace('\\', '_');
       username = username.replace('\000', '_');


### PR DESCRIPTION
Prefer SystemProperties.getUsername() or StandardSystemProperty.USER_NAME.value()

SystemProperties.getUsername() supports mocking via SystemProperties#setTestUserName,
so use it whenever code runs in the IDE and mock support makes sense.