### PR TITLE
Improve performance retrieving experiment data

### DIFF
--- a/common/experiments/src/com/google/idea/common/experiments/ExperimentsUtil.java
+++ b/common/experiments/src/com/google/idea/common/experiments/ExperimentsUtil.java
@@ -18,14 +18,18 @@ package com.google.idea.common.experiments;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 final class ExperimentsUtil {
 
   private static final HashFunction HASHER = Hashing.sha512();
+  private static final Map<String, String> hashCache = new ConcurrentHashMap<>();
 
   private ExperimentsUtil() {}
 
   static String hashExperimentName(String name) {
-    return HASHER.hashString(name, StandardCharsets.UTF_8).toString();
+    return hashCache.computeIfAbsent(
+        name, s -> HASHER.hashString(s, StandardCharsets.UTF_8).toString());
   }
 }


### PR DESCRIPTION
Improve performance retrieving experiment data

- keep a global cache of hashed keys
- never calculate experiments list synchronously, instead refresh list every 5 minutes.

This means users will need to start an experiment scope (e.g. by syncing), restart the IDE, or wait 5 minutes to see experiment changes, but that's an acceptable cost.