### PR TITLE
Fetch common manifest attributes directly from manifest file.

### DIFF
--- a/aswb/sdkcompat/as34/com/google/idea/blaze/android/run/DefaultActivityLocatorCompat.java
+++ b/aswb/sdkcompat/as34/com/google/idea/blaze/android/run/DefaultActivityLocatorCompat.java
@@ -1,0 +1,328 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.android.run;
+
+import static com.android.SdkConstants.ANDROID_URI;
+import static com.android.SdkConstants.ATTR_NAME;
+import static com.android.SdkConstants.ATTR_PACKAGE;
+import static com.android.SdkConstants.PREFIX_RESOURCE_REF;
+import static com.android.xml.AndroidManifest.NODE_ACTION;
+import static com.android.xml.AndroidManifest.NODE_CATEGORY;
+import static com.android.xml.AndroidManifest.NODE_INTENT;
+
+import com.android.SdkConstants;
+import com.android.tools.idea.apk.ApkFacet;
+import com.android.tools.idea.run.activity.ActivityLocatorUtils;
+import com.android.tools.idea.run.activity.DefaultActivityLocator;
+import com.google.common.collect.Lists;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.psi.PsiClass;
+import com.intellij.util.xml.DomElement;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.jetbrains.android.dom.converters.PackageClassConverter;
+import org.jetbrains.android.dom.manifest.Activity;
+import org.jetbrains.android.dom.manifest.ActivityAlias;
+import org.jetbrains.android.dom.manifest.Application;
+import org.jetbrains.android.dom.manifest.Manifest;
+import org.jetbrains.android.util.AndroidUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.w3c.dom.Attr;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+/** Compatibility class for {@link DefaultActivityLocator} and {@link ActivityLocatorUtils}. */
+public class DefaultActivityLocatorCompat {
+  private static final Logger LOG = Logger.getInstance(DefaultActivityLocatorCompat.class);
+
+  @Nullable
+  public static String computeDefaultActivity(
+      @NotNull List<DefaultActivityLocatorCompat.ActivityWrapper> activities) {
+    List<DefaultActivityLocatorCompat.ActivityWrapper> launchableActivities =
+        getLaunchableActivities(activities);
+    if (launchableActivities.isEmpty()) {
+      return null;
+    } else if (launchableActivities.size() == 1) {
+      return launchableActivities.get(0).getQualifiedName();
+    }
+
+    // Prefer the launcher which has the CATEGORY_DEFAULT intent filter.
+    // There is no such rule, but since Context.startActivity() prefers such activities, we do the
+    // same.
+    // https://code.google.com/p/android/issues/detail?id=67068
+    DefaultActivityLocatorCompat.ActivityWrapper defaultLauncher =
+        findDefaultLauncher(launchableActivities);
+    if (defaultLauncher != null) {
+      return defaultLauncher.getQualifiedName();
+    }
+
+    // Just return the first one we find
+    return launchableActivities.isEmpty() ? null : launchableActivities.get(0).getQualifiedName();
+  }
+
+  @Nullable
+  private static DefaultActivityLocatorCompat.ActivityWrapper findDefaultLauncher(
+      @NotNull List<DefaultActivityLocatorCompat.ActivityWrapper> launcherActivities) {
+    for (DefaultActivityLocatorCompat.ActivityWrapper activity : launcherActivities) {
+      if (activity.hasCategory(AndroidUtils.DEFAULT_CATEGORY_NAME)) {
+        return activity;
+      }
+    }
+
+    return null;
+  }
+
+  @NotNull
+  private static List<DefaultActivityLocatorCompat.ActivityWrapper> getLaunchableActivities(
+      @NotNull List<DefaultActivityLocatorCompat.ActivityWrapper> allActivities) {
+    List<DefaultActivityLocatorCompat.ActivityWrapper> launchableActivities =
+        allActivities.stream()
+            .filter(activity -> containsLauncherIntent(activity) && activity.isEnabled())
+            .collect(Collectors.toList());
+
+    if (launchableActivities.isEmpty() && LOG.isDebugEnabled()) {
+      LOG.debug("No launchable activities found, total # of activities: " + allActivities.size());
+      allActivities.forEach(
+          wrapper ->
+              LOG.debug(
+                  String.format(
+                      "activity: %1$s, isEnabled: %2$s, containsLauncherIntent: %3$s",
+                      wrapper.getQualifiedName(),
+                      wrapper.isEnabled(),
+                      containsLauncherIntent(wrapper))));
+    }
+
+    return launchableActivities;
+  }
+
+  /**
+   * {@link DefaultActivityLocatorCompat.ActivityWrapper} is a simple wrapper class around an {@link
+   * Activity} or an {@link ActivityAlias}.
+   */
+  public abstract static class ActivityWrapper {
+
+    public abstract boolean hasCategory(@NotNull String name);
+
+    public abstract boolean hasAction(@NotNull String name);
+
+    public abstract boolean isEnabled();
+
+    /**
+     * The value of android:exported attribute for the activity, null if not specified. Note that
+     * when the attribute is not explicitly set, it is considered exported if it has an intent
+     * filter.
+     */
+    @Nullable
+    public abstract Boolean getExported();
+
+    @Nullable
+    public abstract String getQualifiedName();
+
+    public static List<DefaultActivityLocatorCompat.ActivityWrapper> get(
+        @NotNull List<Element> activities, @NotNull List<Element> aliases) {
+      List<DefaultActivityLocatorCompat.ActivityWrapper> list =
+          Lists.newArrayListWithCapacity(activities.size() + aliases.size());
+      for (Element element : activities) {
+        list.add(new DefaultActivityLocatorCompat.ElementActivityWrapper(element));
+      }
+      for (Element element : aliases) {
+        list.add(new DefaultActivityLocatorCompat.ElementActivityWrapper(element));
+      }
+      return list;
+    }
+  }
+
+  private static class ElementActivityWrapper extends DefaultActivityLocatorCompat.ActivityWrapper {
+
+    private final Element myActivity;
+
+    public ElementActivityWrapper(Element activity) {
+      myActivity = activity;
+    }
+
+    @Override
+    public boolean hasCategory(@NotNull String name) {
+      Node node = myActivity.getFirstChild();
+      while (node != null) {
+        if (node.getNodeType() == Node.ELEMENT_NODE && NODE_INTENT.equals(node.getNodeName())) {
+          Element filter = (Element) node;
+          if (containsCategory(filter, name)) {
+            return true;
+          }
+        }
+        node = node.getNextSibling();
+      }
+
+      return false;
+    }
+
+    @Override
+    public boolean hasAction(@NotNull String name) {
+      Node node = myActivity.getFirstChild();
+      while (node != null) {
+        if (node.getNodeType() == Node.ELEMENT_NODE && NODE_INTENT.equals(node.getNodeName())) {
+          Element filter = (Element) node;
+          if (containsAction(filter, name)) {
+            return true;
+          }
+        }
+        node = node.getNextSibling();
+      }
+
+      return false;
+    }
+
+    @Override
+    public boolean isEnabled() {
+      String enabledAttr =
+          myActivity.getAttributeNS(SdkConstants.ANDROID_URI, SdkConstants.ATTR_ENABLED);
+      return StringUtil.isEmpty(enabledAttr) // true if not specified
+          || Boolean.parseBoolean(enabledAttr)
+          || enabledAttr.startsWith(PREFIX_RESOURCE_REF);
+    }
+
+    @Nullable
+    @Override
+    public Boolean getExported() {
+      String exportedAttr =
+          myActivity.getAttributeNS(SdkConstants.ANDROID_URI, SdkConstants.ATTR_EXPORTED);
+      return StringUtil.isEmpty(exportedAttr) ? null : Boolean.parseBoolean(exportedAttr);
+    }
+
+    @Nullable
+    @Override
+    public String getQualifiedName() {
+      return DefaultActivityLocatorCompat.getQualifiedName(myActivity);
+    }
+  }
+
+  public static boolean containsAction(@NotNull Element filter, @NotNull String name) {
+    Node action = filter.getFirstChild();
+    while (action != null) {
+      if (action.getNodeType() == Node.ELEMENT_NODE && NODE_ACTION.equals(action.getNodeName())) {
+        if (name.equals(((Element) action).getAttributeNS(ANDROID_URI, ATTR_NAME))) {
+          return true;
+        }
+      }
+      action = action.getNextSibling();
+    }
+    return false;
+  }
+
+  public static boolean containsCategory(@NotNull Element filter, @NotNull String name) {
+    Node action = filter.getFirstChild();
+    while (action != null) {
+      if (action.getNodeType() == Node.ELEMENT_NODE && NODE_CATEGORY.equals(action.getNodeName())) {
+        if (name.equals(((Element) action).getAttributeNS(ANDROID_URI, ATTR_NAME))) {
+          return true;
+        }
+      }
+      action = action.getNextSibling();
+    }
+    return false;
+  }
+
+  public static boolean containsLauncherIntent(
+      @NotNull DefaultActivityLocatorCompat.ActivityWrapper activity) {
+    return activity.hasAction(AndroidUtils.LAUNCH_ACTION_NAME)
+        && (activity.hasCategory(AndroidUtils.LAUNCH_CATEGORY_NAME)
+            || activity.hasCategory(AndroidUtils.LEANBACK_LAUNCH_CATEGORY_NAME));
+  }
+
+  @Nullable
+  public static String getQualifiedName(@NotNull Element component) {
+    Attr nameNode = component.getAttributeNodeNS(ANDROID_URI, ATTR_NAME);
+    if (nameNode == null) {
+      return null;
+    }
+    String name = nameNode.getValue();
+
+    int dotIndex = name.indexOf('.');
+    if (dotIndex > 0) { // fully qualified
+      return name;
+    }
+
+    // attempt to retrieve the package name from the manifest in which this alias was defined
+    Element root = component.getOwnerDocument().getDocumentElement();
+    Attr pkgNode = root.getAttributeNode(ATTR_PACKAGE);
+    if (pkgNode != null) {
+      // if we have a package name, prepend that to the activity alias
+      String pkg = pkgNode.getValue();
+      return pkg + (dotIndex == -1 ? "." : "") + name;
+    }
+
+    return name;
+  }
+
+  @Nullable
+  public static String getQualifiedName(@NotNull ActivityAlias alias) {
+    ApplicationManager.getApplication().assertReadAccessAllowed();
+
+    String name = alias.getName().getStringValue();
+    if (name == null) {
+      return null;
+    }
+
+    int dotIndex = name.indexOf('.');
+    if (dotIndex > 0) { // fully qualified
+      return name;
+    }
+
+    // attempt to retrieve the package name from the manifest in which this alias was defined
+    String pkg = null;
+    DomElement parent = alias.getParent();
+    if (parent instanceof Application) {
+      parent = parent.getParent();
+      if (parent instanceof Manifest) {
+        Manifest manifest = (Manifest) parent;
+        pkg = manifest.getPackage().getStringValue();
+      }
+    }
+
+    // if we have a package name, prepend that to the activity alias
+    return pkg == null ? name : pkg + (dotIndex == -1 ? "." : "") + name;
+  }
+
+  @Nullable
+  public static String getQualifiedName(@NotNull Activity activity) {
+    ApplicationManager.getApplication().assertReadAccessAllowed();
+
+    PsiClass psiClass = activity.getActivityClass().getValue();
+    if (psiClass == null) {
+      Module module = activity.getModule();
+      if (module != null && ApkFacet.getInstance(module) != null) {
+        // In APK project we doesn't necessarily have the source/class file of the activity.
+        return activity.getActivityClass().getStringValue();
+      }
+      return null;
+    }
+
+    return getQualifiedActivityName(psiClass);
+  }
+
+  /**
+   * Returns a fully qualified activity name as accepted by "am start" command: In particular,
+   * rather than return "com.foo.Bar.Inner", this will return "com.foo.Bar$Inner" for inner classes.
+   */
+  @Nullable
+  public static String getQualifiedActivityName(@NotNull PsiClass c) {
+    return PackageClassConverter.getQualifiedName(c);
+  }
+}

