### PR TITLE
Cleanup: package target data together as a top-level BlazeProjectData message.

### DIFF
--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -466,9 +466,7 @@
     <AutoSyncProvider implementation="com.google.idea.blaze.base.sync.autosync.BuildFileAutoSyncProvider"/>
     <AutoSyncProvider implementation="com.google.idea.blaze.base.sync.autosync.ProtoAutoSyncProvider"/>
     <WorkspacePathResolverExtractor implementation="com.google.idea.blaze.base.sync.workspace.WorkspacePathResolverImpl$Extractor"/>
-    <SyncDataExtractor implementation="com.google.idea.blaze.base.sync.aspects.BlazeIdeInterfaceState$Extractor"/>
     <SyncDataExtractor implementation="com.google.idea.blaze.base.lang.buildfile.sync.LanguageSpecResult$Extractor"/>
-    <SyncDataExtractor implementation="com.google.idea.blaze.base.model.RemoteOutputArtifacts$Extractor"/>
     <LoggedSettingsProvider implementation="com.google.idea.blaze.base.settings.BlazeUserSettings$SettingsLogger" id="BlazeUserSettingsLogger"/>
     <LoggedSettingsProvider implementation="com.google.idea.blaze.base.sync.autosync.AutoSyncSettings$SettingsLogger" order="after BlazeUserSettingsLogger"/>
     <TargetKindProvider implementation="com.google.idea.blaze.base.model.primitives.GenericBlazeRules"/>

--- a/base/src/com/google/idea/blaze/base/model/BlazeProjectData.java
+++ b/base/src/com/google/idea/blaze/base/model/BlazeProjectData.java
@@ -21,6 +21,7 @@ import com.google.idea.blaze.base.command.info.BlazeInfo;
 import com.google.idea.blaze.base.ideinfo.ProtoWrapper;
 import com.google.idea.blaze.base.ideinfo.TargetMap;
 import com.google.idea.blaze.base.settings.BuildSystem;
+import com.google.idea.blaze.base.sync.aspects.BlazeIdeInterfaceState;
 import com.google.idea.blaze.base.sync.projectview.WorkspaceLanguageSettings;
 import com.google.idea.blaze.base.sync.workspace.ArtifactLocationDecoder;
 import com.google.idea.blaze.base.sync.workspace.ArtifactLocationDecoderImpl;
