### PR TITLE
Allow internal devs to disable specific rollout experiments by setting them to "disabled".

### DIFF
--- a/common/experiments/src/com/google/idea/common/experiments/FeatureRolloutExperiment.java
+++ b/common/experiments/src/com/google/idea/common/experiments/FeatureRolloutExperiment.java
@@ -16,13 +16,15 @@
 package com.google.idea.common.experiments;
 
 import com.google.common.annotations.VisibleForTesting;
+import java.util.Objects;
 import javax.annotation.Nullable;
 
 /**
  * An experiment controlling gradual rollout of a feature. The experiment value must be an integer
  * between 0 and 100, indicating the percentage of users for whom the feature should be active.
  *
- * <p>If no experiment value is found, it will always default to disabled.
+ * <p>If no experiment value is found, it will default to disabled. It will always be enabled for
+ * internal plugin developers, unless the experiment value is set to the string "disabled".
  */
 public class FeatureRolloutExperiment extends Experiment {
 
@@ -32,6 +34,11 @@ public class FeatureRolloutExperiment extends Experiment {
 
   /** Returns true if the feature should be enabled for this user. */
   public boolean isEnabled() {
+    if (Objects.equals(
+        ExperimentService.getInstance().getExperimentString(getKey(), /* defaultValue= */ null),
+        "disabled")) {
+      return false;
+    }
     if (InternalDevFlag.isInternalDev()) {
       return true;
     }

--- a/common/experiments/tests/unittests/com/google/idea/common/experiments/FeatureRolloutExperimentTest.java
+++ b/common/experiments/tests/unittests/com/google/idea/common/experiments/FeatureRolloutExperimentTest.java
@@ -209,6 +209,21 @@ public class FeatureRolloutExperimentTest {
     assertThat(userNames.stream().noneMatch(this::isEnabled)).isTrue();
   }
 
+  @Test
+  public void testAlwaysDisabledWhenExplicitlyDisabled() {
+    List<String> userNames =
+        Stream.generate(FeatureRolloutExperimentTest::generateUsername)
+            .limit(10000)
+            .collect(Collectors.toList());
+    experimentService.setExperimentRaw(rolloutExperiment.getKey(), "disabled");
+
+    InternalDevFlag.markUserAsInternalDev(false);
+    assertThat(userNames.stream().noneMatch(this::isEnabled)).isTrue();
+
+    InternalDevFlag.markUserAsInternalDev(true);
+    assertThat(userNames.stream().noneMatch(this::isEnabled)).isTrue();
+  }
+
   private boolean isEnabled(String userName) {
     SystemProperties.setTestUserName(userName);
     return rolloutExperiment.isEnabled();

--- a/common/experiments/tests/utils/unit/com/google/idea/common/experiments/MockExperimentService.java
+++ b/common/experiments/tests/utils/unit/com/google/idea/common/experiments/MockExperimentService.java
@@ -30,6 +30,10 @@ public class MockExperimentService implements ExperimentService {
   @Override
   public void endExperimentScope() {}
 
+  public void setExperimentRaw(String key, Object value) {
+    experiments.put(key, value);
+  }
+
   public void setExperiment(BoolExperiment experiment, boolean value) {
     experiments.put(experiment.getKey(), value);
   }
@@ -50,7 +54,7 @@ public class MockExperimentService implements ExperimentService {
   @Nullable
   public String getExperimentString(String key, @Nullable String defaultValue) {
     if (experiments.containsKey(key)) {
-      return (String) experiments.get(key);
+      return experiments.get(key).toString();
     }
     return defaultValue;
   }


### PR DESCRIPTION
Allow internal devs to disable specific rollout experiments by setting them to "disabled".