--- a/aswb/sdkcompat/as35/com/google/idea/blaze/android/run/DefaultActivityLocatorCompat.java
+++ b/aswb/sdkcompat/as35/com/google/idea/blaze/android/run/DefaultActivityLocatorCompat.java
@@ -1,0 +1,328 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.android.run;
+
+import static com.android.SdkConstants.ANDROID_URI;
+import static com.android.SdkConstants.ATTR_NAME;
+import static com.android.SdkConstants.ATTR_PACKAGE;
+import static com.android.SdkConstants.PREFIX_RESOURCE_REF;
+import static com.android.xml.AndroidManifest.NODE_ACTION;
+import static com.android.xml.AndroidManifest.NODE_CATEGORY;
+import static com.android.xml.AndroidManifest.NODE_INTENT;
+
+import com.android.SdkConstants;
+import com.android.tools.idea.apk.ApkFacet;
+import com.android.tools.idea.run.activity.ActivityLocatorUtils;
+import com.android.tools.idea.run.activity.DefaultActivityLocator;
+import com.google.common.collect.Lists;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.psi.PsiClass;
+import com.intellij.util.xml.DomElement;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.jetbrains.android.dom.converters.PackageClassConverter;
+import org.jetbrains.android.dom.manifest.Activity;
+import org.jetbrains.android.dom.manifest.ActivityAlias;
+import org.jetbrains.android.dom.manifest.Application;
+import org.jetbrains.android.dom.manifest.Manifest;
+import org.jetbrains.android.util.AndroidUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.w3c.dom.Attr;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+/** Compatibility class for {@link DefaultActivityLocator} and {@link ActivityLocatorUtils}. */
+public class DefaultActivityLocatorCompat {
+  private static final Logger LOG = Logger.getInstance(DefaultActivityLocatorCompat.class);
+
+  @Nullable
+  public static String computeDefaultActivity(
+      @NotNull List<DefaultActivityLocatorCompat.ActivityWrapper> activities) {
+    List<DefaultActivityLocatorCompat.ActivityWrapper> launchableActivities =
+        getLaunchableActivities(activities);
+    if (launchableActivities.isEmpty()) {
+      return null;
+    } else if (launchableActivities.size() == 1) {
+      return launchableActivities.get(0).getQualifiedName();
+    }
+
+    // Prefer the launcher which has the CATEGORY_DEFAULT intent filter.
+    // There is no such rule, but since Context.startActivity() prefers such activities, we do the
+    // same.
+    // https://code.google.com/p/android/issues/detail?id=67068
+    DefaultActivityLocatorCompat.ActivityWrapper defaultLauncher =
+        findDefaultLauncher(launchableActivities);
+    if (defaultLauncher != null) {
+      return defaultLauncher.getQualifiedName();
+    }
+
+    // Just return the first one we find
+    return launchableActivities.isEmpty() ? null : launchableActivities.get(0).getQualifiedName();
+  }
+
+  @Nullable
+  private static DefaultActivityLocatorCompat.ActivityWrapper findDefaultLauncher(
+      @NotNull List<DefaultActivityLocatorCompat.ActivityWrapper> launcherActivities) {
+    for (DefaultActivityLocatorCompat.ActivityWrapper activity : launcherActivities) {
+      if (activity.hasCategory(AndroidUtils.DEFAULT_CATEGORY_NAME)) {
+        return activity;
+      }
+    }
+
+    return null;
+  }
+
+  @NotNull
+  private static List<DefaultActivityLocatorCompat.ActivityWrapper> getLaunchableActivities(
+      @NotNull List<DefaultActivityLocatorCompat.ActivityWrapper> allActivities) {
+    List<DefaultActivityLocatorCompat.ActivityWrapper> launchableActivities =
+        allActivities.stream()
+            .filter(activity -> containsLauncherIntent(activity) && activity.isEnabled())
+            .collect(Collectors.toList());
+
+    if (launchableActivities.isEmpty() && LOG.isDebugEnabled()) {
+      LOG.debug("No launchable activities found, total # of activities: " + allActivities.size());
+      allActivities.forEach(
+          wrapper ->
+              LOG.debug(
+                  String.format(
+                      "activity: %1$s, isEnabled: %2$s, containsLauncherIntent: %3$s",
+                      wrapper.getQualifiedName(),
+                      wrapper.isEnabled(),
+                      containsLauncherIntent(wrapper))));
+    }
+
+    return launchableActivities;
+  }
+
+  /**
+   * {@link DefaultActivityLocatorCompat.ActivityWrapper} is a simple wrapper class around an {@link
+   * Activity} or an {@link ActivityAlias}.
+   */
+  public abstract static class ActivityWrapper {
+
+    public abstract boolean hasCategory(@NotNull String name);
+
+    public abstract boolean hasAction(@NotNull String name);
+
+    public abstract boolean isEnabled();
+
+    /**
+     * The value of android:exported attribute for the activity, null if not specified. Note that
+     * when the attribute is not explicitly set, it is considered exported if it has an intent
+     * filter.
+     */
+    @Nullable
+    public abstract Boolean getExported();
+
+    @Nullable
+    public abstract String getQualifiedName();
+
+    public static List<DefaultActivityLocatorCompat.ActivityWrapper> get(
+        @NotNull List<Element> activities, @NotNull List<Element> aliases) {
+      List<DefaultActivityLocatorCompat.ActivityWrapper> list =
+          Lists.newArrayListWithCapacity(activities.size() + aliases.size());
+      for (Element element : activities) {
+        list.add(new DefaultActivityLocatorCompat.ElementActivityWrapper(element));
+      }
+      for (Element element : aliases) {
+        list.add(new DefaultActivityLocatorCompat.ElementActivityWrapper(element));
+      }
+      return list;
+    }
+  }
+
+  private static class ElementActivityWrapper extends DefaultActivityLocatorCompat.ActivityWrapper {
+
+    private final Element myActivity;
+
+    public ElementActivityWrapper(Element activity) {
+      myActivity = activity;
+    }
+
+    @Override
+    public boolean hasCategory(@NotNull String name) {
+      Node node = myActivity.getFirstChild();
+      while (node != null) {
+        if (node.getNodeType() == Node.ELEMENT_NODE && NODE_INTENT.equals(node.getNodeName())) {
+          Element filter = (Element) node;
+          if (containsCategory(filter, name)) {
+            return true;
+          }
+        }
+        node = node.getNextSibling();
+      }
+
+      return false;
+    }
+
+    @Override
+    public boolean hasAction(@NotNull String name) {
+      Node node = myActivity.getFirstChild();
+      while (node != null) {
+        if (node.getNodeType() == Node.ELEMENT_NODE && NODE_INTENT.equals(node.getNodeName())) {
+          Element filter = (Element) node;
+          if (containsAction(filter, name)) {
+            return true;
+          }
+        }
+        node = node.getNextSibling();
+      }
+
+      return false;
+    }
+
+    @Override
+    public boolean isEnabled() {
+      String enabledAttr =
+          myActivity.getAttributeNS(SdkConstants.ANDROID_URI, SdkConstants.ATTR_ENABLED);
+      return StringUtil.isEmpty(enabledAttr) // true if not specified
+          || Boolean.parseBoolean(enabledAttr)
+          || enabledAttr.startsWith(PREFIX_RESOURCE_REF);
+    }
+
+    @Nullable
+    @Override
+    public Boolean getExported() {
+      String exportedAttr =
+          myActivity.getAttributeNS(SdkConstants.ANDROID_URI, SdkConstants.ATTR_EXPORTED);
+      return StringUtil.isEmpty(exportedAttr) ? null : Boolean.parseBoolean(exportedAttr);
+    }
+
+    @Nullable
+    @Override
+    public String getQualifiedName() {
+      return DefaultActivityLocatorCompat.getQualifiedName(myActivity);
+    }
+  }
+
+  public static boolean containsAction(@NotNull Element filter, @NotNull String name) {
+    Node action = filter.getFirstChild();
+    while (action != null) {
+      if (action.getNodeType() == Node.ELEMENT_NODE && NODE_ACTION.equals(action.getNodeName())) {
+        if (name.equals(((Element) action).getAttributeNS(ANDROID_URI, ATTR_NAME))) {
+          return true;
+        }
+      }
+      action = action.getNextSibling();
+    }
+    return false;
+  }
+
+  public static boolean containsCategory(@NotNull Element filter, @NotNull String name) {
+    Node action = filter.getFirstChild();
+    while (action != null) {
+      if (action.getNodeType() == Node.ELEMENT_NODE && NODE_CATEGORY.equals(action.getNodeName())) {
+        if (name.equals(((Element) action).getAttributeNS(ANDROID_URI, ATTR_NAME))) {
+          return true;
+        }
+      }
+      action = action.getNextSibling();
+    }
+    return false;
+  }
+
+  public static boolean containsLauncherIntent(
+      @NotNull DefaultActivityLocatorCompat.ActivityWrapper activity) {
+    return activity.hasAction(AndroidUtils.LAUNCH_ACTION_NAME)
+        && (activity.hasCategory(AndroidUtils.LAUNCH_CATEGORY_NAME)
+            || activity.hasCategory(AndroidUtils.LEANBACK_LAUNCH_CATEGORY_NAME));
+  }
+
+  @Nullable
+  public static String getQualifiedName(@NotNull Element component) {
+    Attr nameNode = component.getAttributeNodeNS(ANDROID_URI, ATTR_NAME);
+    if (nameNode == null) {
+      return null;
+    }
+    String name = nameNode.getValue();
+
+    int dotIndex = name.indexOf('.');
+    if (dotIndex > 0) { // fully qualified
+      return name;
+    }
+
+    // attempt to retrieve the package name from the manifest in which this alias was defined
+    Element root = component.getOwnerDocument().getDocumentElement();
+    Attr pkgNode = root.getAttributeNode(ATTR_PACKAGE);
+    if (pkgNode != null) {
+      // if we have a package name, prepend that to the activity alias
+      String pkg = pkgNode.getValue();
+      return pkg + (dotIndex == -1 ? "." : "") + name;
+    }
+
+    return name;
+  }
+
+  @Nullable
+  public static String getQualifiedName(@NotNull ActivityAlias alias) {
+    ApplicationManager.getApplication().assertReadAccessAllowed();
+
+    String name = alias.getName().getStringValue();
+    if (name == null) {
+      return null;
+    }
+
+    int dotIndex = name.indexOf('.');
+    if (dotIndex > 0) { // fully qualified
+      return name;
+    }
+
+    // attempt to retrieve the package name from the manifest in which this alias was defined
+    String pkg = null;
+    DomElement parent = alias.getParent();
+    if (parent instanceof Application) {
+      parent = parent.getParent();
+      if (parent instanceof Manifest) {
+        Manifest manifest = (Manifest) parent;
+        pkg = manifest.getPackage().getStringValue();
+      }
+    }
+
+    // if we have a package name, prepend that to the activity alias
+    return pkg == null ? name : pkg + (dotIndex == -1 ? "." : "") + name;
+  }
+
+  @Nullable
+  public static String getQualifiedName(@NotNull Activity activity) {
+    ApplicationManager.getApplication().assertReadAccessAllowed();
+
+    PsiClass psiClass = activity.getActivityClass().getValue();
+    if (psiClass == null) {
+      Module module = activity.getModule();
+      if (module != null && ApkFacet.getInstance(module) != null) {
+        // In APK project we doesn't necessarily have the source/class file of the activity.
+        return activity.getActivityClass().getStringValue();
+      }
+      return null;
+    }
+
+    return getQualifiedActivityName(psiClass);
+  }
+
+  /**
+   * Returns a fully qualified activity name as accepted by "am start" command: In particular,
+   * rather than return "com.foo.Bar.Inner", this will return "com.foo.Bar$Inner" for inner classes.
+   */
+  @Nullable
+  public static String getQualifiedActivityName(@NotNull PsiClass c) {
+    return PackageClassConverter.getQualifiedName(c);
+  }
+}

