### PR TITLE
Bazel fixes for --incompatible_disallow_empty_glob

### DIFF
--- a/dart/BUILD
+++ b/dart/BUILD
@@ -6,7 +6,6 @@ load("//testing:test_defs.bzl", "intellij_unit_test_suite")
 java_library(
     name = "dart",
     srcs = glob(["src/**/*.java"]),
-    resources = glob(["resources/**/*"]),
     deps = [
         "//base",
         "//common/experiments",

--- a/intellij_platform_sdk/BUILD.android_studio
+++ b/intellij_platform_sdk/BUILD.android_studio
@@ -17,9 +17,7 @@ java_import(
         [
             "android-studio/plugins/android/lib/*.jar",
             "android-studio/plugins/android-ndk/lib/*.jar",
-            "android-studio/plugins/sdk-updates/lib/*.jar",
         ],
-        allow_empty = True,
     ),
 )
 
@@ -86,12 +84,10 @@ java_import(
             "android-studio/plugins/Groovy/lib/*.jar",
             "android-studio/plugins/java-i18n/lib/*.jar",
             "android-studio/plugins/junit/lib/*.jar",
-            "android-studio/plugins/ndk-workspace/lib/*.jar",
             "android-studio/plugins/properties/lib/*.jar",
             "android-studio/plugins/smali/lib/*.jar",
             "android-studio/plugins/IntelliLang/lib/*.jar",
         ],
-        allow_empty = True,
         exclude = [
             # Conflict with lib/guava-*.jar
             "android-studio/plugins/gradle/lib/guava-*.jar",

--- a/intellij_platform_sdk/BUILD.android_studio
+++ b/intellij_platform_sdk/BUILD.android_studio
@@ -13,11 +13,14 @@ java_import(
 
 java_import(
     name = "android_plugin",
-    jars = glob([
-        "android-studio/plugins/android/lib/*.jar",
-        "android-studio/plugins/android-ndk/lib/*.jar",
-        "android-studio/plugins/sdk-updates/lib/*.jar",
-    ]),
+    jars = glob(
+        [
+            "android-studio/plugins/android/lib/*.jar",
+            "android-studio/plugins/android-ndk/lib/*.jar",
+            "android-studio/plugins/sdk-updates/lib/*.jar",
+        ],
+        allow_empty = True,
+    ),
 )
 
 java_import(
@@ -27,7 +30,7 @@ java_import(
     ]),
     runtime_deps = [
         ":kotlin",
-    ],    
+    ],
 )
 
 java_import(
@@ -88,6 +91,7 @@ java_import(
             "android-studio/plugins/smali/lib/*.jar",
             "android-studio/plugins/IntelliLang/lib/*.jar",
         ],
+        allow_empty = True,
         exclude = [
             # Conflict with lib/guava-*.jar
             "android-studio/plugins/gradle/lib/guava-*.jar",

--- a/intellij_platform_sdk/BUILD.android_studio
+++ b/intellij_platform_sdk/BUILD.android_studio
@@ -13,12 +13,10 @@ java_import(
 
 java_import(
     name = "android_plugin",
-    jars = glob(
-        [
-            "android-studio/plugins/android/lib/*.jar",
-            "android-studio/plugins/android-ndk/lib/*.jar",
-        ],
-    ),
+    jars = glob([
+        "android-studio/plugins/android/lib/*.jar",
+        "android-studio/plugins/android-ndk/lib/*.jar",
+    ]),
 )
 
 java_import(

--- a/intellij_platform_sdk/BUILD.android_studio34
+++ b/intellij_platform_sdk/BUILD.android_studio34
@@ -17,9 +17,7 @@ java_import(
         [
             "android-studio/plugins/android/lib/*.jar",
             "android-studio/plugins/android-ndk/lib/*.jar",
-            "android-studio/plugins/sdk-updates/lib/*.jar",
         ],
-        allow_empty = True,
     ),
 )
 
@@ -83,12 +81,10 @@ java_import(
             "android-studio/plugins/Groovy/lib/*.jar",
             "android-studio/plugins/java-i18n/lib/*.jar",
             "android-studio/plugins/junit/lib/*.jar",
-            "android-studio/plugins/ndk-workspace/lib/*.jar",
             "android-studio/plugins/properties/lib/*.jar",
             "android-studio/plugins/smali/lib/*.jar",
             "android-studio/plugins/IntelliLang/lib/*.jar",
         ],
-        allow_empty = True,
         exclude = [
             # Conflict with lib/guava-*.jar
             "android-studio/plugins/gradle/lib/guava-*.jar",

--- a/intellij_platform_sdk/BUILD.android_studio34
+++ b/intellij_platform_sdk/BUILD.android_studio34
@@ -13,12 +13,10 @@ java_import(
 
 java_import(
     name = "android_plugin",
-    jars = glob(
-        [
-            "android-studio/plugins/android/lib/*.jar",
-            "android-studio/plugins/android-ndk/lib/*.jar",
-        ],
-    ),
+    jars = glob([
+        "android-studio/plugins/android/lib/*.jar",
+        "android-studio/plugins/android-ndk/lib/*.jar",
+    ]),
 )
 
 java_import(

--- a/intellij_platform_sdk/BUILD.android_studio34
+++ b/intellij_platform_sdk/BUILD.android_studio34
@@ -13,11 +13,14 @@ java_import(
 
 java_import(
     name = "android_plugin",
-    jars = glob([
-        "android-studio/plugins/android/lib/*.jar",
-        "android-studio/plugins/android-ndk/lib/*.jar",
-        "android-studio/plugins/sdk-updates/lib/*.jar",
-    ]),
+    jars = glob(
+        [
+            "android-studio/plugins/android/lib/*.jar",
+            "android-studio/plugins/android-ndk/lib/*.jar",
+            "android-studio/plugins/sdk-updates/lib/*.jar",
+        ],
+        allow_empty = True,
+    ),
 )
 
 java_import(
@@ -85,6 +88,7 @@ java_import(
             "android-studio/plugins/smali/lib/*.jar",
             "android-studio/plugins/IntelliLang/lib/*.jar",
         ],
+        allow_empty = True,
         exclude = [
             # Conflict with lib/guava-*.jar
             "android-studio/plugins/gradle/lib/guava-*.jar",


### PR DESCRIPTION
Globs that don't match anything may be removed, or made explicit with an
attribute. This is needed for compatiblity with Bazel 1.0.
