### PR TITLE
Improve performance parsing BEP output during sync.

### DIFF
--- a/base/src/com/google/idea/blaze/base/command/buildresult/BepArtifactData.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/BepArtifactData.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.command.buildresult;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+/** All the relevant output data for a single {@link OutputArtifact}. */
+public class BepArtifactData {
+
+  public final OutputArtifact artifact;
+  /** The output groups this artifact belongs to. */
+  public final ImmutableSet<String> outputGroups;
+  /** The top-level targets this artifact is transitively associated with. */
+  public final ImmutableSet<String> topLevelTargets;
+
+  BepArtifactData(
+      OutputArtifact artifact,
+      Collection<String> outputGroups,
+      Collection<String> topLevelTargets) {
+    this.artifact = artifact;
+    this.outputGroups = ImmutableSet.copyOf(outputGroups);
+    this.topLevelTargets = ImmutableSet.copyOf(topLevelTargets);
+  }
+
+  @Override
+  public int hashCode() {
+    return artifact.getKey().hashCode();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return obj instanceof BepArtifactData && artifact.equals(((BepArtifactData) obj).artifact);
+  }
+
+  /** Returns null if this was the only top-level target the artifact was associated with. */
+  @Nullable
+  public BepArtifactData removeTargetAssociation(String target) {
+    Set<String> newTargets = new HashSet<>(topLevelTargets);
+    newTargets.remove(target);
+    return newTargets.isEmpty() ? null : new BepArtifactData(artifact, outputGroups, newTargets);
+  }
+
+  /** Combines this data with a newer version. */
+  public BepArtifactData update(BepArtifactData newer) {
+    Preconditions.checkState(artifact.getKey().equals(newer.artifact.getKey()));
+    return new BepArtifactData(
+        newer.artifact,
+        Sets.union(outputGroups, newer.outputGroups).immutableCopy(),
+        Sets.union(topLevelTargets, newer.topLevelTargets).immutableCopy());
+  }
+}

--- a/base/src/com/google/idea/blaze/base/command/buildresult/BuildResultHelper.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/BuildResultHelper.java
@@ -16,7 +16,6 @@
 package com.google.idea.blaze.base.command.buildresult;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableListMultimap;
 import com.google.idea.blaze.base.model.primitives.Label;
 import java.util.List;
 import java.util.function.Predicate;
