### PR TITLE
Add required jar to the sdk import to support IntelliJ 2019.2

### DIFF
--- a/intellij_platform_sdk/BUILD.idea
+++ b/intellij_platform_sdk/BUILD.idea
@@ -6,7 +6,7 @@ package(default_visibility = ["//visibility:public"])
 
 java_import(
     name = "sdk",
-    jars = glob(["lib/*.jar"]),
+    jars = glob(["lib/*.jar", "plugins/java/lib/*.jar"]),
     tags = ["intellij-provided-by-sdk"],
     deps = ["@error_prone_annotations//jar"],
 )

--- a/intellij_platform_sdk/BUILD.ue
+++ b/intellij_platform_sdk/BUILD.ue
@@ -6,7 +6,7 @@ package(default_visibility = ["//visibility:public"])
 
 java_import(
     name = "sdk",
-    jars = glob(["lib/*.jar"]),
+    jars = glob(["lib/*.jar", "plugins/java/lib/*.jar"]),
     tags = ["intellij-provided-by-sdk"],
     deps = ["@error_prone_annotations//jar"],
 )


### PR DESCRIPTION
https://github.com/bazelbuild/intellij/issues/731
Adds the jar dependency in order to compile `intellij-2019.2` and `intellij-ue-2019.2`