### PR TITLE
Add support for running/debugging android_instrumentation_test targets.

### DIFF
--- a/aswb/src/com/google/idea/blaze/android/manifest/ParsedManifestService.java
+++ b/aswb/src/com/google/idea/blaze/android/manifest/ParsedManifestService.java
@@ -32,7 +32,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Collection;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -69,8 +68,8 @@ public class ParsedManifestService {
     return manifestFileToParsedManifests.get(file);
   }
 
-  public void invalidateCachedManifests(Collection<File> manifestFiles) {
-    manifestFileToParsedManifests.keySet().removeAll(manifestFiles);
+  public void invalidateCachedManifest(File manifestFile) {
+    manifestFileToParsedManifests.keySet().remove(manifestFile);
   }
 
   static class ClearManifestParser implements SyncListener {

--- a/aswb/src/com/google/idea/blaze/android/run/runner/BlazeApkBuildStepInstrumentation.java
+++ b/aswb/src/com/google/idea/blaze/android/run/runner/BlazeApkBuildStepInstrumentation.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.android.run.runner;
+
+import com.android.tools.idea.run.ApkProvisionException;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.idea.blaze.android.run.deployinfo.BlazeAndroidDeployInfo;
+import com.google.idea.blaze.android.run.deployinfo.BlazeApkDeployInfoProtoHelper;
+import com.google.idea.blaze.android.run.deployinfo.BlazeApkDeployInfoProtoHelper.GetDeployInfoException;
+import com.google.idea.blaze.base.async.executor.ProgressiveTaskWithProgressIndicator;
+import com.google.idea.blaze.base.async.process.ExternalTask;
+import com.google.idea.blaze.base.async.process.LineProcessingOutputStream;
+import com.google.idea.blaze.base.command.BlazeCommand;
+import com.google.idea.blaze.base.command.BlazeCommandName;
+import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
+import com.google.idea.blaze.base.command.buildresult.BuildResultHelperProvider;
+import com.google.idea.blaze.base.console.BlazeConsoleLineProcessorProvider;
+import com.google.idea.blaze.base.filecache.FileCaches;
+import com.google.idea.blaze.base.ideinfo.AndroidIdeInfo;
+import com.google.idea.blaze.base.ideinfo.AndroidInstrumentationInfo;
+import com.google.idea.blaze.base.ideinfo.TargetIdeInfo;
+import com.google.idea.blaze.base.ideinfo.TargetKey;
+import com.google.idea.blaze.base.ideinfo.TargetMap;
+import com.google.idea.blaze.base.model.BlazeProjectData;
+import com.google.idea.blaze.base.model.primitives.Label;
+import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
+import com.google.idea.blaze.base.scope.BlazeContext;
+import com.google.idea.blaze.base.scope.ScopedTask;
+import com.google.idea.blaze.base.scope.output.IssueOutput;
+import com.google.idea.blaze.base.settings.Blaze;
+import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
+import com.google.idea.blaze.base.util.SaveUtil;
+import com.google.idea.blaze.java.AndroidBlazeRules.RuleTypes;
+import com.intellij.execution.ExecutionException;
+import com.intellij.openapi.project.Project;
+import java.util.concurrent.CancellationException;
+
+/** Builds the APKs required for an android instrumentation test. */
+public class BlazeApkBuildStepInstrumentation implements BlazeApkBuildStep {
+
+  /** Do not modify this suffix without confirming it's required by a build rule change. */
+  private static final String DEPLOY_INFO_FILE_SUFFIX = ".deployinfo.pb";
+
+  private final Project project;
+  private final Label instrumentationTestLabel;
+  private final ImmutableList<String> buildFlags;
+  private final BlazeApkDeployInfoProtoHelper deployInfoProtoHelper;
+  private BlazeAndroidDeployInfo deployInfo = null;
+
+  /**
+   * Note: Target kind of {@param instrumentationTestlabel} must be "android_instrumentation_test".
+   */
+  public BlazeApkBuildStepInstrumentation(
+      Project project, Label instrumentationTestLabel, ImmutableList<String> buildFlags) {
+    this(
+        project,
+        instrumentationTestLabel,
+        buildFlags,
+        new BlazeApkDeployInfoProtoHelper(
+            project, buildFlags, fileName -> fileName.endsWith(DEPLOY_INFO_FILE_SUFFIX)));
+  }
+
+  @VisibleForTesting
+  public BlazeApkBuildStepInstrumentation(
+      Project project,
+      Label instrumentationTestLabel,
+      ImmutableList<String> buildFlags,
+      BlazeApkDeployInfoProtoHelper deployInfoProtoHelper) {
+    this.project = project;
+    this.instrumentationTestLabel = instrumentationTestLabel;
+    this.buildFlags = buildFlags;
+    this.deployInfoProtoHelper = deployInfoProtoHelper;
+  }
+
+  @Override
+  public boolean build(
+      BlazeContext context, BlazeAndroidDeviceSelector.DeviceSession deviceSession) {
+    ScopedTask<Void> buildTask =
+        new ScopedTask<Void>(context) {
+          @Override
+          protected Void execute(BlazeContext context) {
+            InstrumentorToTarget instrumentationCompoments = getInstrumentorToTargetPair(context);
+            BlazeCommand.Builder command =
+                BlazeCommand.builder(
+                    Blaze.getBuildSystemProvider(project).getBinaryPath(project),
+                    BlazeCommandName.BUILD);
+            WorkspaceRoot workspaceRoot = WorkspaceRoot.fromProject(project);
+
+            try (BuildResultHelper buildResultHelper = BuildResultHelperProvider.create(project)) {
+              command
+                  .addTargets(
+                      instrumentationCompoments.instrumentor, instrumentationCompoments.target)
+                  .addBlazeFlags("--output_groups=android_deploy_info")
+                  .addBlazeFlags(buildFlags)
+                  .addBlazeFlags(buildResultHelper.getBuildFlags());
+
+              SaveUtil.saveAllFiles();
+              int retVal =
+                  ExternalTask.builder(workspaceRoot)
+                      .addBlazeCommand(command.build())
+                      .context(context)
+                      .stderr(
+                          LineProcessingOutputStream.of(
+                              BlazeConsoleLineProcessorProvider.getAllStderrLineProcessors(
+                                  context)))
+                      .build()
+                      .run();
+              FileCaches.refresh(project, context);
+
+              if (retVal != 0) {
+                context.setHasError();
+                return null;
+              }
+              try {
+                deployInfo =
+                    deployInfoProtoHelper.readDeployInfoForInstrumentationTest(
+                        context,
+                        buildResultHelper,
+                        instrumentationCompoments.instrumentor,
+                        instrumentationCompoments.target);
+              } catch (GetDeployInfoException e) {
+                IssueOutput.error("Could not read apk deploy info from build: " + e.getMessage())
+                    .submit(context);
+              }
+            }
+            return null;
+          }
+        };
+    ListenableFuture<Void> buildFuture =
+        ProgressiveTaskWithProgressIndicator.builder(
+                project, String.format("Executing %s apk build", Blaze.buildSystemName(project)))
+            .submitTaskWithResult(buildTask);
+
+    try {
+      Futures.getChecked(buildFuture, ExecutionException.class);
+    } catch (ExecutionException e) {
+      context.setHasError();
+    } catch (CancellationException e) {
+      context.setCancelled();
+    }
+    return context.shouldContinue();
+  }
+
+  @Override
+  public BlazeAndroidDeployInfo getDeployInfo() throws ApkProvisionException {
+    if (deployInfo != null) {
+      return deployInfo;
+    }
+    throw new ApkProvisionException(
+        "Failed to read APK deploy info.  Either build step hasn't been executed or there was an"
+            + " error obtaining deploy info after build.");
+  }
+
+  /**
+   * Extracts test instrumentor and instrumentation target labels from the target map.
+   *
+   * @return The labels contained in an {@link InstrumentorToTarget} object.
+   */
+  @VisibleForTesting
+  public InstrumentorToTarget getInstrumentorToTargetPair(BlazeContext context) {
+    BlazeProjectData projectData =
+        BlazeProjectDataManager.getInstance(project).getBlazeProjectData();
+    if (projectData == null) {
+      IssueOutput.error("Invalid project data. Please sync the project.").submit(context);
+      return null;
+    }
+
+    // The following extracts the dependency info required during an instrumentation test.
+    // To disambiguate, the following terms are used:
+    // - test: The android_instrumentation_test target.
+    // - instrumentor: The target of kind android_binary that's used as the binary that
+    // orchestrates the instrumentation test.
+    // - target: The target of kind android_binary that's being tested in this
+    // instrumentation test through the instrumentor.
+    TargetMap targetMap = projectData.getTargetMap();
+    TargetIdeInfo testTarget = targetMap.get(TargetKey.forPlainTarget(instrumentationTestLabel));
+    if (testTarget == null
+        || testTarget.getKind() != RuleTypes.ANDROID_INSTRUMENTATION_TEST.getKind()) {
+      IssueOutput.error("Invalid target map. Please sync the project.").submit(context);
+      return null;
+    }
+    AndroidInstrumentationInfo testInstrumentationInfo = testTarget.getAndroidInstrumentationInfo();
+    if (testInstrumentationInfo == null) {
+      IssueOutput.error("Test instrumentor data is missing. Please sync the project.")
+          .submit(context);
+      return null;
+    }
+
+    Label instrumentorLabel = testInstrumentationInfo.getTestApp();
+    if (instrumentorLabel == null) {
+      IssueOutput.error(
+              "No instrumentator target defined in "
+                  + testTarget.getKey().getLabel()
+                  + ". Please ensure a instrumentator target is defined.  See"
+                  + " https://docs.bazel.build/versions/master/be/android.html#android_instrumentation_test.test_app"
+                  + " for more information.")
+          .submit(context);
+      return null;
+    }
+
+    TargetIdeInfo instrumentorTarget = targetMap.get(TargetKey.forPlainTarget(instrumentorLabel));
+    if (instrumentorTarget == null) {
+      IssueOutput.error("Cannot find instrumentation target. Please sync the project.")
+          .submit(context);
+      return null;
+    }
+    AndroidIdeInfo instrumentorAndroidInfo = instrumentorTarget.getAndroidIdeInfo();
+    if (instrumentorAndroidInfo == null) {
+      IssueOutput.error("Required data about the test target is missing. Please sync the project.")
+          .submit(context);
+      return null;
+    }
+    Label targetLabel = instrumentorAndroidInfo.getInstruments();
+    if (targetLabel == null) {
+      IssueOutput.error(
+              "No instrumentation target defined in "
+                  + instrumentorLabel
+                  + ". Please ensure a instrumentation target is defined.  See"
+                  + " https://docs.bazel.build/versions/master/be/android.html#android_binary.instruments"
+                  + " for more information.")
+          .submit(context);
+      return null;
+    }
+
+    return new InstrumentorToTarget(targetLabel, instrumentorLabel);
+  }
+
+  /** A container for a instrumentation test instrumentor and the target app it instruments. */
+  @VisibleForTesting
+  public static class InstrumentorToTarget {
+    public final Label target;
+    public final Label instrumentor;
+
+    InstrumentorToTarget(Label target, Label instrumentor) {
+      this.target = target;
+      this.instrumentor = instrumentor;
+    }
+  }
+}

--- a/aswb/src/com/google/idea/blaze/android/run/runner/BlazeApkBuildStepNormalBuild.java
+++ b/aswb/src/com/google/idea/blaze/android/run/runner/BlazeApkBuildStepNormalBuild.java
@@ -21,30 +21,23 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.idea.blaze.android.run.deployinfo.BlazeAndroidDeployInfo;
 import com.google.idea.blaze.android.run.deployinfo.BlazeApkDeployInfoProtoHelper;
+import com.google.idea.blaze.android.run.deployinfo.BlazeApkDeployInfoProtoHelper.GetDeployInfoException;
 import com.google.idea.blaze.base.async.executor.ProgressiveTaskWithProgressIndicator;
 import com.google.idea.blaze.base.async.process.ExternalTask;
 import com.google.idea.blaze.base.async.process.LineProcessingOutputStream;
 import com.google.idea.blaze.base.command.BlazeCommand;
 import com.google.idea.blaze.base.command.BlazeCommandName;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
-import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtifactsException;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelperProvider;
 import com.google.idea.blaze.base.console.BlazeConsoleLineProcessorProvider;
 import com.google.idea.blaze.base.filecache.FileCaches;
-import com.google.idea.blaze.base.ideinfo.Dependency;
-import com.google.idea.blaze.base.ideinfo.TargetIdeInfo;
-import com.google.idea.blaze.base.ideinfo.TargetKey;
-import com.google.idea.blaze.base.ideinfo.TargetMap;
-import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.scope.ScopedTask;
 import com.google.idea.blaze.base.scope.output.IssueOutput;
 import com.google.idea.blaze.base.settings.Blaze;
-import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
 import com.google.idea.blaze.base.util.SaveUtil;
-import com.google.idea.blaze.java.AndroidBlazeRules;
 import com.intellij.execution.ExecutionException;
 import com.intellij.openapi.project.Project;
 import java.util.concurrent.CancellationException;
@@ -63,33 +56,6 @@ public class BlazeApkBuildStepNormalBuild implements BlazeApkBuildStep {
     this.buildFlags = buildFlags;
   }
 
-  /**
-   * In case we're dealing with an {@link AndroidBlazeRules.RuleTypes#ANDROID_INSTRUMENTATION_TEST},
-   * build the underlying {@link AndroidBlazeRules.RuleTypes#ANDROID_BINARY} instead.
-   */
-  private Label getTargetToBuild() {
-    BlazeProjectData projectData =
-        BlazeProjectDataManager.getInstance(project).getBlazeProjectData();
-    if (projectData == null) {
-      return label;
-    }
-    TargetMap targetMap = projectData.getTargetMap();
-    TargetIdeInfo target = targetMap.get(TargetKey.forPlainTarget(label));
-    if (target == null
-        || target.getKind() != AndroidBlazeRules.RuleTypes.ANDROID_INSTRUMENTATION_TEST.getKind()) {
-      return label;
-    }
-    for (Dependency dependency : target.getDependencies()) {
-      TargetIdeInfo dependencyInfo = targetMap.get(dependency.getTargetKey());
-      // Should exist via test_app attribute, and be unique.
-      if (dependencyInfo != null
-          && dependencyInfo.getKind() == AndroidBlazeRules.RuleTypes.ANDROID_BINARY.getKind()) {
-        return dependency.getTargetKey().getLabel();
-      }
-    }
-    return label;
-  }
-
   @Override
   public boolean build(
       BlazeContext context, BlazeAndroidDeviceSelector.DeviceSession deviceSession) {
@@ -104,12 +70,13 @@ public class BlazeApkBuildStepNormalBuild implements BlazeApkBuildStep {
             WorkspaceRoot workspaceRoot = WorkspaceRoot.fromProject(project);
 
             BlazeApkDeployInfoProtoHelper deployInfoHelper =
-                new BlazeApkDeployInfoProtoHelper(project, buildFlags);
+                new BlazeApkDeployInfoProtoHelper(
+                    project, buildFlags, fileName -> fileName.endsWith(".deployinfo.pb"));
             try (BuildResultHelper buildResultHelper = BuildResultHelperProvider.create(project)) {
 
               command
-                  .addTargets(getTargetToBuild())
-                  .addBlazeFlags("--output_groups=+android_deploy_info")
+                  .addTargets(label)
+                  .addBlazeFlags("--output_groups=android_deploy_info")
                   .addBlazeFlags(buildFlags)
                   .addBlazeFlags(buildResultHelper.getBuildFlags());
 
@@ -132,17 +99,11 @@ public class BlazeApkBuildStepNormalBuild implements BlazeApkBuildStep {
               }
               try {
                 deployInfo =
-                    deployInfoHelper.readDeployInfo(
-                        context,
-                        buildResultHelper,
-                        fileName -> fileName.endsWith(".deployinfo.pb"));
-              } catch (GetArtifactsException e) {
+                    deployInfoHelper.readDeployInfoForNormalBuild(
+                        context, buildResultHelper, label);
+              } catch (GetDeployInfoException e) {
                 IssueOutput.error("Could not read apk deploy info from build: " + e.getMessage())
                     .submit(context);
-                return null;
-              }
-              if (deployInfo == null) {
-                IssueOutput.error("Could not read apk deploy info from build").submit(context);
               }
               return null;
             }

--- a/aswb/src/com/google/idea/blaze/android/run/test/BlazeAndroidTestProgramRunner.java
+++ b/aswb/src/com/google/idea/blaze/android/run/test/BlazeAndroidTestProgramRunner.java
@@ -19,7 +19,6 @@ import com.android.tools.idea.run.AndroidSessionInfo;
 import com.google.idea.blaze.android.run.AndroidSessionInfoCompat;
 import com.google.idea.blaze.android.run.BlazeAndroidRunConfigurationHandler;
 import com.google.idea.blaze.base.run.BlazeCommandRunConfiguration;
-import com.google.idea.blaze.java.AndroidBlazeRules;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.RunConfiguration;
 import com.intellij.execution.configurations.RunConfigurationBase;
@@ -44,13 +43,8 @@ public class BlazeAndroidTestProgramRunner extends DefaultProgramRunner {
     if (!(profile instanceof BlazeCommandRunConfiguration)) {
       return false;
     }
-    BlazeCommandRunConfiguration configuration = (BlazeCommandRunConfiguration) profile;
-    // Debugging android_instrumentation_test doesn't work yet.
-    if (DefaultDebugExecutor.EXECUTOR_ID.equals(executorId)) {
-      return configuration.getTargetKind()
-          != AndroidBlazeRules.RuleTypes.ANDROID_INSTRUMENTATION_TEST.getKind();
-    }
-    return DefaultRunExecutor.EXECUTOR_ID.equals(executorId);
+    return DefaultRunExecutor.EXECUTOR_ID.equals(executorId)
+        || DefaultDebugExecutor.EXECUTOR_ID.equals(executorId);
   }
 
   @Override

--- a/aswb/src/com/google/idea/blaze/android/run/test/BlazeAndroidTestRunContextBase.java
+++ b/aswb/src/com/google/idea/blaze/android/run/test/BlazeAndroidTestRunContextBase.java
@@ -32,12 +32,14 @@ import com.google.idea.blaze.android.run.deployinfo.BlazeApkProvider;
 import com.google.idea.blaze.android.run.runner.BlazeAndroidDeviceSelector;
 import com.google.idea.blaze.android.run.runner.BlazeAndroidRunContext;
 import com.google.idea.blaze.android.run.runner.BlazeApkBuildStep;
+import com.google.idea.blaze.android.run.runner.BlazeApkBuildStepInstrumentation;
 import com.google.idea.blaze.android.run.runner.BlazeApkBuildStepNormalBuild;
 import com.google.idea.blaze.android.run.test.BlazeAndroidTestLaunchMethodsProvider.AndroidTestLaunchMethod;
 import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.run.BlazeCommandRunConfiguration;
 import com.google.idea.blaze.base.run.smrunner.BlazeTestUiSession;
 import com.google.idea.blaze.base.run.smrunner.TestUiSessionProvider;
+import com.google.idea.blaze.java.AndroidBlazeRules;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.Executor;
 import com.intellij.execution.executors.DefaultDebugExecutor;
@@ -78,10 +80,18 @@ abstract class BlazeAndroidTestRunContextBase implements BlazeAndroidRunContext 
     this.env = env;
     this.label = label;
     this.configState = configState;
-    this.buildStep =
-        configState.getLaunchMethod().equals(AndroidTestLaunchMethod.MOBILE_INSTALL)
-            ? new BlazeApkBuildStepMobileInstall(project, label, blazeFlags, exeFlags)
-            : new BlazeApkBuildStepNormalBuild(project, label, blazeFlags);
+
+    // android_instrumentation_test targets require a dedicated build step that builds both
+    // test and target APKs.
+    if (configState.getLaunchMethod().equals(AndroidTestLaunchMethod.MOBILE_INSTALL)) {
+      this.buildStep = new BlazeApkBuildStepMobileInstall(project, label, blazeFlags, exeFlags);
+    } else if (runConfiguration.getTargetKind()
+        == AndroidBlazeRules.RuleTypes.ANDROID_INSTRUMENTATION_TEST.getKind()) {
+      this.buildStep = new BlazeApkBuildStepInstrumentation(project, label, blazeFlags);
+    } else {
+      this.buildStep = new BlazeApkBuildStepNormalBuild(project, label, blazeFlags);
+    }
+
     this.applicationIdProvider = new BlazeAndroidTestApplicationIdProvider(buildStep);
     this.apkProvider = new BlazeApkProvider(project, buildStep);
 

--- a/aswb/tests/integrationtests/com/google/idea/blaze/android/functional/BlazeApkBuildStepInstrumentationIntegrationTest.java
+++ b/aswb/tests/integrationtests/com/google/idea/blaze/android/functional/BlazeApkBuildStepInstrumentationIntegrationTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.android.functional;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.idea.blaze.android.targetmapbuilder.NbAndroidInstrumentationTestTarget.android_instrumentation_test;
+import static com.google.idea.blaze.android.targetmapbuilder.NbAndroidTarget.android_binary;
+
+import com.google.common.collect.ImmutableList;
+import com.google.idea.blaze.android.BlazeAndroidIntegrationTestCase;
+import com.google.idea.blaze.android.MockSdkUtil;
+import com.google.idea.blaze.android.run.runner.BlazeApkBuildStepInstrumentation;
+import com.google.idea.blaze.android.run.runner.BlazeApkBuildStepInstrumentation.InstrumentorToTarget;
+import com.google.idea.blaze.base.model.primitives.Label;
+import com.google.idea.blaze.base.model.primitives.WorkspacePath;
+import com.google.idea.blaze.base.scope.BlazeContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Integration tests for {@link
+ * com.google.idea.blaze.android.run.runner.BlazeApkBuildStepInstrumentation}
+ */
+@RunWith(JUnit4.class)
+public class BlazeApkBuildStepInstrumentationIntegrationTest
+    extends BlazeAndroidIntegrationTestCase {
+
+  @Before
+  public void setup() {
+    setProjectView(
+        "directories:",
+        "  java/com/foo/app",
+        "targets:",
+        "  //java/com/foo/app:instrumentation_test",
+        "android_sdk_platform: android-27");
+    MockSdkUtil.registerSdk(workspace, "27");
+
+    workspace.createFile(
+        new WorkspacePath("java/com/foo/app/MainActivity.java"),
+        "package com.foo.app",
+        "import android.app.Activity;",
+        "public class MainActivity extends Activity {}");
+
+    workspace.createFile(
+        new WorkspacePath("java/com/foo/app/Test.java"),
+        "package com.foo.app",
+        "public class Test {}");
+
+    setTargetMap(
+        android_binary("//java/com/foo/app:app").src("MainActivity.java"),
+        android_binary("//java/com/foo/app:test_app")
+            .src("Test.java")
+            .instruments("//java/com/foo/app:app"),
+        android_instrumentation_test("//java/com/foo/app:instrumentation_test")
+            .test_app("//java/com/foo/app:test_app"));
+    runFullBlazeSync();
+  }
+
+  @Test
+  public void findInstrumentorAndTestTargets() {
+    BlazeApkBuildStepInstrumentation buildStep =
+        new BlazeApkBuildStepInstrumentation(
+            getProject(),
+            Label.create("//java/com/foo/app:instrumentation_test"),
+            ImmutableList.of());
+
+    InstrumentorToTarget pair = buildStep.getInstrumentorToTargetPair(new BlazeContext());
+    assertThat(pair.instrumentor).isEqualTo(Label.create("//java/com/foo/app:test_app"));
+    assertThat(pair.target).isEqualTo(Label.create("//java/com/foo/app:app"));
+  }
+}

--- a/aswb/tests/integrationtests/com/google/idea/blaze/android/targetmapbuilder/NbTargetMapUtilsTest.java
+++ b/aswb/tests/integrationtests/com/google/idea/blaze/android/targetmapbuilder/NbTargetMapUtilsTest.java
@@ -15,10 +15,12 @@
  */
 package com.google.idea.blaze.android.targetmapbuilder;
 
+import static com.google.common.truth.Truth.assertThat;
 import static com.google.idea.blaze.android.targetmapbuilder.NbTargetMapUtils.blazePackageForLabel;
+import static com.google.idea.blaze.android.targetmapbuilder.NbTargetMapUtils.makeLabelFromTargetExpression;
 import static com.google.idea.blaze.android.targetmapbuilder.NbTargetMapUtils.workspacePathForLabel;
 
-import com.google.common.truth.Truth;
+import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.model.primitives.WorkspacePath;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,7 +32,7 @@ public class NbTargetMapUtilsTest {
   @Test
   public void testWorkspacePathForLabel() {
     WorkspacePath blazePackage = WorkspacePath.createIfValid("com/google/foo");
-    Truth.assertThat(workspacePathForLabel(blazePackage, "Foo.java"))
+    assertThat(workspacePathForLabel(blazePackage, "Foo.java"))
         .isEqualTo(workspacePathForLabel(blazePackage, "//com/google/foo/Foo.java"));
   }
 
@@ -39,6 +41,22 @@ public class NbTargetMapUtilsTest {
     String label = "//com/google/foo:foobar";
     WorkspacePath blazePackageForLabel = WorkspacePath.createIfValid("com/google/foo");
 
-    Truth.assertThat(blazePackageForLabel(label)).isEqualTo(blazePackageForLabel);
+    assertThat(blazePackageForLabel(label)).isEqualTo(blazePackageForLabel);
+  }
+
+  @Test
+  public void testMakeLabelFromTargetExpression_absolutePath() {
+    String labelStr = "//com/google/foo:foobar";
+    WorkspacePath blazePackageForLabel = WorkspacePath.createIfValid("com/google/foo");
+    assertThat(makeLabelFromTargetExpression(blazePackageForLabel, labelStr))
+        .isEqualTo(Label.create("//com/google/foo:foobar"));
+  }
+
+  @Test
+  public void testMakeLabelFromTargetExpression_relativePath() {
+    String labelStr = ":foobar";
+    WorkspacePath blazePackageForLabel = WorkspacePath.createIfValid("com/google/foo");
+    assertThat(makeLabelFromTargetExpression(blazePackageForLabel, labelStr))
+        .isEqualTo(Label.create("//com/google/foo:foobar"));
   }
 }

--- a/aswb/tests/unittests/com/google/idea/blaze/android/run/deployinfo/BlazeApkDeployInfoProtoHelperTest.java
+++ b/aswb/tests/unittests/com/google/idea/blaze/android/run/deployinfo/BlazeApkDeployInfoProtoHelperTest.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright 2018 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.android.run.deployinfo;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.devtools.build.lib.rules.android.deployinfo.AndroidDeployInfoOuterClass;
+import com.google.devtools.build.lib.rules.android.deployinfo.AndroidDeployInfoOuterClass.AndroidDeployInfo;
+import com.google.devtools.build.lib.rules.android.deployinfo.AndroidDeployInfoOuterClass.Artifact;
+import com.google.idea.blaze.android.manifest.ManifestParser.ParsedManifest;
+import com.google.idea.blaze.android.manifest.ParsedManifestService;
+import com.google.idea.blaze.android.run.deployinfo.BlazeApkDeployInfoProtoHelper.AndroidDeployInfoReader;
+import com.google.idea.blaze.base.BlazeTestCase;
+import com.google.idea.blaze.base.bazel.BuildSystemProvider;
+import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
+import com.google.idea.blaze.base.command.info.BlazeInfo;
+import com.google.idea.blaze.base.command.info.BlazeInfoRunner;
+import com.google.idea.blaze.base.model.primitives.Label;
+import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
+import com.google.idea.blaze.base.scope.BlazeContext;
+import com.google.idea.blaze.base.settings.BlazeImportSettings;
+import com.google.idea.blaze.base.settings.BlazeImportSettingsManager;
+import com.google.idea.blaze.base.settings.BuildSystem;
+import com.intellij.openapi.extensions.ExtensionPoint;
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import kotlin.text.Charsets;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+/** Unit tests for {@link BlazeApkDeployInfoProtoHelper} */
+@RunWith(JUnit4.class)
+public class BlazeApkDeployInfoProtoHelperTest extends BlazeTestCase {
+  private static final BlazeImportSettings DUMMY_IMPORT_SETTINGS =
+      new BlazeImportSettings("root", "", "", "", BuildSystem.Bazel);
+  private static final String TEST_EXECUTION_ROOT = "execution_root";
+
+  private final ParsedManifestService mockParsedManifestService =
+      Mockito.mock(ParsedManifestService.class);
+  private final BlazeContext context = new BlazeContext();
+
+  /**
+   * Initializes the following extensions/services:
+   *
+   * <p>Registers the {@link BuildSystemProvider} extension point with a mock implementation that
+   * returns a fake binary path. This is required for obtaining the execution root (which runs blaze
+   * info and needs to know where the blaze executable is).
+   *
+   * <p>Registers a {@link BlazeImportSettingsManager} with dummy settings. This is required for
+   * finding the correct workspace root as a part of proto helper init.
+   *
+   * <p>Registers a {@link MockBlazeInfoRunner} that quickly returns {@link #TEST_EXECUTION_ROOT}.
+   * This is required by the proto helper to obtain test execution root path.
+   *
+   * <p>Registers a mocked {@link ParsedManifestService} to return predetermined matching parsed
+   * manifests and verify manifest refreshes are called correctly.
+   */
+  @Override
+  protected void initTest(Container applicationServices, Container projectServices) {
+    ExtensionPoint<BuildSystemProvider> extensionPoint =
+        registerExtensionPoint(BuildSystemProvider.EP_NAME, BuildSystemProvider.class);
+    BuildSystemProvider mockBuildSystemProvider = Mockito.mock(BuildSystemProvider.class);
+    when(mockBuildSystemProvider.getBinaryPath(project)).thenReturn("binary/path");
+    extensionPoint.registerExtension(mockBuildSystemProvider);
+
+    projectServices.register(
+        BlazeImportSettingsManager.class, new BlazeImportSettingsManager(project));
+    BlazeImportSettingsManager.getInstance(getProject()).setImportSettings(DUMMY_IMPORT_SETTINGS);
+
+    MockBlazeInfoRunner blazeInfoRunner = new MockBlazeInfoRunner();
+    blazeInfoRunner.setResults(ImmutableMap.of(BlazeInfo.EXECUTION_ROOT_KEY, TEST_EXECUTION_ROOT));
+    applicationServices.register(BlazeInfoRunner.class, blazeInfoRunner);
+
+    projectServices.register(ParsedManifestService.class, mockParsedManifestService);
+  }
+
+  @Test
+  public void readDeployInfoForNormalBuild_onlyMainManifest() throws Exception {
+    // setup
+    AndroidDeployInfo deployInfoProto =
+        AndroidDeployInfo.newBuilder()
+            .setMergedManifest(makeArtifact("path/to/manifest"))
+            .addApksToDeploy(makeArtifact("path/to/apk"))
+            .build();
+
+    Label target = Label.create("//test:target");
+    File mainApk = new File("execution_root/path/to/apk");
+    File mainManifestFile = new File("execution_root/path/to/manifest");
+    ParsedManifest parsedMainManifest = new ParsedManifest("main", null, null);
+    when(mockParsedManifestService.getParsedManifest(mainManifestFile))
+        .thenReturn(parsedMainManifest);
+
+    AndroidDeployInfoReader mockAndroidDeployInfoReader =
+        Mockito.mock(AndroidDeployInfoReader.class);
+    BuildResultHelper buildResultHelper = Mockito.mock(BuildResultHelper.class);
+    when(mockAndroidDeployInfoReader.getDeployInfo(buildResultHelper, target))
+        .thenReturn(deployInfoProto);
+
+    // perform
+    BlazeApkDeployInfoProtoHelper helper =
+        new BlazeApkDeployInfoProtoHelper(
+            getProject(), ImmutableList.of(), mockAndroidDeployInfoReader);
+    BlazeAndroidDeployInfo deployInfo =
+        helper.readDeployInfoForNormalBuild(context, buildResultHelper, target);
+
+    // verify
+    assertThat(deployInfo.getApksToDeploy()).containsExactly(mainApk);
+    assertThat(deployInfo.getMergedManifest()).isEqualTo(parsedMainManifest);
+    assertThat(deployInfo.getTestTargetMergedManifest()).isNull();
+    verify(mockParsedManifestService, times(1)).invalidateCachedManifest(mainManifestFile);
+  }
+
+  @Test
+  public void readDeployInfoForNormalBuild_withTestTargetManifest() throws Exception {
+    // setup
+    AndroidDeployInfo deployInfoProto =
+        AndroidDeployInfo.newBuilder()
+            .setMergedManifest(makeArtifact("path/to/manifest"))
+            .addAdditionalMergedManifests(makeArtifact("path/to/testtarget/manifest"))
+            .addApksToDeploy(makeArtifact("path/to/apk"))
+            .addApksToDeploy(makeArtifact("path/to/testtarget/apk"))
+            .build();
+
+    Label target = Label.create("//test:target");
+    File mainApk = new File("execution_root/path/to/apk");
+    File testApk = new File("execution_root/path/to/testtarget/apk");
+    File mainManifest = new File("execution_root/path/to/manifest");
+    File testTargetManifest = new File("execution_root/path/to/testtarget/manifest");
+    ParsedManifest parsedMainManifest = new ParsedManifest("main", null, null);
+    ParsedManifest parsedTestManifest = new ParsedManifest("testtarget", null, null);
+    when(mockParsedManifestService.getParsedManifest(mainManifest)).thenReturn(parsedMainManifest);
+    when(mockParsedManifestService.getParsedManifest(testTargetManifest))
+        .thenReturn(parsedTestManifest);
+
+    AndroidDeployInfoReader mockAndroidDeployInfoReader =
+        Mockito.mock(AndroidDeployInfoReader.class);
+    BuildResultHelper buildResultHelper = Mockito.mock(BuildResultHelper.class);
+    when(mockAndroidDeployInfoReader.getDeployInfo(buildResultHelper, target))
+        .thenReturn(deployInfoProto);
+
+    // perform
+    BlazeApkDeployInfoProtoHelper helper =
+        new BlazeApkDeployInfoProtoHelper(
+            getProject(), ImmutableList.of(), mockAndroidDeployInfoReader);
+    BlazeAndroidDeployInfo deployInfo =
+        helper.readDeployInfoForNormalBuild(context, buildResultHelper, target);
+
+    // verify
+    assertThat(deployInfo.getApksToDeploy()).containsExactly(mainApk, testApk).inOrder();
+    assertThat(deployInfo.getMergedManifest()).isEqualTo(parsedMainManifest);
+    assertThat(deployInfo.getTestTargetMergedManifest()).isEqualTo(parsedTestManifest);
+
+    ArgumentCaptor<File> expectedArgs = ArgumentCaptor.forClass(File.class);
+    verify(mockParsedManifestService, times(2)).invalidateCachedManifest(expectedArgs.capture());
+    expectedArgs.getAllValues().containsAll(ImmutableList.of(mainManifest, testTargetManifest));
+  }
+
+  @Test
+  public void readDeployInfoForInstrumentationTest() throws Exception {
+    AndroidDeployInfoReader mockAndroidDeployInfoReader =
+        Mockito.mock(AndroidDeployInfoReader.class);
+    BuildResultHelper buildResultHelper = Mockito.mock(BuildResultHelper.class);
+
+    // Setup instrumentor
+    AndroidDeployInfo instrumentorDeployInfoProto =
+        AndroidDeployInfo.newBuilder()
+            .setMergedManifest(makeArtifact("path/to/instrumentor/manifest"))
+            .addApksToDeploy(makeArtifact("path/to/instrumentor/apk"))
+            .build();
+    Label instrumentorLabel = Label.create("//test:instrumentor");
+    File instrumentorApk = new File("execution_root/path/to/instrumentor/apk");
+    File instrumentorManifest = new File("execution_root/path/to/instrumentor/manifest");
+    ParsedManifest parsedInstrumentorManifest = new ParsedManifest("test", null, null);
+    when(mockParsedManifestService.getParsedManifest(instrumentorManifest))
+        .thenReturn(parsedInstrumentorManifest);
+    when(mockAndroidDeployInfoReader.getDeployInfo(buildResultHelper, instrumentorLabel))
+        .thenReturn(instrumentorDeployInfoProto);
+
+    // Setup test target
+    AndroidDeployInfo testDeployInfoProto =
+        AndroidDeployInfo.newBuilder()
+            .setMergedManifest(makeArtifact("path/to/test/manifest"))
+            .addApksToDeploy(makeArtifact("path/to/test/apk"))
+            .build();
+    Label testLabel = Label.create("//test:test");
+    File testApk = new File("execution_root/path/to/test/apk");
+    File testManifest = new File("execution_root/path/to/test/manifest");
+    ParsedManifest parsedTestManifest = new ParsedManifest("main", null, null);
+    when(mockParsedManifestService.getParsedManifest(testManifest)).thenReturn(parsedTestManifest);
+    when(mockAndroidDeployInfoReader.getDeployInfo(buildResultHelper, testLabel))
+        .thenReturn(testDeployInfoProto);
+
+    // perform
+    BlazeApkDeployInfoProtoHelper helper =
+        new BlazeApkDeployInfoProtoHelper(
+            getProject(), ImmutableList.of(), mockAndroidDeployInfoReader);
+    BlazeAndroidDeployInfo deployInfo =
+        helper.readDeployInfoForInstrumentationTest(
+            context, buildResultHelper, instrumentorLabel, testLabel);
+
+    // verify
+    assertThat(deployInfo.getApksToDeploy()).containsExactly(instrumentorApk, testApk).inOrder();
+    assertThat(deployInfo.getMergedManifest()).isEqualTo(parsedInstrumentorManifest);
+    assertThat(deployInfo.getTestTargetMergedManifest()).isEqualTo(parsedTestManifest);
+
+    ArgumentCaptor<File> expectedArgs = ArgumentCaptor.forClass(File.class);
+    verify(mockParsedManifestService, times(2)).invalidateCachedManifest(expectedArgs.capture());
+    expectedArgs.getAllValues().containsAll(ImmutableList.of(instrumentorManifest, testManifest));
+  }
+
+  private static Artifact makeArtifact(String execRootPath) {
+    return AndroidDeployInfoOuterClass.Artifact.newBuilder().setExecRootPath(execRootPath).build();
+  }
+
+  /** Returns predefined results set by {@link MockBlazeInfoRunner#setResults(java.util.Map)} */
+  private static class MockBlazeInfoRunner extends BlazeInfoRunner {
+    private final Map<String, String> results = Maps.newHashMap();
+
+    @Override
+    public ListenableFuture<byte[]> runBlazeInfoGetBytes(
+        @Nullable BlazeContext context,
+        String binaryPath,
+        WorkspaceRoot workspaceRoot,
+        List<String> blazeFlags,
+        String key) {
+      return Futures.immediateFuture(results.get(key).getBytes(Charsets.UTF_8));
+    }
+
+    @Override
+    public ListenableFuture<String> runBlazeInfo(
+        @Nullable BlazeContext context,
+        String binaryPath,
+        WorkspaceRoot workspaceRoot,
+        List<String> blazeFlags,
+        String key) {
+      return Futures.immediateFuture(results.get(key));
+    }
+
+    @Override
+    public ListenableFuture<BlazeInfo> runBlazeInfo(
+        @Nullable BlazeContext context,
+        BuildSystem buildSystem,
+        String binaryPath,
+        WorkspaceRoot workspaceRoot,
+        List<String> blazeFlags) {
+      return Futures.immediateFuture(BlazeInfo.create(buildSystem, ImmutableMap.copyOf(results)));
+    }
+
+    public void setResults(Map<String, String> results) {
+      this.results.clear();
+      this.results.putAll(results);
+    }
+  }
+}

--- a/aswb/tests/utils/integration/com/google/idea/blaze/android/targetmapbuilder/NbAndroidInstrumentationTestTarget.java
+++ b/aswb/tests/utils/integration/com/google/idea/blaze/android/targetmapbuilder/NbAndroidInstrumentationTestTarget.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.android.targetmapbuilder;
+
+import static com.google.idea.blaze.android.targetmapbuilder.NbTargetMapUtils.makeSourceArtifact;
+
+import com.google.idea.blaze.base.ideinfo.AndroidInstrumentationInfo;
+import com.google.idea.blaze.base.ideinfo.ArtifactLocation;
+import com.google.idea.blaze.base.ideinfo.TargetIdeInfo;
+import com.google.idea.blaze.base.model.primitives.Label;
+import com.google.idea.blaze.base.model.primitives.WorkspacePath;
+import com.google.idea.blaze.java.AndroidBlazeRules.RuleTypes;
+
+/** Builder for a blaze android instrumentation test target's IDE info. */
+public class NbAndroidInstrumentationTestTarget extends NbBaseTargetBuilder {
+  private final TargetIdeInfo.Builder targetIdeInfoBuilder;
+  private final AndroidInstrumentationInfo.Builder androidInstrumentationInfoBuilder;
+  private final WorkspacePath blazePackage;
+
+  public static NbAndroidInstrumentationTestTarget android_instrumentation_test(String label) {
+    return new NbAndroidInstrumentationTestTarget(BlazeInfoData.DEFAULT, label);
+  }
+
+  public NbAndroidInstrumentationTestTarget test_app(String targetLabel) {
+    Label target = NbTargetMapUtils.makeLabelFromTargetExpression(blazePackage, targetLabel);
+    androidInstrumentationInfoBuilder.setTestApp(target);
+    return this;
+  }
+
+  NbAndroidInstrumentationTestTarget(BlazeInfoData blazeInfoData, String label) {
+    super(blazeInfoData);
+    this.blazePackage = NbTargetMapUtils.blazePackageForLabel(label);
+    this.androidInstrumentationInfoBuilder = new AndroidInstrumentationInfo.Builder();
+    this.targetIdeInfoBuilder = new TargetIdeInfo.Builder();
+
+    targetIdeInfoBuilder
+        .setKind(RuleTypes.ANDROID_INSTRUMENTATION_TEST.getKind())
+        .setLabel(label)
+        .setBuildFile(inferBuildFileLocation(label));
+  }
+
+  @Override
+  TargetIdeInfo.Builder getIdeInfoBuilder() {
+    return targetIdeInfoBuilder.setAndroidInstrumentationInfo(
+        androidInstrumentationInfoBuilder.build());
+  }
+
+  private static ArtifactLocation inferBuildFileLocation(String label) {
+    return makeSourceArtifact(NbTargetMapUtils.blazePackageForLabel(label) + "/BUILD");
+  }
+}

--- a/aswb/tests/utils/integration/com/google/idea/blaze/android/targetmapbuilder/NbAndroidTarget.java
+++ b/aswb/tests/utils/integration/com/google/idea/blaze/android/targetmapbuilder/NbAndroidTarget.java
@@ -68,6 +68,7 @@ public class NbAndroidTarget extends NbBaseTargetBuilder {
     if (kind.equals(AndroidBlazeRules.RuleTypes.ANDROID_BINARY.getKind())) {
       // The android_binary rule requires a manifest.
       setDefaultManifest();
+      setGenerateResourceClass();
     }
 
     // blaze java packages all take the form "java/<actual_package_here>".
@@ -173,6 +174,12 @@ public class NbAndroidTarget extends NbBaseTargetBuilder {
 
   public NbAndroidTarget java_toolchain_version(String version) {
     javaTarget.java_toolchain_version(version);
+    return this;
+  }
+
+  public NbAndroidTarget instruments(String targetLabel) {
+    androidIdeInfoBuilder.setInstruments(
+        NbTargetMapUtils.makeLabelFromTargetExpression(blazePackage, targetLabel));
     return this;
   }
 }

--- a/aswb/tests/utils/integration/com/google/idea/blaze/android/targetmapbuilder/NbTargetMapUtils.java
+++ b/aswb/tests/utils/integration/com/google/idea/blaze/android/targetmapbuilder/NbTargetMapUtils.java
@@ -44,4 +44,13 @@ public class NbTargetMapUtils {
   public static ArtifactLocation makeSourceArtifact(String workspacePath) {
     return ArtifactLocation.builder().setRelativePath(workspacePath).setIsSource(true).build();
   }
+
+  /** Returns a label for a target expression of a possibly relative target. */
+  public static Label makeLabelFromTargetExpression(
+      WorkspacePath blazePackage, String targetExpression) {
+    if (targetExpression.startsWith("//")) {
+      return Label.create(targetExpression);
+    }
+    return Label.create("//" + blazePackage + targetExpression);
+  }
 }

--- a/base/src/com/google/idea/blaze/base/ideinfo/AndroidIdeInfo.java
+++ b/base/src/com/google/idea/blaze/base/ideinfo/AndroidIdeInfo.java
@@ -45,6 +45,7 @@ public final class AndroidIdeInfo implements ProtoWrapper<IntellijIdeInfo.Androi
   @Nullable private final String resourceJavaPackage;
   private final boolean generateResourceClass;
   @Nullable private final Label legacyResources;
+  @Nullable private final Label instruments;
 
   private AndroidIdeInfo(
       List<AndroidResFolder> resources,
@@ -55,7 +56,8 @@ public final class AndroidIdeInfo implements ProtoWrapper<IntellijIdeInfo.Androi
       @Nullable LibraryArtifact idlJar,
       @Nullable LibraryArtifact resourceJar,
       boolean hasIdlSources,
-      @Nullable Label legacyResources) {
+      @Nullable Label legacyResources,
+      @Nullable Label instruments) {
     this.resources = ImmutableList.copyOf(resources);
     this.resourceJavaPackage = resourceJavaPackage;
     this.generateResourceClass = generateResourceClass;
@@ -65,6 +67,7 @@ public final class AndroidIdeInfo implements ProtoWrapper<IntellijIdeInfo.Androi
     this.resourceJar = resourceJar;
     this.hasIdlSources = hasIdlSources;
     this.legacyResources = legacyResources;
+    this.instruments = instruments;
   }
 
   static AndroidIdeInfo fromProto(IntellijIdeInfo.AndroidIdeInfo proto) {
@@ -81,6 +84,9 @@ public final class AndroidIdeInfo implements ProtoWrapper<IntellijIdeInfo.Androi
         proto.getHasIdlSources(),
         !Strings.isNullOrEmpty(proto.getLegacyResources())
             ? Label.create(proto.getLegacyResources())
+            : null,
+        !Strings.isNullOrEmpty(proto.getInstruments())
+            ? Label.create(proto.getInstruments())
             : null);
   }
 
@@ -97,6 +103,7 @@ public final class AndroidIdeInfo implements ProtoWrapper<IntellijIdeInfo.Androi
     ProtoWrapper.unwrapAndSetIfNotNull(builder::setIdlJar, idlJar);
     ProtoWrapper.unwrapAndSetIfNotNull(builder::setResourceJar, resourceJar);
     ProtoWrapper.unwrapAndSetIfNotNull(builder::setLegacyResources, legacyResources);
+    ProtoWrapper.unwrapAndSetIfNotNull(builder::setInstruments, instruments);
     return builder.build();
   }
 
@@ -146,6 +153,11 @@ public final class AndroidIdeInfo implements ProtoWrapper<IntellijIdeInfo.Androi
     return legacyResources;
   }
 
+  @Nullable
+  public Label getInstruments() {
+    return instruments;
+  }
+
   public static Builder builder() {
     return new Builder();
   }
@@ -161,6 +173,7 @@ public final class AndroidIdeInfo implements ProtoWrapper<IntellijIdeInfo.Androi
     private String resourceJavaPackage;
     private boolean generateResourceClass;
     private Label legacyResources;
+    private Label instruments;
 
     public Builder setManifestFile(ArtifactLocation artifactLocation) {
       this.manifest = artifactLocation;
@@ -211,6 +224,11 @@ public final class AndroidIdeInfo implements ProtoWrapper<IntellijIdeInfo.Androi
       return this;
     }
 
+    public Builder setInstruments(@Nullable Label instruments) {
+      this.instruments = instruments;
+      return this;
+    }
+
     public AndroidIdeInfo build() {
       if (!resources.isEmpty() || manifest != null) {
         if (!generateResourceClass) {
@@ -228,7 +246,8 @@ public final class AndroidIdeInfo implements ProtoWrapper<IntellijIdeInfo.Androi
           idlJar,
           resourceJar,
           hasIdlSources,
-          legacyResources);
+          legacyResources,
+          instruments);
     }
   }
 
@@ -249,7 +268,8 @@ public final class AndroidIdeInfo implements ProtoWrapper<IntellijIdeInfo.Androi
         && Objects.equals(idlJar, that.idlJar)
         && Objects.equals(resourceJar, that.resourceJar)
         && Objects.equals(resourceJavaPackage, that.resourceJavaPackage)
-        && Objects.equals(legacyResources, that.legacyResources);
+        && Objects.equals(legacyResources, that.legacyResources)
+        && Objects.equals(instruments, that.instruments);
   }
 
   @Override
