### PR TITLE
Remove some more injected constructor parameters for application/project services, not compatible with 2019.2

### DIFF
--- a/testing/src/com/google/idea/testing/ServiceHelper.java
+++ b/testing/src/com/google/idea/testing/ServiceHelper.java
@@ -107,7 +107,7 @@ public class ServiceHelper {
     Object old;
     try {
       old = container.getComponentInstance(key);
-    } catch (UnsatisfiableDependenciesException e) {
+    } catch (UnsatisfiableDependenciesException | IllegalArgumentException e) {
       old = null;
     }
     container.unregisterComponent(key.getName());


### PR DESCRIPTION
Remove some more injected constructor parameters for application/project services, not compatible with 2019.2