### PR TITLE
Focus Blaze console editor when tool window is focused.

### DIFF
--- a/base/src/com/google/idea/blaze/base/console/BlazeConsoleView.java
+++ b/base/src/com/google/idea/blaze/base/console/BlazeConsoleView.java
@@ -48,6 +48,8 @@ import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.ui.content.Content;
 import com.intellij.ui.content.ContentFactory;
+import java.awt.Component;
+import java.awt.Container;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -55,6 +57,7 @@ import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Nullable;
 import javax.swing.JComponent;
+import javax.swing.LayoutFocusTraversalPolicy;
 
 /** Console view showing blaze output. */
 public class BlazeConsoleView implements Disposable {
@@ -182,7 +185,18 @@ public class BlazeConsoleView implements Disposable {
 
     JComponent layoutComponent = layoutUi.getComponent();
 
-    //noinspection ConstantConditions
+    layoutComponent.setFocusTraversalPolicyProvider(true);
+    layoutComponent.setFocusTraversalPolicy(
+        new LayoutFocusTraversalPolicy() {
+          @Override
+          public Component getDefaultComponent(Container container) {
+            if (container.equals(layoutComponent)) {
+              return consoleView.getPreferredFocusableComponent();
+            }
+            return super.getDefaultComponent(container);
+          }
+        });
+
     Content content =
         ContentFactory.SERVICE.getInstance().createContent(layoutComponent, null, true);
     content.setCloseable(false);


### PR DESCRIPTION
Focus Blaze console editor when tool window is focused.

This should already happen by default, but there's a bug in
RunnerLayoutUi's RunnerContentUi. It wraps our content in a GridImpl,
but doesn't override TabInfo's preferred focus component to be either
the root content, or the content's preferred focus component.
So GridImpl gets to decide what should be focused, and always picks
the first empty placeholder cell...