### PR TITLE
Use a consistent truth version for third_party aspect tests

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -180,8 +180,8 @@ jvm_maven_import_external(
 
 jvm_maven_import_external(
     name = "truth",
-    artifact = "com.google.truth:truth:0.30",
-    artifact_sha256 = "f4a4c5e69c4994b750ce3ee80adbb2b7150fe39f057d7dff89832c8ca3af512e",
+    artifact = "com.google.truth:truth:0.42",
+    artifact_sha256 = "dd652bdf0c4427c59848ac0340fd6b6d20c2cbfaa3c569a8366604dbcda5214c",
     licenses = ["notice"],  # Apache 2.0
     server_urls = ["http://central.maven.org/maven2"],
 )

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/cpp/ccbinary/BUILD
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/cpp/ccbinary/BUILD
@@ -24,8 +24,8 @@ java_test(
         "//aspect/testing:guava",
         "//aspect/testing/rules:IntellijAspectTest",
         "//aspect/testing/rules:intellij_aspect_test_fixture_java_proto",
+        "//intellij_platform_sdk:test_libs",
         "//proto:intellij_ide_info_java_proto",
         "@junit//jar",
-        "@truth//jar",
     ],
 )

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/cpp/cclibrary/BUILD
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/cpp/cclibrary/BUILD
@@ -63,8 +63,8 @@ java_test(
         "//aspect/testing:guava",
         "//aspect/testing/rules:IntellijAspectTest",
         "//aspect/testing/rules:intellij_aspect_test_fixture_java_proto",
+        "//intellij_platform_sdk:test_libs",
         "//proto:intellij_ide_info_java_proto",
         "@junit//jar",
-        "@truth//jar",
     ],
 )

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/cpp/cctest/BUILD
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/cpp/cctest/BUILD
@@ -24,8 +24,8 @@ java_test(
         "//aspect/testing:guava",
         "//aspect/testing/rules:IntellijAspectTest",
         "//aspect/testing/rules:intellij_aspect_test_fixture_java_proto",
+        "//intellij_platform_sdk:test_libs",
         "//proto:intellij_ide_info_java_proto",
         "@junit//jar",
-        "@truth//jar",
     ],
 )

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/cpp/cctoolchain/BUILD
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/cpp/cctoolchain/BUILD
@@ -25,8 +25,8 @@ java_test(
         "//aspect/testing:guava",
         "//aspect/testing/rules:IntellijAspectTest",
         "//aspect/testing/rules:intellij_aspect_test_fixture_java_proto",
+        "//intellij_platform_sdk:test_libs",
         "//proto:intellij_ide_info_java_proto",
         "@junit//jar",
-        "@truth//jar",
     ],
 )

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/cpp/coptsmakevars/BUILD
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/cpp/coptsmakevars/BUILD
@@ -30,8 +30,8 @@ java_test(
         "//aspect/testing:guava",
         "//aspect/testing/rules:IntellijAspectTest",
         "//aspect/testing/rules:intellij_aspect_test_fixture_java_proto",
+        "//intellij_platform_sdk:test_libs",
         "//proto:intellij_ide_info_java_proto",
         "@junit//jar",
-        "@truth//jar",
     ],
 )

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/general/alias/BUILD
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/general/alias/BUILD
@@ -40,8 +40,8 @@ java_test(
         "//aspect/testing:guava",
         "//aspect/testing/rules:IntellijAspectTest",
         "//aspect/testing/rules:intellij_aspect_test_fixture_java_proto",
+        "//intellij_platform_sdk:test_libs",
         "//proto:intellij_ide_info_java_proto",
         "@junit//jar",
-        "@truth//jar",
     ],
 )

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/general/artifacts/BUILD
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/general/artifacts/BUILD
@@ -40,8 +40,8 @@ java_test(
         "//aspect/testing:guava",
         "//aspect/testing/rules:IntellijAspectTest",
         "//aspect/testing/rules:intellij_aspect_test_fixture_java_proto",
+        "//intellij_platform_sdk:test_libs",
         "//proto:intellij_ide_info_java_proto",
         "@junit//jar",
-        "@truth//jar",
     ],
 )

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/general/build/BUILD
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/general/build/BUILD
@@ -24,8 +24,8 @@ java_test(
         "//aspect/testing:guava",
         "//aspect/testing/rules:IntellijAspectTest",
         "//aspect/testing/rules:intellij_aspect_test_fixture_java_proto",
+        "//intellij_platform_sdk:test_libs",
         "//proto:intellij_ide_info_java_proto",
         "@junit//jar",
-        "@truth//jar",
     ],
 )

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/general/noide/BUILD
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/general/noide/BUILD
@@ -40,8 +40,8 @@ java_test(
         "//aspect/testing:guava",
         "//aspect/testing/rules:IntellijAspectTest",
         "//aspect/testing/rules:intellij_aspect_test_fixture_java_proto",
+        "//intellij_platform_sdk:test_libs",
         "//proto:intellij_ide_info_java_proto",
         "@junit//jar",
-        "@truth//jar",
     ],
 )

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/general/tags/BUILD
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/general/tags/BUILD
@@ -32,8 +32,8 @@ java_test(
         "//aspect/testing:guava",
         "//aspect/testing/rules:IntellijAspectTest",
         "//aspect/testing/rules:intellij_aspect_test_fixture_java_proto",
+        "//intellij_platform_sdk:test_libs",
         "//proto:intellij_ide_info_java_proto",
         "@junit//jar",
-        "@truth//jar",
     ],
 )

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/java/dependencies/BUILD
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/java/dependencies/BUILD
@@ -112,8 +112,8 @@ java_test(
         "//aspect/testing:guava",
         "//aspect/testing/rules:IntellijAspectTest",
         "//aspect/testing/rules:intellij_aspect_test_fixture_java_proto",
+        "//intellij_platform_sdk:test_libs",
         "//proto:intellij_ide_info_java_proto",
         "@junit//jar",
-        "@truth//jar",
     ],
 )

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/java/filteredgenjar/BUILD
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/java/filteredgenjar/BUILD
@@ -57,8 +57,8 @@ java_test(
         "//aspect/testing:guava",
         "//aspect/testing/rules:IntellijAspectTest",
         "//aspect/testing/rules:intellij_aspect_test_fixture_java_proto",
+        "//intellij_platform_sdk:test_libs",
         "//proto:intellij_ide_info_java_proto",
         "@junit//jar",
-        "@truth//jar",
     ],
 )

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/java/genjars/BUILD
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/java/genjars/BUILD
@@ -38,8 +38,8 @@ java_test(
         "//aspect/testing:guava",
         "//aspect/testing/rules:IntellijAspectTest",
         "//aspect/testing/rules:intellij_aspect_test_fixture_java_proto",
+        "//intellij_platform_sdk:test_libs",
         "//proto:intellij_ide_info_java_proto",
         "@junit//jar",
-        "@truth//jar",
     ],
 )

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/java/javabinary/BUILD
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/java/javabinary/BUILD
@@ -31,8 +31,8 @@ java_test(
         "//aspect/testing:guava",
         "//aspect/testing/rules:IntellijAspectTest",
         "//aspect/testing/rules:intellij_aspect_test_fixture_java_proto",
+        "//intellij_platform_sdk:test_libs",
         "//proto:intellij_ide_info_java_proto",
         "@junit//jar",
-        "@truth//jar",
     ],
 )

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/java/javalibrary/BUILD
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/java/javalibrary/BUILD
@@ -24,8 +24,8 @@ java_test(
         "//aspect/testing:guava",
         "//aspect/testing/rules:IntellijAspectTest",
         "//aspect/testing/rules:intellij_aspect_test_fixture_java_proto",
+        "//intellij_platform_sdk:test_libs",
         "//proto:intellij_ide_info_java_proto",
         "@junit//jar",
-        "@truth//jar",
     ],
 )

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/java/javaplugin/BUILD
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/java/javaplugin/BUILD
@@ -25,8 +25,8 @@ java_test(
         "//aspect/testing:guava",
         "//aspect/testing/rules:IntellijAspectTest",
         "//aspect/testing/rules:intellij_aspect_test_fixture_java_proto",
+        "//intellij_platform_sdk:test_libs",
         "//proto:intellij_ide_info_java_proto",
         "@junit//jar",
-        "@truth//jar",
     ],
 )

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/java/javatest/BUILD
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/java/javatest/BUILD
@@ -30,9 +30,9 @@ java_test(
         "//aspect/testing:guava",
         "//aspect/testing/rules:IntellijAspectTest",
         "//aspect/testing/rules:intellij_aspect_test_fixture_java_proto",
+        "//intellij_platform_sdk:test_libs",
         "//proto:intellij_ide_info_java_proto",
         "@junit//jar",
-        "@truth//jar",
     ],
 )
 
