### PR TITLE
Fast run/debug: don't get BlazeInfo from the project data, which might be using a different blaze binary.

### DIFF
--- a/java/src/com/google/idea/blaze/java/fastbuild/FastBuildInfo.java
+++ b/java/src/com/google/idea/blaze/java/fastbuild/FastBuildInfo.java
@@ -18,6 +18,7 @@ package com.google.idea.blaze.java.fastbuild;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.idea.blaze.base.command.info.BlazeInfo;
 import com.google.idea.blaze.base.model.primitives.Label;
 import java.io.File;
 import java.util.List;
@@ -35,9 +36,19 @@ public abstract class FastBuildInfo {
 
   public abstract ImmutableMap<Label, FastBuildBlazeData> blazeData();
 
+  public abstract BlazeInfo blazeInfo();
+
   public static FastBuildInfo create(
-      Label label, File deployJar, List<File> classpath, Map<Label, FastBuildBlazeData> blazeData) {
+      Label label,
+      File deployJar,
+      List<File> classpath,
+      Map<Label, FastBuildBlazeData> blazeData,
+      BlazeInfo blazeInfo) {
     return new AutoValue_FastBuildInfo(
-        label, deployJar, ImmutableList.copyOf(classpath), ImmutableMap.copyOf(blazeData));
+        label,
+        deployJar,
+        ImmutableList.copyOf(classpath),
+        ImmutableMap.copyOf(blazeData),
+        blazeInfo);
   }
 }

