### PR TITLE
Fix target outputs being dropped when sharding sync

### DIFF
--- a/base/src/com/google/idea/blaze/base/command/buildresult/ParsedBepOutput.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/ParsedBepOutput.java
@@ -243,7 +243,7 @@ public final class ParsedBepOutput {
       Builder updateFromParent(Builder parent) {
         configId = parent.configId;
         outputGroups.addAll(parent.outputGroups);
-        targets.addAll(parent.outputGroups);
+        targets.addAll(parent.targets);
         return this;
       }
 


### PR DESCRIPTION
Fix target outputs being dropped when sharding sync