### PR TITLE
Don't keep tracking old remote outputs when they've been replaced by local versions in a more recent build.

### DIFF
--- a/base/src/com/google/idea/blaze/base/model/RemoteOutputArtifacts.java
+++ b/base/src/com/google/idea/blaze/base/model/RemoteOutputArtifacts.java
@@ -22,6 +22,7 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.intellij.model.ProjectData;
+import com.google.idea.blaze.base.command.buildresult.OutputArtifact;
 import com.google.idea.blaze.base.command.buildresult.RemoteOutputArtifact;
 import com.google.idea.blaze.base.command.info.BlazeConfigurationHandler;
 import com.google.idea.blaze.base.ideinfo.ArtifactLocation;
@@ -81,15 +82,20 @@ public final class RemoteOutputArtifacts
    * Merges this set of outputs with another set, returning a new {@link RemoteOutputArtifacts}
    * instance.
    */
-  public RemoteOutputArtifacts appendNewOutputs(Set<RemoteOutputArtifact> outputs) {
+  public RemoteOutputArtifacts appendNewOutputs(Set<OutputArtifact> outputs) {
     HashMap<String, RemoteOutputArtifact> map = new HashMap<>(remoteOutputArtifacts);
     // more recently built artifacts replace existing ones with the same path
     outputs.forEach(
         a -> {
           String key = a.getKey();
-          RemoteOutputArtifact other = map.get(key);
-          if (other == null || other.getSyncTimeMillis() < a.getSyncTimeMillis()) {
-            map.put(key, a);
+          if (!(a instanceof RemoteOutputArtifact)) {
+            map.remove(key);
+          } else {
+            RemoteOutputArtifact newOutput = (RemoteOutputArtifact) a;
+            RemoteOutputArtifact other = map.get(key);
+            if (other == null || other.getSyncTimeMillis() < newOutput.getSyncTimeMillis()) {
+              map.put(key, newOutput);
+            }
           }
         });
     return new RemoteOutputArtifacts(ImmutableMap.copyOf(map));

--- a/base/src/com/google/idea/blaze/base/sync/aspects/BlazeIdeInterfaceAspectsImpl.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/BlazeIdeInterfaceAspectsImpl.java
@@ -162,21 +162,18 @@ public class BlazeIdeInterfaceAspectsImpl implements BlazeIdeInterface {
     // combine outputs map, then filter to remove out-of-date / unnecessary items
     RemoteOutputArtifacts newRemoteOutputs =
         oldRemoteOutputs
-            .appendNewOutputs(getTrackedRemoteOutputs(buildResult))
+            .appendNewOutputs(getTrackedOutputs(buildResult))
             .removeUntrackedOutputs(state.targetMap, projectState.getLanguageSettings());
 
     return new ProjectTargetData(state.targetMap, state.state, newRemoteOutputs);
   }
 
-  /** Returns the {@link RemoteOutputArtifact}s we want to track between syncs. */
-  private static ImmutableSet<RemoteOutputArtifact> getTrackedRemoteOutputs(
-      BlazeBuildOutputs buildOutput) {
-    // don't track remote intellij-info.txt outputs -- they're already tracked in
+  /** Returns the {@link OutputArtifact}s we want to track between syncs. */
+  private static ImmutableSet<OutputArtifact> getTrackedOutputs(BlazeBuildOutputs buildOutput) {
+    // don't track intellij-info.txt outputs -- they're already tracked in
     // BlazeIdeInterfaceState
     Predicate<String> pathFilter = AspectStrategy.ASPECT_OUTPUT_FILE_PREDICATE.negate();
     return buildOutput.perOutputGroupArtifacts.values().stream()
-        .filter(a -> a instanceof RemoteOutputArtifact)
-        .map(a -> (RemoteOutputArtifact) a)
         .filter(a -> pathFilter.test(a.getRelativePath()))
         .collect(toImmutableSet());
   }


### PR DESCRIPTION
Don't keep tracking old remote outputs when they've been replaced by local versions in a more recent build.