--- a/java/src/com/google/idea/blaze/java/fastbuild/FastBuildParameters.java
+++ b/java/src/com/google/idea/blaze/java/fastbuild/FastBuildParameters.java
@@ -29,7 +29,9 @@ abstract class FastBuildParameters {
 
   abstract String blazeBinary();
 
-  abstract ImmutableList<String> blazeFlags();
+  abstract ImmutableList<String> buildFlags();
+
+  abstract ImmutableList<String> infoFlags();
 
   static Builder builder() {
     return new AutoValue_FastBuildParameters.Builder();
@@ -39,10 +41,17 @@ abstract class FastBuildParameters {
   abstract static class Builder {
     abstract Builder setBlazeBinary(String blazeBinary);
 
-    abstract ImmutableList.Builder<String> blazeFlagsBuilder();
+    abstract ImmutableList.Builder<String> buildFlagsBuilder();
 
-    Builder addBlazeFlags(List<String> blazeFlags) {
-      blazeFlagsBuilder().addAll(blazeFlags);
+    Builder addBuildFlags(List<String> buildFlags) {
+      buildFlagsBuilder().addAll(buildFlags);
+      return this;
+    }
+
+    abstract ImmutableList.Builder<String> infoFlagsBuilder();
+
+    Builder addInfoFlags(List<String> infoFlags) {
+      infoFlagsBuilder().addAll(infoFlags);
       return this;
     }
 

--- a/java/src/com/google/idea/blaze/java/fastbuild/FastBuildState.java
+++ b/java/src/com/google/idea/blaze/java/fastbuild/FastBuildState.java
@@ -17,6 +17,7 @@ package com.google.idea.blaze.java.fastbuild;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.idea.blaze.base.command.info.BlazeInfo;
 import com.google.idea.blaze.base.model.primitives.Label;
 import java.io.File;
 import java.util.Map;
@@ -37,8 +38,11 @@ abstract class FastBuildState {
 
     abstract Map<Label, FastBuildBlazeData> blazeData();
 
-    static BuildOutput create(File deployJar, Map<Label, FastBuildBlazeData> blazeData) {
-      return new AutoValue_FastBuildState_BuildOutput(deployJar, blazeData);
+    abstract BlazeInfo blazeInfo();
+
+    static BuildOutput create(
+        File deployJar, Map<Label, FastBuildBlazeData> blazeData, BlazeInfo blazeInfo) {
+      return new AutoValue_FastBuildState_BuildOutput(deployJar, blazeData, blazeInfo);
     }
   }
 

--- a/java/tests/integrationtests/com/google/idea/blaze/java/fastbuild/FastBuildChangedFilesServiceTest.java
+++ b/java/tests/integrationtests/com/google/idea/blaze/java/fastbuild/FastBuildChangedFilesServiceTest.java
@@ -29,11 +29,13 @@ import com.google.common.util.concurrent.SettableFuture;
 import com.google.devtools.intellij.aspect.Common.ArtifactLocation;
 import com.google.devtools.intellij.aspect.FastBuildInfo;
 import com.google.idea.blaze.base.BlazeIntegrationTestCase;
+import com.google.idea.blaze.base.command.info.BlazeInfo;
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.MockBlazeProjectDataBuilder;
 import com.google.idea.blaze.base.model.MockBlazeProjectDataManager;
 import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.model.primitives.WorkspacePath;
+import com.google.idea.blaze.base.settings.BuildSystem;
 import com.google.idea.blaze.base.sync.workspace.ArtifactLocationDecoder;
 import com.google.idea.blaze.java.fastbuild.FastBuildBlazeData.JavaInfo;
 import com.google.idea.blaze.java.fastbuild.FastBuildChangedFilesService.ChangedSources;
@@ -49,6 +51,19 @@ import org.junit.runners.JUnit4;
 /** Tests for {@link FastBuildChangedFilesService}. */
 @RunWith(JUnit4.class)
 public class FastBuildChangedFilesServiceTest extends BlazeIntegrationTestCase {
+
+  private static final String BLAZE_EXECROOT = "/blaze/execution-root";
+  private static final String BLAZE_BIN = BLAZE_EXECROOT + "/blaze-bin";
+  private static final String BLAZE_TESTLOGS = BLAZE_EXECROOT + "/testlog";
+  private static final BlazeInfo BLAZE_INFO =
+      BlazeInfo.create(
+          BuildSystem.Blaze,
+          ImmutableMap.of(
+              "blaze-bin", BLAZE_BIN,
+              "blaze-genfiles", BLAZE_EXECROOT + "/blaze-genfiles",
+              "blaze-testlogs", BLAZE_TESTLOGS,
+              "execution_root", BLAZE_EXECROOT,
+              "output_base", "/blaze/output-base"));
 
   private FastBuildChangedFilesService changedFilesService;
   private ArtifactLocationDecoder artifactLocationDecoder;
@@ -109,7 +124,8 @@ public class FastBuildChangedFilesServiceTest extends BlazeIntegrationTestCase {
     changedFilesService.newBuild(
         Label.create("//java:all_files"),
         Futures.immediateFuture(
-            BuildOutput.create(new File("deploy.jar"), /* blazeData= */ ImmutableMap.of())));
+            BuildOutput.create(
+                new File("deploy.jar"), /* blazeData= */ ImmutableMap.of(), BLAZE_INFO)));
 
     ChangedSources changedSources =
         changedFilesService.getAndResetChangedSources(Label.create("//java:all_files"));
@@ -124,7 +140,8 @@ public class FastBuildChangedFilesServiceTest extends BlazeIntegrationTestCase {
         BuildOutput.create(
             new File("deploy.jar"),
             ImmutableMap.of(
-                Label.create("//java:all_files"), sources("java/com/google/Hello.java").build()));
+                Label.create("//java:all_files"), sources("java/com/google/Hello.java").build()),
+            BLAZE_INFO);
     changedFilesService.newBuild(
         Label.create("//java:all_files"), Futures.immediateFuture(buildOutput));
 
@@ -141,7 +158,8 @@ public class FastBuildChangedFilesServiceTest extends BlazeIntegrationTestCase {
         BuildOutput.create(
             new File("deploy.jar"),
             ImmutableMap.of(
-                Label.create("//java:all_files"), sources("java/com/google/Hello.java").build()));
+                Label.create("//java:all_files"), sources("java/com/google/Hello.java").build()),
+            BLAZE_INFO);
     changedFilesService.newBuild(
         Label.create("//java:all_files"), Futures.immediateFuture(buildOutput));
 
@@ -166,7 +184,8 @@ public class FastBuildChangedFilesServiceTest extends BlazeIntegrationTestCase {
         BuildOutput.create(
             new File("deploy.jar"),
             ImmutableMap.of(
-                Label.create("//java:all_files"), sources("java/com/google/Hello.java").build())));
+                Label.create("//java:all_files"), sources("java/com/google/Hello.java").build()),
+            BLAZE_INFO));
 
     ChangedSources changedSources =
         changedFilesService.getAndResetChangedSources(Label.create("//java:all_files"));
@@ -182,7 +201,8 @@ public class FastBuildChangedFilesServiceTest extends BlazeIntegrationTestCase {
         BuildOutput.create(
             new File("deploy.jar"),
             ImmutableMap.of(
-                Label.create("//java:all_files"), sources("java/com/google/Hello.java").build()));
+                Label.create("//java:all_files"), sources("java/com/google/Hello.java").build()),
+            BLAZE_INFO);
     changedFilesService.newBuild(
         Label.create("//java:all_files"), Futures.immediateFuture(buildOutput));
 