@@ -263,6 +283,7 @@ public final class AndroidIdeInfo implements ProtoWrapper<IntellijIdeInfo.Androi
         hasIdlSources,
         resourceJavaPackage,
         generateResourceClass,
-        legacyResources);
+        legacyResources,
+        instruments);
   }
 }

--- a/base/src/com/google/idea/blaze/base/ideinfo/AndroidInstrumentationInfo.java
+++ b/base/src/com/google/idea/blaze/base/ideinfo/AndroidInstrumentationInfo.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.ideinfo;
+
+import com.google.common.base.Strings;
+import com.google.devtools.intellij.ideinfo.IntellijIdeInfo;
+import com.google.idea.blaze.base.model.primitives.Label;
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/** Ide info specific to android instrumentation tests */
+public class AndroidInstrumentationInfo
+    implements ProtoWrapper<IntellijIdeInfo.AndroidInstrumentationInfo> {
+
+  @Nullable
+  public Label getTestApp() {
+    return testApp;
+  }
+
+  @Nullable private final Label testApp;
+
+  private AndroidInstrumentationInfo(@Nullable Label testApp) {
+    this.testApp = testApp;
+  }
+
+  static AndroidInstrumentationInfo fromProto(IntellijIdeInfo.AndroidInstrumentationInfo proto) {
+    return new AndroidInstrumentationInfo(
+        !Strings.isNullOrEmpty(proto.getTestApp()) ? Label.create(proto.getTestApp()) : null);
+  }
+
+  @Override
+  public IntellijIdeInfo.AndroidInstrumentationInfo toProto() {
+    IntellijIdeInfo.AndroidInstrumentationInfo.Builder builder =
+        IntellijIdeInfo.AndroidInstrumentationInfo.newBuilder();
+    ProtoWrapper.unwrapAndSetIfNotNull(builder::setTestApp, testApp);
+    return builder.build();
+  }
+
+  /** Builder for android instrumentation test rule */
+  public static class Builder {
+    private Label testApp;
+
+    public Builder setTestApp(Label testApp) {
+      this.testApp = testApp;
+      return this;
+    }
+
+    public AndroidInstrumentationInfo build() {
+      return new AndroidInstrumentationInfo(testApp);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof Builder)) {
+        return false;
+      }
+      if (!(o instanceof AndroidInstrumentationInfo)) {
+        return false;
+      }
+      AndroidInstrumentationInfo that = (AndroidInstrumentationInfo) o;
+      return testApp.equals(that.getTestApp());
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(testApp);
+    }
+  }
+}