@@ -39,7 +40,7 @@ import javax.annotation.concurrent.Immutable;
 /** The top-level object serialized to cache. */
 @Immutable
 public final class BlazeProjectData implements ProtoWrapper<ProjectData.BlazeProjectData> {
-  private final TargetMap targetMap;
+  private final ProjectTargetData targetData;
   private final BlazeInfo blazeInfo;
   private final BlazeVersionData blazeVersionData;
   private final WorkspacePathResolver workspacePathResolver;
@@ -48,14 +49,14 @@ public final class BlazeProjectData implements ProtoWrapper<ProjectData.BlazePro
   private final SyncState syncState;
 
   public BlazeProjectData(
-      TargetMap targetMap,
+      ProjectTargetData targetData,
       BlazeInfo blazeInfo,
       BlazeVersionData blazeVersionData,
       WorkspacePathResolver workspacePathResolver,
       ArtifactLocationDecoder artifactLocationDecoder,
       WorkspaceLanguageSettings workspaceLanguageSettings,
       SyncState syncState) {
-    this.targetMap = targetMap;
+    this.targetData = targetData;
     this.blazeInfo = blazeInfo;
     this.blazeVersionData = blazeVersionData;
     this.workspacePathResolver = workspacePathResolver;
@@ -70,23 +71,36 @@ public final class BlazeProjectData implements ProtoWrapper<ProjectData.BlazePro
     BlazeInfo blazeInfo = BlazeInfo.fromProto(buildSystem, proto.getBlazeInfo());
     WorkspacePathResolver workspacePathResolver =
         WorkspacePathResolver.fromProto(proto.getWorkspacePathResolver());
-    SyncState syncState = SyncState.fromProto(proto.getSyncState());
-    RemoteOutputArtifacts remoteOutputs =
-        syncState.getOptional(RemoteOutputArtifacts.class).orElse(RemoteOutputArtifacts.EMPTY);
+    ProjectTargetData targetData = parseTargetData(proto);
     return new BlazeProjectData(
-        TargetMap.fromProto(proto.getTargetMap()),
+        targetData,
         blazeInfo,
         BlazeVersionData.fromProto(proto.getBlazeVersionData()),
         workspacePathResolver,
-        new ArtifactLocationDecoderImpl(blazeInfo, workspacePathResolver, remoteOutputs),
+        new ArtifactLocationDecoderImpl(blazeInfo, workspacePathResolver, targetData.remoteOutputs),
         WorkspaceLanguageSettings.fromProto(proto.getWorkspaceLanguageSettings()),
-        syncState);
+        SyncState.fromProto(proto.getSyncState()));
+  }
+
+  private static ProjectTargetData parseTargetData(ProjectData.BlazeProjectData proto) {
+    if (proto.hasTargetData()) {
+      return ProjectTargetData.fromProto(proto.getTargetData());
+    }
+    // handle older version of project data
+    TargetMap map = TargetMap.fromProto(proto.getTargetMap());
+    BlazeIdeInterfaceState ideInterfaceState =
+        BlazeIdeInterfaceState.fromProto(proto.getSyncState().getBlazeIdeInterfaceState());
+    RemoteOutputArtifacts remoteOutputs =
+        proto.getSyncState().hasRemoteOutputArtifacts()
+            ? RemoteOutputArtifacts.fromProto(proto.getSyncState().getRemoteOutputArtifacts())
+            : RemoteOutputArtifacts.EMPTY;
+    return new ProjectTargetData(map, ideInterfaceState, remoteOutputs);
   }
 
   @Override
   public ProjectData.BlazeProjectData toProto() {
     return ProjectData.BlazeProjectData.newBuilder()
-        .setTargetMap(targetMap.toProto())
+        .setTargetData(targetData.toProto())
         .setBlazeInfo(blazeInfo.toProto())
         .setBlazeVersionData(blazeVersionData.toProto())
         .setWorkspacePathResolver(workspacePathResolver.toProto())
@@ -95,8 +109,12 @@ public final class BlazeProjectData implements ProtoWrapper<ProjectData.BlazePro
         .build();
   }
 
+  public ProjectTargetData getTargetData() {
+    return targetData;
+  }
+
   public TargetMap getTargetMap() {
-    return targetMap;
+    return targetData.targetMap;
   }
 
   public BlazeInfo getBlazeInfo() {
@@ -120,7 +138,7 @@ public final class BlazeProjectData implements ProtoWrapper<ProjectData.BlazePro
   }
 
   public RemoteOutputArtifacts getRemoteOutputs() {
-    return syncState.getOptional(RemoteOutputArtifacts.class).orElse(RemoteOutputArtifacts.EMPTY);
+    return targetData.remoteOutputs;
   }
 
   public SyncState getSyncState() {
@@ -150,7 +168,7 @@ public final class BlazeProjectData implements ProtoWrapper<ProjectData.BlazePro
       return false;
     }
     BlazeProjectData other = (BlazeProjectData) o;
-    return Objects.equals(targetMap, other.targetMap)
+    return Objects.equals(targetData, other.targetData)
         && Objects.equals(blazeInfo, other.blazeInfo)
         && Objects.equals(blazeVersionData, other.blazeVersionData)
         && Objects.equals(workspacePathResolver, other.workspacePathResolver)
