### PR TITLE
Fix fast run/debug manual compilation failing with mismatched java versions.

### DIFF
--- a/aspect/fast_build_info.bzl
+++ b/aspect/fast_build_info.bzl
@@ -33,14 +33,19 @@ def _fast_build_info_impl(target, ctx):
             )
             for datadep in ctx.rule.attr.data
         ]
+
     if hasattr(target, "java_toolchain"):
         write_output = True
         toolchain = target.java_toolchain
         javac_jars = []
         if hasattr(toolchain, "tools"):
             javac_jars = [artifact_location(f) for f in toolchain.tools.to_list()]
+        bootclasspath_jars = []
+        if hasattr(toolchain, "bootclasspath"):
+            bootclasspath_jars = [artifact_location(f) for f in toolchain.bootclasspath.to_list()]
         info["java_toolchain_info"] = struct_omit_none(
             javac_jars = javac_jars,
+            bootclasspath_jars = bootclasspath_jars,
             source_version = toolchain.source_version,
             target_version = toolchain.target_version,
         )

--- a/java/src/com/google/idea/blaze/java/fastbuild/FastBuildBlazeData.java
+++ b/java/src/com/google/idea/blaze/java/fastbuild/FastBuildBlazeData.java
@@ -218,14 +218,19 @@ public abstract class FastBuildBlazeData {
   abstract static class JavaToolchainInfo {
     public abstract ImmutableList<ArtifactLocation> javacJars();
 
+    public abstract ImmutableList<ArtifactLocation> bootClasspathJars();
+
     public abstract String sourceVersion();
 
     public abstract String targetVersion();
 
     static JavaToolchainInfo create(
-        ImmutableList<ArtifactLocation> javacJars, String sourceVersion, String targetVersion) {
+        ImmutableList<ArtifactLocation> javacJars,
+        ImmutableList<ArtifactLocation> bootJars,
+        String sourceVersion,
+        String targetVersion) {
       return new AutoValue_FastBuildBlazeData_JavaToolchainInfo(
-          javacJars, sourceVersion, targetVersion);
+          javacJars, bootJars, sourceVersion, targetVersion);
     }
 
     static JavaToolchainInfo fromProto(FastBuildInfo.JavaToolchainInfo javaToolchainInfo) {
@@ -233,8 +238,15 @@ public abstract class FastBuildBlazeData {
           javaToolchainInfo.getJavacJarsList().stream()
               .map(ArtifactLocation::fromProto)
               .collect(toImmutableList());
+      ImmutableList<ArtifactLocation> bootJars =
+          javaToolchainInfo.getBootclasspathJarsList().stream()
+              .map(ArtifactLocation::fromProto)
+              .collect(toImmutableList());
       return create(
-          javacJars, javaToolchainInfo.getSourceVersion(), javaToolchainInfo.getTargetVersion());
+          javacJars,
+          bootJars,
+          javaToolchainInfo.getSourceVersion(),
+          javaToolchainInfo.getTargetVersion());
     }
   }
 }

--- a/java/src/com/google/idea/blaze/java/fastbuild/FastBuildJavac.java
+++ b/java/src/com/google/idea/blaze/java/fastbuild/FastBuildJavac.java
@@ -16,23 +16,115 @@
 package com.google.idea.blaze.java.fastbuild;
 
 import java.io.File;
+import java.net.URI;
 import java.util.Collection;
 import java.util.List;