--- a/base/src/com/google/idea/blaze/base/ideinfo/TargetIdeInfo.java
+++ b/base/src/com/google/idea/blaze/base/ideinfo/TargetIdeInfo.java
@@ -44,6 +44,7 @@ public final class TargetIdeInfo implements ProtoWrapper<IntellijIdeInfo.TargetI
   @Nullable private final AndroidIdeInfo androidIdeInfo;
   @Nullable private final AndroidSdkIdeInfo androidSdkIdeInfo;
   @Nullable private final AndroidAarIdeInfo androidAarIdeInfo;
+  @Nullable private final AndroidInstrumentationInfo androidInstrumentationInfo;
   @Nullable private final PyIdeInfo pyIdeInfo;
   @Nullable private final GoIdeInfo goIdeInfo;
   @Nullable private final JsIdeInfo jsIdeInfo;
@@ -67,6 +68,7 @@ public final class TargetIdeInfo implements ProtoWrapper<IntellijIdeInfo.TargetI
       @Nullable AndroidIdeInfo androidIdeInfo,
       @Nullable AndroidSdkIdeInfo androidSdkIdeInfo,
       @Nullable AndroidAarIdeInfo androidAarIdeInfo,
+      @Nullable AndroidInstrumentationInfo androidInstrumentationInfo,
       @Nullable PyIdeInfo pyIdeInfo,
       @Nullable GoIdeInfo goIdeInfo,
       @Nullable JsIdeInfo jsIdeInfo,