@@ -162,7 +180,7 @@ public final class BlazeProjectData implements ProtoWrapper<ProjectData.BlazePro
   @Override
   public int hashCode() {
     return Objects.hash(
-        targetMap,
+        targetData,
         blazeInfo,
         blazeVersionData,
         workspaceLanguageSettings,

--- a/base/src/com/google/idea/blaze/base/model/RemoteOutputArtifacts.java
+++ b/base/src/com/google/idea/blaze/base/model/RemoteOutputArtifacts.java
@@ -25,6 +25,7 @@ import com.google.devtools.intellij.model.ProjectData;
 import com.google.idea.blaze.base.command.buildresult.RemoteOutputArtifact;
 import com.google.idea.blaze.base.command.info.BlazeConfigurationHandler;
 import com.google.idea.blaze.base.ideinfo.ArtifactLocation;
+import com.google.idea.blaze.base.ideinfo.ProtoWrapper;
 import com.google.idea.blaze.base.ideinfo.TargetIdeInfo;
 import com.google.idea.blaze.base.ideinfo.TargetMap;
 import com.google.idea.blaze.base.sync.projectview.WorkspaceLanguageSettings;
@@ -39,7 +40,8 @@ import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
 /** A set of {@link RemoteOutputArtifact}s we want to retain a reference to between syncs. */
-public final class RemoteOutputArtifacts implements SyncData<ProjectData.RemoteOutputArtifacts> {
+public final class RemoteOutputArtifacts
+    implements ProtoWrapper<ProjectData.RemoteOutputArtifacts> {
 
   public static RemoteOutputArtifacts fromProjectData(@Nullable BlazeProjectData projectData) {
     return projectData == null ? EMPTY : projectData.getRemoteOutputs();
@@ -66,7 +68,7 @@ public final class RemoteOutputArtifacts implements SyncData<ProjectData.RemoteO
     return proto.build();
   }
 
-  private static RemoteOutputArtifacts fromProto(ProjectData.RemoteOutputArtifacts proto) {
+  public static RemoteOutputArtifacts fromProto(ProjectData.RemoteOutputArtifacts proto) {
     ImmutableMap.Builder<String, RemoteOutputArtifact> map = ImmutableMap.builder();
     proto.getArtifactsList().stream()
         .map(RemoteOutputArtifact::fromProto)
@@ -188,11 +190,6 @@ public final class RemoteOutputArtifacts implements SyncData<ProjectData.RemoteO
   }
 
   @Override
-  public void insert(ProjectData.SyncState.Builder builder) {
-    builder.setRemoteOutputArtifacts(toProto());
-  }
-
-  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;
@@ -206,15 +203,5 @@ public final class RemoteOutputArtifacts implements SyncData<ProjectData.RemoteO
   @Override
   public int hashCode() {
     return Objects.hashCode(remoteOutputArtifacts);
-  }
-
-  static class Extractor implements SyncData.Extractor<RemoteOutputArtifacts> {
-    @Nullable
-    @Override
-    public RemoteOutputArtifacts extract(ProjectData.SyncState syncState) {
-      return syncState.hasRemoteOutputArtifacts()
-          ? RemoteOutputArtifacts.fromProto(syncState.getRemoteOutputArtifacts())
-          : null;
-    }
   }
 }

--- a/base/src/com/google/idea/blaze/base/sync/ProjectUpdateSyncTask.java
+++ b/base/src/com/google/idea/blaze/base/sync/ProjectUpdateSyncTask.java
@@ -157,15 +157,11 @@ final class ProjectUpdateSyncTask {
       context.setHasError();
       throw new SyncFailedException();
     }
-    if (targetData.getIdeInterfaceState() != null) {
-      syncStateBuilder.put(targetData.getIdeInterfaceState());
-    }
-    syncStateBuilder.put(targetData.getRemoteOutputs());
-    TargetMap targetMap = targetData.getTargetMap();
+    TargetMap targetMap = targetData.targetMap;
     context.output(PrintOutput.log("Target map size: " + targetMap.targets().size()));
 
     RemoteOutputArtifacts oldRemoteState = RemoteOutputArtifacts.fromProjectData(oldProjectData);
-    RemoteOutputArtifacts newRemoteState = targetData.getRemoteOutputs();
+    RemoteOutputArtifacts newRemoteState = targetData.remoteOutputs;
 
     ArtifactLocationDecoder artifactLocationDecoder =
         new ArtifactLocationDecoderImpl(
@@ -214,7 +210,7 @@ final class ProjectUpdateSyncTask {
 
     BlazeProjectData newProjectData =
         new BlazeProjectData(
-            targetMap,
+            targetData,
             projectState.getBlazeInfo(),
             projectState.getBlazeVersionData(),
             projectState.getWorkspacePathResolver(),

--- a/base/src/com/google/idea/blaze/base/sync/aspects/BlazeIdeInterfaceAspectsImpl.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/BlazeIdeInterfaceAspectsImpl.java
@@ -163,7 +163,7 @@ public class BlazeIdeInterfaceAspectsImpl implements BlazeIdeInterface {
             .appendNewOutputs(getTrackedRemoteOutputs(buildResult))
             .removeUntrackedOutputs(state.targetMap, projectState.getLanguageSettings());
 
-    return ProjectTargetData.create(state.targetMap, state.state, newRemoteOutputs);
+    return new ProjectTargetData(state.targetMap, state.state, newRemoteOutputs);
   }
 
   /** Returns the {@link RemoteOutputArtifact}s we want to track between syncs. */
@@ -196,9 +196,7 @@ public class BlazeIdeInterfaceAspectsImpl implements BlazeIdeInterface {
 
     TargetMap oldTargetMap = oldProjectData != null ? oldProjectData.getTargetMap() : null;
     BlazeIdeInterfaceState prevState =
-        oldProjectData != null
-            ? oldProjectData.getSyncState().get(BlazeIdeInterfaceState.class)
-            : null;
+        oldProjectData != null ? oldProjectData.getTargetData().ideInterfaceState : null;
 
     Predicate<String> ideInfoPredicate = AspectStrategy.ASPECT_OUTPUT_FILE_PREDICATE;
     Collection<OutputArtifact> files =

--- a/base/src/com/google/idea/blaze/base/sync/aspects/BlazeIdeInterfaceState.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/BlazeIdeInterfaceState.java
@@ -25,12 +25,11 @@ import com.google.devtools.intellij.model.ProjectData.LocalFileOrOutputArtifact;
 import com.google.idea.blaze.base.filecache.ArtifactState;
 import com.google.idea.blaze.base.ideinfo.ProtoWrapper;
 import com.google.idea.blaze.base.ideinfo.TargetKey;
-import com.google.idea.blaze.base.model.SyncData;
 import java.util.Objects;
-import javax.annotation.Nullable;
 
 /** Sync state for aspect output files, and their mapping to targets. */
-public final class BlazeIdeInterfaceState implements SyncData<ProjectData.BlazeIdeInterfaceState> {
+public final class BlazeIdeInterfaceState
+    implements ProtoWrapper<ProjectData.BlazeIdeInterfaceState> {
 
   /**
    * File strings here are any string uniquely identifying output artifacts. It's not used to
@@ -47,7 +46,7 @@ public final class BlazeIdeInterfaceState implements SyncData<ProjectData.BlazeI
     this.ideInfoFileToTargetKey = ImmutableBiMap.copyOf(ideInfoFileToTargetKey);
   }
 
-  private static BlazeIdeInterfaceState fromProto(ProjectData.BlazeIdeInterfaceState proto) {
+  public static BlazeIdeInterfaceState fromProto(ProjectData.BlazeIdeInterfaceState proto) {
     ImmutableBiMap<String, TargetKey> targets =
         ImmutableBiMap.copyOf(
             ProtoWrapper.map(
@@ -103,21 +102,6 @@ public final class BlazeIdeInterfaceState implements SyncData<ProjectData.BlazeI
 
     BlazeIdeInterfaceState build() {
       return new BlazeIdeInterfaceState(ideInfoFileState, ideInfoToTargetKey);
-    }
-  }
-
-  @Override
-  public void insert(ProjectData.SyncState.Builder builder) {
-    builder.setBlazeIdeInterfaceState(toProto());
-  }
-
-  static class Extractor implements SyncData.Extractor<BlazeIdeInterfaceState> {
-    @Nullable
-    @Override
-    public BlazeIdeInterfaceState extract(ProjectData.SyncState syncState) {
-      return syncState.hasBlazeIdeInterfaceState()
-          ? BlazeIdeInterfaceState.fromProto(syncState.getBlazeIdeInterfaceState())
-          : null;
     }
   }
 }

--- a/base/tests/utils/integration/com/google/idea/blaze/base/sync/BlazeSyncIntegrationTestCase.java
+++ b/base/tests/utils/integration/com/google/idea/blaze/base/sync/BlazeSyncIntegrationTestCase.java
@@ -271,7 +271,7 @@ public abstract class BlazeSyncIntegrationTestCase extends BlazeIntegrationTestC
         BlazeBuildOutputs buildResult,
         boolean mergeWithOldState,
         @Nullable BlazeProjectData oldProjectData) {
-      return ProjectTargetData.create(targetMap, null, RemoteOutputArtifacts.fromProjectData(null));
+      return new ProjectTargetData(targetMap, null, RemoteOutputArtifacts.fromProjectData(null));
     }
 
     @Override

--- a/base/tests/utils/unit/com/google/idea/blaze/base/model/MockBlazeProjectDataBuilder.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/model/MockBlazeProjectDataBuilder.java
@@ -134,7 +134,8 @@ public class MockBlazeProjectDataBuilder {
         this.syncState != null ? this.syncState : new SyncState(ImmutableMap.of());
 
     return new BlazeProjectData(
-        targetMap,
+        new ProjectTargetData(
+            targetMap, /* ideInterfaceState= */ null, RemoteOutputArtifacts.EMPTY),
         blazeInfo,
         blazeVersionData,
         workspacePathResolver,

--- a/proto/project_data.proto
+++ b/proto/project_data.proto
@@ -194,6 +194,12 @@ message RemoteOutputArtifacts {
   repeated OutputArtifact artifacts = 1;
 }
 
+message TargetData {
+  TargetMap target_map = 1;
+  BlazeIdeInterfaceState ide_interface_state = 2;
+  RemoteOutputArtifacts remote_outputs = 3;
+}
+
 message SyncState {
   BlazeJavaSyncData blaze_java_sync_data = 1;
   BlazeAndroidSyncData blaze_android_sync_data = 2;
@@ -201,16 +207,17 @@ message SyncState {
   BlazeJavaSyncData blaze_scala_sync_data = 3;
   LanguageSpecResult language_spec_result = 4;
   JdepsState jdeps_state = 5;
-  BlazeIdeInterfaceState blaze_ide_interface_state = 6;
-  RemoteOutputArtifacts remote_output_artifacts = 7;
+  BlazeIdeInterfaceState blaze_ide_interface_state = 6 [deprecated = true];
+  RemoteOutputArtifacts remote_output_artifacts = 7 [deprecated = true];
 }
 
 message BlazeProjectData {
   reserved 1;
-  TargetMap target_map = 2;
+  TargetMap target_map = 2 [deprecated = true];
   BlazeInfo blaze_info = 3;
   BlazeVersionData blaze_version_data = 4;
   WorkspacePathResolver workspace_path_resolver = 5;
   WorkspaceLanguageSettings workspace_language_settings = 6;
   SyncState sync_state = 7;
+  TargetData target_data = 8;
 }


### PR DESCRIPTION
Cleanup: package target data together as a top-level BlazeProjectData message.

The only reason to put it in SyncState was to hide the aspect-specific implementation details, back when there was a possibility of implementing the IDE-blaze interface differently.

We've well and truly settled on using an aspect, and the ProjectTargetData state already exposes BlazeIdeInterfaceState outside the 'aspect' package, so time to move it out of SyncState.