### PR TITLE
Don't use BlazeAutoAndroidDebugger by default.

### DIFF
--- a/aswb/src/com/google/idea/blaze/android/cppimpl/debug/BlazeAutoAndroidDebugger.java
+++ b/aswb/src/com/google/idea/blaze/android/cppimpl/debug/BlazeAutoAndroidDebugger.java
@@ -59,4 +59,10 @@ class BlazeAutoAndroidDebugger extends AutoAndroidDebugger {
   public String getDisplayName() {
     return ID;
   }
+
+  @Override
+  public boolean shouldBeDefault() {
+    // TODO b/134190522 Set as default again when blaze native debugger works.
+    return false;
+  }
 }


### PR DESCRIPTION
Don't use BlazeAutoAndroidDebugger by default.