@@ -88,6 +90,7 @@ public final class TargetIdeInfo implements ProtoWrapper<IntellijIdeInfo.TargetI
     this.androidIdeInfo = androidIdeInfo;
     this.androidSdkIdeInfo = androidSdkIdeInfo;
     this.androidAarIdeInfo = androidAarIdeInfo;
+    this.androidInstrumentationInfo = androidInstrumentationInfo;
     this.pyIdeInfo = pyIdeInfo;
     this.goIdeInfo = goIdeInfo;
     this.jsIdeInfo = jsIdeInfo;
@@ -176,6 +179,9 @@ public final class TargetIdeInfo implements ProtoWrapper<IntellijIdeInfo.TargetI
         proto.hasAndroidAarIdeInfo()
             ? AndroidAarIdeInfo.fromProto(proto.getAndroidAarIdeInfo())
             : null,
+        proto.hasAndroidInstrumentationInfo()
+            ? AndroidInstrumentationInfo.fromProto(proto.getAndroidInstrumentationInfo())
+            : null,
         pyIdeInfo,
         goIdeInfo,
         jsIdeInfo,
@@ -206,6 +212,8 @@ public final class TargetIdeInfo implements ProtoWrapper<IntellijIdeInfo.TargetI
     ProtoWrapper.unwrapAndSetIfNotNull(builder::setAndroidIdeInfo, androidIdeInfo);
     ProtoWrapper.unwrapAndSetIfNotNull(builder::setAndroidSdkIdeInfo, androidSdkIdeInfo);
     ProtoWrapper.unwrapAndSetIfNotNull(builder::setAndroidAarIdeInfo, androidAarIdeInfo);
