### PR TITLE
Run gdbserver script under bash manually. Fixes #494.

### DIFF
--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeGDBServerProvider.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeGDBServerProvider.java
@@ -132,8 +132,11 @@ public class BlazeGDBServerProvider {
     if (useRemoteDebuggingWrapper.getValue()) {
       String runUnderOption =
           String.format(
-              "--run_under='%s' '%s' --once localhost:%d --target",
-              GDBSERVER_WRAPPER.getValue(), gdbServerPath, handlerState.getDebugPortState().port);
+              "--run_under='%s' '%s' '%s' --once localhost:%d --target",
+              "bash",
+              GDBSERVER_WRAPPER.getValue(),
+              gdbServerPath,
+              handlerState.getDebugPortState().port);
       builder.add(runUnderOption);
     } else {
       String runUnderOption =


### PR DESCRIPTION
Run gdbserver script under bash manually. Fixes #494.

CLion removes the executable permission on the gdbserver script if the
plugin is installed through the marketplace.