### PR TITLE
Fix python support for GoLand, PyCharm.

### DIFF
--- a/python/src/com/google/idea/blaze/python/PythonPluginUtils.java
+++ b/python/src/com/google/idea/blaze/python/PythonPluginUtils.java
@@ -17,6 +17,7 @@ package com.google.idea.blaze.python;
 
 import com.google.common.collect.ImmutableMap;
 import com.intellij.util.PlatformUtils;
+import javax.annotation.Nullable;
 
 /** Utilities class related to the JetBrains python plugin. */
 public final class PythonPluginUtils {
@@ -24,22 +25,19 @@ public final class PythonPluginUtils {
   private PythonPluginUtils() {}
 
   private static final ImmutableMap<String, String> PRODUCT_TO_PLUGIN_ID =
-      ImmutableMap.of(
-          PlatformUtils.IDEA_PREFIX,
-          "Pythonid",
-          PlatformUtils.IDEA_CE_PREFIX,
-          "PythonCore",
-          "AndroidStudio",
-          "PythonCore",
-          PlatformUtils.CLION_PREFIX,
-          "com.intellij.clion-python");
+      ImmutableMap.<String, String>builder()
+          .put(PlatformUtils.CLION_PREFIX, "com.intellij.clion-python")
+          .put(PlatformUtils.IDEA_PREFIX, "Pythonid")
+          .put(PlatformUtils.IDEA_CE_PREFIX, "PythonCore")
+          .put(PlatformUtils.GOIDE_PREFIX, "PythonCore")
+          .put(PlatformUtils.RIDER_PREFIX, "PythonCore")
+          .put(PlatformUtils.DBE_PREFIX, "PythonCore")
+          .put("AndroidStudio", "PythonCore")
+          .build();
 
+  /** The python plugin ID for this IDE, or null if not available/relevant. */
+  @Nullable
   public static String getPythonPluginId() {
-    String pluginId = PRODUCT_TO_PLUGIN_ID.get(PlatformUtils.getPlatformPrefix());
-    if (pluginId == null) {
-      throw new RuntimeException(
-          "No python plugin ID for unhandled platform: " + PlatformUtils.getPlatformPrefix());
-    }
-    return pluginId;
+    return PRODUCT_TO_PLUGIN_ID.get(PlatformUtils.getPlatformPrefix());
   }
 }

--- a/python/src/com/google/idea/blaze/python/sync/AlwaysPresentPythonSyncPlugin.java
+++ b/python/src/com/google/idea/blaze/python/sync/AlwaysPresentPythonSyncPlugin.java
@@ -48,14 +48,19 @@ public class AlwaysPresentPythonSyncPlugin implements BlazeSyncPlugin {
 
   @Override
   public ImmutableList<String> getRequiredExternalPluginIds(Collection<LanguageClass> languages) {
-    return languages.contains(LanguageClass.PYTHON)
-        ? ImmutableList.of(PythonPluginUtils.getPythonPluginId())
+    String pluginId = PythonPluginUtils.getPythonPluginId();
+    return pluginId != null && languages.contains(LanguageClass.PYTHON)
+        ? ImmutableList.of(pluginId)
         : ImmutableList.of();
   }
 
   @Override
   public boolean validate(
       Project project, BlazeContext context, BlazeProjectData blazeProjectData) {
+    String pluginId = PythonPluginUtils.getPythonPluginId();
+    if (pluginId == null) {
+      return true;
+    }
     ImportRoots importRoots = ImportRoots.forProjectSafe(project);
     if (importRoots == null) {
       return true;
@@ -67,7 +72,6 @@ public class AlwaysPresentPythonSyncPlugin implements BlazeSyncPlugin {
     if (!hasPythonTarget) {
       return true;
     }
-    String pluginId = PythonPluginUtils.getPythonPluginId();
     if (!PluginUtils.isPluginEnabled(pluginId)) {
       IssueOutput.warn(
               "Your project appears to contain Python targets. To enable Python support, "


### PR DESCRIPTION
Fix python support for GoLand, PyCharm.

Still doesn't behave well for IDEs which don't support python, but we don't support those IDEs, and it's also relatively harmless -- it will just incorrectly show 'python' as a possible additional language.