### PR TITLE
Stop depending on deprecated @local_jdk//:langtools for tools.jar.

### DIFF
--- a/java/BUILD
+++ b/java/BUILD
@@ -175,9 +175,21 @@ java_binary(
     runtime_deps = [":jdk_tools_jar"],
 )
 
+# Getting tools.jar from @local_jdk//:langtools is deprecated. Instead,
+# copy tools.jar from @bazel_Tools//tools_jdk:current_java_runtime.
+# https://github.com/bazelbuild/bazel/issues/5594
+# https://stackoverflow.com/questions/53066974/how-can-i-use-the-jar-tool-with-bazel-v0-19
+genrule(
+    name = "jdk_tools_jar_cp",
+    cmd = "cp $(JAVABASE)/lib/tools.jar $@",
+    tools = ["@bazel_tools//tools/jdk:current_java_runtime"],
+    toolchains = ["@bazel_tools//tools/jdk:current_java_runtime"],
+    outs = ["tools.jar"]
+)
+
 java_import(
     name = "jdk_tools_jar",
-    jars = ["@local_jdk//:langtools"],
+    jars = [":tools.jar"]
 )
 
 java_binary(


### PR DESCRIPTION
This removes the warning when building `//java:fast_build_javac` and `//java:jdk_tools_lib`:

```
$ bazel build //java:jdk_tools_lib //java:fast_build_javac
WARNING: /Users/jingwen/code/intellij/java/BUILD:178:1: in java_import rule //java:jdk_tools_jar: target '//java:jdk_tools_jar' depends on deprecated target '@local_jdk//:langtools': Don't depend on targets in the JDK workspace; use @bazel_tools//tools/jdk:current_java_runtime instead (see https://github.com/bazelbuild/bazel/issues/5594)
```