+    ProtoWrapper.unwrapAndSetIfNotNull(
+        builder::setAndroidInstrumentationInfo, androidInstrumentationInfo);
     ProtoWrapper.unwrapAndSetIfNotNull(builder::setPyIdeInfo, pyIdeInfo);
     ProtoWrapper.unwrapAndSetIfNotNull(builder::setGoIdeInfo, goIdeInfo);
     ProtoWrapper.unwrapAndSetIfNotNull(builder::setJsIdeInfo, jsIdeInfo);
@@ -240,6 +248,7 @@ public final class TargetIdeInfo implements ProtoWrapper<IntellijIdeInfo.TargetI
         androidIdeInfo,
         androidSdkIdeInfo,
         androidAarIdeInfo,
+        androidInstrumentationInfo,
         pyIdeInfo,
         goIdeInfo,
         jsIdeInfo,
@@ -304,6 +313,11 @@ public final class TargetIdeInfo implements ProtoWrapper<IntellijIdeInfo.TargetI
   @Nullable
   public AndroidAarIdeInfo getAndroidAarIdeInfo() {
     return androidAarIdeInfo;
+  }
+
+  @Nullable
+  public AndroidInstrumentationInfo getAndroidInstrumentationInfo() {
+    return androidInstrumentationInfo;
   }
 
   @Nullable
