### PR TITLE
Fix "Multiple entries with same key" error when syncing an updated project.

### DIFF
--- a/java/src/com/google/idea/blaze/java/sync/jdeps/JdepsFileReader.java
+++ b/java/src/com/google/idea/blaze/java/sync/jdeps/JdepsFileReader.java
@@ -161,6 +161,10 @@ public class JdepsFileReader {
     if (oldState != null) {
       state.list.addAll(oldState.data);
     }
+    state.removeArtifacts(
+        diff.getUpdatedOutputs().stream()
+            .map(OutputArtifact::toArtifactState)
+            .collect(toImmutableList()));
     state.removeArtifacts(diff.getRemovedOutputs());
     for (Result result : Futures.allAsList(futures).get()) {
       if (result != null) {


### PR DESCRIPTION
Fix "Multiple entries with same key" error when syncing an updated project.