@@ -77,8 +77,8 @@ java_test(
         "//aspect/testing:guava",
         "//aspect/testing/rules:FastBuildAspectLoader",
         "//aspect/testing/rules:fast_build_aspect_test_fixture_java_proto",
+        "//intellij_platform_sdk:test_libs",
         "//proto:fast_build_info_java_proto",
         "@junit//jar",
-        "@truth//jar",
     ],
 )

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/proto/jpl/BUILD
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/proto/jpl/BUILD
@@ -43,8 +43,8 @@ java_test(
         "//aspect/testing:guava",
         "//aspect/testing/rules:IntellijAspectTest",
         "//aspect/testing/rules:intellij_aspect_test_fixture_java_proto",
+        "//intellij_platform_sdk:test_libs",
         "//proto:intellij_ide_info_java_proto",
         "@junit//jar",
-        "@truth//jar",
     ],
 )

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/python/pybinary/BUILD
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/python/pybinary/BUILD
@@ -59,8 +59,8 @@ java_test(
         "//aspect/testing:guava",
         "//aspect/testing/rules:IntellijAspectTest",
         "//aspect/testing/rules:intellij_aspect_test_fixture_java_proto",
+        "//intellij_platform_sdk:test_libs",
         "//proto:intellij_ide_info_java_proto",
         "@junit//jar",
-        "@truth//jar",
     ],
 )

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/python/pylibrary/BUILD
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/python/pylibrary/BUILD
@@ -24,8 +24,8 @@ java_test(
         "//aspect/testing:guava",
         "//aspect/testing/rules:IntellijAspectTest",
         "//aspect/testing/rules:intellij_aspect_test_fixture_java_proto",
+        "//intellij_platform_sdk:test_libs",
         "//proto:intellij_ide_info_java_proto",
         "@junit//jar",
-        "@truth//jar",
     ],
 )

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/python/pytest/BUILD
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/python/pytest/BUILD
@@ -25,8 +25,8 @@ java_test(
         "//aspect/testing:guava",
         "//aspect/testing/rules:IntellijAspectTest",
         "//aspect/testing/rules:intellij_aspect_test_fixture_java_proto",
+        "//intellij_platform_sdk:test_libs",
         "//proto:intellij_ide_info_java_proto",
         "@junit//jar",
-        "@truth//jar",
     ],
 )

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/scala/scalabinary/BUILD
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/scala/scalabinary/BUILD
@@ -6,8 +6,8 @@ load(
 )
 load(
     "@io_bazel_rules_scala//scala:scala.bzl",
-    "scala_library",
     "scala_binary",
+    "scala_library",
 )
 
 scala_library(
@@ -36,8 +36,8 @@ java_test(
         "//aspect/testing:guava",
         "//aspect/testing/rules:IntellijAspectTest",
         "//aspect/testing/rules:intellij_aspect_test_fixture_java_proto",
+        "//intellij_platform_sdk:test_libs",
         "//proto:intellij_ide_info_java_proto",
         "@junit//jar",
-        "@truth//jar",
     ],
 )

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/scala/scalalibrary/BUILD
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/scala/scalalibrary/BUILD
@@ -27,8 +27,8 @@ java_test(
         "//aspect/testing:BazelIntellijAspectTest",
         "//aspect/testing/rules:IntellijAspectTest",
         "//aspect/testing/rules:intellij_aspect_test_fixture_java_proto",
+        "//intellij_platform_sdk:test_libs",
         "//proto:intellij_ide_info_java_proto",
         "@junit//jar",
-        "@truth//jar",
     ],
 )

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/scala/scalamacrolibrary/BUILD
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/scala/scalamacrolibrary/BUILD
@@ -27,8 +27,8 @@ java_test(
         "//aspect/testing:BazelIntellijAspectTest",
         "//aspect/testing/rules:IntellijAspectTest",
         "//aspect/testing/rules:intellij_aspect_test_fixture_java_proto",
+        "//intellij_platform_sdk:test_libs",
         "//proto:intellij_ide_info_java_proto",
         "@junit//jar",
-        "@truth//jar",
     ],
 )

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/scala/scalatest/BUILD
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/scala/scalatest/BUILD
@@ -29,8 +29,8 @@ java_test(
         "//aspect/testing:guava",
         "//aspect/testing/rules:IntellijAspectTest",
         "//aspect/testing/rules:intellij_aspect_test_fixture_java_proto",
+        "//intellij_platform_sdk:test_libs",
         "//proto:intellij_ide_info_java_proto",
         "@junit//jar",
-        "@truth//jar",
     ],
 )


### PR DESCRIPTION
Use a consistent truth version for third_party aspect tests