### PR TITLE
Expand test coverage on Bazel CI to also include the latest version of each product

### DIFF
--- a/.bazelci/android-studio.yml
+++ b/.bazelci/android-studio.yml
@@ -1,12 +1,24 @@
 ---
-platforms:
-  ubuntu1604:
+tasks:
+  ubuntu1604-android-studio-beta:
+    platform: ubuntu1604
     build_flags:
       - --define=ij_product=android-studio-beta
     build_targets:
       - //aswb/...
     test_flags:
       - --define=ij_product=android-studio-beta
+      - --test_output=errors
+    test_targets:
+      - //:aswb_tests
+  ubuntu1604-android-studio-latest:
+    platform: ubuntu1604
+    build_flags:
+      - --define=ij_product=android-studio-latest
+    build_targets:
+      - //aswb/...
+    test_flags:
+      - --define=ij_product=android-studio-latest
       - --test_output=errors
     test_targets:
       - //:aswb_tests

--- a/.bazelci/aspect.yml
+++ b/.bazelci/aspect.yml
@@ -1,12 +1,24 @@
 ---
-platforms:
-  ubuntu1604:
+tasks:
+  ubuntu1604-intellij-beta:
+    platform: ubuntu1604
     build_flags:
       - --define=ij_product=intellij-beta
     build_targets:
       - //aspect:aspect_files
     test_flags:
       - --define=ij_product=intellij-beta
+      - --test_output=errors
+    test_targets:
+      - //aspect/testing/...
+  ubuntu1604-intellij-latest:
+    platform: ubuntu1604
+    build_flags:
+      - --define=ij_product=intellij-latest
+    build_targets:
+      - //aspect:aspect_files
+    test_flags:
+      - --define=ij_product=intellij-latest
       - --test_output=errors
     test_targets:
       - //aspect/testing/...

--- a/.bazelci/clion.yml
+++ b/.bazelci/clion.yml
@@ -1,12 +1,24 @@
 ---
-platforms:
-  ubuntu1604:
+tasks:
+  ubuntu1604-clion-beta:
+    platform: ubuntu1604
     build_flags:
       - --define=ij_product=clion-beta
     build_targets:
       - //clwb/...
     test_flags:
       - --define=ij_product=clion-beta
+      - --test_output=errors
+    test_targets:
+      - //:clwb_tests
+  ubuntu1604-clion-latest:
+    platform: ubuntu1604
+    build_flags:
+      - --define=ij_product=clion-latest
+    build_targets:
+      - //clwb/...
+    test_flags:
+      - --define=ij_product=clion-latest
       - --test_output=errors
     test_targets:
       - //:clwb_tests

--- a/.bazelci/intellij.yml
+++ b/.bazelci/intellij.yml
@@ -1,12 +1,24 @@
 ---
-platforms:
-  ubuntu1604:
+tasks:
+  ubuntu1604-intellij-beta:
+    platform: ubuntu1604
     build_flags:
       - --define=ij_product=intellij-beta
     build_targets:
       - //ijwb/...
     test_flags:
       - --define=ij_product=intellij-beta
+      - --test_output=errors
+    test_targets:
+      - //:ijwb_tests
+  ubuntu1604-intellij-latest:
+    platform: ubuntu1604
+    build_flags:
+      - --define=ij_product=intellij-latest
+    build_targets:
+      - //ijwb/...
+    test_flags:
+      - --define=ij_product=intellij-latest
       - --test_output=errors
     test_targets:
       - //:ijwb_tests


### PR DESCRIPTION
This increases the coverage of the tests to both `-beta` and `-latest` variations of IJ products.