### PR TITLE
Remove illegal named arguments in bzl file

### DIFF
--- a/aspect/fast_build_info.bzl
+++ b/aspect/fast_build_info.bzl
@@ -93,7 +93,7 @@ def _get_all_dep_targets(target, ctx):
     """Get all the targets mentioned in one of the _DEP_ATTRS attributes of the target"""
     targets = []
     for attr_name in _DEP_ATTRS:
-        attr_val = getattr(ctx.rule.attr, attr_name, default = None)
+        attr_val = getattr(ctx.rule.attr, attr_name, None)
         if not attr_val:
             continue
         attr_type = type(attr_val)

--- a/aspect/intellij_info_impl.bzl
+++ b/aspect/intellij_info_impl.bzl
@@ -267,7 +267,7 @@ _SRCS_VERSION_MAPPING = {
 }
 
 def _get_python_srcs_version(ctx):
-    srcs_version = getattr(ctx.rule.attr, "srcs_version", default = "PY2AND3")
+    srcs_version = getattr(ctx.rule.attr, "srcs_version", "PY2AND3")
     return _SRCS_VERSION_MAPPING.get(srcs_version, default = SRC_PY2AND3)
 
 ##### Builders for individual parts of the aspect output


### PR DESCRIPTION
The function getattr doesn't allow any named argument, only positional
argument (like in Python).

Bazel will enforce it in the future (see --incompatible_restrict_named_params).
