### PR TITLE
Upstream ag/6237454

### DIFF
--- a/aswb/src/com/google/idea/blaze/android/sync/model/idea/BlazeAndroidModel.java
+++ b/aswb/src/com/google/idea/blaze/android/sync/model/idea/BlazeAndroidModel.java
@@ -24,7 +24,6 @@ import com.android.tools.idea.model.ClassJarProvider;
 import com.android.tools.lint.detector.api.Desugaring;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
-import com.google.idea.blaze.android.manifest.ManifestParser;
 import com.google.idea.blaze.base.actions.BlazeBuildService;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
@@ -43,7 +42,6 @@ import java.io.File;
 import java.util.List;
 import java.util.Set;
 import javax.annotation.Nullable;
-import org.jetbrains.android.dom.manifest.Manifest;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -55,8 +53,7 @@ public class BlazeAndroidModel implements AndroidModel {
   private final File rootDirPath;
   private final SourceProvider sourceProvider;
   private final List<SourceProvider> sourceProviders; // Singleton list of sourceProvider
-  private final File moduleManifest;
-  private final String resourceJavaPackage;
+  private final String applicationId;
   private final int minSdkVersion;
   private boolean desugarJava8Libs;
 
@@ -65,16 +62,14 @@ public class BlazeAndroidModel implements AndroidModel {
       Project project,
       File rootDirPath,
       SourceProvider sourceProvider,
-      File moduleManifest,
-      String resourceJavaPackage,
+      String applicationId,
       int minSdkVersion,
       boolean desugarJava8Libs) {
     this.project = project;
     this.rootDirPath = rootDirPath;
     this.sourceProvider = sourceProvider;
     this.sourceProviders = ImmutableList.of(sourceProvider);
-    this.moduleManifest = moduleManifest;
-    this.resourceJavaPackage = resourceJavaPackage;
+    this.applicationId = applicationId;
     this.minSdkVersion = minSdkVersion;
     this.desugarJava8Libs = desugarJava8Libs;
   }
@@ -101,19 +96,7 @@ public class BlazeAndroidModel implements AndroidModel {
 
   @Override
   public String getApplicationId() {
-    // Run in a read action since otherwise, it might throw a read access exception.
-    return ApplicationManager.getApplication()
-        .runReadAction(
-            (Computable<String>)
-                () -> {
-                  Manifest manifest =
-                      ManifestParser.getInstance(project).getManifest(moduleManifest);
-                  if (manifest == null) {
-                    return resourceJavaPackage;
-                  }
-                  String packageName = manifest.getPackage().getValue();
-                  return packageName == null ? resourceJavaPackage : packageName;
-                });
+    return applicationId;
   }
 
   @Override

--- a/aswb/tests/unittests/com/google/idea/blaze/android/sync/model/idea/BlazeAndroidModelTest.java
+++ b/aswb/tests/unittests/com/google/idea/blaze/android/sync/model/idea/BlazeAndroidModelTest.java
@@ -95,7 +95,7 @@ public class BlazeAndroidModelTest extends BlazeTestCase {
 
     projectServices.register(JavaPsiFacade.class, facade);
     module = new MockModule(() -> {});
-    model = new BlazeAndroidModel(project, null, mock(SourceProvider.class), null, "", 0, false);
+    model = new BlazeAndroidModel(project, null, mock(SourceProvider.class), null, 0, false);
   }
 
   @Test


### PR DESCRIPTION
Upstream ag/6237454

Original commit message: 

Currently, BlazeAndroidModel recomputes a module's application ID from
its Android manifest each time getApplicationId() is called. When the
user tries to attach the debugger to a running Android target,
AndroidProcesssChooserDialog ends up calling this method on the EDT for
each module in the project. For large projects, this can mean hundreds
of file operations and sometimes results in UI freezes.

This CL resolves the issue by pre-computing the application IDs during
Blaze sync. As a result, changes to package names in any
AndroidManifest.xml won't affect application IDs until after the project
has been synced.