### PR TITLE
Add bazel-invoking integration test for the bundled aspect

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -266,10 +266,27 @@ load("@build_bazel_integration_testing//tools:bazel_java_integration_test.bzl", 
 bazel_java_integration_test_deps(versions = [
     "0.28.1",
     "0.27.2",
-    #    "0.22.0",
-    #    "0.23.2",
-    #    "0.21.0",
 ])
+
+load("@build_bazel_integration_testing//tools:import.bzl", "bazel_external_dependency_archive")
+
+bazel_external_dependency_archive(
+    name = "integration_test_deps",
+    srcs = {
+        # Bazel 0.28.1, 0.27.2
+        "cc470e529fafb6165b5be3929ff2d99b38429b386ac100878687416603a67889": [
+            "https://mirror.bazel.build/bazel_coverage_output_generator/releases/coverage_output_generator-v1.0.zip",
+        ],
+        # Bazel 0.28.1
+        "96e223094a12c842a66db0bb7bb6866e88e26e678f045842911f9bd6b47161f5": [
+            "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v4.0/java_tools_javac11_linux-v4.0.zip",
+        ],
+        # Bazel 0.27.2
+        "074d624fb34441df369afdfd454e75dba821d5d54932fcfee5ba598d17dc1b99": [
+            "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v2.0/java_tools_javac11_linux-v2.0.zip",
+        ],
+    },
+)
 
 # LICENSE: The Apache Software License, Version 2.0
 # proto_library rules implicitly depend on @com_google_protobuf//:protoc

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -254,6 +254,23 @@ http_archive(
     url = "https://github.com/bazelbuild/bazel-skylib/releases/download/0.8.0/bazel-skylib.0.8.0.tar.gz",
 )
 
+http_archive(
+    name = "build_bazel_integration_testing",
+    sha256 = "490554b98da4ce6e3e1e074e01b81e8440b760d4f086fccf50085a25528bf5cd",
+    strip_prefix = "bazel-integration-testing-922d2b04bfb9721ab14ff6d26d4a8a6ab847aa07",
+    url = "https://github.com/bazelbuild/bazel-integration-testing/archive/922d2b04bfb9721ab14ff6d26d4a8a6ab847aa07.zip",
+)
+
+load("@build_bazel_integration_testing//tools:bazel_java_integration_test.bzl", "bazel_java_integration_test_deps")
+
+bazel_java_integration_test_deps(versions = [
+    "0.28.1",
+    "0.27.2",
+    #    "0.22.0",
+    #    "0.23.2",
+    #    "0.21.0",
+])
+
 # LICENSE: The Apache Software License, Version 2.0
 # proto_library rules implicitly depend on @com_google_protobuf//:protoc
 http_archive(

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/integration/BUILD
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/integration/BUILD
@@ -1,0 +1,13 @@
+load("@build_bazel_integration_testing//tools:bazel_java_integration_test.bzl", "bazel_java_integration_test")
+
+bazel_java_integration_test(
+    name = "BazelInvokingIntegrationTest",
+    srcs = ["BazelInvokingIntegrationTest.java"],
+    data = [
+        "//aspect:aspect_files",
+    ],
+    versions = [
+        "0.28.1",
+        "0.27.2",
+    ],
+)

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/integration/BUILD
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/integration/BUILD
@@ -2,7 +2,9 @@ load("@build_bazel_integration_testing//tools:bazel_java_integration_test.bzl", 
 
 bazel_java_integration_test(
     name = "BazelInvokingIntegrationTest",
-    srcs = ["BazelInvokingIntegrationTest.java"],
+    srcs = [
+        "BazelInvokingIntegrationTest.java",
+    ],
     data = [
         "//aspect:aspect_files",
     ],
@@ -13,5 +15,10 @@ bazel_java_integration_test(
     versions = [
         "0.28.1",
         "0.27.2",
+    ],
+    deps = [
+        "//aspect/testing:guava",
+        "//base",
+        "//base:integration_test_utils",
     ],
 )

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/integration/BUILD
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/integration/BUILD
@@ -6,6 +6,10 @@ bazel_java_integration_test(
     data = [
         "//aspect:aspect_files",
     ],
+    external_deps = [
+        "@integration_test_deps",
+    ],
+    tags = ["block-network"],
     versions = [
         "0.28.1",
         "0.27.2",

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/integration/BazelInvokingIntegrationTest.java
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/integration/BazelInvokingIntegrationTest.java
@@ -15,14 +15,12 @@
  */
 package com.google.idea.blaze.aspect.integration;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.idea.blaze.base.sync.aspects.strategy.AspectStrategy.getOutputGroups;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import build.bazel.tests.integration.BazelCommand;
 import build.bazel.tests.integration.WorkspaceDriver;
-import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.idea.blaze.base.model.primitives.LanguageClass;
 import com.google.idea.blaze.base.sync.aspects.strategy.AspectStrategy.OutputGroup;
@@ -30,8 +28,8 @@ import com.google.idea.blaze.base.sync.aspects.strategy.AspectStrategyBazel;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -104,10 +102,10 @@ public class BazelInvokingIntegrationTest {
       Collection<OutputGroup> outputGroups, Collection<LanguageClass> languageClassList) {
     // e.g. --output_groups=intellij-info-generic,intellij-resolve-java,intellij-compile-java
     Set<LanguageClass> languageClasses = new HashSet<>(languageClassList);
-    List<String> outputGroupNames =
+    String outputGroupNames =
         outputGroups.stream()
             .flatMap(g -> getOutputGroups(g, languageClasses).stream())
-            .collect(toImmutableList());
-    return "--output_groups=" + Joiner.on(',').join(outputGroupNames);
+            .collect(Collectors.joining(","));
+    return "--output_groups=" + outputGroupNames;
   }
 }

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/integration/BazelInvokingIntegrationTest.java
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/integration/BazelInvokingIntegrationTest.java
@@ -1,0 +1,50 @@
+package com.google.idea.blaze.aspect.integration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import build.bazel.tests.integration.BazelCommand;
+import build.bazel.tests.integration.WorkspaceDriver;
+import java.io.IOException;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class BazelInvokingIntegrationTest {
+
+  private WorkspaceDriver driver = new WorkspaceDriver();
+
+  @BeforeClass
+  public static void setUpClass() throws IOException {
+    WorkspaceDriver.setUpClass();
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    driver.setUp();
+  }
+
+  @Test
+  public void aspect_intelliJInfoGenericOutputGroup_generatesInfoTxt() throws Exception {
+    driver.scratchFile("foo/BUILD", "sh_test(name = \"bar\",\n" + "srcs = [\"bar.sh\"])");
+    driver.scratchExecutableFile("foo/bar.sh", "echo \"bar\"", "exit 0");
+
+    BazelCommand cmd = driver.bazel(
+        "build",
+        "//foo:bar",
+        "--repository_cache=\"\"",
+        "--override_repository=intellij_aspect="
+            + System.getenv("TEST_SRCDIR")
+            + "/intellij_with_bazel/aspect",
+        "--define=ij_product=intellij-latest",
+        "--aspects=@intellij_aspect//:intellij_info_bundled.bzl%intellij_info_aspect",
+        "--output_groups=intellij-info-generic"
+    ).runVerbose();
+
+    assertEquals("return code is 0", 0, cmd.exitCode());
+    assertTrue(
+        "stderr contains intellij-info.txt",
+        cmd.errorLines().stream().anyMatch(x -> x.contains("intellij-info.txt")));
+  }
+
+}

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/integration/BazelInvokingIntegrationTest.java
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/integration/BazelInvokingIntegrationTest.java
@@ -10,6 +10,12 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+/**
+ * A Bazel-invoking integration test for the bundled IntelliJ aspect.
+ *
+ * These tests assert the end-to-end behavior of the plugin's aspect during a sync, and
+ * ensure that it generates the correct IDE info files.
+ */
 public class BazelInvokingIntegrationTest {
 
   private WorkspaceDriver driver = new WorkspaceDriver();

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/integration/BazelInvokingIntegrationTest.java
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/integration/BazelInvokingIntegrationTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.idea.blaze.aspect.integration;
 
 import static org.junit.Assert.assertEquals;

--- a/base/src/com/google/idea/blaze/base/sync/aspects/strategy/AspectStrategy.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/strategy/AspectStrategy.java
@@ -97,7 +97,7 @@ public abstract class AspectStrategy implements BuildSystemExtensionPoint {
    * Get the names of the output groups created by the aspect for the given {@link OutputGroup} and
    * languages.
    */
-  private ImmutableList<String> getOutputGroups(
+  public static ImmutableList<String> getOutputGroups(
       OutputGroup outputGroup, Set<LanguageClass> activeLanguages) {
     TreeSet<String> outputGroups = new TreeSet<>();
     if (outputGroup.equals(OutputGroup.INFO)) {

--- a/base/src/com/google/idea/blaze/base/sync/aspects/strategy/AspectStrategyBazel.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/strategy/AspectStrategyBazel.java
@@ -27,8 +27,13 @@ public class AspectStrategyBazel extends AspectStrategy {
 
   private AspectStrategyBazel() {}
 
+  // These flags are static constants for sharing between the implementation and tests.
   public static final String ASPECT_FLAG =
       "--aspects=@intellij_aspect//:intellij_info_bundled.bzl%intellij_info_aspect";
+
+  // In tests, the location of @intellij_aspect is not known at compile time.
+  public static final String OVERRIDE_REPOSITORY_FLAG =
+      "--override_repository=intellij_aspect";
 
   @Override
   public String getName() {
@@ -49,8 +54,7 @@ public class AspectStrategyBazel extends AspectStrategy {
   }
 
   private static String getAspectRepositoryOverrideFlag() {
-    return String.format(
-        "--override_repository=intellij_aspect=%s", findAspectDirectory().getPath());
+    return OVERRIDE_REPOSITORY_FLAG + "=" + findAspectDirectory().getPath();
   }
 
   @Override

--- a/base/src/com/google/idea/blaze/base/sync/aspects/strategy/AspectStrategyBazel.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/strategy/AspectStrategyBazel.java
@@ -23,9 +23,12 @@ import com.intellij.ide.plugins.PluginManager;
 import java.io.File;
 import java.util.List;
 
-class AspectStrategyBazel extends AspectStrategy {
+public class AspectStrategyBazel extends AspectStrategy {
 
   private AspectStrategyBazel() {}
+
+  public static final String ASPECT_FLAG =
+      "--aspects=@intellij_aspect//:intellij_info_bundled.bzl%intellij_info_aspect";
 
   @Override
   public String getName() {
@@ -35,7 +38,7 @@ class AspectStrategyBazel extends AspectStrategy {
   @Override
   protected List<String> getAspectFlags() {
     return ImmutableList.of(
-        "--aspects=@intellij_aspect//:intellij_info_bundled.bzl%intellij_info_aspect",
+        ASPECT_FLAG,
         getAspectRepositoryOverrideFlag());
   }
 


### PR DESCRIPTION
This test covers the end to end behavior of calling Bazel with the bundled aspect in a workspace. This should help us capture future incompatible changes to bzl files.