### PR TITLE
Allow external repo targets for run configurations

### DIFF
--- a/base/src/com/google/idea/blaze/base/run/BlazeCommandRunConfiguration.java
+++ b/base/src/com/google/idea/blaze/base/run/BlazeCommandRunConfiguration.java
@@ -371,7 +371,9 @@ public class BlazeCommandRunConfiguration extends LocatableConfigurationBase
           String.format(
               "You must specify a %s target expression.", Blaze.buildSystemName(getProject())));
     }
-    if (!targetPattern.startsWith("//")) {
+
+    // Target patterns can either start with // or @ for external repositories in Bazel.
+    if (!targetPattern.startsWith("//") && !targetPattern.startsWith("@")) {
       throw new RuntimeConfigurationError(
           "You must specify the full target expression, starting with //");
     }

--- a/base/src/com/google/idea/blaze/base/run/BlazeCommandRunConfiguration.java
+++ b/base/src/com/google/idea/blaze/base/run/BlazeCommandRunConfiguration.java
@@ -374,11 +374,11 @@ public class BlazeCommandRunConfiguration extends LocatableConfigurationBase
     }
 
     if (!targetPattern.startsWith("//")) {
-      String errorMessage = "You must specify the full target expression, starting with //.";
+      String errorMessage = "You must specify the full target expression, starting with //";
       if (Blaze.getBuildSystem(getProject()) == BuildSystem.Bazel
           && !targetPattern.startsWith("@")) {
         // Target patterns can either start with // or @ for external repositories in Bazel.
-        errorMessage = "You must specify the full target expression, starting with // or @.";
+        errorMessage = "You must specify the full target expression, starting with // or @";
       }
       throw new RuntimeConfigurationError(errorMessage);
     }

--- a/base/src/com/google/idea/blaze/base/run/BlazeCommandRunConfiguration.java
+++ b/base/src/com/google/idea/blaze/base/run/BlazeCommandRunConfiguration.java
@@ -44,6 +44,7 @@ import com.google.idea.blaze.base.run.targetfinder.TargetFinder;
 import com.google.idea.blaze.base.settings.Blaze;
 import com.google.idea.blaze.base.settings.BlazeImportSettings;
 import com.google.idea.blaze.base.settings.BlazeImportSettingsManager;
+import com.google.idea.blaze.base.settings.BuildSystem;
 import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
 import com.google.idea.blaze.base.sync.projectview.ImportRoots;
 import com.google.idea.blaze.base.ui.UiUtil;
@@ -372,11 +373,16 @@ public class BlazeCommandRunConfiguration extends LocatableConfigurationBase
               "You must specify a %s target expression.", Blaze.buildSystemName(getProject())));
     }
 
-    // Target patterns can either start with // or @ for external repositories in Bazel.
-    if (!targetPattern.startsWith("//") && !targetPattern.startsWith("@")) {
-      throw new RuntimeConfigurationError(
-          "You must specify the full target expression, starting with //");
+    if (!targetPattern.startsWith("//")) {
+      String errorMessage = "You must specify the full target expression, starting with //.";
+      if (Blaze.getBuildSystem(getProject()) == BuildSystem.Bazel
+          && !targetPattern.startsWith("@")) {
+        // Target patterns can either start with // or @ for external repositories in Bazel.
+        errorMessage = "You must specify the full target expression, starting with // or @.";
+      }
+      throw new RuntimeConfigurationError(errorMessage);
     }
+
     String error = TargetExpression.validate(targetPattern);
     if (error != null) {
       throw new RuntimeConfigurationError(error);


### PR DESCRIPTION
[rules_jvm_external](https://github.com/bazelbuild/rules_jvm_external/#pinning-artifacts-and-integration-with-bazels-downloader) relies on running a script in an external repository to pin Maven artifacts. This can be specified as a run configuration, but the current implementation doesn't allow that. 