### PR TITLE
Do not add "- //bazel-bin/... - //.ijwb/... " etc. into the excluded workspace paths for Bazel projects.

### DIFF
--- a/base/src/com/google/idea/blaze/base/sync/projectview/ImportRoots.java
+++ b/base/src/com/google/idea/blaze/base/sync/projectview/ImportRoots.java
@@ -19,7 +19,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.idea.blaze.base.bazel.BuildSystemProvider;
 import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.model.primitives.TargetExpression;
 import com.google.idea.blaze.base.model.primitives.WorkspacePath;
@@ -31,7 +30,6 @@ import com.google.idea.blaze.base.projectview.section.sections.DirectorySection;
 import com.google.idea.blaze.base.projectview.section.sections.TargetSection;
 import com.google.idea.blaze.base.settings.Blaze;
 import com.google.idea.blaze.base.settings.BuildSystem;
-import com.google.idea.blaze.base.sync.data.BlazeDataStorage;
 import com.google.idea.blaze.base.util.WorkspacePathUtil;
 import com.google.idea.common.experiments.BoolExperiment;
 import com.intellij.openapi.project.Project;
@@ -94,10 +92,6 @@ public final class ImportRoots {
 
     public ImportRoots build() {
       ImmutableCollection<WorkspacePath> rootDirectories = rootDirectoriesBuilder.build();
-      if (buildSystem == BuildSystem.Bazel && hasWorkspaceRoot(rootDirectories)) {
-        excludeBuildSystemArtifacts();
-        excludeProjectDataSubDirectory();
-      }
       ImmutableSet<WorkspacePath> minimalExcludes =
           WorkspacePathUtil.calculateMinimalWorkspacePaths(excludeDirectoriesBuilder.build());
 
@@ -109,22 +103,6 @@ public final class ImportRoots {
           minimalRootDirectories,
           minimalExcludes,
           ProjectTargetsHelper.create(projectTargets.build()));
-    }
-
-    private void excludeBuildSystemArtifacts() {
-      for (String dir :
-          BuildSystemProvider.getBuildSystemProvider(buildSystem)
-              .buildArtifactDirectories(workspaceRoot)) {
-        excludeDirectoriesBuilder.add(new WorkspacePath(dir));
-      }
-    }
-
-    private void excludeProjectDataSubDirectory() {
-      excludeDirectoriesBuilder.add(new WorkspacePath(BlazeDataStorage.PROJECT_DATA_SUBDIRECTORY));
-    }
-
-    private static boolean hasWorkspaceRoot(ImmutableCollection<WorkspacePath> rootDirectories) {
-      return rootDirectories.stream().anyMatch(WorkspacePath::isWorkspaceRoot);
     }
   }
 


### PR DESCRIPTION
Do not add "- //bazel-bin/... - //.ijwb/... " etc. into the excluded workspace paths for Bazel projects.

Since these directories don't have build files / targets in them, subtracting them in the final constructed query results in an error:

---

$ bazel query --tool_tag=ijwb:IDEA:community --output=label_kind 'attr("tags", "^((?!manual).)*$", //... - //.ijwb/... -//bazel-bin/...)' -k
ERROR: Skipping '//.ijwb/...': no targets found beneath '.ijwb'
ERROR: Skipping '//bazel-bin/...': no targets found beneath 'bazel-bin'
WARNING: --keep_going specified, ignoring errors.  Results may be inaccurate
test_suite rule //:test
scala_test rule //:test_test_suite_src_test_scala_hello_EndpointSpec.scala
scala_test rule //:test_test_suite_src_test_scala_hello_ConfigurationSpec.scala
scala_binary rule //:app
scala_library rule //:lib
Loading: 0 packages loaded
jingwen@jingwen:~/code/intellij_test_project/examples/scala_akka
$ echo $?
3

---

With this (and cl/259436943), derive_targets_from_directories for Bazel projects work perfectly:

---

Syncing project: Sync (incremental)...
Updating VCS...
Running Bazel info...
Command: bazel info --tool_tag=ijwb:IDEA:community --curses=no --color=yes --progress_in_terminal_title=no --

Computing VCS working set...
Querying targets in project directories...
Command: bazel query --tool_tag=ijwb:IDEA:community --output=label_kind attr("tags", "^((?!manual).)*$", //...) --

Loading: 0 packages loaded
Loading: 0 packages loaded
Loading: 0 packages loaded
Sync targets from project view directories:
  //:lib
  //:test
  //:test_test_suite_src_test_scala_hello_EndpointSpec.scala
  //:test_test_suite_src_test_scala_hello_ConfigurationSpec.scala
  //:app