-import javax.tools.DiagnosticListener;
-import javax.tools.JavaFileObject;
+import java.util.stream.Collectors;
+import javax.tools.Diagnostic.Kind;
 
 /**
  * A small wrapper around javac.
  *
  * <p>This interface is used by two classloaders (the plugin's and the compiler's) whose only shared
  * classes are those from the JRE, so it mustn't import anything besides that.
+ *
+ * <p>Additionally, the compiler and plugin can have different versions of java, so we try to limit
+ * the interface to classes which don't change (javax.tools.DiagnosticListener is out), at the
+ * expense of code cleanliness and type safety.
  */
 // TODO(plumpy): have FastBuildJavacImpl implement JavaCompiler instead, which would get rid of the
 // need for this class. It's a lot more complicated to do that, however.
 interface FastBuildJavac {
 
-  boolean compile(
-      List<String> args,
-      Collection<File> sources,
-      DiagnosticListener<? super JavaFileObject> listener);
+  /** Returns an encoded version of CompilerOutput. Call {@link CompilerOutput#decode} to decode. */
+  Object[] compile(List<String> args, Collection<File> sources);
+
+  final class CompilerOutput {
+    final boolean result;
+    final List<DiagnosticLine> diagnostics;
+
+    CompilerOutput(boolean result, List<DiagnosticLine> diagnostics) {
+      this.result = result;
+      this.diagnostics = diagnostics;
+    }
+
+    Object[] encode() {
+      return new Object[] {
+        result, diagnostics.stream().map(DiagnosticLine::encode).collect(Collectors.toList())
+      };
+    }
+
+    @SuppressWarnings("unchecked")
+    public static CompilerOutput decode(Object[] rawOutput) {
+      boolean result = (boolean) rawOutput[0];
+      List<DiagnosticLine> diagnostics =
+          ((List<Object[]>) rawOutput[1])
+              .stream().map(DiagnosticLine::decode).collect(Collectors.toList());
+      return new CompilerOutput(result, diagnostics);
+    }
+  }
+
+  final class DiagnosticLine {
+    final Kind kind;
+    final String message;
+    final String formattedMessage;
+    /** uri is nullable (but we can't add a dependency on jsr305 annotations) */
+    final URI uri;
+
+    final long lineNumber;
+    final long columnNumber;
+
+    DiagnosticLine(
+        Kind kind,
+        String message,
+        String formattedMessage,
+        URI uri,
+        long lineNumber,
+        long columnNumber) {
+      this.kind = kind;
+      this.message = message;
+      this.formattedMessage = formattedMessage;
+      this.uri = uri;
+      this.lineNumber = lineNumber;
+      this.columnNumber = columnNumber;
+    }
+
+    Object[] encode() {
+      return new Object[] {
+        kind.toString(),
+        message,
+        formattedMessage,
+        uri == null ? null : uri.toString(),
+        lineNumber,
+        columnNumber
+      };
+    }
+
+    @SuppressWarnings("unchecked")
+    static DiagnosticLine decode(Object[] encoded) {
+      return new DiagnosticLine(
+          decodeKind((String) encoded[0]),
+          (String) encoded[1],
+          (String) encoded[2],
+          decodeUri((String) encoded[3]),
+          (long) encoded[4],
+          (long) encoded[5]);
+    }
+
+    private static Kind decodeKind(String kind) {
+      try {
+        return Kind.valueOf(kind);
+      } catch (IllegalArgumentException e) {
+        return Kind.OTHER;
+      }
+    }
+
+    private static URI decodeUri(String uri) {
+      try {
+        return uri == null ? null : URI.create(uri);
+      } catch (IllegalArgumentException e) {
+        return null;
+      }
+    }
+  }
 }

--- a/java/tests/unittests/com/google/idea/blaze/java/fastbuild/FastBuildCompilerFactoryImplTest.java
+++ b/java/tests/unittests/com/google/idea/blaze/java/fastbuild/FastBuildCompilerFactoryImplTest.java
@@ -71,7 +71,11 @@ public final class FastBuildCompilerFactoryImplTest {
   }
 
   private static final JavaToolchainInfo JAVA_TOOLCHAIN =
-      JavaToolchainInfo.create(getJavacJars(), /* sourceVersion= */ "8", /* targetVersion= */ "8");
+      JavaToolchainInfo.create(
+          getJavacJars(),
+          /* bootJars= */ ImmutableList.of(),
+          /* sourceVersion= */ "8",
+          /* targetVersion= */ "8");
   private static final JavaInfo JAVA_LIBRARY_WITHOUT_SOURCES = JavaInfo.builder().build();
 
   private FastBuildCompilerFactory compilerFactory;
@@ -153,7 +157,10 @@ public final class FastBuildCompilerFactoryImplTest {
             .setJavaInfo(JAVA_LIBRARY_WITHOUT_SOURCES)
             .setJavaToolchainInfo(
                 JavaToolchainInfo.create(
-                    getJavacJars(), /* sourceVersion= */ "12345", /* targetVersion= */ "9876"))
+                    getJavacJars(),
+                    /* bootJars= */ ImmutableList.of(),
+                    /* sourceVersion= */ "12345",
+                    /* targetVersion= */ "9876"))
             .build();
     blazeData.put(targetLabel, targetData);
     blazeData.put(jdkOneLabel, jdkOneData);
@@ -284,7 +291,10 @@ public final class FastBuildCompilerFactoryImplTest {
     try {
       getCompiler(
               JavaToolchainInfo.create(
-                  getJavacJars(), /* sourceVersion= */ "7", /* targetVersion= */ "8"))
+                  getJavacJars(),
+                  /* bootJars= */ ImmutableList.of(),
+                  /* sourceVersion= */ "7",
+                  /* targetVersion= */ "8"))
           .compile(
               createBlazeContext(javacOutput),
               createCompileInstructions(java, javacOutput).build());

--- a/proto/fast_build_info.proto
+++ b/proto/fast_build_info.proto
@@ -56,4 +56,5 @@ message JavaToolchainInfo {
   string source_version = 2;
   string target_version = 3;
   repeated ArtifactLocation javac_jars = 4;
+  repeated ArtifactLocation bootclasspath_jars = 5;
 }


### PR DESCRIPTION
Fix fast run/debug manual compilation failing with mismatched java versions.

There were two problems:
- the FastBuildJavac interface included classes which changed between java versions, so we couldn't map between the two instances in the classpath
- we weren't specifying the boot classpath during compilation, so if core jdk classes referenced in the files being compiled had changed, recompilation failed