### PR TITLE
Add DirectDependencyTargetProvider that finds the list of Blaze targets that are direct dependencies for a given target.

### DIFF
--- a/base/BUILD
+++ b/base/BUILD
@@ -199,6 +199,7 @@ java_library(
 java_library(
     name = "dep_finder_api",
     srcs = [
+        "src/com/google/idea/blaze/base/dependencies/DirectDependencyTargetProvider.java",
         "src/com/google/idea/blaze/base/dependencies/SourceToTargetProvider.java",
         "src/com/google/idea/blaze/base/dependencies/TargetInfo.java",
         "src/com/google/idea/blaze/base/dependencies/TestSize.java",

--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -431,6 +431,9 @@
     <extensionPoint qualifiedName="com.google.idea.blaze.HeuristicTestIdentifier" interface="com.google.idea.blaze.base.run.producers.HeuristicTestIdentifier"/>
     <extensionPoint qualifiedName="com.google.idea.blaze.OutputsProvider" interface="com.google.idea.blaze.base.model.OutputsProvider"/>
     <extensionPoint qualifiedName="com.google.idea.blaze.VcsSyncListener" interface="com.google.idea.blaze.base.vcs.VcsSyncListener"/>
+    <extensionPoint
+        qualifiedName="com.google.idea.blaze.DirectDependencyTargetProvider"
+        interface="com.google.idea.blaze.base.dependencies.DirectDependencyTargetProvider"/>
   </extensionPoints>
 
   <extensions defaultExtensionNs="com.google.idea.blaze">
@@ -494,6 +497,7 @@
     <VcsSyncListener implementation="com.google.idea.blaze.base.sync.autosync.VcsAutoSyncProvider"/>
     <VcsSyncListener implementation="com.google.idea.blaze.base.sync.libraries.ExternalLibraryManager$VcsListener"/>
     <SettingsUiContributor implementation="com.google.idea.blaze.base.settings.ui.BlazeUserSettingsConfigurable$UiContributor" order="first" id="base"/>
+    <DirectDependencyTargetProvider implementation="com.google.idea.blaze.base.dependencies.BlazeQueryDirectDependencyTargetProvider" order="last"/>
   </extensions>
 
 </idea-plugin>

--- a/base/src/com/google/idea/blaze/base/dependencies/BlazeQueryDirectDependencyTargetProvider.java
+++ b/base/src/com/google/idea/blaze/base/dependencies/BlazeQueryDirectDependencyTargetProvider.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.dependencies;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.Futures;
+import com.google.idea.blaze.base.async.process.ExternalTask;
+import com.google.idea.blaze.base.async.process.LineProcessingOutputStream;
+import com.google.idea.blaze.base.async.process.PrintOutputLineProcessor;
+import com.google.idea.blaze.base.bazel.BuildSystemProvider;
+import com.google.idea.blaze.base.command.BlazeCommand;
+import com.google.idea.blaze.base.command.BlazeCommandName;
+import com.google.idea.blaze.base.model.primitives.Label;
+import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
+import com.google.idea.blaze.base.query.BlazeQueryLabelKindParser;
+import com.google.idea.blaze.base.scope.BlazeContext;
+import com.google.idea.blaze.base.scope.Scope;
+import com.google.idea.blaze.base.scope.scopes.IdeaLogScope;
+import com.google.idea.blaze.base.settings.Blaze;
+import com.google.idea.common.experiments.BoolExperiment;
+import com.intellij.openapi.project.Project;
+import java.util.List;
+import java.util.concurrent.Future;
+import javax.annotation.Nullable;
+import org.jetbrains.ide.PooledThreadExecutor;
+
+/**
+ * Given a blaze target, runs a blaze query invocation to find the direct dependencies of that
+ * target.
+ *
+ * <p>This is expected to be slow, so should be asynchronous and/or cancellable.
+ */
+class BlazeQueryDirectDependencyTargetProvider implements DirectDependencyTargetProvider {
+
+  /**
+   * Currently disabled for performance reasons. DirectDependencyTargetProvider is called often, in
+   * the background, and we don't want to monopolize the local blaze server.
+   */
+  private static final BoolExperiment enabled =
+      new BoolExperiment("use.blaze.query.for.directdeps", false);
+
+  @Override
+  public Future<List<TargetInfo>> getDirectDependencyTargets(Project project, Label target) {
+    if (!enabled.getValue()) {
+      return Futures.immediateFuture(null);
+    }
+    return PooledThreadExecutor.INSTANCE.submit(
+        () ->
+            Scope.root(
+                context -> {
+                  context.push(new IdeaLogScope());
+                  return runQuery(project, target, context);
+                }));
+  }
+
+  @Nullable
+  private static ImmutableList<TargetInfo> runQuery(
+      Project project, Label target, BlazeContext context) {
+    String query =
+        String.format("let x = \"%s\" in deps($x, 1) - $x - labels(\"exports\", $x)", target);
+    BlazeCommand command =
+        BlazeCommand.builder(getBinaryPath(project), BlazeCommandName.QUERY)
+            .addBlazeFlags("--output=label_kind")
+            .addBlazeFlags(query)
+            .build();
+
+    BlazeQueryLabelKindParser outputProcessor = new BlazeQueryLabelKindParser(t -> true);
+    int retVal =
+        ExternalTask.builder(WorkspaceRoot.fromProject(project))
+            .addBlazeCommand(command)
+            .context(context)
+            .stdout(LineProcessingOutputStream.of(outputProcessor))
+            .stderr(LineProcessingOutputStream.of(new PrintOutputLineProcessor(context)))
+            .build()
+            .run();
+    if (retVal != 0) {
+      return null;
+    }
+    return outputProcessor.getTargets();
+  }
+
+  private static String getBinaryPath(Project project) {
+    BuildSystemProvider buildSystemProvider = Blaze.getBuildSystemProvider(project);
+    return buildSystemProvider.getSyncBinaryPath(project);
+  }
+}

--- a/base/src/com/google/idea/blaze/base/dependencies/DirectDependencyTargetProvider.java
+++ b/base/src/com/google/idea/blaze/base/dependencies/DirectDependencyTargetProvider.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.dependencies;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.idea.blaze.base.model.primitives.Label;
+import com.google.idea.blaze.base.run.targetfinder.FuturesUtil;
+import com.intellij.openapi.extensions.ExtensionPointName;
+import com.intellij.openapi.project.Project;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+
+/** Provides the blaze targets that are direct dependencies for a given target. */
+public interface DirectDependencyTargetProvider {
+
+  ExtensionPointName<DirectDependencyTargetProvider> EP_NAME =
+      ExtensionPointName.create("com.google.idea.blaze.DirectDependencyTargetProvider");
+
+  /**
+   * Returns the blaze targets provided by the first available {@link
+   * DirectDependencyTargetProvider} able to handle the given target, prioritizing any which are
+   * immediately available.
+   *
+   * <p>Future returns null if no provider was able to handle the given target.
+   */
+  static ListenableFuture<List<TargetInfo>> findDirectDependencyTargets(
+      Project project, Label target) {
+    Iterable<Future<List<TargetInfo>>> futures =
+        Arrays.stream(DirectDependencyTargetProvider.EP_NAME.getExtensions())
+            .map(f -> f.getDirectDependencyTargets(project, target))
+            .collect(Collectors.toList());
+    ListenableFuture<List<TargetInfo>> future =
+        FuturesUtil.getFirstFutureSatisfyingPredicate(futures, Objects::nonNull);
+    return future;
+  }
+
+  /**
+   * Query the blaze targets that are direct dependencies for the given target.
+   *
+   * <p>Future returns null if this provider was unable to query the blaze targets.
+   */
+  Future<List<TargetInfo>> getDirectDependencyTargets(Project project, Label target);
+}

--- a/base/tests/integrationtests/com/google/idea/blaze/base/dependencies/DirectDependencyTargetProviderTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/dependencies/DirectDependencyTargetProviderTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.dependencies;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.Futures;
+import com.google.idea.blaze.base.BlazeIntegrationTestCase;
+import com.google.idea.blaze.base.model.primitives.Label;
+import com.intellij.openapi.project.Project;
+import com.intellij.testFramework.PlatformTestUtil;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/** Tests for {@link DirectDependencyTargetProvider}. */
+@RunWith(JUnit4.class)
+public class DirectDependencyTargetProviderTest extends BlazeIntegrationTestCase {
+
+  @Mock private DirectDependencyTargetProvider mockDirectDependencyTargetProvider1;
+  @Mock private DirectDependencyTargetProvider mockDirectDependencyTargetProvider2;
+  @Mock private DirectDependencyTargetProvider mockDirectDependencyTargetProvider3;
+
+  @Before
+  public void initTest() {
+    MockitoAnnotations.initMocks(this);
+    PlatformTestUtil.maskExtensions(
+        DirectDependencyTargetProvider.EP_NAME,
+        ImmutableList.of(
+            mockDirectDependencyTargetProvider1,
+            mockDirectDependencyTargetProvider2,
+            mockDirectDependencyTargetProvider3),
+        getTestRootDisposable());
+  }
+
+  @Test
+  public void testFindDirectDependencyTargets() throws ExecutionException, InterruptedException {
+    TargetInfo targetInfo1 =
+        TargetInfo.builder(Label.create("//test:target1"), "proto_library").build();
+    TargetInfo targetInfo2 =
+        TargetInfo.builder(Label.create("//test:target2"), "proto_library").build();
+
+    when(mockDirectDependencyTargetProvider1.getDirectDependencyTargets(
+            any(Project.class), any(Label.class)))
+        .thenReturn(Futures.immediateFuture(null));
+    when(mockDirectDependencyTargetProvider2.getDirectDependencyTargets(
+            any(Project.class), any(Label.class)))
+        .thenReturn(Futures.immediateFuture(ImmutableList.of(targetInfo1, targetInfo2)));
+    when(mockDirectDependencyTargetProvider3.getDirectDependencyTargets(
+            any(Project.class), any(Label.class)))
+        .thenReturn(Futures.immediateFuture(null));
+
+    List<TargetInfo> actual =
+        DirectDependencyTargetProvider.findDirectDependencyTargets(
+                getProject(), Label.create("//test:target"))
+            .get();
+
+    assertThat(actual).containsExactly(targetInfo1, targetInfo2);
+  }
+}


### PR DESCRIPTION
Add DirectDependencyTargetProvider that finds the list of Blaze targets that are direct dependencies for a given target.