### PR TITLE
Add a SourceToDependencyTargetProvider that finds a list of Blaze targets that build a given source file for the purpose of using the targets in the dependency list of other targets.

### DIFF
--- a/base/BUILD
+++ b/base/BUILD
@@ -199,6 +199,8 @@ java_library(
 java_library(
     name = "dep_finder_api",
     srcs = [
+        "src/com/google/idea/blaze/base/dependencies/SourceToDependencyTargetHelper.java",
+        "src/com/google/idea/blaze/base/dependencies/SourceToDependencyTargetProvider.java",
         "src/com/google/idea/blaze/base/dependencies/SourceToTargetProvider.java",
         "src/com/google/idea/blaze/base/dependencies/TargetInfo.java",
         "src/com/google/idea/blaze/base/dependencies/TestSize.java",

--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -425,6 +425,7 @@
     <extensionPoint qualifiedName="com.google.idea.blaze.HeuristicTestIdentifier" interface="com.google.idea.blaze.base.run.producers.HeuristicTestIdentifier"/>
     <extensionPoint qualifiedName="com.google.idea.blaze.OutputsProvider" interface="com.google.idea.blaze.base.model.OutputsProvider"/>
     <extensionPoint qualifiedName="com.google.idea.blaze.VcsSyncListener" interface="com.google.idea.blaze.base.vcs.VcsSyncListener"/>
+    <extensionPoint qualifiedName="com.google.idea.blaze.SourceToDependencyTargetProvider" interface="com.google.idea.blaze.base.dependencies.SourceToDependencyTargetProvider"/>
   </extensionPoints>
 
   <extensions defaultExtensionNs="com.google.idea.blaze">
@@ -487,6 +488,7 @@
     <VcsSyncListener implementation="com.google.idea.blaze.base.prefetch.PrefetchVcsSyncListener"/>
     <VcsSyncListener implementation="com.google.idea.blaze.base.sync.autosync.VcsAutoSyncProvider"/>
     <SettingsUiContributor implementation="com.google.idea.blaze.base.settings.ui.BlazeUserSettingsConfigurable$UiContributor" order="first" id="base"/>
+    <SourceToDependencyTargetProvider implementation="com.google.idea.blaze.base.dependencies.BlazeSyncSourceToDependencyTargetProvider"/>
   </extensions>
 
 </idea-plugin>

--- a/base/src/com/google/idea/blaze/base/dependencies/BlazeSyncSourceToDependencyTargetProvider.java
+++ b/base/src/com/google/idea/blaze/base/dependencies/BlazeSyncSourceToDependencyTargetProvider.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.dependencies;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.util.concurrent.Futures;
+import com.google.idea.blaze.base.ideinfo.ArtifactLocation;
+import com.google.idea.blaze.base.ideinfo.TargetIdeInfo;
+import com.google.idea.blaze.base.model.BlazeProjectData;
+import com.google.idea.blaze.base.sync.SyncCache;
+import com.intellij.openapi.project.Project;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Future;
+
+/** Given a source file, finds the targets building it from the blaze sync data. */
+public class BlazeSyncSourceToDependencyTargetProvider implements SourceToDependencyTargetProvider {
+
+  @Override
+  public Future<List<TargetInfo>> getTargetsBuildingSourceFile(
+      Project project, String workspaceRelativePath) {
+    Multimap<String, TargetInfo> sourceToDependencyTargetMap =
+        getSourceToDependencyTargetMap(project);
+    Collection<TargetInfo> targetInfos = sourceToDependencyTargetMap.get(workspaceRelativePath);
+    return Futures.immediateFuture(ImmutableList.copyOf(targetInfos));
+  }
+
+  private static Multimap<String, TargetInfo> getSourceToDependencyTargetMap(Project project) {
+    return SyncCache.getInstance(project)
+        .get(
+            BlazeSyncSourceToDependencyTargetProvider.class,
+            BlazeSyncSourceToDependencyTargetProvider::createSourceToDependencyTargetMap);
+  }
+
+  @SuppressWarnings("unused")
+  private static Multimap<String, TargetInfo> createSourceToDependencyTargetMap(
+      Project project, BlazeProjectData blazeProjectData) {
+    ImmutableSetMultimap.Builder<String, TargetInfo> sourceToDependencyTargetMap =
+        ImmutableSetMultimap.builder();
+    for (TargetIdeInfo targetIdeInfo : blazeProjectData.getTargetMap().targets()) {
+      ImmutableSet<ArtifactLocation> sources = targetIdeInfo.getSources();
+      if (sources.isEmpty()) {
+        continue;
+      }
+      for (ArtifactLocation source : sources) {
+        sourceToDependencyTargetMap.put(
+            source.getRelativePath(),
+            TargetInfo.builder(
+                    targetIdeInfo.getKey().getLabel(), targetIdeInfo.getKind().getKindString())
+                .build());
+      }
+    }
+    return sourceToDependencyTargetMap.build();
+  }
+}

--- a/base/src/com/google/idea/blaze/base/dependencies/SourceToDependencyTargetHelper.java
+++ b/base/src/com/google/idea/blaze/base/dependencies/SourceToDependencyTargetHelper.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.dependencies;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.idea.blaze.base.run.targetfinder.FuturesUtil;
+import com.intellij.openapi.project.Project;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+
+/**
+ * A helper class to complement {@link SourceToDependencyTargetProvider}. Separated from that class
+ * to keep that shared API minimal.
+ */
+public final class SourceToDependencyTargetHelper {
+
+  /**
+   * Returns the blaze targets provided by the first available {@link
+   * SourceToDependencyTargetProvider} able to handle the given source file, prioritizing any which
+   * are immediately available.
+   *
+   * <p>Future returns null if no provider was able to handle the given source file.
+   */
+  public static ListenableFuture<List<TargetInfo>> findTargetsBuildingSourceFile(
+      Project project, String workspaceRelativePath) {
+    Iterable<Future<List<TargetInfo>>> futures =
+        Arrays.stream(SourceToDependencyTargetProvider.EP_NAME.getExtensions())
+            .map(f -> f.getTargetsBuildingSourceFile(project, workspaceRelativePath))
+            .collect(Collectors.toList());
+    ListenableFuture<List<TargetInfo>> future =
+        FuturesUtil.getFirstFutureSatisfyingPredicate(futures, Objects::nonNull);
+    return future;
+  }
+
+  private SourceToDependencyTargetHelper() {}
+}

--- a/base/src/com/google/idea/blaze/base/dependencies/SourceToDependencyTargetProvider.java
+++ b/base/src/com/google/idea/blaze/base/dependencies/SourceToDependencyTargetProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.dependencies;
+
+import com.intellij.openapi.extensions.ExtensionPointName;
+import com.intellij.openapi.project.Project;
+import java.util.List;
+import java.util.concurrent.Future;
+
+/**
+ * Maps a source file to appropriate blaze target(s) building that source file. Here 'appropriate'
+ * means for the purposes of using the targets as build dependencies.
+ *
+ * <p>This provider is similar to {@link SourceToTargetProvider} but it attempts to return all known
+ * blaze target(s) building the source file.
+ */
+public interface SourceToDependencyTargetProvider {
+
+  ExtensionPointName<SourceToDependencyTargetProvider> EP_NAME =
+      ExtensionPointName.create("com.google.idea.blaze.SourceToDependencyTargetProvider");
+
+  /**
+   * Query the blaze targets building the given source file.
+   *
+   * <p>Future returns null if this provider was unable to query the blaze targets.
+   */
+  Future<List<TargetInfo>> getTargetsBuildingSourceFile(
+      Project project, String workspaceRelativePath);
+}

--- a/base/tests/integrationtests/com/google/idea/blaze/base/dependencies/BlazeSyncSourceToDependencyTargetProviderTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/dependencies/BlazeSyncSourceToDependencyTargetProviderTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.dependencies;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.idea.blaze.base.BlazeIntegrationTestCase;
+import com.google.idea.blaze.base.ideinfo.ArtifactLocation;
+import com.google.idea.blaze.base.ideinfo.TargetIdeInfo;
+import com.google.idea.blaze.base.ideinfo.TargetMap;
+import com.google.idea.blaze.base.model.BlazeProjectData;
+import com.google.idea.blaze.base.model.MockBlazeProjectDataBuilder;
+import com.google.idea.blaze.base.model.primitives.Label;
+import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
+import com.google.idea.testing.ServiceHelper;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/** Tests for {@link BlazeSyncSourceToDependencyTargetProvider}. */
+@RunWith(JUnit4.class)
+public final class BlazeSyncSourceToDependencyTargetProviderTest extends BlazeIntegrationTestCase {
+
+  @Mock private BlazeProjectDataManager mockBlazeProjectDataManager;
+
+  private BlazeSyncSourceToDependencyTargetProvider blazeSyncSourceToDependencyTargetProvider;
+
+  @Before
+  public void initTest() {
+    MockitoAnnotations.initMocks(this);
+    ServiceHelper.registerProjectService(
+        testFixture.getProject(),
+        BlazeProjectDataManager.class,
+        mockBlazeProjectDataManager,
+        getTestRootDisposable());
+    blazeSyncSourceToDependencyTargetProvider = new BlazeSyncSourceToDependencyTargetProvider();
+  }
+
+  @Test
+  public void testGetTargetsBuildingSourceFile() throws ExecutionException, InterruptedException {
+    ImmutableList<TargetIdeInfo> targetIdeInfos =
+        ImmutableList.of(
+            createTargetIdeInfo(
+                "//test:target1",
+                "package1/source1.proto",
+                "package1/source2.proto",
+                "package2/source3.proto"),
+            createTargetIdeInfo(
+                "//test:target2",
+                "package1/source4.proto",
+                "package2/source5.proto",
+                "package2/source6.proto"),
+            createTargetIdeInfo(
+                "//test:target3",
+                "package1/source4.proto",
+                "package2/source3.proto",
+                "package2/source7.proto"));
+    BlazeProjectData blazeProjectData =
+        MockBlazeProjectDataBuilder.builder()
+            .setTargetMap(
+                new TargetMap(
+                    targetIdeInfos.stream()
+                        .collect(
+                            ImmutableMap.toImmutableMap(
+                                targetIdeInfo -> targetIdeInfo.getKey(),
+                                targetIdeInfo -> targetIdeInfo))))
+            .build();
+
+    when(mockBlazeProjectDataManager.getBlazeProjectData()).thenReturn(blazeProjectData);
+
+    List<TargetInfo> actual =
+        blazeSyncSourceToDependencyTargetProvider
+            .getTargetsBuildingSourceFile(testFixture.getProject(), "package2/source3.proto")
+            .get();
+
+    assertThat(actual)
+        .containsExactly(
+            TargetInfo.builder(Label.create("//test:target1"), "proto_library").build(),
+            TargetInfo.builder(Label.create("//test:target3"), "proto_library").build());
+  }
+
+  private static TargetIdeInfo createTargetIdeInfo(String label, String... sourceRelativePaths) {
+    TargetIdeInfo.Builder targetIdeInfo =
+        TargetIdeInfo.builder().setLabel(label).setKind("proto_library");
+    for (String sourceRelativePath : sourceRelativePaths) {
+      targetIdeInfo.addSource(ArtifactLocation.builder().setRelativePath(sourceRelativePath));
+    }
+    return targetIdeInfo.build();
+  }
+}

--- a/base/tests/integrationtests/com/google/idea/blaze/base/dependencies/SourceToDependencyTargetHelperTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/dependencies/SourceToDependencyTargetHelperTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.dependencies;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.idea.blaze.base.BlazeIntegrationTestCase;
+import com.google.idea.blaze.base.ideinfo.ArtifactLocation;
+import com.google.idea.blaze.base.ideinfo.TargetIdeInfo;
+import com.google.idea.blaze.base.ideinfo.TargetKey;
+import com.google.idea.blaze.base.ideinfo.TargetMap;
+import com.google.idea.blaze.base.model.BlazeProjectData;
+import com.google.idea.blaze.base.model.MockBlazeProjectDataBuilder;
+import com.google.idea.blaze.base.model.primitives.Label;
+import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
+import com.google.idea.testing.ServiceHelper;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/** Tests for {@link SourceToDependencyTargetHelper}. */
+@RunWith(JUnit4.class)
+public final class SourceToDependencyTargetHelperTest extends BlazeIntegrationTestCase {
+
+  @Mock private BlazeProjectDataManager mockBlazeProjectDataManager;
+
+  @Before
+  public void initTest() {
+    MockitoAnnotations.initMocks(this);
+    ServiceHelper.registerProjectService(
+        testFixture.getProject(),
+        BlazeProjectDataManager.class,
+        mockBlazeProjectDataManager,
+        getTestRootDisposable());
+  }
+
+  @Test
+  public void testFindTargetsBuildingSourceFile() throws ExecutionException, InterruptedException {
+    Label target = Label.create("//test:target");
+    String kind = "proto_library";
+    String sourceRelativePath = "package/source.proto";
+    BlazeProjectData blazeProjectData =
+        MockBlazeProjectDataBuilder.builder()
+            .setTargetMap(
+                new TargetMap(
+                    ImmutableMap.of(
+                        TargetKey.forPlainTarget(target),
+                        TargetIdeInfo.builder()
+                            .setLabel(target)
+                            .setKind(kind)
+                            .addSource(
+                                ArtifactLocation.builder().setRelativePath(sourceRelativePath))
+                            .build())))
+            .build();
+
+    when(mockBlazeProjectDataManager.getBlazeProjectData()).thenReturn(blazeProjectData);
+
+    List<TargetInfo> actual =
+        SourceToDependencyTargetHelper.findTargetsBuildingSourceFile(
+                testFixture.getProject(), sourceRelativePath)
+            .get();
+
+    assertThat(actual).containsExactly(TargetInfo.builder(target, kind).build());
+  }
+}


### PR DESCRIPTION
Add a SourceToDependencyTargetProvider that finds a list of Blaze targets that build a given source file for the purpose of using the targets in the dependency list of other targets.