### PR TITLE
Add blaze integration tests for building/parsing android deploy info.

### DIFF
--- a/aswb/src/com/google/idea/blaze/android/run/binary/mobileinstall/BlazeApkBuildStepMobileInstall.java
+++ b/aswb/src/com/google/idea/blaze/android/run/binary/mobileinstall/BlazeApkBuildStepMobileInstall.java
@@ -23,6 +23,8 @@ import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.UncheckedExecutionException;
+import com.google.devtools.build.lib.rules.android.deployinfo.AndroidDeployInfoOuterClass.AndroidDeployInfo;
+import com.google.idea.blaze.android.manifest.ParsedManifestService;
 import com.google.idea.blaze.android.run.deployinfo.BlazeAndroidDeployInfo;
 import com.google.idea.blaze.android.run.deployinfo.BlazeApkDeployInfoProtoHelper;
 import com.google.idea.blaze.android.run.runner.BlazeAndroidDeviceSelector;
@@ -39,6 +41,7 @@ import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtif
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelperProvider;
 import com.google.idea.blaze.base.console.BlazeConsoleLineProcessorProvider;
 import com.google.idea.blaze.base.filecache.FileCaches;
+import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
 import com.google.idea.blaze.base.scope.BlazeContext;
@@ -47,6 +50,7 @@ import com.google.idea.blaze.base.scope.output.IssueOutput;
 import com.google.idea.blaze.base.scope.output.StatusOutput;
 import com.google.idea.blaze.base.settings.Blaze;
 import com.google.idea.blaze.base.settings.BuildSystem;
+import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
 import com.google.idea.blaze.base.util.SaveUtil;
 import com.google.idea.common.experiments.BoolExperiment;
 import com.intellij.execution.ExecutionException;
