### PR TITLE
WIP: Menu bar action to file a GitHub issue

### DIFF
--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -129,7 +129,6 @@
       <group id="Blaze.MenuGroupsBookmark"/>
       <separator/>
       <reference id="Blaze.ExportRunConfigurations"/>
-      <separator/>
       <reference id="Blaze.FileGitHubIssueAction"/>
       <!--Add single menu items anchored after this bookmark-->
       <group id="Blaze.MenuFooter"/>

--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -88,6 +88,11 @@
       text="Export Run Configurations"
       icon="AllIcons.Actions.Export">
     </action>
+    <action id="Blaze.FileGitHubIssueAction"
+        class="com.google.idea.blaze.base.actions.FileGitHubIssueAction"
+        text="File an issue on GitHub"
+        icon="BlazeIcons.Logo">
+    </action>
     <action id="Blaze.NewPackageAction"
       class="com.google.idea.blaze.base.ide.NewBlazePackageAction"
       text="New Package">
@@ -124,6 +129,8 @@
       <group id="Blaze.MenuGroupsBookmark"/>
       <separator/>
       <reference id="Blaze.ExportRunConfigurations"/>
+      <separator/>
+      <reference id="Blaze.FileGitHubIssueAction"/>
       <!--Add single menu items anchored after this bookmark-->
       <group id="Blaze.MenuFooter"/>
     </group>

--- a/base/src/com/google/idea/blaze/base/actions/FileGitHubIssueAction.java
+++ b/base/src/com/google/idea/blaze/base/actions/FileGitHubIssueAction.java
@@ -1,0 +1,112 @@
+package com.google.idea.blaze.base.actions;
+
+import com.google.common.collect.ImmutableList;
+import com.google.idea.blaze.base.model.BlazeProjectData;
+import com.google.idea.blaze.base.settings.Blaze;
+import com.google.idea.blaze.base.settings.BuildSystem;
+import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
+import com.intellij.ide.BrowserUtil;
+import com.intellij.ide.plugins.IdeaPluginDescriptor;
+import com.intellij.ide.plugins.PluginManager;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.application.ApplicationInfo;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.Messages;
+import com.intellij.openapi.util.SystemInfo;
+import com.intellij.util.PlatformUtils;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLEncoder;
+import org.jetbrains.annotations.Nullable;
+
+public final class FileGitHubIssueAction extends BlazeProjectAction {
+
+  private static final String BASE_URL = "https://github.com/bazelbuild/intellij/issues/new?";
+
+  private static final ImmutableList<String> BAZEL_PLUGIN_IDS =
+      ImmutableList.of(
+          "com.google.idea.bazel.aswb", "com.google.idea.bazel.ijwb", "com.google.idea.bazel.clwb");
+
+  @Override
+  protected void actionPerformedInBlazeProject(Project project, AnActionEvent e) {
+
+    // TODO(jingwen): Find somewhere else to hide this from the Blaze plugin
+    if (Blaze.getBuildSystem(project).equals(BuildSystem.Blaze)) {
+      Messages.showErrorDialog(
+          e.getProject(),
+          "GitHub issue filing is only supported when using the plugin with Bazel.",
+          "Bazel Plugin Required");
+      return;
+    }
+
+    // Open the browser to the GitHub repository with pre-filled information.
+    BrowserUtil.browse(buildGitHubUrl(project));
+  }
+
+  @Nullable
+  private URL buildGitHubUrl(Project project) {
+    StringBuilder issueParameterBuilder = new StringBuilder();
+    StringBuilder bodyParam = new StringBuilder();
+
+    bodyParam.append("#### Description of the issue. Please be specific.\n");
+    bodyParam.append("\n");
+    bodyParam.append(
+        "#### What's the simplest set of steps to reproduce this issue? Please provide "
+            + "an example project, if possible.\n");
+    bodyParam.append("\n");
+    bodyParam.append("#### Version information\n");
+
+    // Get the IDE version
+    bodyParam.append(
+        String.format("%s: %s\n", getProductId(), ApplicationInfo.getInstance().getFullVersion()));
+
+    // Get information about the operating system
+    bodyParam.append(String.format("Platform: %s %s\n", SystemInfo.OS_NAME, SystemInfo.OS_VERSION));
+
+    // Get the plugin version
+    for (IdeaPluginDescriptor plugin : PluginManager.getPlugins()) {
+      if (BAZEL_PLUGIN_IDS.contains(plugin.getPluginId().getIdString())) {
+        bodyParam.append(
+            String.format(
+                "%s plugin: %s%s\n",
+                plugin.getName(), plugin.getVersion(), plugin.isEnabled() ? "" : " (disabled)"));
+      }
+    }
+
+    // Get the Bazel version
+    BlazeProjectData projectData =
+        BlazeProjectDataManager.getInstance(project).getBlazeProjectData();
+    if (projectData != null) {
+      bodyParam.append(String.format("Bazel: %s\n", projectData.getBlazeVersionData().toString()));
+    }
+
+    try {
+      issueParameterBuilder.append("&body=" + URLEncoder.encode(bodyParam.toString(), "UTF-8"));
+    } catch (UnsupportedEncodingException ex) {
+      ex.printStackTrace();
+    }
+
+    URL url = null;
+    try {
+      url = new URL(BASE_URL + issueParameterBuilder);
+    } catch (MalformedURLException ex) {
+      ex.printStackTrace();
+    }
+
+    return url;
+  }
+
+  String getProductId() {
+    String platformPrefix = PlatformUtils.getPlatformPrefix();
+
+    // IDEA Community Edition is "Idea", whereas IDEA Ultimate Edition is "idea". Let's make them
+    // more useful.
+    if (PlatformUtils.isIdeaCommunity()) {
+      platformPrefix = "IdeaCommunity";
+    } else if (PlatformUtils.isIdeaUltimate()) {
+      platformPrefix = "IdeaUltimate";
+    }
+    return platformPrefix;
+  }
+}