@@ -210,7 +230,8 @@ public class FastBuildChangedFilesServiceTest extends BlazeIntegrationTestCase {
                     sources("a.java").setDependencies(deps("//b:b", "//c:c")).build(),
                 Label.create("//b:b"), sources("b.java").setDependencies(deps("//d:d")).build(),
                 Label.create("//c:c"), sources("c.java").setDependencies(deps("//b:b")).build(),
-                Label.create("//d:d"), sources("d.java").build()));
+                Label.create("//d:d"), sources("d.java").build()),
+            BLAZE_INFO);
     changedFilesService.newBuild(Label.create("//a:a"), Futures.immediateFuture(buildOutput));
 
     workspace.createFile(WorkspacePath.createIfValid("d.java"));
@@ -231,7 +252,8 @@ public class FastBuildChangedFilesServiceTest extends BlazeIntegrationTestCase {
             BuildOutput.create(
                 new File("deploy.jar"),
                 ImmutableMap.of(
-                    Label.create("//java:all_files"), sources("One.java", "Two.java").build()))));
+                    Label.create("//java:all_files"), sources("One.java", "Two.java").build()),
+                BLAZE_INFO)));
 
     workspace.createFile(WorkspacePath.createIfValid("One.java"));
     workspace.createFile(WorkspacePath.createIfValid("Three.java"));
@@ -256,7 +278,8 @@ public class FastBuildChangedFilesServiceTest extends BlazeIntegrationTestCase {
         BuildOutput.create(
             new File("deploy.jar"),
             ImmutableMap.of(
-                Label.create("//java:all_files"), sources("One.java", "Two.java").build())));
+                Label.create("//java:all_files"), sources("One.java", "Two.java").build()),
+            BLAZE_INFO));
 
     ChangedSources changedSources =
         changedFilesService.getAndResetChangedSources(Label.create("//java:all_files"));
@@ -274,7 +297,8 @@ public class FastBuildChangedFilesServiceTest extends BlazeIntegrationTestCase {
     BuildOutput buildOutput =
         BuildOutput.create(
             new File("deploy.jar"),
-            ImmutableMap.of(Label.create("//java:all_files"), sources(filenames).build()));
+            ImmutableMap.of(Label.create("//java:all_files"), sources(filenames).build()),
+            BLAZE_INFO);
     changedFilesService.newBuild(
         Label.create("//java:all_files"), Futures.immediateFuture(buildOutput));
 
@@ -300,7 +324,8 @@ public class FastBuildChangedFilesServiceTest extends BlazeIntegrationTestCase {
     buildOutput.set(
         BuildOutput.create(
             new File("deploy.jar"),
-            ImmutableMap.of(Label.create("//java:all_files"), sources(filenames).build())));
+            ImmutableMap.of(Label.create("//java:all_files"), sources(filenames).build()),
+            BLAZE_INFO));
 
     ChangedSources changedSources =
         changedFilesService.getAndResetChangedSources(Label.create("//java:all_files"));


### PR DESCRIPTION
Fast run/debug: don't get BlazeInfo from the project data, which might be using a different blaze binary.