--- a/aswb/sdkcompat/as36/com/google/idea/blaze/android/run/DefaultActivityLocatorCompat.java
+++ b/aswb/sdkcompat/as36/com/google/idea/blaze/android/run/DefaultActivityLocatorCompat.java
@@ -1,0 +1,328 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.android.run;
+
+import static com.android.SdkConstants.ANDROID_URI;
+import static com.android.SdkConstants.ATTR_NAME;
+import static com.android.SdkConstants.ATTR_PACKAGE;
+import static com.android.SdkConstants.PREFIX_RESOURCE_REF;
+import static com.android.xml.AndroidManifest.NODE_ACTION;
+import static com.android.xml.AndroidManifest.NODE_CATEGORY;
+import static com.android.xml.AndroidManifest.NODE_INTENT;
+
+import com.android.SdkConstants;
+import com.android.tools.idea.apk.ApkFacet;
+import com.android.tools.idea.run.activity.ActivityLocatorUtils;
+import com.android.tools.idea.run.activity.DefaultActivityLocator;
+import com.google.common.collect.Lists;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.psi.PsiClass;
+import com.intellij.util.xml.DomElement;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.jetbrains.android.dom.converters.PackageClassConverter;
+import org.jetbrains.android.dom.manifest.Activity;
+import org.jetbrains.android.dom.manifest.ActivityAlias;
+import org.jetbrains.android.dom.manifest.Application;
+import org.jetbrains.android.dom.manifest.Manifest;
+import org.jetbrains.android.util.AndroidUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.w3c.dom.Attr;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+/** Compatibility class for {@link DefaultActivityLocator} and {@link ActivityLocatorUtils}. */
+public class DefaultActivityLocatorCompat {
+  private static final Logger LOG = Logger.getInstance(DefaultActivityLocatorCompat.class);
+
+  @Nullable
+  public static String computeDefaultActivity(
+      @NotNull List<DefaultActivityLocatorCompat.ActivityWrapper> activities) {
+    List<DefaultActivityLocatorCompat.ActivityWrapper> launchableActivities =
+        getLaunchableActivities(activities);
+    if (launchableActivities.isEmpty()) {
+      return null;
+    } else if (launchableActivities.size() == 1) {
+      return launchableActivities.get(0).getQualifiedName();
+    }
+
+    // Prefer the launcher which has the CATEGORY_DEFAULT intent filter.
+    // There is no such rule, but since Context.startActivity() prefers such activities, we do the
+    // same.
+    // https://code.google.com/p/android/issues/detail?id=67068
+    DefaultActivityLocatorCompat.ActivityWrapper defaultLauncher =
+        findDefaultLauncher(launchableActivities);
+    if (defaultLauncher != null) {
+      return defaultLauncher.getQualifiedName();
+    }
+
+    // Just return the first one we find
+    return launchableActivities.isEmpty() ? null : launchableActivities.get(0).getQualifiedName();
+  }
+
+  @Nullable
+  private static DefaultActivityLocatorCompat.ActivityWrapper findDefaultLauncher(
+      @NotNull List<DefaultActivityLocatorCompat.ActivityWrapper> launcherActivities) {
+    for (DefaultActivityLocatorCompat.ActivityWrapper activity : launcherActivities) {
+      if (activity.hasCategory(AndroidUtils.DEFAULT_CATEGORY_NAME)) {
+        return activity;
+      }
+    }
+
+    return null;
+  }
+
+  @NotNull
+  private static List<DefaultActivityLocatorCompat.ActivityWrapper> getLaunchableActivities(
+      @NotNull List<DefaultActivityLocatorCompat.ActivityWrapper> allActivities) {
+    List<DefaultActivityLocatorCompat.ActivityWrapper> launchableActivities =
+        allActivities.stream()
+            .filter(activity -> containsLauncherIntent(activity) && activity.isEnabled())
+            .collect(Collectors.toList());
+
+    if (launchableActivities.isEmpty() && LOG.isDebugEnabled()) {
+      LOG.debug("No launchable activities found, total # of activities: " + allActivities.size());
+      allActivities.forEach(
+          wrapper ->
+              LOG.debug(
+                  String.format(
+                      "activity: %1$s, isEnabled: %2$s, containsLauncherIntent: %3$s",
+                      wrapper.getQualifiedName(),
+                      wrapper.isEnabled(),
+                      containsLauncherIntent(wrapper))));
+    }
+
+    return launchableActivities;
+  }
+
+  /**
+   * {@link DefaultActivityLocatorCompat.ActivityWrapper} is a simple wrapper class around an {@link
+   * Activity} or an {@link ActivityAlias}.
+   */
+  public abstract static class ActivityWrapper {
+
+    public abstract boolean hasCategory(@NotNull String name);
+
+    public abstract boolean hasAction(@NotNull String name);
+
+    public abstract boolean isEnabled();
+
+    /**
+     * The value of android:exported attribute for the activity, null if not specified. Note that
+     * when the attribute is not explicitly set, it is considered exported if it has an intent
+     * filter.
+     */
+    @Nullable
+    public abstract Boolean getExported();
+
+    @Nullable
+    public abstract String getQualifiedName();
+
+    public static List<DefaultActivityLocatorCompat.ActivityWrapper> get(
+        @NotNull List<Element> activities, @NotNull List<Element> aliases) {
+      List<DefaultActivityLocatorCompat.ActivityWrapper> list =
+          Lists.newArrayListWithCapacity(activities.size() + aliases.size());
+      for (Element element : activities) {
+        list.add(new DefaultActivityLocatorCompat.ElementActivityWrapper(element));
+      }
+      for (Element element : aliases) {
+        list.add(new DefaultActivityLocatorCompat.ElementActivityWrapper(element));
+      }
+      return list;
+    }
+  }
+
+  private static class ElementActivityWrapper extends DefaultActivityLocatorCompat.ActivityWrapper {
+
+    private final Element myActivity;
+
+    public ElementActivityWrapper(Element activity) {
+      myActivity = activity;
+    }
+
+    @Override
+    public boolean hasCategory(@NotNull String name) {
+      Node node = myActivity.getFirstChild();
+      while (node != null) {
+        if (node.getNodeType() == Node.ELEMENT_NODE && NODE_INTENT.equals(node.getNodeName())) {
+          Element filter = (Element) node;
+          if (containsCategory(filter, name)) {
+            return true;
+          }
+        }
+        node = node.getNextSibling();
+      }
+
+      return false;
+    }
+
+    @Override
+    public boolean hasAction(@NotNull String name) {
+      Node node = myActivity.getFirstChild();
+      while (node != null) {
+        if (node.getNodeType() == Node.ELEMENT_NODE && NODE_INTENT.equals(node.getNodeName())) {
+          Element filter = (Element) node;
+          if (containsAction(filter, name)) {
+            return true;
+          }
+        }
+        node = node.getNextSibling();
+      }
+
+      return false;
+    }
+
+    @Override
+    public boolean isEnabled() {
+      String enabledAttr =
+          myActivity.getAttributeNS(SdkConstants.ANDROID_URI, SdkConstants.ATTR_ENABLED);
+      return StringUtil.isEmpty(enabledAttr) // true if not specified
+          || Boolean.parseBoolean(enabledAttr)
+          || enabledAttr.startsWith(PREFIX_RESOURCE_REF);
+    }
+
+    @Nullable
+    @Override
+    public Boolean getExported() {
+      String exportedAttr =
+          myActivity.getAttributeNS(SdkConstants.ANDROID_URI, SdkConstants.ATTR_EXPORTED);
+      return StringUtil.isEmpty(exportedAttr) ? null : Boolean.parseBoolean(exportedAttr);
+    }
+
+    @Nullable
+    @Override
+    public String getQualifiedName() {
+      return DefaultActivityLocatorCompat.getQualifiedName(myActivity);
+    }
+  }
+
+  public static boolean containsAction(@NotNull Element filter, @NotNull String name) {
+    Node action = filter.getFirstChild();
+    while (action != null) {
+      if (action.getNodeType() == Node.ELEMENT_NODE && NODE_ACTION.equals(action.getNodeName())) {
+        if (name.equals(((Element) action).getAttributeNS(ANDROID_URI, ATTR_NAME))) {
+          return true;
+        }
+      }
+      action = action.getNextSibling();
+    }
+    return false;
+  }
+
+  public static boolean containsCategory(@NotNull Element filter, @NotNull String name) {
+    Node action = filter.getFirstChild();
+    while (action != null) {
+      if (action.getNodeType() == Node.ELEMENT_NODE && NODE_CATEGORY.equals(action.getNodeName())) {
+        if (name.equals(((Element) action).getAttributeNS(ANDROID_URI, ATTR_NAME))) {
+          return true;
+        }
+      }
+      action = action.getNextSibling();
+    }
+    return false;
+  }
+
+  public static boolean containsLauncherIntent(
+      @NotNull DefaultActivityLocatorCompat.ActivityWrapper activity) {
+    return activity.hasAction(AndroidUtils.LAUNCH_ACTION_NAME)
+        && (activity.hasCategory(AndroidUtils.LAUNCH_CATEGORY_NAME)
+            || activity.hasCategory(AndroidUtils.LEANBACK_LAUNCH_CATEGORY_NAME));
+  }
+
+  @Nullable
+  public static String getQualifiedName(@NotNull Element component) {
+    Attr nameNode = component.getAttributeNodeNS(ANDROID_URI, ATTR_NAME);
+    if (nameNode == null) {
+      return null;
+    }
+    String name = nameNode.getValue();
+
+    int dotIndex = name.indexOf('.');
+    if (dotIndex > 0) { // fully qualified
+      return name;
+    }
+
+    // attempt to retrieve the package name from the manifest in which this alias was defined
+    Element root = component.getOwnerDocument().getDocumentElement();
+    Attr pkgNode = root.getAttributeNode(ATTR_PACKAGE);
+    if (pkgNode != null) {
+      // if we have a package name, prepend that to the activity alias
+      String pkg = pkgNode.getValue();
+      return pkg + (dotIndex == -1 ? "." : "") + name;
+    }
+
+    return name;
+  }
+
+  @Nullable
+  public static String getQualifiedName(@NotNull ActivityAlias alias) {
+    ApplicationManager.getApplication().assertReadAccessAllowed();
+
+    String name = alias.getName().getStringValue();
+    if (name == null) {
+      return null;
+    }
+
+    int dotIndex = name.indexOf('.');
+    if (dotIndex > 0) { // fully qualified
+      return name;
+    }
+
+    // attempt to retrieve the package name from the manifest in which this alias was defined
+    String pkg = null;
+    DomElement parent = alias.getParent();
+    if (parent instanceof Application) {
+      parent = parent.getParent();
+      if (parent instanceof Manifest) {
+        Manifest manifest = (Manifest) parent;
+        pkg = manifest.getPackage().getStringValue();
+      }
+    }
+
+    // if we have a package name, prepend that to the activity alias
+    return pkg == null ? name : pkg + (dotIndex == -1 ? "." : "") + name;
+  }
+
+  @Nullable
+  public static String getQualifiedName(@NotNull Activity activity) {
+    ApplicationManager.getApplication().assertReadAccessAllowed();
+
+    PsiClass psiClass = activity.getActivityClass().getValue();
+    if (psiClass == null) {
+      Module module = activity.getModule();
+      if (module != null && ApkFacet.getInstance(module) != null) {
+        // In APK project we doesn't necessarily have the source/class file of the activity.
+        return activity.getActivityClass().getStringValue();
+      }
+      return null;
+    }
+
+    return getQualifiedActivityName(psiClass);
+  }
+
+  /**
+   * Returns a fully qualified activity name as accepted by "am start" command: In particular,
+   * rather than return "com.foo.Bar.Inner", this will return "com.foo.Bar$Inner" for inner classes.
+   */
+  @Nullable
+  public static String getQualifiedActivityName(@NotNull PsiClass c) {
+    return PackageClassConverter.getQualifiedName(c);
+  }
+}

