### PR TITLE
Don't canonicalize file paths when comparing output artifacts.

### DIFF
--- a/base/src/com/google/idea/blaze/base/command/buildresult/LocalFileOutputArtifact.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/LocalFileOutputArtifact.java
@@ -87,7 +87,7 @@ public class LocalFileOutputArtifact implements OutputArtifact, LocalFileArtifac
     if (!(obj instanceof LocalFileOutputArtifact)) {
       return false;
     }
-    return FileUtil.filesEqual(file, ((LocalFileOutputArtifact) obj).file);
+    return file.getPath().equals(((LocalFileOutputArtifact) obj).file.getPath());
   }
 
   @Override


### PR DESCRIPTION
Don't canonicalize file paths when comparing output artifacts.