### PR TITLE
Address Bazel's --incompatible_depset_is_not_iterable in build_defs.bzl

### DIFF
--- a/build_defs/build_defs.bzl
+++ b/build_defs/build_defs.bzl
@@ -284,7 +284,7 @@ def _plugin_deploy_zip_impl(ctx):
     for target in ctx.attr.srcs:
         data = target[repackaged_files_data]
         input_files = depset(transitive = [input_files, data.files])
-        for f in data.files:
+        for f in data.files.to_list():
             exec_path_to_zip_path[f.path] = output_path(f, data)
 
     args = []


### PR DESCRIPTION
Address Bazel's --incompatible_depset_is_not_iterable in build_defs.bzl

Fixes https://github.com/bazelbuild/intellij/issues/529

With this change, the Bazel build is compatible with all flags listed in https://github.com/bazelbuild/intellij/issues/529#issue-417792349