@@ -395,6 +409,7 @@ public final class TargetIdeInfo implements ProtoWrapper<IntellijIdeInfo.TargetI
     private JavaIdeInfo javaIdeInfo;
     private AndroidIdeInfo androidIdeInfo;
     private AndroidAarIdeInfo androidAarIdeInfo;
+    private AndroidInstrumentationInfo androidInstrumentationInfo;
     private PyIdeInfo pyIdeInfo;
     private GoIdeInfo goIdeInfo;
     private JsIdeInfo jsIdeInfo;
@@ -464,6 +479,11 @@ public final class TargetIdeInfo implements ProtoWrapper<IntellijIdeInfo.TargetI
 
     public Builder setAndroidAarInfo(AndroidAarIdeInfo aarInfo) {
       this.androidAarIdeInfo = aarInfo;
+      return this;
+    }
+
+    public Builder setAndroidInstrumentationInfo(AndroidInstrumentationInfo instrumentationInfo) {
+      this.androidInstrumentationInfo = instrumentationInfo;
       return this;
     }
 
@@ -551,6 +571,7 @@ public final class TargetIdeInfo implements ProtoWrapper<IntellijIdeInfo.TargetI
           androidIdeInfo,
           null,
           androidAarIdeInfo,
+          androidInstrumentationInfo,
           pyIdeInfo,
           goIdeInfo,
           jsIdeInfo,
