### PR TITLE
Enable legacy PicoContainer behavior in 2019.2 tests, to match production.

### DIFF
--- a/testing/test_defs.bzl
+++ b/testing/test_defs.bzl
@@ -94,6 +94,7 @@ def intellij_unit_test_suite(
         "-Didea.classpath.index.enabled=false",
         "-Djava.awt.headless=true",
         "-Dblaze.idea.api.version.file=$(location %s)" % api_version_txt_name,
+        "-Didea.register.ep.in.pico.container=true",  #api192: needed for constructor injection
     ])
 
     _generate_test_suite(
@@ -171,6 +172,7 @@ def intellij_integration_test_suite(
         "-Didea.classpath.index.enabled=false",
         "-Djava.awt.headless=true",
         "-Dblaze.idea.api.version.file=$(location %s)" % api_version_txt_name,
+        "-Didea.register.ep.in.pico.container=true",  #api192: needed for constructor injection
     ])
 
     if required_plugins:


### PR DESCRIPTION
Enable legacy PicoContainer behavior in 2019.2 tests, to match production.