--- a/aswb/src/META-INF/aswb.xml
+++ b/aswb/src/META-INF/aswb.xml
@@ -27,7 +27,7 @@
     <executor implementation="com.google.idea.blaze.android.run.binary.mobileinstall.IncrementalInstallDebugExecutor" order="last"/>
     <applicationService serviceInterface="com.google.idea.blaze.base.plugin.BlazePluginId"
                         serviceImplementation="com.google.idea.blaze.android.plugin.AswbPlugin"/>
-    <projectService serviceImplementation="com.google.idea.blaze.android.manifest.ManifestParser"/>
+    <projectService serviceImplementation="com.google.idea.blaze.android.manifest.ParsedManifestService"/>
     <projectService serviceImplementation="com.google.idea.blaze.android.sync.model.AndroidResourceModuleRegistry"/>
     <projectService serviceImplementation="com.google.idea.blaze.android.projectsystem.ExternalLibraryInterner"/>
     <projectService serviceImplementation="com.google.idea.blaze.android.libraries.UnpackedAars"/>
@@ -57,7 +57,7 @@
   <extensions defaultExtensionNs="com.google.idea.blaze">
     <SyncPlugin implementation="com.google.idea.blaze.android.sync.BlazeAndroidSyncPlugin"/>
     <SyncListener implementation="com.google.idea.blaze.android.sync.BlazeAndroidSyncListener"/>
