### PR TITLE
Make zip_plugin_files.py Python 3 compatible

### DIFF
--- a/build_defs/zip_plugin_files.py
+++ b/build_defs/zip_plugin_files.py
@@ -28,7 +28,7 @@ def main():
   args = parser.parse_args()
   with zipfile.ZipFile(args.output, "w") as outfile:
     for exec_path, zip_path in pairwise(args.files_to_zip):
-      with open(exec_path) as input_file:
+      with open(exec_path, mode = "r", encoding = "ISO-8859-1") as input_file:
         zipinfo = zipfile.ZipInfo(zip_path, (2000, 1, 1, 0, 0, 0))
         filemode = stat.S_IMODE(os.fstat(input_file.fileno()).st_mode)
         zipinfo.external_attr = filemode << 16


### PR DESCRIPTION
Bazel 0.27.0 introduced an incompatible change flag that forces the host python to be python3. This changes the way encoding/decoding is done, causing failures as seen in https://github.com/bazelbuild/intellij/issues/976#issue-466707469:

```
$ bazel build //aswb:aswb_bazel_zip --define=ij_product=android-studio-latest --experimental_google_legacy_api
INFO: Analyzed target //aswb:aswb_bazel_zip (62 packages loaded, 2243 targets configured).
INFO: Found 1 target...
ERROR: /Users/jingwen/code/intellij/aswb/BUILD:234:1: Creating final plugin zip archive failed (Exit 1) zip_plugin_files failed: error executing command bazel-out/host/bin/build_defs/zip_plugin_files --output bazel-out/darwin-fastbuild/bin/aswb/aswb_bazel.zip aspect/WORKSPACE aswb/aspect/WORKSPACE aspect/artifacts.bzl aswb/aspect/artifacts.bzl ... (remaining 20 argument(s) skipped)

Use --sandbox_debug to see verbose messages from the sandbox
Traceback (most recent call last):
  File "/private/var/tmp/_bazel_jingwen/a7f9cfb321ff8f053a43633ca4d90cc9/sandbox/darwin-sandbox/379/execroot/intellij_with_bazel/bazel-out/host/bin/build_defs/zip_plugin_files.runfiles/intellij_with_bazel/build_defs/zip_plugin_files.py", line 38, in <module>
    main()
  File "/private/var/tmp/_bazel_jingwen/a7f9cfb321ff8f053a43633ca4d90cc9/sandbox/darwin-sandbox/379/execroot/intellij_with_bazel/bazel-out/host/bin/build_defs/zip_plugin_files.runfiles/intellij_with_bazel/build_defs/zip_plugin_files.py", line 35, in main
    outfile.writestr(zipinfo, input_file.read(), zipfile.ZIP_DEFLATED)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xfe in position 39: ordinal not in range(128)
----------------
Note: The failure of target //build_defs:zip_plugin_files (with exit code 1) may have been caused by the fact that it is a Python 2 program that was built in the host configuration, which uses Python 3. You can change the host configuration (for the entire build) to instead use Python 2 by setting --host_force_python=PY2.

If this error started occurring in Bazel 0.27 and later, it may be because the Python toolchain now enforces that targets analyzed as PY2 and PY3 run under a Python 2 and Python 3 interpreter, respectively. See https://github.com/bazelbuild/bazel/issues/7899 for more information.
----------------
Target //aswb:aswb_bazel_zip failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 347.553s, Critical Path: 91.50s
INFO: 370 processes: 348 darwin-sandbox, 22 worker.
FAILED: Build did NOT complete successfully
```

This PR fixes that breakage by extending the decoder character set from ascii to latin1, allowing zip_plugin_files.py to be used with Python 3 directly.