### PR TITLE
Migrate clion 2019.2 to beta

### DIFF
--- a/intellij_platform_sdk/build_defs.bzl
+++ b/intellij_platform_sdk/build_defs.bzl
@@ -11,7 +11,7 @@ INDIRECT_IJ_PRODUCTS = {
     "android-studio-beta-mac": "android-studio-3.5-mac",
     "android-studio-canary": "android-studio-3.6",
     "clion-latest": "clion-2019.1",
-    "clion-beta": "clion-2019.1",
+    "clion-beta": "clion-2019.2",
 }
 
 DIRECT_IJ_PRODUCTS = {


### PR DESCRIPTION
Migrate clion 2019.2 to beta