-    <SyncListener implementation="com.google.idea.blaze.android.manifest.ManifestParser$ClearManifestParser"/>
+    <SyncListener implementation="com.google.idea.blaze.android.manifest.ParsedManifestService$ClearManifestParser"/>
     <SyncListener implementation="com.google.idea.blaze.android.projectsystem.BlazeProjectSystemSyncManager$SyncStatusPublisher"/>
     <JavaSyncAugmenter implementation="com.google.idea.blaze.android.sync.BlazeAndroidJavaSyncAugmenter"/>
     <FileCache implementation="com.google.idea.blaze.android.libraries.UnpackedAars$FileCacheAdapter"/>

--- a/aswb/src/com/google/idea/blaze/android/manifest/ParsedManifestService.java
+++ b/aswb/src/com/google/idea/blaze/android/manifest/ParsedManifestService.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.android.manifest;
+
+import static com.google.idea.blaze.android.manifest.ManifestParser.parseManifestFromInputStream;
+
+import com.google.common.collect.Maps;
+import com.google.idea.blaze.base.model.BlazeProjectData;
+import com.google.idea.blaze.base.projectview.ProjectViewSet;
+import com.google.idea.blaze.base.scope.BlazeContext;
+import com.google.idea.blaze.base.settings.BlazeImportSettings;
+import com.google.idea.blaze.base.sync.SyncListener;
+import com.google.idea.blaze.base.sync.SyncMode;
+import com.google.idea.blaze.base.sync.SyncResult;
+import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.project.Project;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/** Obtains and caches {@link ManifestParser.ParsedManifest}. */
+public class ParsedManifestService {
+  private final Map<File, ManifestParser.ParsedManifest> manifestFileToParsedManifests =
+      Maps.newHashMap();
+
+  public static ParsedManifestService getInstance(Project project) {
+    return ServiceManager.getService(project, ParsedManifestService.class);
+  }
+
+  /**
+   * Returns parsed manifest from the given manifest file. Returns null if the manifest is invalid.
+   *
+   * <p>An invalid manifest is anything that could not be parsed by the parser, such as a malformed
+   * manifest file.
+   *
+   * @throws IOException only when an IO error occurs. Errors related to malformed manifests are
+   *     indicated by returning null.
+   */
+  @Nullable
+  public ManifestParser.ParsedManifest getParsedManifest(File file) throws IOException {
+    if (!manifestFileToParsedManifests.containsKey(file)) {
+      try (InputStream inputStream = new FileInputStream(file)) {
+        ManifestParser.ParsedManifest parsedManifest = parseManifestFromInputStream(inputStream);
+        if (parsedManifest == null) {
+          return null;
+        }
+        manifestFileToParsedManifests.put(file, parsedManifest);
+      }
+    }
+
+    return manifestFileToParsedManifests.get(file);
+  }
+
+  public void invalidateCachedManifests(Collection<File> manifestFiles) {
+    manifestFileToParsedManifests.keySet().removeAll(manifestFiles);
+  }
+
+  static class ClearManifestParser implements SyncListener {
+    @Override
+    public void onSyncComplete(
+        Project project,
+        BlazeContext context,
+        BlazeImportSettings importSettings,
+        ProjectViewSet projectViewSet,
+        BlazeProjectData blazeProjectData,
+        SyncMode syncMode,
+        SyncResult syncResult) {
+      getInstance(project).manifestFileToParsedManifests.clear();
+    }
+  }
+
+  private ParsedManifestService() {}
+}

--- a/aswb/src/com/google/idea/blaze/android/run/binary/BlazeAndroidBinaryApplicationIdProvider.java
+++ b/aswb/src/com/google/idea/blaze/android/run/binary/BlazeAndroidBinaryApplicationIdProvider.java
@@ -17,12 +17,10 @@ package com.google.idea.blaze.android.run.binary;
 
 import com.android.tools.idea.run.ApkProvisionException;
 import com.android.tools.idea.run.ApplicationIdProvider;