@@ -66,6 +70,15 @@ public class BlazeApkBuildStepMobileInstall implements BlazeApkBuildStep {
   private final ImmutableList<String> exeFlags;
   private BlazeAndroidDeployInfo deployInfo = null;
 
+  /**
+   * Returns the correct DeployInfo file suffix for mobile-install classic (bazel). This should be
+   * removed once mobile-install v2 is open sourced, at which point the internal and external
+   * versions will both use _mi.deployinfo.pb
+   */
+  public static String getDeployInfoSuffix(BuildSystem buildSystem) {
+    return buildSystem == BuildSystem.Bazel ? "_incremental.deployinfo.pb" : "_mi.deployinfo.pb";
+  }
+
   public BlazeApkBuildStepMobileInstall(
       Project project,
       Label label,
@@ -84,6 +97,14 @@ public class BlazeApkBuildStepMobileInstall implements BlazeApkBuildStep {
         new ScopedTask<Void>(context) {
           @Override
           protected Void execute(BlazeContext context) {
+            BlazeProjectData projectData =
+                BlazeProjectDataManager.getInstance(project).getBlazeProjectData();
+
+            if (projectData == null) {
+              IssueOutput.error("Missing project data. Please sync and try again.").submit(context);
+              return null;
+            }
+
             DeviceFutures deviceFutures = deviceSession.deviceFutures;
             assert deviceFutures != null;
 
@@ -113,19 +134,10 @@ public class BlazeApkBuildStepMobileInstall implements BlazeApkBuildStep {
             }
 
             WorkspaceRoot workspaceRoot = WorkspaceRoot.fromProject(project);
+            File executionRoot = projectData.getBlazeInfo().getExecutionRoot();
+            final String deployInfoSuffix = getDeployInfoSuffix(Blaze.getBuildSystem(project));
 
-            // Use the correct DeployInfo file suffix for mobile-install classic (bazel).
-            // This should be removed once mobile-install v2 is open sourced, at which point
-            // the internal and external versions will both use _mi.deployinfo.pb
-            final String deployInfoSuffix =
-                Blaze.getBuildSystem(project) == BuildSystem.Bazel
-                    ? "_incremental.deployinfo.pb"
-                    : "_mi.deployinfo.pb";
-
-            BlazeApkDeployInfoProtoHelper deployInfoHelper =
-                new BlazeApkDeployInfoProtoHelper(project, blazeFlags);
             try (BuildResultHelper buildResultHelper = BuildResultHelperProvider.create(project)) {
-
               command
                   .addTargets(label)
                   .addBlazeFlags(blazeFlags)
@@ -150,23 +162,19 @@ public class BlazeApkBuildStepMobileInstall implements BlazeApkBuildStep {
                 context.setHasError();
                 return null;
               }
-              try {
-                context.output(new StatusOutput("Reading deployment information..."));
-                deployInfo =
-                    deployInfoHelper.readDeployInfo(
-                        context,
-                        buildResultHelper,
-                        fileName -> fileName.endsWith(deployInfoSuffix));
-              } catch (GetArtifactsException e) {
-                IssueOutput.error("Could not read apk deploy info from build: " + e.getMessage())
-                    .submit(context);
-                return null;
-              }
-              if (deployInfo == null) {
-                IssueOutput.error("Could not read apk deploy info from build").submit(context);
-              }
-              return null;
+
+              context.output(new StatusOutput("Reading deployment information..."));
+              AndroidDeployInfo deployInfoProto =
+                  BlazeApkDeployInfoProtoHelper.readDeployInfoProtoForTarget(
+                      label, buildResultHelper, fileName -> fileName.endsWith(deployInfoSuffix));
+              deployInfo = new BlazeAndroidDeployInfo(project, executionRoot, deployInfoProto);
+              ParsedManifestService.getInstance(project)
+                  .invalidateCachedManifests(deployInfo.getManifestFiles());
+            } catch (GetArtifactsException e) {
+              IssueOutput.error("Could not read apk deploy info from build: " + e.getMessage())
+                  .submit(context);
             }
+            return null;
           }
         };
 

--- a/aswb/src/com/google/idea/blaze/android/run/deployinfo/BlazeApkDeployInfoProtoHelper.java
+++ b/aswb/src/com/google/idea/blaze/android/run/deployinfo/BlazeApkDeployInfoProtoHelper.java
@@ -17,90 +17,47 @@ package com.google.idea.blaze.android.run.deployinfo;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import com.google.common.util.concurrent.ListenableFuture;
 import com.google.devtools.build.lib.rules.android.deployinfo.AndroidDeployInfoOuterClass;
-import com.google.idea.blaze.android.manifest.ParsedManifestService;
+import com.google.devtools.build.lib.rules.android.deployinfo.AndroidDeployInfoOuterClass.AndroidDeployInfo;
 import com.google.idea.blaze.base.command.buildresult.BlazeArtifact;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtifactsException;
-import com.google.idea.blaze.base.command.info.BlazeInfo;
-import com.google.idea.blaze.base.command.info.BlazeInfoRunner;
-import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
-import com.google.idea.blaze.base.scope.BlazeContext;
-import com.google.idea.blaze.base.settings.Blaze;
-import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.openapi.project.Project;
+import com.google.idea.blaze.base.model.primitives.Label;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.List;
-import java.util.concurrent.ExecutionException;
 import java.util.function.Predicate;
-import javax.annotation.Nullable;
+import java.util.stream.Collectors;
 
 /** Reads the deploy info from a build step. */
 public class BlazeApkDeployInfoProtoHelper {
-  private static final Logger LOG = Logger.getInstance(BlazeApkDeployInfoProtoHelper.class);
-
-  private final Project project;
-  private final WorkspaceRoot workspaceRoot;
-  private final ImmutableList<String> buildFlags;
-
-  public BlazeApkDeployInfoProtoHelper(Project project, ImmutableList<String> buildFlags) {
-    this.project = project;
-    this.buildFlags = buildFlags;
-    this.workspaceRoot = WorkspaceRoot.fromProject(project);
-  }
-
-  @Nullable
-  public BlazeAndroidDeployInfo readDeployInfo(
-      BlazeContext context, BuildResultHelper buildResultHelper, Predicate<String> pathFilter)
+  public static AndroidDeployInfo readDeployInfoProtoForTarget(
+      Label target, BuildResultHelper buildResultHelper, Predicate<String> pathFilter)
       throws GetArtifactsException {
-    File deployInfoFile =
-        Iterables.getOnlyElement(
-            BlazeArtifact.getLocalFiles(buildResultHelper.getAllOutputArtifacts(pathFilter)), null);
-    if (deployInfoFile == null) {
-      return null;
+    ImmutableList<File> artifacts =
+        BlazeArtifact.getLocalFiles(
+            buildResultHelper.getBuildArtifactsForTarget(target, pathFilter));
+    if (artifacts.isEmpty()) {
+      throw new GetArtifactsException(
+          "No deploy info proto artifact found.  Was android_deploy_info in the output groups?");
     }
-    AndroidDeployInfoOuterClass.AndroidDeployInfo deployInfo;
+    if (artifacts.size() != 1) {
+      String errMsg =
+          "More than one deploy info proto artifact found: "
+              + artifacts.stream().map(File::getPath).collect(Collectors.joining(", ", "[", "]"));
+      throw new GetArtifactsException(errMsg);
+    }
+    File deployInfoFile = Iterables.getOnlyElement(artifacts, null);
+    if (deployInfoFile == null) {
+      throw new GetArtifactsException("Deploy info file doesn't exist.");
+    }
+    AndroidDeployInfo deployInfo;
     try (InputStream inputStream = new FileInputStream(deployInfoFile)) {
       deployInfo = AndroidDeployInfoOuterClass.AndroidDeployInfo.parseFrom(inputStream);
     } catch (IOException e) {
-      LOG.error(e);
-      return null;
+      throw new GetArtifactsException(e.getMessage());
     }
-    String executionRoot = getExecutionRoot(context);
-    if (executionRoot == null) {
-      return null;
-    }
-    BlazeAndroidDeployInfo androidDeployInfo =
-        new BlazeAndroidDeployInfo(project, new File(executionRoot), deployInfo);
-
-    List<File> manifestFiles = androidDeployInfo.getManifestFiles();
-    ParsedManifestService.getInstance(project).invalidateCachedManifests(manifestFiles);
-
-    return androidDeployInfo;
-  }
-
-  @Nullable
-  private String getExecutionRoot(BlazeContext context) {
-    ListenableFuture<String> execRootFuture =
-        BlazeInfoRunner.getInstance()
-            .runBlazeInfo(
-                context,
-                Blaze.getBuildSystemProvider(project).getBinaryPath(project),
-                workspaceRoot,
-                buildFlags,
-                BlazeInfo.EXECUTION_ROOT_KEY);
-    try {
-      return execRootFuture.get();
-    } catch (InterruptedException e) {
-      context.setCancelled();
-    } catch (ExecutionException e) {
-      LOG.error(e);
-      context.setHasError();
-    }
-    return null;
+    return deployInfo;
   }
 }


### PR DESCRIPTION
Add blaze integration tests for building/parsing android deploy info.

Currently there are no tests that verify deploy info protos are built/parsed
correctly.  These deploy info protos are required for ASwB to correctly
perform many run/debug functions such as debugger attachment, APK deployment,
etc.

This CL adds tests for building and parsing android deploy info for android_binary
targets from both normal build and mobile-install scenarios. 

* BlazeApkDeployInfoProtoHelper has been simplified to static utilities.  It didn't make sense for a proto helper to run blaze-info just to fetch the exec root anyway.

* BlazeApkBuildStepNormalBuild and BlazeApkBuildStepMobileInstall have been modified to obtain exec root from blaze project data instead of re-running blaze info.

* MobileInstallSanityTest has been deleted because it's no longer needed. It's purpose is now fulfilled by BlazeApkDeployInfoTest.