### PR TITLE
Refactor BEP readers to pass through ParsedBepOutput directly.

### DIFF
--- a/aswb/src/com/google/idea/blaze/android/run/binary/mobileinstall/BlazeApkBuildStepMobileInstall.java
+++ b/aswb/src/com/google/idea/blaze/android/run/binary/mobileinstall/BlazeApkBuildStepMobileInstall.java
@@ -124,9 +124,7 @@ public class BlazeApkBuildStepMobileInstall implements BlazeApkBuildStep {
 
             BlazeApkDeployInfoProtoHelper deployInfoHelper =
                 new BlazeApkDeployInfoProtoHelper(project, blazeFlags);
-            try (BuildResultHelper buildResultHelper =
-                BuildResultHelperProvider.forFiles(
-                    project, fileName -> fileName.endsWith(deployInfoSuffix))) {
+            try (BuildResultHelper buildResultHelper = BuildResultHelperProvider.create(project)) {
 
               command
                   .addTargets(label)
@@ -154,7 +152,11 @@ public class BlazeApkBuildStepMobileInstall implements BlazeApkBuildStep {
               }
               try {
                 context.output(new StatusOutput("Reading deployment information..."));
-                deployInfo = deployInfoHelper.readDeployInfo(context, buildResultHelper);
+                deployInfo =
+                    deployInfoHelper.readDeployInfo(
+                        context,
+                        buildResultHelper,
+                        fileName -> fileName.endsWith(deployInfoSuffix));
               } catch (GetArtifactsException e) {
                 IssueOutput.error("Could not read apk deploy info from build: " + e.getMessage())
                     .submit(context);

--- a/aswb/src/com/google/idea/blaze/android/run/deployinfo/BlazeApkDeployInfoProtoHelper.java
+++ b/aswb/src/com/google/idea/blaze/android/run/deployinfo/BlazeApkDeployInfoProtoHelper.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
 /** Reads the deploy info from a build step. */
@@ -54,10 +55,12 @@ public class BlazeApkDeployInfoProtoHelper {
 
   @Nullable
   public BlazeAndroidDeployInfo readDeployInfo(
-      BlazeContext context, BuildResultHelper buildResultHelper) throws GetArtifactsException {
+      BlazeContext context, BuildResultHelper buildResultHelper, Predicate<String> pathFilter)
+      throws GetArtifactsException {
     File deployInfoFile =
         Iterables.getOnlyElement(
-            LocalFileOutputArtifact.getLocalOutputFiles(buildResultHelper.getBuildArtifacts()),
+            LocalFileOutputArtifact.getLocalOutputFiles(
+                buildResultHelper.getAllOutputArtifacts(pathFilter)),
             null);
     if (deployInfoFile == null) {
       return null;

--- a/aswb/src/com/google/idea/blaze/android/run/runner/BlazeApkBuildStepNormalBuild.java
+++ b/aswb/src/com/google/idea/blaze/android/run/runner/BlazeApkBuildStepNormalBuild.java
@@ -105,9 +105,7 @@ public class BlazeApkBuildStepNormalBuild implements BlazeApkBuildStep {
 
             BlazeApkDeployInfoProtoHelper deployInfoHelper =
                 new BlazeApkDeployInfoProtoHelper(project, buildFlags);
-            try (BuildResultHelper buildResultHelper =
-                BuildResultHelperProvider.forFiles(
-                    project, fileName -> fileName.endsWith(".deployinfo.pb"))) {
+            try (BuildResultHelper buildResultHelper = BuildResultHelperProvider.create(project)) {
 
               command
                   .addTargets(getTargetToBuild())
@@ -133,7 +131,11 @@ public class BlazeApkBuildStepNormalBuild implements BlazeApkBuildStep {
                 return null;
               }
               try {
-                deployInfo = deployInfoHelper.readDeployInfo(context, buildResultHelper);
+                deployInfo =
+                    deployInfoHelper.readDeployInfo(
+                        context,
+                        buildResultHelper,
+                        fileName -> fileName.endsWith(".deployinfo.pb"));
               } catch (GetArtifactsException e) {
                 IssueOutput.error("Could not read apk deploy info from build: " + e.getMessage())
                     .submit(context);

--- a/base/src/com/google/idea/blaze/base/command/buildresult/BuildEventProtocolOutputReader.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/BuildEventProtocolOutputReader.java
@@ -18,7 +18,6 @@ package com.google.idea.blaze.base.command.buildresult;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos;
 import com.google.idea.blaze.base.model.primitives.Kind;
@@ -43,37 +42,9 @@ public final class BuildEventProtocolOutputReader {
 
   private BuildEventProtocolOutputReader() {}
 
-  /**
-   * Returns all output artifacts listed in the BEP output that satisfy the specified predicate.
-   *
-   * @throws IOException if the BEP output file is incorrectly formatted
-   */
-  public static ImmutableList<OutputArtifact> parseAllOutputs(
-      InputStream inputStream, Predicate<String> fileFilter) throws IOException {
-    ParsedBepOutput output = ParsedBepOutput.parseBepArtifacts(inputStream);
-    return output.getAllOutputArtifacts(fileFilter).asList();
-  }
-
-  /**
-   * Returns all artifacts associated with the given target that satisfy the specified predicate.
-   *
-   * @throws IOException if the BEP output file is incorrectly formatted
-   */
-  public static ImmutableList<OutputArtifact> parseArtifactsForTarget(
-      InputStream inputStream, Label label, Predicate<String> fileFilter) throws IOException {
-    ParsedBepOutput output = ParsedBepOutput.parseBepArtifacts(inputStream);
-    return output.getArtifactsForTarget(label, fileFilter).asList();
-  }
-
-  /**
-   * Returns all output artifacts belonging to the given output group(s).
-   *
-   * @throws IOException if the BEP output file is incorrectly formatted
-   */
-  public static ImmutableListMultimap<String, OutputArtifact> parsePerOutputGroupArtifacts(
-      InputStream inputStream, Predicate<String> fileFilter) throws IOException {
-    ParsedBepOutput output = ParsedBepOutput.parseBepArtifacts(inputStream);
-    return output.getPerOutputGroupArtifacts(fileFilter);
+  /** Parses a BEP input stream, returning a {@link ParsedBepOutput}. */
+  public static ParsedBepOutput parseBepOutput(InputStream inputStream) throws IOException {
+    return ParsedBepOutput.parseBepArtifacts(inputStream);
   }
 
   /**

--- a/base/src/com/google/idea/blaze/base/command/buildresult/BuildResultHelper.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/BuildResultHelper.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.idea.blaze.base.model.primitives.Label;
 import java.util.List;
+import java.util.function.Predicate;
 
 /** Assists in getting build artifacts from a build operation. */
 public interface BuildResultHelper extends AutoCloseable {
@@ -31,12 +32,21 @@ public interface BuildResultHelper extends AutoCloseable {
   List<String> getBuildFlags();
 
   /**
+   * Parses the BEP output data and returns the corresponding {@link ParsedBepOutput}. May only be
+   * called once, after the build is complete.
+   */
+  ParsedBepOutput getBuildOutput() throws GetArtifactsException;
+
+  /**
    * Returns the build result. May only be called once, after the build is complete, or no artifacts
    * will be returned.
    *
    * @return The build artifacts from the build operation.
    */
-  ImmutableList<OutputArtifact> getBuildArtifacts() throws GetArtifactsException;
+  default ImmutableList<OutputArtifact> getAllOutputArtifacts(Predicate<String> pathFilter)
+      throws GetArtifactsException {
+    return getBuildOutput().getAllOutputArtifacts(pathFilter).asList();
+  }
 
   /**
    * Returns the build artifacts, filtering out all artifacts not directly produced by the specified
@@ -44,16 +54,18 @@ public interface BuildResultHelper extends AutoCloseable {
    *
    * <p>May only be called once, after the build is complete, or no artifacts will be returned.
    */
-  ImmutableList<OutputArtifact> getBuildArtifactsForTarget(Label target)
-      throws GetArtifactsException;
+  default ImmutableList<OutputArtifact> getBuildArtifactsForTarget(
+      Label target, Predicate<String> pathFilter) throws GetArtifactsException {
+    return getBuildOutput().getDirectArtifactsForTarget(target, pathFilter).asList();
+  }
 
   /**
    * Returns all build artifacts belonging to the given output groups. May only be called once,
    * after the build is complete, or no artifacts will be returned.
    */
-  default ImmutableList<OutputArtifact> getArtifactsForOutputGroup(String outputGroup)
-      throws GetArtifactsException {
-    return getPerOutputGroupArtifacts().get(outputGroup);
+  default ImmutableList<OutputArtifact> getArtifactsForOutputGroup(
+      String outputGroup, Predicate<String> pathFilter) throws GetArtifactsException {
+    return getBuildOutput().getPerOutputGroupArtifacts(pathFilter).get(outputGroup);
   }
 
   /**
@@ -61,8 +73,10 @@ public interface BuildResultHelper extends AutoCloseable {
    * groups). May only be called once, after the build is complete, or no artifacts will be
    * returned.
    */
-  ImmutableListMultimap<String, OutputArtifact> getPerOutputGroupArtifacts()
-      throws GetArtifactsException;
+  default ImmutableListMultimap<String, OutputArtifact> getPerOutputGroupArtifacts(
+      Predicate<String> pathFilter) throws GetArtifactsException {
+    return getBuildOutput().getPerOutputGroupArtifacts(pathFilter);
+  }
 
   @Override
   void close();

--- a/base/src/com/google/idea/blaze/base/sync/aspects/BlazeIdeInterfaceAspectsImpl.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/BlazeIdeInterfaceAspectsImpl.java
@@ -343,7 +343,7 @@ public class BlazeIdeInterfaceAspectsImpl implements BlazeIdeInterface {
       List<TargetExpression> targets,
       AspectStrategy aspectStrategy) {
     try (BuildResultHelper buildResultHelper =
-        BuildResultHelperProvider.forFilesForSync(project, blazeInfo, f -> true)) {
+        BuildResultHelperProvider.createForSync(project, blazeInfo)) {
 
       BlazeCommand.Builder builder =
           BlazeCommand.builder(getBinaryPath(project), BlazeCommandName.BUILD)
@@ -380,7 +380,7 @@ public class BlazeIdeInterfaceAspectsImpl implements BlazeIdeInterface {
             try {
               childContext.push(new TimingScope("ReadingBuildOutputs", EventType.Other));
               return new BlazeBuildOutputs(
-                  buildResultHelper.getPerOutputGroupArtifacts(), buildResult);
+                  buildResultHelper.getPerOutputGroupArtifacts(file -> true), buildResult);
             } catch (GetArtifactsException e) {
               IssueOutput.error("Failed to get build outputs: " + e.getMessage()).submit(context);
               return new BlazeBuildOutputs(ImmutableListMultimap.of(), buildResult);

--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrRunConfigurationRunner.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrRunConfigurationRunner.java
@@ -95,8 +95,7 @@ public class BlazeCidrRunConfigurationRunner implements BlazeCommandRunConfigura
    */
   private File getExecutableToDebug(ExecutionEnvironment env) throws ExecutionException {
     SaveUtil.saveAllFiles();
-    try (BuildResultHelper buildResultHelper =
-        BuildResultHelperProvider.forFiles(env.getProject(), file -> true)) {
+    try (BuildResultHelper buildResultHelper = BuildResultHelperProvider.create(env.getProject())) {
 
       List<String> extraDebugFlags;
       if (!BlazeGDBServerProvider.shouldUseGdbserver()) {
@@ -142,7 +141,8 @@ public class BlazeCidrRunConfigurationRunner implements BlazeCommandRunConfigura
       try {
         candidateFiles =
             LocalFileOutputArtifact.getLocalOutputFiles(
-                    buildResultHelper.getBuildArtifactsForTarget((Label) configuration.getTarget()))
+                    buildResultHelper.getBuildArtifactsForTarget(
+                        (Label) configuration.getTarget(), file -> true))
                 .stream()
                 .filter(File::canExecute)
                 .collect(Collectors.toList());

--- a/golang/src/com/google/idea/blaze/golang/run/BlazeGoRunConfigurationRunner.java
+++ b/golang/src/com/google/idea/blaze/golang/run/BlazeGoRunConfigurationRunner.java
@@ -265,8 +265,7 @@ public class BlazeGoRunConfigurationRunner implements BlazeCommandRunConfigurati
     }
 
     SaveUtil.saveAllFiles();
-    try (BuildResultHelper buildResultHelper =
-        BuildResultHelperProvider.forFiles(project, file -> true)) {
+    try (BuildResultHelper buildResultHelper = BuildResultHelperProvider.create(project)) {
       ImmutableList.Builder<String> flags = ImmutableList.builder();
       if (Blaze.getBuildSystem(project) == BuildSystem.Blaze) {
         // $ go tool compile
@@ -330,7 +329,7 @@ public class BlazeGoRunConfigurationRunner implements BlazeCommandRunConfigurati
           candidateFiles =
               LocalFileOutputArtifact.getLocalOutputFiles(
                       buildResultHelper.getBuildArtifactsForTarget(
-                          (Label) configuration.getTarget()))
+                          (Label) configuration.getTarget(), file -> true))
                   .stream()
                   .filter(File::canExecute)
                   .collect(Collectors.toList());

--- a/java/src/com/google/idea/blaze/java/fastbuild/FastBuildServiceImpl.java
+++ b/java/src/com/google/idea/blaze/java/fastbuild/FastBuildServiceImpl.java
@@ -70,6 +70,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
 final class FastBuildServiceImpl implements FastBuildService, ProjectComponent {
@@ -249,12 +250,7 @@ final class FastBuildServiceImpl implements FastBuildService, ProjectComponent {
         FastBuildAspectStrategy.getInstance(
             projectDataManager.getBlazeProjectData().getBlazeVersionData().buildSystem());
     @SuppressWarnings("MustBeClosedChecker") // close buildResultHelper manually via a listener
-    BuildResultHelper buildResultHelper =
-        BuildResultHelperProvider.forFiles(
-            project,
-            file ->
-                file.endsWith(deployJarLabel.targetName().toString())
-                    || aspectStrategy.getAspectOutputFilePredicate().test(file));
+    BuildResultHelper buildResultHelper = BuildResultHelperProvider.create(project);
 
     Stopwatch timer = Stopwatch.createUnstarted();
 
@@ -304,17 +300,22 @@ final class FastBuildServiceImpl implements FastBuildService, ProjectComponent {
               if (result.status != Status.SUCCESS) {
                 throw new RuntimeException("Blaze failure building deploy jar");
               }
+              Predicate<String> filePredicate =
+                  file ->
+                      file.endsWith(deployJarLabel.targetName().toString())
+                          || aspectStrategy.getAspectOutputFilePredicate().test(file);
               try {
                 ImmutableList<File> deployJarArtifacts =
                     LocalFileOutputArtifact.getLocalOutputFiles(
-                        buildResultHelper.getBuildArtifactsForTarget(deployJarLabel));
+                        buildResultHelper.getBuildArtifactsForTarget(
+                            deployJarLabel, filePredicate));
                 checkState(deployJarArtifacts.size() == 1);
                 File deployJar = deployJarArtifacts.get(0);
 
                 ImmutableList<File> ideInfoFiles =
                     LocalFileOutputArtifact.getLocalOutputFiles(
                         buildResultHelper.getArtifactsForOutputGroup(
-                            aspectStrategy.getAspectOutputGroup()));
+                            aspectStrategy.getAspectOutputGroup(), filePredicate));
 
                 // if targets are built with multiple configurations, just take the first one
                 // TODO(brendandouglas): choose a consistent configuration instead

--- a/java/src/com/google/idea/blaze/java/run/hotswap/ClassFileManifestBuilder.java
+++ b/java/src/com/google/idea/blaze/java/run/hotswap/ClassFileManifestBuilder.java
@@ -95,8 +95,7 @@ public class ClassFileManifestBuilder {
     }
 
     SaveUtil.saveAllFiles();
-    try (BuildResultHelper buildResultHelper =
-        BuildResultHelperProvider.forFiles(project, file -> true)) {
+    try (BuildResultHelper buildResultHelper = BuildResultHelperProvider.create(project)) {
 
       ListenableFuture<BuildResult> buildOperation =
           BlazeBeforeRunCommandHelper.runBlazeCommand(
@@ -128,7 +127,7 @@ public class ClassFileManifestBuilder {
         jars =
             LocalFileOutputArtifact.getLocalOutputFiles(
                     buildResultHelper.getArtifactsForOutputGroup(
-                        JavaClasspathAspectStrategy.OUTPUT_GROUP))
+                        JavaClasspathAspectStrategy.OUTPUT_GROUP, file -> true))
                 .stream()
                 .filter(f -> f.getName().endsWith(".jar"))
                 .collect(toImmutableList());

--- a/plugin_dev/src/com/google/idea/blaze/plugin/run/BlazeIntellijPluginDeployer.java
+++ b/plugin_dev/src/com/google/idea/blaze/plugin/run/BlazeIntellijPluginDeployer.java
@@ -28,6 +28,7 @@ import com.google.idea.blaze.base.async.executor.BlazeExecutor;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtifactsException;
 import com.google.idea.blaze.base.command.buildresult.LocalFileOutputArtifact;
+import com.google.idea.blaze.base.command.buildresult.OutputArtifact;
 import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.common.experiments.BoolExperiment;
 import com.google.protobuf.repackaged.TextFormat;
@@ -89,13 +90,10 @@ class BlazeIntellijPluginDeployer {
       throws GetArtifactsException {
     this.executionRoot = executionRoot;
     deployInfoFiles.clear();
-    for (File file :
-        LocalFileOutputArtifact.getLocalOutputFiles(
-            buildResultHelper.getBuildArtifactsForTarget(pluginTarget))) {
-      if (file.getName().endsWith(".intellij-plugin-debug-target-deploy-info")) {
-        deployInfoFiles.add(file);
-      }
-    }
+    ImmutableList<OutputArtifact> outputs =
+        buildResultHelper.getBuildArtifactsForTarget(
+            pluginTarget, file -> file.endsWith(".intellij-plugin-debug-target-deploy-info"));
+    deployInfoFiles.addAll(LocalFileOutputArtifact.getLocalOutputFiles(outputs));
   }
 
   /**

--- a/plugin_dev/src/com/google/idea/blaze/plugin/run/BuildPluginBeforeRunTaskProvider.java
+++ b/plugin_dev/src/com/google/idea/blaze/plugin/run/BuildPluginBeforeRunTaskProvider.java
@@ -222,7 +222,7 @@ public final class BuildPluginBeforeRunTaskProvider
                   }
 
                   try (BuildResultHelper buildResultHelper =
-                      BuildResultHelperProvider.forFiles(project, f -> true)) {
+                      BuildResultHelperProvider.create(project)) {
                     BlazeCommand command =
                         BlazeCommand.builder(binaryPath, BlazeCommandName.BUILD)
                             .addTargets(config.getTarget())

--- a/python/src/com/google/idea/blaze/python/run/BlazePyRunConfigurationRunner.java
+++ b/python/src/com/google/idea/blaze/python/run/BlazePyRunConfigurationRunner.java
@@ -292,8 +292,7 @@ public class BlazePyRunConfigurationRunner implements BlazeCommandRunConfigurati
     }
 
     SaveUtil.saveAllFiles();
-    try (BuildResultHelper buildResultHelper =
-        BuildResultHelperProvider.forFiles(project, file -> true)) {
+    try (BuildResultHelper buildResultHelper = BuildResultHelperProvider.create(project)) {
 
       ListenableFuture<BuildResult> buildOperation =
           BlazeBeforeRunCommandHelper.runBlazeCommand(
@@ -322,7 +321,8 @@ public class BlazePyRunConfigurationRunner implements BlazeCommandRunConfigurati
       try {
         candidateFiles =
             LocalFileOutputArtifact.getLocalOutputFiles(
-                    buildResultHelper.getBuildArtifactsForTarget((Label) configuration.getTarget()))
+                    buildResultHelper.getBuildArtifactsForTarget(
+                        (Label) configuration.getTarget(), file -> true))
                 .stream()
                 .filter(File::canExecute)
                 .collect(Collectors.toList());

--- a/scala/src/com/google/idea/blaze/scala/run/producers/GenerateDeployableJarTaskProvider.java
+++ b/scala/src/com/google/idea/blaze/scala/run/producers/GenerateDeployableJarTaskProvider.java
@@ -157,8 +157,7 @@ class GenerateDeployableJarTaskProvider
       RunConfiguration configuration, ExecutionEnvironment env, Label target)
       throws ExecutionException {
     Project project = env.getProject();
-    try (BuildResultHelper buildResultHelper =
-        BuildResultHelperProvider.forFiles(project, file -> true)) {
+    try (BuildResultHelper buildResultHelper = BuildResultHelperProvider.create(project)) {
 
       SaveUtil.saveAllFiles();
 
@@ -183,7 +182,8 @@ class GenerateDeployableJarTaskProvider
       }
 
       List<File> outputs =
-          LocalFileOutputArtifact.getLocalOutputFiles(buildResultHelper.getBuildArtifacts());
+          LocalFileOutputArtifact.getLocalOutputFiles(
+              buildResultHelper.getAllOutputArtifacts(file -> true));
       if (outputs.isEmpty()) {
         throw new ExecutionException(
             String.format("Failed to find deployable jar when building %s", target));


### PR DESCRIPTION
Refactor BEP readers to pass through ParsedBepOutput directly.

Also adds a ParsedBepOutput#getPerTargetOutputArtifacts to get transitive outputs associated with a target.