+import com.google.idea.blaze.android.manifest.ManifestParser;
 import com.google.idea.blaze.android.run.deployinfo.BlazeAndroidDeployInfo;
 import com.google.idea.blaze.android.run.runner.BlazeApkBuildStep;
-import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.util.Computable;
 import javax.annotation.Nullable;
-import org.jetbrains.android.dom.manifest.Manifest;
 
 /** Application id provider for android_binary. */
 public class BlazeAndroidBinaryApplicationIdProvider implements ApplicationIdProvider {
@@ -35,19 +33,16 @@ public class BlazeAndroidBinaryApplicationIdProvider implements ApplicationIdPro
   @Override
   public String getPackageName() throws ApkProvisionException {
     BlazeAndroidDeployInfo deployInfo = buildStep.getDeployInfo();
-    Manifest manifest = deployInfo.getMergedManifest();
-    if (manifest == null) {
+    ManifestParser.ParsedManifest parsedManifest = deployInfo.getMergedManifest();
+    if (parsedManifest == null) {
       throw new ApkProvisionException(
           "Could not find merged manifest: " + deployInfo.getMergedManifestFile());
     }
-    String applicationId =
-        ApplicationManager.getApplication()
-            .runReadAction((Computable<String>) () -> manifest.getPackage().getValue());
-    if (applicationId == null) {
+    if (parsedManifest.packageName == null) {
       throw new ApkProvisionException(
           "No application id in merged manifest: " + deployInfo.getMergedManifestFile());
     }
-    return applicationId;
+    return parsedManifest.packageName;
   }
 
   @Nullable

--- a/aswb/src/com/google/idea/blaze/android/run/binary/BlazeAndroidBinaryApplicationLaunchTaskProvider.java
+++ b/aswb/src/com/google/idea/blaze/android/run/binary/BlazeAndroidBinaryApplicationLaunchTaskProvider.java
@@ -23,10 +23,10 @@ import com.android.tools.idea.run.tasks.DefaultActivityLaunchTask;
 import com.android.tools.idea.run.tasks.LaunchTask;
 import com.android.tools.idea.run.tasks.SpecificActivityLaunchTask;
 import com.android.tools.idea.run.util.ProcessHandlerLaunchStatus;
+import com.google.idea.blaze.android.manifest.ManifestParser;
 import com.google.idea.blaze.android.run.LaunchStatusCompat;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
-import java.io.File;
 
 /** Provides the launch task for android_binary */
 public class BlazeAndroidBinaryApplicationLaunchTaskProvider {
@@ -36,7 +36,7 @@ public class BlazeAndroidBinaryApplicationLaunchTaskProvider {
   public static LaunchTask getApplicationLaunchTask(
       Project project,
       ApplicationIdProvider applicationIdProvider,
-      File mergedManifestFile,
+      ManifestParser.ParsedManifest mergedManifestParsedManifest,
       BlazeAndroidBinaryRunConfigurationState configState,
       StartActivityFlagsProvider startActivityFlagsProvider,
       ProcessHandlerLaunchStatus processHandlerLaunchStatus) {
@@ -46,12 +46,9 @@ public class BlazeAndroidBinaryApplicationLaunchTaskProvider {
       final LaunchTask launchTask;
 
       switch (configState.getMode()) {
-        case BlazeAndroidBinaryRunConfigurationState.DO_NOTHING:
-          launchTask = null;
-          break;
         case BlazeAndroidBinaryRunConfigurationState.LAUNCH_DEFAULT_ACTIVITY:
           BlazeDefaultActivityLocator activityLocator =
-              new BlazeDefaultActivityLocator(project, mergedManifestFile);
+              new BlazeDefaultActivityLocator(mergedManifestParsedManifest);
           launchTask =
               new DefaultActivityLaunchTask(
                   applicationId, activityLocator, startActivityFlagsProvider);
@@ -65,6 +62,7 @@ public class BlazeAndroidBinaryApplicationLaunchTaskProvider {
           launchTask =
               new AndroidDeepLinkLaunchTask(configState.getDeepLink(), startActivityFlagsProvider);
           break;
+        case BlazeAndroidBinaryRunConfigurationState.DO_NOTHING:
         default:
           launchTask = null;
           break;

--- a/aswb/src/com/google/idea/blaze/android/run/binary/BlazeAndroidBinaryNormalBuildRunContext.java
+++ b/aswb/src/com/google/idea/blaze/android/run/binary/BlazeAndroidBinaryNormalBuildRunContext.java
@@ -188,7 +188,7 @@ public class BlazeAndroidBinaryNormalBuildRunContext implements BlazeAndroidRunC
     return BlazeAndroidBinaryApplicationLaunchTaskProvider.getApplicationLaunchTask(
         project,
         applicationIdProvider,
-        deployInfo.getMergedManifestFile(),
+        deployInfo.getMergedManifest(),
         configState,
         startActivityFlagsProvider,
         processHandlerLaunchStatus);

--- a/aswb/src/com/google/idea/blaze/android/run/binary/mobileinstall/BlazeAndroidBinaryMobileInstallRunContext.java
+++ b/aswb/src/com/google/idea/blaze/android/run/binary/mobileinstall/BlazeAndroidBinaryMobileInstallRunContext.java
@@ -150,7 +150,7 @@ public class BlazeAndroidBinaryMobileInstallRunContext implements BlazeAndroidRu
     return BlazeAndroidBinaryApplicationLaunchTaskProvider.getApplicationLaunchTask(
         project,
         applicationIdProvider,
-        deployInfo.getMergedManifestFile(),
+        deployInfo.getMergedManifest(),
         configState,
         startActivityFlagsProvider,
         processHandlerLaunchStatus);

--- a/aswb/src/com/google/idea/blaze/android/run/deployinfo/BlazeAndroidDeployInfo.java
+++ b/aswb/src/com/google/idea/blaze/android/run/deployinfo/BlazeAndroidDeployInfo.java
@@ -18,18 +18,19 @@ package com.google.idea.blaze.android.run.deployinfo;
 import com.google.common.collect.Lists;
 import com.google.devtools.build.lib.rules.android.deployinfo.AndroidDeployInfoOuterClass;
 import com.google.idea.blaze.android.manifest.ManifestParser;
-import com.intellij.openapi.application.ApplicationManager;
+import com.google.idea.blaze.android.manifest.ParsedManifestService;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.util.Computable;
 import java.io.File;
+import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
-import org.jetbrains.android.dom.manifest.Manifest;
 
 /** Info about the android_binary/android_test to deploy. */
 public class BlazeAndroidDeployInfo {
+  private static final Logger log = Logger.getInstance(BlazeAndroidDeployInfo.class);
   private final Project project;
   private final File executionRoot;
   private final AndroidDeployInfoOuterClass.AndroidDeployInfo deployInfo;
@@ -43,22 +44,22 @@ public class BlazeAndroidDeployInfo {
     this.deployInfo = deployInfo;
   }
 
-  @Nullable
   public File getMergedManifestFile() {
     return new File(executionRoot, deployInfo.getMergedManifest().getExecRootPath());
   }
 
   @Nullable
-  public Manifest getMergedManifest() {
+  public ManifestParser.ParsedManifest getMergedManifest() {
     File manifestFile = getMergedManifestFile();
-    // Run in a read action since otherwise, it might throw a read access exception.
-    return ApplicationManager.getApplication()
-        .runReadAction(
-            (Computable<Manifest>)
-                () -> ManifestParser.getInstance(project).getManifest(manifestFile));
+    try {
+      return ParsedManifestService.getInstance(project).getParsedManifest(manifestFile);
+    } catch (IOException e) {
+      log.warn("Could not read merged manifest file: " + manifestFile);
+      return null;
+    }
   }
 
-  public List<File> getAdditionalMergedManifestFiles() {
+  private List<File> getAdditionalMergedManifestFiles() {
     return deployInfo
         .getAdditionalMergedManifestsList()
         .stream()
@@ -66,10 +67,17 @@ public class BlazeAndroidDeployInfo {
         .collect(Collectors.toList());
   }
 
-  public List<Manifest> getAdditionalMergedManifests() {
-    return getAdditionalMergedManifestFiles()
-        .stream()
-        .map(file -> ManifestParser.getInstance(project).getManifest(file))
+  public List<ManifestParser.ParsedManifest> getAdditionalMergedManifest() {
+    return getAdditionalMergedManifestFiles().stream()
+        .map(
+            file -> {
+              try {
+                return ParsedManifestService.getInstance(project).getParsedManifest(file);
+              } catch (IOException e) {
+                log.warn("Could not read merged manifest file: " + file);
+                return null;
+              }
+            })
         .filter(Objects::nonNull)
         .collect(Collectors.toList());
   }

--- a/aswb/src/com/google/idea/blaze/android/run/deployinfo/BlazeApkDeployInfoProtoHelper.java
+++ b/aswb/src/com/google/idea/blaze/android/run/deployinfo/BlazeApkDeployInfoProtoHelper.java
@@ -19,7 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.devtools.build.lib.rules.android.deployinfo.AndroidDeployInfoOuterClass;
-import com.google.idea.blaze.android.manifest.ManifestParser;
+import com.google.idea.blaze.android.manifest.ParsedManifestService;
 import com.google.idea.blaze.base.command.buildresult.BlazeArtifact;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtifactsException;
@@ -78,7 +78,7 @@ public class BlazeApkDeployInfoProtoHelper {
         new BlazeAndroidDeployInfo(project, new File(executionRoot), deployInfo);
 
     List<File> manifestFiles = androidDeployInfo.getManifestFiles();
-    ManifestParser.getInstance(project).refreshManifests(manifestFiles);
+    ParsedManifestService.getInstance(project).invalidateCachedManifests(manifestFiles);
 
     return androidDeployInfo;
   }

--- a/aswb/src/com/google/idea/blaze/android/run/test/StockAndroidTestLaunchTask.java
+++ b/aswb/src/com/google/idea/blaze/android/run/test/StockAndroidTestLaunchTask.java
@@ -24,6 +24,7 @@ import com.android.tools.idea.run.tasks.LaunchTask;
 import com.android.tools.idea.run.util.LaunchStatus;
 import com.android.tools.idea.testartifacts.instrumented.AndroidTestListener;
 import com.google.common.collect.ImmutableList;
+import com.google.idea.blaze.android.manifest.ManifestParser;
 import com.google.idea.blaze.android.run.LaunchStatusCompat;
 import com.google.idea.blaze.android.run.deployinfo.BlazeAndroidDeployInfo;
 import com.intellij.openapi.application.ApplicationManager;
@@ -31,9 +32,6 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.util.text.StringUtil;
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
-import org.jetbrains.android.dom.manifest.Manifest;
 import org.jetbrains.annotations.NotNull;
 
 final class StockAndroidTestLaunchTask implements LaunchTask {
@@ -144,13 +142,9 @@ final class StockAndroidTestLaunchTask implements LaunchTask {
               (Computable<ImmutableList<String>>) () -> getRunnersFromManifest(deployInfo));
     }
 
-    Manifest manifest = deployInfo.getMergedManifest();
-    if (manifest != null) {
-      return ImmutableList.copyOf(
-          manifest.getInstrumentations().stream()
-              .map(instrumentation -> instrumentation.getInstrumentationClass().getStringValue())
-              .filter(Objects::nonNull)
-              .collect(Collectors.toList()));
+    ManifestParser.ParsedManifest parsedManifest = deployInfo.getMergedManifest();
+    if (parsedManifest != null) {
+      return ImmutableList.copyOf(parsedManifest.instrumentationClassNames);
     }
     return ImmutableList.of();
   }

--- a/aswb/src/com/google/idea/blaze/android/sync/BlazeAndroidSyncPlugin.java
+++ b/aswb/src/com/google/idea/blaze/android/sync/BlazeAndroidSyncPlugin.java
@@ -219,6 +219,7 @@ public class BlazeAndroidSyncPlugin implements BlazeSyncPlugin {
       SyncMode syncMode) {
     BlazeAndroidProjectStructureSyncer.updateInMemoryState(
         project,
+        context,
         workspaceRoot,
         projectViewSet,
         blazeProjectData,

--- a/aswb/tests/unittests/com/google/idea/blaze/android/manifest/ManifestParserTest.java
+++ b/aswb/tests/unittests/com/google/idea/blaze/android/manifest/ManifestParserTest.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.android.manifest;
+
+import static com.google.common.truth.Truth.assertThat;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import org.intellij.lang.annotations.Language;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link com.google.idea.blaze.android.manifest.ManifestParser}. */
+@RunWith(JUnit4.class)
+public class ManifestParserTest {
+
+  /**
+   * This is an example merged manifest from the instrumentation APK for hellogoogle3 project. It
+   * contains a package name, two instrumentation classes, but no default activity (because it's an
+   * instrumentation APK, those don't have default activities).
+   */
+  @Language("XML")
+  public static final String TEST_MANIFEST_XML_CONTENTS =
+      "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+          + "<manifest\n"
+          + "    xmlns:android=\"http://schemas.android.com/apk/res/android\"\n"
+          + "    android:versionCode=\"1\"\n"
+          + "    android:versionName=\"1.0\"\n"
+          + "    android:compileSdkVersion=\"29\"\n"
+          + "    android:compileSdkVersionCodename=\"10\"\n"
+          + "    package=\"com.google.android.samples.hellogoogle3.test\"\n"
+          + "    platformBuildVersionCode=\"29\"\n"
+          + "    platformBuildVersionName=\"10\">\n"
+          + "  <uses-sdk\n"
+          + "      android:minSdkVersion=\"7\"\n"
+          + "      android:targetSdkVersion=\"28\" />\n"
+          + "  <instrumentation\n"
+          + "     "
+          + " android:name=\"com.google.android.apps.common.testing.testrunner.Google3InstrumentationTestRunner\"\n"
+          + "      android:targetPackage=\"com.google.android.samples.hellogoogle3\" />\n"
+          + "  <instrumentation\n"
+          + "      android:name=\"androidx.test.runner.AndroidJUnitRunner\"\n"
+          + "      android:targetPackage=\"com.google.android.samples.hellogoogle3\" />\n"
+          + "  <application\n"
+          + "      android:label=\"SampleTest\"\n"
+          + "      android:debuggable=\"true\">\n"
+          + "    <uses-library\n"
+          + "        android:name=\"android.test.runner\" />\n"
+          + "    <activity\n"
+          + "        android:label=\"@ref/0x7f040015\"\n"
+          + "       "
+          + " android:name=\"com.google.android.samples.hellogoogle3lib.activities.AddActivity\""
+          + " />\n"
+          + "    <activity\n"
+          + "        android:label=\"@ref/0x7f04001a\"\n"
+          + "       "
+          + " android:name=\"com.google.android.samples.hellogoogle3lib.activities.SubtractActivity\""
+          + " />\n"
+          + "    <activity\n"
+          + "        android:label=\"@ref/0x7f040016\"\n"
+          + "       "
+          + " android:name=\"com.google.android.samples.hellogoogle3lib.activities.DisplayMessageActivity\""
+          + " />\n"
+          + "    <service\n"
+          + "       "
+          + " android:name=\"com.google.android.samples.hellogoogle3lib.service.MessageServer\"\n"
+          + "        android:enabled=\"true\"\n"
+          + "        android:exported=\"true\">\n"
+          + "      <intent-filter>\n"
+          + "        <action\n"
+          + "           "
+          + " android:name=\"com.google.android.samples.hellogoogle3lib.service.MessageService\""
+          + " />\n"
+          + "      </intent-filter>\n"
+          + "    </service>\n"
+          + "    <service\n"
+          + "       "
+          + " android:name=\"com.google.android.samples.hellogoogle3lib.service.AdditionServer\"\n"
+          + "        android:enabled=\"true\"\n"
+          + "        android:exported=\"true\">\n"
+          + "      <intent-filter>\n"
+          + "        <action\n"
+          + "           "
+          + " android:name=\"com.google.android.samples.hellogoogle3lib.service.AdditionService\""
+          + " />\n"
+          + "      </intent-filter>\n"
+          + "    </service>\n"
+          + "    <service\n"
+          + "       "
+          + " android:name=\"com.google.android.samples.hellogoogle3lib.service.SubtractionServer\"\n"
+          + "        android:enabled=\"true\"\n"
+          + "        android:exported=\"true\">\n"
+          + "      <intent-filter>\n"
+          + "        <action\n"
+          + "           "
+          + " android:name=\"com.google.android.samples.hellogoogle3lib.service.SubtractionService\""
+          + " />\n"
+          + "      </intent-filter>\n"
+          + "    </service>\n"
+          + "  </application>\n"
+          + "</manifest>";
+
+  /**
+   * This is an example merged manifest from the app APK for hellogoogle3 project. It contains a
+   * package name and a default activity.
+   */
+  @Language("XML")
+  public static final String APP_MANIFEST_XML_CONTENTS =
+      "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+          + "<manifest\n"
+          + "    xmlns:android=\"http://schemas.android.com/apk/res/android\"\n"
+          + "    android:versionCode=\"1\"\n"
+          + "    android:versionName=\"1.0\"\n"
+          + "    android:compileSdkVersion=\"29\"\n"
+          + "    android:compileSdkVersionCodename=\"10\"\n"
+          + "    package=\"com.google.android.samples.hellogoogle3\"\n"
+          + "    platformBuildVersionCode=\"29\"\n"
+          + "    platformBuildVersionName=\"10\">\n"
+          + "  <uses-sdk\n"
+          + "      android:minSdkVersion=\"7\"\n"
+          + "      android:targetSdkVersion=\"28\"/>\n"
+          + "  <uses-permission\n"
+          + "      android:name=\"android.permission.WRITE_EXTERNAL_STORAGE\"/>\n"
+          + "  <application\n"
+          + "      android:label=\"@ref/0x7f040000\"\n"
+          + "      android:icon=\"@ref/0x7f010000\"\n"
+          + "      android:debuggable=\"true\">\n"
+          + "    <activity\n"
+          + "        android:label=\"@ref/0x7f040018\"\n"
+          + "       "
+          + " android:name=\"com.google.android.samples.hellogoogle3.activities.MainActivity\">\n"
+          + "      <intent-filter>\n"
+          + "        <action android:name=\"android.intent.action.MAIN\"/>\n"
+          + "        <category android:name=\"android.intent.category.LAUNCHER\"/>\n"
+          + "      </intent-filter>\n"
+          + "    </activity>\n"
+          + "    <activity\n"
+          + "        android:label=\"@ref/0x7f040019\"\n"
+          + "       "
+          + " android:name=\"com.google.android.samples.hellogoogle3.activities.MultiplyActivity\"/>\n"
+          + "    <activity\n"
+          + "        android:label=\"@ref/0x7f040017\"\n"
+          + "       "
+          + " android:name=\"com.google.android.samples.hellogoogle3.activities.DivideActivity\"/>\n"
+          + "    <service\n"
+          + "       "
+          + " android:name=\"com.google.android.samples.hellogoogle3.service.DivisionServer\"\n"
+          + "        android:enabled=\"true\"\n"
+          + "        android:exported=\"true\">\n"
+          + "      <intent-filter>\n"
+          + "        <action\n"
+          + "           "
+          + " android:name=\"com.google.android.samples.hellogoogle3.service.DivisionService\"/>\n"
+          + "      </intent-filter>\n"
+          + "    </service>\n"
+          + "    <service\n"
+          + "       "
+          + " android:name=\"com.google.android.samples.hellogoogle3.service.MultiplicationServer\"\n"
+          + "        android:enabled=\"true\"\n"
+          + "        android:exported=\"true\">\n"
+          + "      <intent-filter>\n"
+          + "        <action"
+          + " android:name=\"com.google.android.samples.hellogoogle3.service.MultiplicationService\"/>\n"
+          + "      </intent-filter>\n"
+          + "    </service>\n"
+          + "    <activity\n"
+          + "        android:label=\"@ref/0x7f040015\"\n"
+          + "       "
+          + " android:name=\"com.google.android.samples.hellogoogle3lib.activities.AddActivity\"/>\n"
+          + "    <activity\n"
+          + "        android:label=\"@ref/0x7f04001a\"\n"
+          + "       "
+          + " android:name=\"com.google.android.samples.hellogoogle3lib.activities.SubtractActivity\"/>\n"
+          + "    <activity\n"
+          + "        android:label=\"@ref/0x7f040016\"\n"
+          + "       "
+          + " android:name=\"com.google.android.samples.hellogoogle3lib.activities.DisplayMessageActivity\"/>\n"
+          + "    <service\n"
+          + "       "
+          + " android:name=\"com.google.android.samples.hellogoogle3lib.service.MessageServer\"\n"
+          + "        android:enabled=\"true\"\n"
+          + "        android:exported=\"true\">\n"
+          + "      <intent-filter>\n"
+          + "        <action"
+          + " android:name=\"com.google.android.samples.hellogoogle3lib.service.MessageService\"/>\n"
+          + "      </intent-filter>\n"
+          + "    </service>\n"
+          + "    <service\n"
+          + "       "
+          + " android:name=\"com.google.android.samples.hellogoogle3lib.service.AdditionServer\"\n"
+          + "        android:enabled=\"true\"\n"
+          + "        android:exported=\"true\">\n"
+          + "      <intent-filter>\n"
+          + "        <action"
+          + " android:name=\"com.google.android.samples.hellogoogle3lib.service.AdditionService\"/>\n"
+          + "      </intent-filter>\n"
+          + "    </service>\n"
+          + "    <service\n"
+          + "       "
+          + " android:name=\"com.google.android.samples.hellogoogle3lib.service.SubtractionServer\"\n"
+          + "        android:enabled=\"true\"\n"
+          + "        android:exported=\"true\">\n"
+          + "      <intent-filter>\n"
+          + "        <action"
+          + " android:name=\"com.google.android.samples.hellogoogle3lib.service.SubtractionService\"/>\n"
+          + "      </intent-filter>\n"
+          + "    </service>\n"
+          + "  </application>\n"
+          + "</manifest>";
+
+  @Test
+  public void extractTestAttributes() throws Exception {
+    InputStream manifestInputStream =
+        new ByteArrayInputStream(TEST_MANIFEST_XML_CONTENTS.getBytes(UTF_8));
+
+    ManifestParser.ParsedManifest parsedManifest =
+        ManifestParser.parseManifestFromInputStream(manifestInputStream);
+    assertThat(parsedManifest).isNotNull();
+    assertThat(parsedManifest.packageName)
+        .isEqualTo("com.google.android.samples.hellogoogle3.test");
+    assertThat(parsedManifest.defaultActivityClassName).isNull();
+    assertThat(parsedManifest.instrumentationClassNames)
+        .containsExactly(
+            "com.google.android.apps.common.testing.testrunner.Google3InstrumentationTestRunner",
+            "androidx.test.runner.AndroidJUnitRunner");
+  }
+
+  @Test
+  public void extractAppAttributes() throws Exception {
+    InputStream manifestInputStream =
+        new ByteArrayInputStream(APP_MANIFEST_XML_CONTENTS.getBytes(UTF_8));
+
+    ManifestParser.ParsedManifest parsedManifest =
+        ManifestParser.parseManifestFromInputStream(manifestInputStream);
+    assertThat(parsedManifest).isNotNull();
+    assertThat(parsedManifest.packageName).isEqualTo("com.google.android.samples.hellogoogle3");
+    assertThat(parsedManifest.defaultActivityClassName)
+        .isEqualTo("com.google.android.samples.hellogoogle3.activities.MainActivity");
+    assertThat(parsedManifest.instrumentationClassNames).isEmpty();
+  }
+
+  @Test
+  public void extractFromInvalidManifestShouldYieldNull() throws Exception {
+    InputStream manifestInputStream = new ByteArrayInputStream("hello world".getBytes(UTF_8));
+
+    ManifestParser.ParsedManifest parsedManifest =
+        ManifestParser.parseManifestFromInputStream(manifestInputStream);
+    assertThat(parsedManifest).isNull();
+  }
+}


### PR DESCRIPTION
Fetch common manifest attributes directly from manifest file.

Currently the ManifestParser parses the manifest using PSI APIs, which
requires that the generated manifest be first refreshed in the VFS.
These VFS refreshes sometimes take too long due to previously queued
refreshes from other sources and cannot proceed until previous refreshes
are flushed.

We work around this issue by changing ManifestParser to use Java file
APIs to read the up-to-date file and implementing our own logic to
extract the few attributes we need from the manifest.

The new ManifestParser does not perform any PSI or VFS related 
operations and therefore doesn't block in the refresh queue.

ManifestParser is now a functional utility class that keeps no state.
ParsedManifests are cached through ParsedManifestService.