### PR TITLE
Fix a bit of the language in the readme, to highlight -beta versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,15 @@ from the project root. This will create a plugin zip file at
 `bazel-bin/<PRODUCT>/<PRODUCT>_bazel.zip`, which can be installed directly
 from the IDE. `<PRODUCT>` can be one of `ijwb, clwb, aswb`.
 
-If the IDE refuses to load the plugin because of version issues, specify
-`ij_product` manually. A mapping of product `latest` to direct versions can be
-found in `intellij_platform_sdk/build_defs.bzl`.
+If the IDE refuses to load the plugin because of version issues, specify the
+correct `ij_product`. These are in the form `<IDE>-<VERSION>` with `<IDE>`
+being one of `intellij, clion, android-studio`, and `<VERSION>` being one
+of `latest, beta`.
+
+If you are  using the most recent version of your IDE, you likely want
+`--define=ij_product=<IDE>-beta` which will be the next version after
+`<IDE>-latest`.  A complete mapping of all currently defined versions can
+be found in  `intellij_platform_sdk/build_defs.bzl`.
 
 ## Contributions
 


### PR DESCRIPTION
The current readme doesn't really show how `-beta` and `-latest` defines work, and don't even note that `<IDE>-beta` exists as a possible `ij_product` definition.

Pure documentary change. 