### PR TITLE
Stop depending on deprecated @local_jdk//:langtools for tools.jar. (bazelbuild/intellij PR import #968)

### DIFF
--- a/java/BUILD
+++ b/java/BUILD
@@ -64,7 +64,7 @@ java_library(
         "//java/com/google/devtools/intellij/blaze/plugin/aswb:__pkg__",
         "//java/com/google/devtools/intellij/blaze/plugin/ijwb:__pkg__",
     ],
-    deps = [":jdk_tools_jar"],
+    deps = ["//third_party/java/jdk:langtools"],
 )
 
 # This is provided by the IDE at runtime
@@ -172,12 +172,7 @@ java_binary(
 java_binary(
     name = "jdk_tools_lib",
     main_class = "None",
-    runtime_deps = [":jdk_tools_jar"],
-)
-
-java_import(
-    name = "jdk_tools_jar",
-    jars = ["@local_jdk//:langtools"],
+    runtime_deps = ["//third_party/java/jdk:langtools"],
 )
 
 java_binary(

--- a/third_party/java/jdk/BUILD
+++ b/third_party/java/jdk/BUILD
@@ -1,0 +1,18 @@
+package(default_visibility = ["//java:__subpackages__"])
+
+# Getting tools.jar from @local_jdk//:langtools is deprecated. Instead,
+# copy tools.jar from @bazel_tools//tools_jdk:current_java_runtime.
+# https://github.com/bazelbuild/bazel/issues/5594
+# https://stackoverflow.com/questions/53066974/how-can-i-use-the-jar-tool-with-bazel-v0-19
+genrule(
+    name = "jdk_tools_jar",
+    outs = ["tools.jar"],
+    cmd = "cp $(JAVABASE)/lib/tools.jar $@",
+    toolchains = ["@bazel_tools//tools/jdk:current_java_runtime"],
+    tools = ["@bazel_tools//tools/jdk:current_java_runtime"],
+)
+
+java_import(
+    name = "langtools",
+    jars = [":tools.jar"],
+)


### PR DESCRIPTION
Stop depending on deprecated @local_jdk//:langtools for tools.jar. (bazelbuild/intellij PR import #968)

This removes the warning when building `//java:fast_build_javac` and `//java:jdk_tools_lib`:

```
$ bazel build //java:jdk_tools_lib //java:fast_build_javac
WARNING: /Users/jingwen/code/intellij/java/BUILD:178:1: in java_import rule //java:jdk_tools_jar: target '//java:jdk_tools_jar' depends on deprecated target '@local_jdk//:langtools': Don't depend on targets in the JDK workspace; use @bazel_tools//tools/jdk:current_java_runtime instead (see https://github.com/bazelbuild/bazel/issues/5594)
```