### PR TITLE
Update to Truth 0.45, and address deprecations.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -180,8 +180,8 @@ jvm_maven_import_external(
 
 jvm_maven_import_external(
     name = "truth",
-    artifact = "com.google.truth:truth:0.30",
-    artifact_sha256 = "f4a4c5e69c4994b750ce3ee80adbb2b7150fe39f057d7dff89832c8ca3af512e",
+    artifact = "com.google.truth:truth:0.45",
+    artifact_sha256 = "0f7dced2a16e55a77e44fc3ff9c5be98d4bf4bb30abc18d78ffd735df950a69f",
     licenses = ["notice"],  # Apache 2.0
     server_urls = ["http://central.maven.org/maven2"],
 )

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/general/noide/NoIdeTest.java
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/general/noide/NoIdeTest.java
@@ -34,7 +34,7 @@ public class NoIdeTest extends BazelIntellijAspectTest {
     assertThat(findTarget(testFixture, ":baz")).isNull();
 
     assertThat(getOutputGroupFiles(testFixture, "intellij-info-java"))
-        .containsAllOf(
+        .containsAtLeast(
             testRelative("foo.java-manifest"), testRelative(intellijInfoFileName("foo")));
     assertThat(getOutputGroupFiles(testFixture, "intellij-resolve-java"))
         .containsExactly(

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/java/dependencies/DependenciesTest.java
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/java/dependencies/DependenciesTest.java
@@ -45,7 +45,7 @@ public class DependenciesTest extends BazelIntellijAspectTest {
     assertThat(dependenciesForTarget(target)).contains(dep(":single_dep"));
 
     assertThat(getOutputGroupFiles(testFixture, "intellij-info-java"))
-        .containsAllOf(
+        .containsAtLeast(
             testRelative("foo.java-manifest"),
             testRelative(intellijInfoFileName("foo")),
             testRelative("single_dep.java-manifest"),
@@ -53,7 +53,7 @@ public class DependenciesTest extends BazelIntellijAspectTest {
             testRelative("transitive_dep.java-manifest"),
             testRelative(intellijInfoFileName("transitive_dep")));
     assertThat(getOutputGroupFiles(testFixture, "intellij-resolve-java"))
-        .containsAllOf(
+        .containsAtLeast(
             testRelative("libfoo.jar"),
             testRelative("libfoo-hjar.jar"),
             testRelative("libfoo-src.jar"),
@@ -64,7 +64,7 @@ public class DependenciesTest extends BazelIntellijAspectTest {
             testRelative("libtransitive_dep-hjar.jar"),
             testRelative("libtransitive_dep-src.jar"));
     assertThat(getOutputGroupFiles(testFixture, "intellij-compile-java"))
-        .containsAllOf(
+        .containsAtLeast(
             testRelative("libfoo.jar"),
             testRelative("libsingle_dep.jar"),
             testRelative("libtransitive_dep.jar"));
@@ -77,7 +77,7 @@ public class DependenciesTest extends BazelIntellijAspectTest {
     IntellijAspectTestFixture testFixture = loadTestFixture(":diamond_dep_fixture");
     TargetIdeInfo target = findTarget(testFixture, ":diamond_dep");
     assertThat(dependenciesForTarget(target))
-        .containsAllOf(dep(":single_dep"), dep(":single_dep_sibling"));
+        .containsAtLeast(dep(":single_dep"), dep(":single_dep_sibling"));
   }
 
   @Test
@@ -91,10 +91,10 @@ public class DependenciesTest extends BazelIntellijAspectTest {
     assertThat(dependenciesForTarget(fooExporter)).contains(dep(":foo"));
 
     assertThat(dependenciesForTarget(exportConsumer))
-        .containsAllOf(dep(":foo_exporter"), dep(":foo"));
+        .containsAtLeast(dep(":foo_exporter"), dep(":foo"));
 
     assertThat(getOutputGroupFiles(testFixture, "intellij-info-java"))
-        .containsAllOf(
+        .containsAtLeast(
             testRelative("foo.java-manifest"),
             testRelative(intellijInfoFileName("foo")),
             testRelative("foo_exporter.java-manifest"),
@@ -102,7 +102,7 @@ public class DependenciesTest extends BazelIntellijAspectTest {
             testRelative("export_consumer.java-manifest"),
             testRelative(intellijInfoFileName("export_consumer")));
     assertThat(getOutputGroupFiles(testFixture, "intellij-resolve-java"))
-        .containsAllOf(
+        .containsAtLeast(
             testRelative("libfoo.jar"),
             testRelative("libfoo-hjar.jar"),
             testRelative("libfoo-src.jar"),
@@ -113,7 +113,7 @@ public class DependenciesTest extends BazelIntellijAspectTest {
             testRelative("libexport_consumer-hjar.jar"),
             testRelative("libexport_consumer-src.jar"));
     assertThat(getOutputGroupFiles(testFixture, "intellij-compile-java"))
-        .containsAllOf(
+        .containsAtLeast(
             testRelative("libfoo.jar"),
             testRelative("libfoo_exporter.jar"),
             testRelative("libexport_consumer.jar"));
@@ -125,7 +125,7 @@ public class DependenciesTest extends BazelIntellijAspectTest {
     TargetIdeInfo transitiveExportConsumer = findTarget(testFixture, ":transitive_export_consumer");
 
     assertThat(dependenciesForTarget(transitiveExportConsumer))
-        .containsAllOf(dep(":foo"), dep(":foo_exporter"), dep(":foo_exporter_exporter"));
+        .containsAtLeast(dep(":foo"), dep(":foo_exporter"), dep(":foo_exporter_exporter"));
   }
 
   @Test

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/java/genjars/GenJarsTest.java
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/java/genjars/GenJarsTest.java
@@ -55,14 +55,14 @@ public class GenJarsTest extends BazelIntellijAspectTest {
                 testRelative("libhas_plugin-gensrc.jar")));
 
     assertThat(getOutputGroupFiles(testFixture, "intellij-info-java"))
-        .containsAllOf(
+        .containsAtLeast(
             testRelative("has_plugin.java-manifest"),
             testRelative(intellijInfoFileName("has_plugin")));
     assertThat(getOutputGroupFiles(testFixture, "intellij-resolve-java"))
-        .containsAllOf(
+        .containsAtLeast(
             testRelative("libhas_plugin-gen.jar"), testRelative("libhas_plugin-gensrc.jar"));
     assertThat(getOutputGroupFiles(testFixture, "intellij-compile-java"))
-        .containsAllOf(testRelative("libhas_plugin.jar"), testRelative("libhas_plugin-gen.jar"));
+        .containsAtLeast(testRelative("libhas_plugin.jar"), testRelative("libhas_plugin-gen.jar"));
 
     assertThat(getOutputGroupFiles(testFixture, "intellij-info-generic")).isEmpty();
   }

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/java/javabinary/JavaBinaryTest.java
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/java/javabinary/JavaBinaryTest.java
@@ -51,13 +51,13 @@ public class JavaBinaryTest extends BazelIntellijAspectTest {
     assertThat(binaryInfo.getJavaIdeInfo().getMainClass()).isEqualTo("com.google.MyMainClass");
 
     assertThat(getOutputGroupFiles(testFixture, "intellij-info-java"))
-        .containsAllOf(
+        .containsAtLeast(
             testRelative("foolib.java-manifest"),
             testRelative(intellijInfoFileName("foolib")),
             testRelative("foo.java-manifest"),
             testRelative(intellijInfoFileName("foo")));
     assertThat(getOutputGroupFiles(testFixture, "intellij-resolve-java"))
-        .containsAllOf(
+        .containsAtLeast(
             testRelative("libfoolib.jar"),
             testRelative("libfoolib-hjar.jar"),
             testRelative("libfoolib-src.jar"),

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/java/javalibrary/JavaLibraryTest.java
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/java/javalibrary/JavaLibraryTest.java
@@ -57,7 +57,7 @@ public class JavaLibraryTest extends BazelIntellijAspectTest {
                 testRelative("libsimple-src.jar")));
 
     assertThat(getOutputGroupFiles(testFixture, "intellij-info-java"))
-        .containsAllOf(
+        .containsAtLeast(
             testRelative("simple.java-manifest"), testRelative(intellijInfoFileName("simple")));
     assertThat(getOutputGroupFiles(testFixture, "intellij-resolve-java"))
         .containsExactly(

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/java/javatest/JavaTestTest.java
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/java/javatest/JavaTestTest.java
@@ -48,15 +48,15 @@ public class JavaTestTest extends BazelIntellijAspectTest {
             jarString(testRelative("FooTest.jar"), null, testRelative("FooTest-src.jar")));
 
     assertThat(getOutputGroupFiles(testFixture, "intellij-info-java"))
-        .containsAllOf(
+        .containsAtLeast(
             testRelative("FooTest.java-manifest"), testRelative(intellijInfoFileName("FooTest")));
     assertThat(getOutputGroupFiles(testFixture, "intellij-resolve-java"))
-        .containsAllOf(testRelative("FooTest.jar"), testRelative("FooTest-src.jar"));
+        .containsAtLeast(testRelative("FooTest.jar"), testRelative("FooTest-src.jar"));
     assertThat(getOutputGroupFiles(testFixture, "intellij-compile-java"))
         .contains(testRelative("FooTest.jar"));
 
     assertThat(getOutputGroupFiles(testFixture, "intellij-info-java"))
-        .containsAllOf(
+        .containsAtLeast(
             testRelative("FooTest.java-manifest"), testRelative(intellijInfoFileName("FooTest")));
     assertThat(getOutputGroupFiles(testFixture, "intellij-info-generic")).isEmpty();
 

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/scala/scalabinary/ScalaBinaryTest.java
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/scala/scalabinary/ScalaBinaryTest.java
@@ -44,13 +44,13 @@ public class ScalaBinaryTest extends BazelIntellijAspectTest {
     assertThat(binaryInfo.getJavaIdeInfo().getMainClass()).isEqualTo("com.google.MyMainClass");
 
     assertThat(getOutputGroupFiles(testFixture, "intellij-info-java"))
-        .containsAllOf(
+        .containsAtLeast(
             testRelative(intellijInfoFileName("foolib")),
             testRelative(intellijInfoFileName("foo")));
     assertThat(getOutputGroupFiles(testFixture, "intellij-resolve-java"))
-        .containsAllOf(testRelative("foolib.jar"), testRelative("foo.jar"));
+        .containsAtLeast(testRelative("foolib.jar"), testRelative("foo.jar"));
     assertThat(getOutputGroupFiles(testFixture, "intellij-compile-java"))
-        .containsAllOf(testRelative("foolib.jar"), testRelative("foo.jar"));
+        .containsAtLeast(testRelative("foolib.jar"), testRelative("foo.jar"));
     assertThat(getOutputGroupFiles(testFixture, "intellij-info-generic")).isEmpty();
   }
 }


### PR DESCRIPTION
Update to Truth 0.45, and address deprecations.

Renames may include:
- containsAllOf => containsAtLeast
- containsAllIn => containsAtLeastElementsIn
- isSameAs => isSameInstanceAs
- isOrdered => isInOrder
- isStrictlyOrdered => isInStrictOrder

The other major change is to change custom subjects to extend raw Subject instead of supplying type parameters. The type parameters are being removed from Subject. This CL will temporarily produce rawtypes warnings, which will go away when I remove the type parameters (as soon as this batch of CLs is submitted).

Some CLs in this batch also migrate calls away from actualAsString(). Its literal replacement is `"<" + actual + ">"` (unless an object overrides actualCustomStringRepresentation()), but usually I've made a larger change, such as switching from an old-style "Not true that..." failure message to one generated with the Fact API. In that case, the new code usually contains a direct reference to this.actual (a field that I occasionally had to create). Another larger change I sometimes made is to switch from a manual check-and-fail approach to instead use check(...). And sometimes I just remove a withMessage() call that's no longer necessary now that the code uses check(...), or I introduce a check(...) call. (An assertion made with check(...) automatically includes the actual value from the original subject, so there's no need to set it again with withMessage().)