### PR TITLE
Don't set up filters as part of a post-startup activity, this only works if post-startup activities haven't already been run.

### DIFF
--- a/base/src/com/google/idea/blaze/base/console/BlazeConsoleView.java
+++ b/base/src/com/google/idea/blaze/base/console/BlazeConsoleView.java
@@ -43,7 +43,6 @@ import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.markup.RangeHighlighter;
 import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.startup.StartupManager;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.psi.search.GlobalSearchScope;
@@ -82,17 +81,11 @@ public class BlazeConsoleView implements Disposable {
             /* viewer= */ false,
             /* usePredefinedFilters= */ false);
 
-    Disposer.register(this, consoleView);
-
-    // setup filters after project creation is complete and BlazeImportSettings have been set
-    StartupManager.getInstance(project).registerPostStartupActivity(this::initializeFilters);
-  }
-
-  private void initializeFilters() {
     consoleView.addMessageFilter(customFilters);
     addWrappedPredefinedFilters();
     // add target filter last, so it doesn't override other links containing a target string
     consoleView.addMessageFilter(new BlazeTargetFilter(false));
+    Disposer.register(this, consoleView);
   }
 
   public static BlazeConsoleView getInstance(Project project) {


### PR DESCRIPTION
Don't set up filters as part of a post-startup activity, this only works if post-startup activities haven't already been run.