@@ -65,17 +64,7 @@ public interface BuildResultHelper extends AutoCloseable {
    */
   default ImmutableList<OutputArtifact> getArtifactsForOutputGroup(
       String outputGroup, Predicate<String> pathFilter) throws GetArtifactsException {
-    return getBuildOutput().getPerOutputGroupArtifacts(pathFilter).get(outputGroup);
-  }
-
-  /**
-   * Returns all build artifacts split by output group (note artifacts may belong to multiple output
-   * groups). May only be called once, after the build is complete, or no artifacts will be
-   * returned.
-   */
-  default ImmutableListMultimap<String, OutputArtifact> getPerOutputGroupArtifacts(
-      Predicate<String> pathFilter) throws GetArtifactsException {
-    return getBuildOutput().getPerOutputGroupArtifacts(pathFilter);
+    return getBuildOutput().getOutputGroupArtifacts(outputGroup, pathFilter);
   }
 
   @Override

--- a/base/src/com/google/idea/blaze/base/command/buildresult/LocalFileOutputArtifact.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/LocalFileOutputArtifact.java
@@ -21,7 +21,6 @@ import com.google.idea.blaze.base.command.buildresult.BlazeArtifact.LocalFileArt
 import com.google.idea.blaze.base.filecache.ArtifactState;
 import com.google.idea.blaze.base.filecache.ArtifactState.LocalFileState;
 import com.google.idea.blaze.base.io.FileOperationProvider;
-import com.intellij.openapi.util.io.FileUtil;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -92,7 +91,7 @@ public class LocalFileOutputArtifact implements OutputArtifact, LocalFileArtifac
 
   @Override
   public int hashCode() {
-    return FileUtil.fileHashCode(file);
+    return file.getPath().hashCode();
   }
 
   @Override

--- a/base/src/com/google/idea/blaze/base/sync/aspects/BlazeBuildOutputs.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/BlazeBuildOutputs.java
@@ -16,26 +16,17 @@
 package com.google.idea.blaze.base.sync.aspects;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
+import com.google.idea.blaze.base.command.buildresult.BepArtifactData;
 import com.google.idea.blaze.base.command.buildresult.OutputArtifact;
 import com.google.idea.blaze.base.command.buildresult.ParsedBepOutput;
-import com.google.idea.blaze.base.model.primitives.Label;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
-import javax.annotation.Nullable;
 
 /** The result of the blaze build sync step. */
 public class BlazeBuildOutputs {
@@ -46,54 +37,21 @@ public class BlazeBuildOutputs {
 
   public static BlazeBuildOutputs fromParsedBepOutput(
       BuildResult result, ParsedBepOutput parsedOutput) {
-    ImmutableListMultimap<String, OutputArtifact> outputGroupOutputs =
-        parsedOutput.getPerOutputGroupArtifacts(path -> true);
-    ImmutableListMultimap<Label, OutputArtifact> targetOutputArtifacts =
-        parsedOutput.getPerTargetOutputArtifacts(path -> true);
-
-    Map<String, ArtifactData.Builder> builders = new LinkedHashMap<>();
-    targetOutputArtifacts.forEach(
-        (label, output) ->
-            builders.compute(
-                output.getKey(),
-                (key, builder) -> {
-                  if (builder == null) {
-                    builder = new ArtifactData.Builder(output);
-                  }
-                  builder.targets.add(label);
-                  return builder;
-                }));
-    outputGroupOutputs.forEach(
-        (group, output) ->
-            builders.compute(
-                output.getKey(),
-                (key, builder) -> {
-                  if (builder == null) {
-                    builder = new ArtifactData.Builder(output);
-                  }
-                  builder.outputGroups.add(group);
-                  return builder;
-                }));
-    Map<String, ArtifactData> allOutputs =
-        builders.values().stream()
-            .map(ArtifactData.Builder::build)
-            .filter(Objects::nonNull)
-            .collect(toImmutableMap(a -> a.artifact.getKey(), a -> a, (a, b) -> a));
-    return new BlazeBuildOutputs(result, allOutputs);
+    return new BlazeBuildOutputs(result, parsedOutput.getFullArtifactData());
   }
 
   public final BuildResult buildResult;
 
-  private final ImmutableMap<String, ArtifactData> artifacts;
+  private final ImmutableMap<String, BepArtifactData> artifacts;
 
   /** The artifacts transitively associated with each top-level target. */
-  private final ImmutableSetMultimap<Label, OutputArtifact> perTargetArtifacts;
+  private final ImmutableSetMultimap<String, OutputArtifact> perTargetArtifacts;
 
-  private BlazeBuildOutputs(BuildResult buildResult, Map<String, ArtifactData> artifacts) {
+  private BlazeBuildOutputs(BuildResult buildResult, Map<String, BepArtifactData> artifacts) {
     this.buildResult = buildResult;
     this.artifacts = ImmutableMap.copyOf(artifacts);
 
-    ImmutableSetMultimap.Builder<Label, OutputArtifact> perTarget = ImmutableSetMultimap.builder();
+    ImmutableSetMultimap.Builder<String, OutputArtifact> perTarget = ImmutableSetMultimap.builder();
     artifacts.values().forEach(a -> a.topLevelTargets.forEach(t -> perTarget.put(t, a.artifact)));
     this.perTargetArtifacts = perTarget.build();
   }
@@ -109,15 +67,15 @@ public class BlazeBuildOutputs {
   public BlazeBuildOutputs updateOutputs(BlazeBuildOutputs nextOutputs) {
 
     // first combine common artifacts
-    Map<String, ArtifactData> combined = new LinkedHashMap<>(artifacts);
-    for (Map.Entry<String, ArtifactData> e : nextOutputs.artifacts.entrySet()) {
-      ArtifactData a = e.getValue();
+    Map<String, BepArtifactData> combined = new LinkedHashMap<>(artifacts);
+    for (Map.Entry<String, BepArtifactData> e : nextOutputs.artifacts.entrySet()) {
+      BepArtifactData a = e.getValue();
       combined.compute(e.getKey(), (k, v) -> v == null ? a : v.update(a));
     }
 
     // then iterate over targets, throwing away old data for rebuilt targets and updating output
     // data accordingly
-    for (Label target : perTargetArtifacts.keySet()) {
+    for (String target : perTargetArtifacts.keySet()) {
       if (!nextOutputs.perTargetArtifacts.containsKey(target)) {
         continue;
       }
@@ -130,7 +88,7 @@ public class BlazeBuildOutputs {
           continue;
         }
         // no longer output by this target; need to update target associations
-        ArtifactData data = combined.get(old.getKey());
+        BepArtifactData data = combined.get(old.getKey());
         if (data != null) {
           data = data.removeTargetAssociation(target);
         }
@@ -143,74 +101,5 @@ public class BlazeBuildOutputs {
     }
     return new BlazeBuildOutputs(
         BuildResult.combine(buildResult, nextOutputs.buildResult), combined);
-  }
-
-  /** All the relevant output data for a single {@link OutputArtifact}. */
-  private static final class ArtifactData {
-    private final OutputArtifact artifact;
-    /** The output groups this artifact belongs to. */
-    private final ImmutableSet<String> outputGroups;
-    /** The top-level targets this artifact is transitively associated with. */
-    private final ImmutableSet<Label> topLevelTargets;
-
-    private ArtifactData(
-        OutputArtifact artifact,
-        Collection<String> outputGroups,
-        Collection<Label> topLevelTargets) {
-      this.artifact = artifact;
-      this.outputGroups = ImmutableSet.copyOf(outputGroups);
-      this.topLevelTargets = ImmutableSet.copyOf(topLevelTargets);
-    }
-
-    @Override
-    public int hashCode() {
-      return artifact.getKey().hashCode();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-      return obj instanceof ArtifactData && artifact.equals(((ArtifactData) obj).artifact);
-    }
-
-    /** Returns null if this was the only top-level target the artifact was associated with. */
-    @Nullable
-    private ArtifactData removeTargetAssociation(Label target) {
-      List<Label> newTargets = new ArrayList<>(topLevelTargets);
-      newTargets.remove(target);
-      return newTargets.isEmpty()
-          ? null
-          : new ArtifactData(artifact, outputGroups, ImmutableList.copyOf(newTargets));
-    }
-
-    /** Combines this data with a newer version. */
-    private ArtifactData update(ArtifactData newer) {
-      Preconditions.checkState(artifact.getKey().equals(newer.artifact.getKey()));
-      return new ArtifactData(
-          newer.artifact,
-          ImmutableSet.<String>builder().addAll(outputGroups).addAll(newer.outputGroups).build(),
-          ImmutableSet.<Label>builder()
-              .addAll(topLevelTargets)
-              .addAll(newer.topLevelTargets)
-              .build());
-    }
-
-    private static class Builder {
-      final OutputArtifact artifact;
-      final List<String> outputGroups = new ArrayList<>();
-      final List<Label> targets = new ArrayList<>();
-
-      Builder(OutputArtifact artifact) {
-        this.artifact = artifact;
-      }
-
-      @Nullable
-      ArtifactData build() {
-        if (outputGroups.isEmpty() || targets.isEmpty()) {
-          return null;
-        }
-        return new ArtifactData(
-            artifact, ImmutableList.copyOf(outputGroups), ImmutableList.copyOf(targets));
-      }
-    }
   }
 }

--- a/base/tests/unittests/com/google/idea/blaze/base/command/buildresult/BuildEventProtocolOutputReaderTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/command/buildresult/BuildEventProtocolOutputReaderTest.java
@@ -19,7 +19,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Streams;
 import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos;
@@ -376,8 +376,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
 
     ImmutableList<OutputArtifact> parsedFilenames =
         BuildEventProtocolOutputReader.parseBepOutput(asInputStream(events))
-            .getPerOutputGroupArtifacts(path -> true)
-            .get("group-name");
+            .getOutputGroupArtifacts("group-name", path -> true);
 
     assertThat(BlazeArtifact.getLocalFiles(parsedFilenames))
         .containsExactlyElementsIn(allFiles)
@@ -418,8 +417,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
 
     ImmutableList<OutputArtifact> parsedFilenames =
         BuildEventProtocolOutputReader.parseBepOutput(asInputStream(events))
-            .getPerOutputGroupArtifacts(path -> true)
-            .get("group-1");
+            .getOutputGroupArtifacts("group-1", path -> true);
 
     assertThat(BlazeArtifact.getLocalFiles(parsedFilenames))
         .containsExactlyElementsIn(allFiles)
@@ -427,45 +425,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
   }
 
   @Test
-  public void parseAllArtifactsInOutputGroups_twoGroups_returnsAllOutputs() throws IOException {
-    ImmutableList<String> fileSet1 =
-        ImmutableList.of("/usr/out/genfiles/foo.pb.h", "/usr/out/genfiles/foo.proto.h");
-    ImmutableList<String> fileSet2 =
-        ImmutableList.of(
-            "/usr/local/lib/File.py", "/usr/bin/python2.7", "/usr/local/home/script.sh");
-
-    List<BuildEvent.Builder> events =
-        ImmutableList.of(
-            BuildEvent.newBuilder()
-                .setStarted(BuildEventStreamProtos.BuildStarted.getDefaultInstance()),
-            BuildEvent.newBuilder()
-                .setProgress(BuildEventStreamProtos.Progress.getDefaultInstance()),
-            configuration("config-id", "k8-opt"),
-            setOfFiles(fileSet1, "set-1"),
-            setOfFiles(fileSet2, "set-2"),
-            targetComplete(
-                "//some:target",
-                "config-id",
-                ImmutableList.of(outputGroup("group-1", ImmutableList.of("set-1")))),
-            targetComplete(
-                "//other:target",
-                "config-id",
-                ImmutableList.of(outputGroup("group-2", ImmutableList.of("set-2")))));
-
-    ImmutableListMultimap<String, OutputArtifact> parsedFilenames =
-        BuildEventProtocolOutputReader.parseBepOutput(asInputStream(events))
-            .getPerOutputGroupArtifacts(path -> true);
-
-    assertThat(BlazeArtifact.getLocalFiles(parsedFilenames.get("group-1")))
-        .containsExactlyElementsIn(fileSet1.stream().map(File::new).toArray())
-        .inOrder();
-    assertThat(BlazeArtifact.getLocalFiles(parsedFilenames.get("group-2")))
-        .containsExactlyElementsIn(fileSet2.stream().map(File::new).toArray())
-        .inOrder();
-  }
-
-  @Test
-  public void getPerTargetOutputArtifacts_returnsTransitiveOutputs() throws IOException {
+  public void getFullArtifactData_returnsTransitiveOutputs() throws IOException {
     ImmutableList<String> fileSet1 =
         ImmutableList.of("/usr/out/genfiles/foo.pb.h", "/usr/out/genfiles/foo.proto.h");
     ImmutableList<String> fileSet2 =
@@ -491,12 +451,12 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
             .map(File::new)
             .collect(toImmutableList());
 
-    ImmutableListMultimap<Label, OutputArtifact> perTargetOutputs =
-        BuildEventProtocolOutputReader.parseBepOutput(asInputStream(events))
-            .getPerTargetOutputArtifacts(path -> true);
+    ImmutableMap<String, BepArtifactData> outputData =
+        BuildEventProtocolOutputReader.parseBepOutput(asInputStream(events)).getFullArtifactData();
+    ImmutableList<OutputArtifact> outputs =
+        outputData.values().stream().map(d -> d.artifact).collect(toImmutableList());
 
-    assertThat(BlazeArtifact.getLocalFiles(perTargetOutputs.get(Label.create("//some:target"))))
-        .containsExactlyElementsIn(allOutputs);
+    assertThat(BlazeArtifact.getLocalFiles(outputs)).containsExactlyElementsIn(allOutputs);
   }
 
   @Test

--- a/scala/src/com/google/idea/blaze/scala/run/producers/GenerateDeployableJarTaskProvider.java
+++ b/scala/src/com/google/idea/blaze/scala/run/producers/GenerateDeployableJarTaskProvider.java
@@ -182,7 +182,8 @@ class GenerateDeployableJarTaskProvider
       }
 
       List<File> outputs =
-          BlazeArtifact.getLocalFiles(buildResultHelper.getAllOutputArtifacts(file -> true));
+          BlazeArtifact.getLocalFiles(
+              buildResultHelper.getBuildArtifactsForTarget(target, file -> true));
       if (outputs.isEmpty()) {
         throw new ExecutionException(
             String.format("Failed to find deployable jar when building %s", target));


### PR DESCRIPTION
Improve performance parsing BEP output during sync.

We were iterating over the graph of file sets once per top-level target. If most top-level targets have a significant fraction of the artifacts in their transitive closure, this scales very badly.