### PR TITLE
Remove unused load statements from .bzl files

### DIFF
--- a/aspect/java_classpath.bzl
+++ b/aspect/java_classpath.bzl
@@ -1,10 +1,5 @@
 """An aspect which extracts the runtime classpath from a java target."""
 
-load(
-    ":artifacts.bzl",
-    "artifact_location",
-)
-
 def _runtime_classpath_impl(target, ctx):
     """The top level aspect implementation function.
 


### PR DESCRIPTION
Remove unused load statements from .bzl files

After transitive loads have been disabled in Blaze, unused load statements have
no effect (besides not useful memory consumption).

The CL has been created automatically by calling `buildifier --lint=fix --warnings=load` on all .bzl files.

The following additional command were run on all affected files to clean them up: