### PR TITLE
When matching test targets to sources, prefer the most recently synced project targets.

### DIFF
--- a/base/src/com/google/idea/blaze/base/dependencies/TargetInfo.java
+++ b/base/src/com/google/idea/blaze/base/dependencies/TargetInfo.java
@@ -20,6 +20,7 @@ import com.google.idea.blaze.base.ideinfo.ArtifactLocation;
 import com.google.idea.blaze.base.model.primitives.Kind;
 import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.model.primitives.RuleType;
+import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -33,6 +34,7 @@ public class TargetInfo {
   public final String kindString;
   @Nullable public final TestSize testSize;
   @Nullable public final String testClass;
+  @Nullable public final Instant syncTime;
   @Nullable private final ImmutableList<ArtifactLocation> sources;
 
   private TargetInfo(
@@ -40,11 +42,13 @@ public class TargetInfo {
       String kindString,
       @Nullable TestSize testSize,
       @Nullable String testClass,
+      @Nullable Instant syncTime,
       @Nullable ImmutableList<ArtifactLocation> sources) {
     this.label = label;
     this.kindString = kindString;
     this.testSize = testSize;
     this.testClass = testClass;
+    this.syncTime = syncTime;
     this.sources = sources;
   }
 
@@ -119,6 +123,7 @@ public class TargetInfo {
     private final String kindString;
     @Nullable private TestSize testSize;
     @Nullable private String testClass;
+    @Nullable private Instant syncTime;
     @Nullable private ImmutableList<ArtifactLocation> sources;
 
     private Builder(Label label, String kindString) {
@@ -136,13 +141,18 @@ public class TargetInfo {
       return this;
     }
 
+    public Builder setSyncTime(@Nullable Instant syncTime) {
+      this.syncTime = syncTime;
+      return this;
+    }
+
     public Builder setSources(ImmutableList<ArtifactLocation> sources) {
       this.sources = sources;
       return this;
     }
 
     public TargetInfo build() {
-      return new TargetInfo(label, kindString, testSize, testClass, sources);
+      return new TargetInfo(label, kindString, testSize, testClass, syncTime, sources);
     }
   }
 }

--- a/base/src/com/google/idea/blaze/base/ideinfo/TargetIdeInfo.java
+++ b/base/src/com/google/idea/blaze/base/ideinfo/TargetIdeInfo.java
@@ -356,6 +356,7 @@ public final class TargetIdeInfo implements ProtoWrapper<IntellijIdeInfo.TargetI
     return TargetInfo.builder(getKey().getLabel(), getKind().getKindString())
         .setTestSize(getTestIdeInfo() != null ? getTestIdeInfo().getTestSize() : null)
         .setTestClass(getJavaIdeInfo() != null ? getJavaIdeInfo().getTestClass() : null)
+        .setSyncTime(syncTime)
         .setSources(ImmutableList.copyOf(getSources()))
         .build();
   }

--- a/base/src/com/google/idea/blaze/base/run/TestTargetHeuristic.java
+++ b/base/src/com/google/idea/blaze/base/run/TestTargetHeuristic.java
@@ -31,6 +31,7 @@ import com.intellij.psi.PsiFile;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Executor;
@@ -148,7 +149,11 @@ public interface TestTargetHeuristic {
         filteredTargets = matches;
       }
     }
-    return filteredTargets.get(0);
+    // finally order by syncTime (if available), returning the most recently synced
+    return filteredTargets.stream()
+        .max(
+            Comparator.comparing(t -> t.syncTime, Comparator.nullsFirst(Comparator.naturalOrder())))
+        .orElse(null);
   }
 
   /** Returns true if the rule and source file match, according to this heuristic. */


### PR DESCRIPTION
When matching test targets to sources, prefer the most recently synced project targets.