### PR TITLE
Ensure target is up to date in android run config handler.

### DIFF
--- a/aswb/src/com/google/idea/blaze/android/run/BlazeAndroidRunConfigurationHandler.java
+++ b/aswb/src/com/google/idea/blaze/android/run/BlazeAndroidRunConfigurationHandler.java
@@ -18,7 +18,11 @@ package com.google.idea.blaze.android.run;
 import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.run.BlazeCommandRunConfiguration;
 import com.google.idea.blaze.base.run.confighandler.BlazeCommandRunConfigurationHandler;
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.RunnerAndConfigurationSettings;
+import com.intellij.execution.configurations.RunConfiguration;
 import com.intellij.execution.configurations.RunProfile;
+import com.intellij.execution.runners.ExecutionEnvironment;
 import org.jetbrains.annotations.Nullable;
 
 /** Common interface for Blaze Android run configuration handlers. */
@@ -51,4 +55,21 @@ public interface BlazeAndroidRunConfigurationHandler extends BlazeCommandRunConf
    */
   @Nullable
   Label getLabel();
+
+  /** Extract {@link BlazeCommandRunConfiguration} from the execution environment. */
+  static BlazeCommandRunConfiguration getCommandConfig(ExecutionEnvironment env)
+      throws ExecutionException {
+    RunnerAndConfigurationSettings settings = env.getRunnerAndConfigurationSettings();
+    if (settings == null) {
+      throw new ExecutionException(
+          "Invalid run configuration. Is the project sync state out of date?");
+    }
+    RunConfiguration configFromEnv = settings.getConfiguration();
+    if (!(configFromEnv instanceof BlazeCommandRunConfiguration)) {
+      throw new ExecutionException(
+          "Invalid run configurations. Is the project sync state out of date?");
+    }
+
+    return (BlazeCommandRunConfiguration) configFromEnv;
+  }
 }

--- a/aswb/src/com/google/idea/blaze/android/run/BlazeAndroidRunConfigurationValidationUtil.java
+++ b/aswb/src/com/google/idea/blaze/android/run/BlazeAndroidRunConfigurationValidationUtil.java
@@ -17,15 +17,9 @@ package com.google.idea.blaze.android.run;
 
 import com.android.tools.idea.project.AndroidProjectInfo;
 import com.android.tools.idea.run.ValidationError;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
-import com.google.idea.blaze.base.dependencies.TargetInfo;
-import com.google.idea.blaze.base.model.primitives.Kind;
-import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.projectview.ProjectViewSet;
-import com.google.idea.blaze.base.run.targetfinder.TargetFinder;
-import com.google.idea.blaze.base.settings.Blaze;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.RuntimeConfigurationError;
 import com.intellij.execution.configurations.RuntimeConfigurationException;
@@ -33,7 +27,6 @@ import com.intellij.execution.configurations.RuntimeConfigurationWarning;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import java.util.List;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.jetbrains.android.facet.AndroidFacet;
 import org.jetbrains.android.util.AndroidBundle;
@@ -89,29 +82,6 @@ public final class BlazeAndroidRunConfigurationValidationUtil {
     }
     if (facet.getConfiguration().getAndroidPlatform() == null) {
       errors.add(ValidationError.fatal(AndroidBundle.message("select.platform.error")));
-    }
-    return errors;
-  }
-
-  public static List<ValidationError> validateLabel(
-      @Nullable Label label, Project project, ImmutableList<Kind> kinds) {
-    List<ValidationError> errors = Lists.newArrayList();
-    if (label == null) {
-      errors.add(ValidationError.fatal("No target selected."));
-      return errors;
-    }
-    TargetInfo target = TargetFinder.findTargetInfo(project, label);
-    if (target == null) {
-      errors.add(
-          ValidationError.fatal(
-              String.format("No existing %s rule selected.", Blaze.buildSystemName(project))));
-    } else if (target.getKind() == null || !kinds.contains(target.getKind())) {
-      errors.add(
-          ValidationError.fatal(
-              String.format(
-                  "Selected %s rule is not one of: %s",
-                  Blaze.buildSystemName(project),
-                  kinds.stream().map(Kind::toString).collect(Collectors.joining(", ")))));
     }
     return errors;
   }

--- a/aswb/src/com/google/idea/blaze/android/run/binary/BlazeAndroidBinaryRunConfigurationHandler.java
+++ b/aswb/src/com/google/idea/blaze/android/run/binary/BlazeAndroidBinaryRunConfigurationHandler.java
@@ -42,7 +42,6 @@ import com.google.idea.blaze.base.run.ExecutorType;
 import com.google.idea.blaze.base.run.confighandler.BlazeCommandRunConfigurationRunner;
 import com.google.idea.blaze.base.run.state.RunConfigurationState;
 import com.google.idea.blaze.base.settings.Blaze;
-import com.google.idea.blaze.java.AndroidBlazeRules;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.Executor;
 import com.intellij.execution.RunManager;
@@ -118,6 +117,22 @@ public class BlazeAndroidBinaryRunConfigurationHandler
       Executor executor, ExecutionEnvironment env) throws ExecutionException {
     Project project = env.getProject();
 
+    // This is a workaround for b/134587683
+    // Due to the way blaze run configuration editors update the underlying configuration state,
+    // it's possible for the configuration referenced in this handler to be out of date. This can
+    // cause tricky side-effects such as incorrect build target and target validation settings.
+    // Fortunately, the only field that can come out of sync is the target label and it's target
+    // kind. The handlers are designed to only handle their supported target kinds, so we can
+    // safely ignore all fields other than target label itself and extract an up to date target
+    // label from the execution environment.
+    // Validation of the updated target label is not needed here because:
+    // 1. The target kind is guaranteed to be an android instrumentation test kind or else this
+    //    specific handler will not be used.
+    // 2. Any other validation is done during edit-time of the run configuration before saving.
+    BlazeCommandRunConfiguration configFromEnv =
+        BlazeAndroidRunConfigurationHandler.getCommandConfig(env);
+    configuration.setTarget(configFromEnv.getTarget());
+
     Module module = getModule();
     AndroidFacet facet = module != null ? AndroidFacet.getInstance(module) : null;
     ProjectViewSet projectViewSet = ProjectViewManager.getInstance(project).getProjectViewSet();
@@ -189,11 +204,6 @@ public class BlazeAndroidBinaryRunConfigurationHandler
       errors.addAll(BlazeAndroidRunConfigurationValidationUtil.validateFacet(facet, module));
     }
     errors.addAll(configState.validate(facet));
-    errors.addAll(
-        BlazeAndroidRunConfigurationValidationUtil.validateLabel(
-            getLabel(),
-            configuration.getProject(),
-            ImmutableList.of(AndroidBlazeRules.RuleTypes.ANDROID_BINARY.getKind())));
     return errors;
   }
 


### PR DESCRIPTION
Ensure target is up to date in android run config handler.

Due to the way blaze run configuration editors update the underlying
configuration state, it's possible for the configuration referenced in
android run config handlers to be out of date. This can cause tricky
side-effects such as incorrect build target being build during test.