@@ -584,6 +605,7 @@ public final class TargetIdeInfo implements ProtoWrapper<IntellijIdeInfo.TargetI
         && Objects.equals(androidIdeInfo, that.androidIdeInfo)
         && Objects.equals(androidSdkIdeInfo, that.androidSdkIdeInfo)
         && Objects.equals(androidAarIdeInfo, that.androidAarIdeInfo)
+        && Objects.equals(androidInstrumentationInfo, that.androidInstrumentationInfo)
         && Objects.equals(pyIdeInfo, that.pyIdeInfo)
         && Objects.equals(goIdeInfo, that.goIdeInfo)
         && Objects.equals(jsIdeInfo, that.jsIdeInfo)
@@ -610,6 +632,7 @@ public final class TargetIdeInfo implements ProtoWrapper<IntellijIdeInfo.TargetI
         androidIdeInfo,
         androidSdkIdeInfo,
         androidAarIdeInfo,
+        androidInstrumentationInfo,
         pyIdeInfo,
         goIdeInfo,
         jsIdeInfo,


### PR DESCRIPTION
Add support for running/debugging android_instrumentation_test targets.

The following are required to support android_instrumentation_test:

* BlazeApkBuildStepInstrumentation is added to specifically handle android_instrumentation_test targets. Doing this also simplifies BlazeApkBuildStepNormalBuild as it doesn't have to have separate logic for building multiple APKs just for instrumentation tests.

* BlazeApkDeployInfoProtoHelper has been updated to handle two scenarios: normal deployment, and instrumentation test deployment.  Normal deployment handles existing usages, while instrumentation test deployment handles the case where there are two deploy info files to process (info for both test and target APKs).

* Finally, BlazeAndroidTestProgramRunner is updated to support android_instrumentation_tests.  
 