--- a/base/src/com/google/idea/blaze/base/actions/FileGitHubIssueAction.java
+++ b/base/src/com/google/idea/blaze/base/actions/FileGitHubIssueAction.java
@@ -25,7 +25,7 @@ public final class FileGitHubIssueAction extends BlazeProjectAction {
 
   private static final Logger logger = Logger.getInstance(FileGitHubIssueAction.class);
 
-  private static final String BASE_URL = "https://github.com/bazelbuild/intellij/issues/new?";
+  private static final String BASE_URL = "https://github.com/bazelbuild/intellij/issues/new";
 
   private static final ImmutableList<String> BAZEL_PLUGIN_IDS =
       ImmutableList.of(
@@ -99,7 +99,7 @@ public final class FileGitHubIssueAction extends BlazeProjectAction {
     }
 
     try {
-      return new URL(BASE_URL + issueParameterBuilder);
+      return new URL(BASE_URL + "?" + issueParameterBuilder);
     } catch (MalformedURLException ex) {
       logger.error(ex);
       return null;

--- a/base/src/com/google/idea/blaze/base/actions/FileGitHubIssueAction.java
+++ b/base/src/com/google/idea/blaze/base/actions/FileGitHubIssueAction.java
@@ -10,6 +10,7 @@ import com.intellij.ide.plugins.IdeaPluginDescriptor;
 import com.intellij.ide.plugins.PluginManager;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.application.ApplicationInfo;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.util.SystemInfo;
@@ -21,6 +22,8 @@ import java.net.URLEncoder;
 import org.jetbrains.annotations.Nullable;
 
 public final class FileGitHubIssueAction extends BlazeProjectAction {
+
+  private static final Logger logger = Logger.getInstance(FileGitHubIssueAction.class);
 
   private static final String BASE_URL = "https://github.com/bazelbuild/intellij/issues/new?";
 
@@ -47,7 +50,6 @@ public final class FileGitHubIssueAction extends BlazeProjectAction {
     } else {
       BrowserUtil.browse(buildGitHubUrl(project));
     }
-
   }
 
   @Nullable
@@ -92,15 +94,16 @@ public final class FileGitHubIssueAction extends BlazeProjectAction {
     } catch (UnsupportedEncodingException ex) {
       // If we can't manage to parse the body for some reason (e.g. weird SystemInfo
       // OS_NAME or OS_VERSION), just proceed and open up an empty GitHub issue form.
+      logger.error(ex);
       return null;
     }
 
     try {
       return new URL(BASE_URL + issueParameterBuilder);
     } catch (MalformedURLException ex) {
+      logger.error(ex);
       return null;
     }
-
   }
 
   private String getProductId() {

--- a/base/src/com/google/idea/blaze/base/actions/FileGitHubIssueAction.java
+++ b/base/src/com/google/idea/blaze/base/actions/FileGitHubIssueAction.java
@@ -1,9 +1,9 @@
 package com.google.idea.blaze.base.actions;
 
 import com.google.common.collect.ImmutableList;
+import com.google.idea.blaze.base.async.process.ExternalTask;
 import com.google.idea.blaze.base.model.BlazeProjectData;
-import com.google.idea.blaze.base.settings.Blaze;
-import com.google.idea.blaze.base.settings.BuildSystem;
+import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
 import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
 import com.intellij.ide.BrowserUtil;
 import com.intellij.ide.plugins.IdeaPluginDescriptor;
@@ -12,7 +12,6 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.application.ApplicationInfo;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.util.SystemInfo;
 import com.intellij.util.PlatformUtils;
 import java.io.UnsupportedEncodingException;
@@ -22,8 +21,8 @@ import java.net.URLEncoder;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * A {@link BlazeProjectAction} to open a GitHub issue with pre-filled information
- * like the versions of the plugin, Bazel and the IDE.
+ * A an action to open a GitHub issue with pre-filled information like the versions of the
+ * plugin, Bazel and the IDE.
  *
  * Read the
  * <a href="https://help.github.com/en/articles/about-automation-for-issues-and-pull-requests-with-query-parameters">GitHub docs</a>
@@ -39,48 +38,63 @@ public final class FileGitHubIssueAction extends BlazeProjectAction {
       ImmutableList.of(
           "com.google.idea.bazel.aswb", "com.google.idea.bazel.ijwb", "com.google.idea.bazel.clwb");
 
+
+  @Override
+  protected void updateForBlazeProject(Project project, AnActionEvent e) {
+    int retVal =
+        ExternalTask.builder(WorkspaceRoot.fromProject(project))
+            .args("glogin", "-version")
+            .build()
+            .run();
+
+    // Only show the menu bar reference if glogin doesn't exist.
+    e.getPresentation().setEnabledAndVisible(retVal != 0);
+  }
+
   @Override
   protected void actionPerformedInBlazeProject(Project project, AnActionEvent e) {
-
-    // TODO(jingwen): Find somewhere else to hide this from the Blaze plugin.
-    if (Blaze.getBuildSystem(project).equals(BuildSystem.Blaze)) {
-      Messages.showErrorDialog(
-          e.getProject(),
-          "GitHub issue filing is only supported when using the plugin with Bazel.",
-          "Bazel Plugin Required");
-      return;
-    }
-
-    URL url = buildGitHubUrl(project);
+    URL url = getGitHubTemplateURL(project);
     if (url == null) {
-      // If for some reason we can't construct the URL, attempt to open the issues page directly.
+      // If, for some reason, we can't construct the URL, open the issues page directly.
       BrowserUtil.browse(BASE_URL);
     } else {
       BrowserUtil.browse(url);
     }
   }
 
+  /**
+   * Constructs a GitHub URL with query parameters containing pre-filled information
+   * about a user's IDE installation and system.
+   *
+   * @param project The Bazel project instance.
+   * @return an URL containing pre-filled instructions and information about a user's system.
+   */
   @Nullable
-  private URL buildGitHubUrl(Project project) {
-    StringBuilder issueParameterBuilder = new StringBuilder();
+  private URL getGitHubTemplateURL(Project project) {
+    // q?body=<param value>
+    // https://help.github.com/en/articles/about-automation-for-issues-and-pull-requests-with-query-parameters#supported-query-parameters
     StringBuilder bodyParam = new StringBuilder();
 
     bodyParam.append("#### Description of the issue. Please be specific.\n");
     bodyParam.append("\n");
-    bodyParam.append(
-        "#### What's the simplest set of steps to reproduce this issue? Please provide "
-            + "an example project, if possible.\n");
+
+    bodyParam.append("#### What's the simplest set of steps to reproduce this issue? ");
+    bodyParam.append("Please provide an example project, if possible.\n");
     bodyParam.append("\n");
+
     bodyParam.append("#### Version information\n");
 
-    // Get the IDE version
+    // Get the IDE version.
+    // e.g. IdeaCommunity: 2019.1.2
     bodyParam.append(
         String.format("%s: %s\n", getProductId(), ApplicationInfo.getInstance().getFullVersion()));
 
-    // Get information about the operating system
+    // Get information about the operating system.
+    // e.g. Platform: Linux 4.19.37-amd64
     bodyParam.append(String.format("Platform: %s %s\n", SystemInfo.OS_NAME, SystemInfo.OS_VERSION));
 
-    // Get the plugin version
+    // Get the plugin version.
+    // e.g. Bazel plugin: 2019.07.23.0.3
     for (IdeaPluginDescriptor plugin : PluginManager.getPlugins()) {
       if (BAZEL_PLUGIN_IDS.contains(plugin.getPluginId().getIdString())) {
         bodyParam.append(
@@ -90,7 +104,8 @@ public final class FileGitHubIssueAction extends BlazeProjectAction {
       }
     }
 
-    // Get the Bazel version
+    // Get the Bazel version.
+    // e.g. Bazel: 0.28.1
     BlazeProjectData projectData =
         BlazeProjectDataManager.getInstance(project).getBlazeProjectData();
     if (projectData != null) {
@@ -98,17 +113,10 @@ public final class FileGitHubIssueAction extends BlazeProjectAction {
     }
 
     try {
-      issueParameterBuilder.append("body=" + URLEncoder.encode(bodyParam.toString(), "UTF-8"));
-    } catch (UnsupportedEncodingException ex) {
+      return new URL(BASE_URL + "?body=" + URLEncoder.encode(bodyParam.toString(), "UTF-8"));
+    } catch (UnsupportedEncodingException | MalformedURLException ex) {
       // If we can't manage to parse the body for some reason (e.g. weird SystemInfo
       // OS_NAME or OS_VERSION), just proceed and open up an empty GitHub issue form.
-      logger.error(ex);
-      return null;
-    }
-
-    try {
-      return new URL(BASE_URL + "?" + issueParameterBuilder);
-    } catch (MalformedURLException ex) {
       logger.error(ex);
       return null;
     }

--- a/base/src/com/google/idea/blaze/base/actions/FileGitHubIssueAction.java
+++ b/base/src/com/google/idea/blaze/base/actions/FileGitHubIssueAction.java
@@ -21,6 +21,14 @@ import java.net.URL;
 import java.net.URLEncoder;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * A {@link BlazeProjectAction} to open a GitHub issue with pre-filled information
+ * like the versions of the plugin, Bazel and the IDE.
+ *
+ * Read the
+ * <a href="https://help.github.com/en/articles/about-automation-for-issues-and-pull-requests-with-query-parameters">GitHub docs</a>
+ * for more information on issue automation.
+ */
 public final class FileGitHubIssueAction extends BlazeProjectAction {
 
   private static final Logger logger = Logger.getInstance(FileGitHubIssueAction.class);
@@ -34,7 +42,7 @@ public final class FileGitHubIssueAction extends BlazeProjectAction {
   @Override
   protected void actionPerformedInBlazeProject(Project project, AnActionEvent e) {
 
-    // TODO(jingwen): Find somewhere else to hide this from the Blaze plugin
+    // TODO(jingwen): Find somewhere else to hide this from the Blaze plugin.
     if (Blaze.getBuildSystem(project).equals(BuildSystem.Blaze)) {
       Messages.showErrorDialog(
           e.getProject(),
@@ -48,7 +56,7 @@ public final class FileGitHubIssueAction extends BlazeProjectAction {
       // If for some reason we can't construct the URL, attempt to open the issues page directly.
       BrowserUtil.browse(BASE_URL);
     } else {
-      BrowserUtil.browse(buildGitHubUrl(project));
+      BrowserUtil.browse(url);
     }
   }
 

--- a/base/src/com/google/idea/blaze/base/actions/FileGitHubIssueAction.java
+++ b/base/src/com/google/idea/blaze/base/actions/FileGitHubIssueAction.java
@@ -40,8 +40,14 @@ public final class FileGitHubIssueAction extends BlazeProjectAction {
       return;
     }
 
-    // Open the browser to the GitHub repository with pre-filled information.
-    BrowserUtil.browse(buildGitHubUrl(project));
+    URL url = buildGitHubUrl(project);
+    if (url == null) {
+      // If for some reason we can't construct the URL, attempt to open the issues page directly.
+      BrowserUtil.browse(BASE_URL);
+    } else {
+      BrowserUtil.browse(buildGitHubUrl(project));
+    }
+
   }
 
   @Nullable
@@ -82,22 +88,22 @@ public final class FileGitHubIssueAction extends BlazeProjectAction {
     }
 
     try {
-      issueParameterBuilder.append("&body=" + URLEncoder.encode(bodyParam.toString(), "UTF-8"));
+      issueParameterBuilder.append("body=" + URLEncoder.encode(bodyParam.toString(), "UTF-8"));
     } catch (UnsupportedEncodingException ex) {
-      ex.printStackTrace();
+      // If we can't manage to parse the body for some reason (e.g. weird SystemInfo
+      // OS_NAME or OS_VERSION), just proceed and open up an empty GitHub issue form.
+      return null;
     }
 
-    URL url = null;
     try {
-      url = new URL(BASE_URL + issueParameterBuilder);
+      return new URL(BASE_URL + issueParameterBuilder);
     } catch (MalformedURLException ex) {
-      ex.printStackTrace();
+      return null;
     }
 
-    return url;
   }
 
-  String getProductId() {
+  private String getProductId() {
     String platformPrefix = PlatformUtils.getPlatformPrefix();
 
     // IDEA Community Edition is "Idea", whereas IDEA Ultimate Edition is "idea". Let's make them


### PR DESCRIPTION
This adds a new menu bar reference to file a GitHub issue directly from the IDE. 

When the user clicks on the reference, the action obtains relevant version information and opens the new issue page and pre-fills the information. The user then fills in the questionnaire and manually submits the issue.

Sample issue content:

```
#### Description of the issue. Please be specific.

#### What's the simplest set of steps to reproduce this issue? Please provide an example project, if possible.

#### Version information
IdeaCommunity: 2019.1.2
Platform: Linux 4.19.37-5rodete1-amd64
Bazel plugin: 9999
Bazel: 0.28.1
```