### PR TITLE
Exclude directories listed in .bazelignore

### DIFF
--- a/base/src/com/google/idea/blaze/base/io/FileOperationProvider.java
+++ b/base/src/com/google/idea/blaze/base/io/FileOperationProvider.java
@@ -20,6 +20,7 @@ import com.intellij.openapi.components.ServiceManager;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.List;
 import javax.annotation.Nullable;
 
 /** File system operations. Mocked out in tests involving file manipulations. */
@@ -76,5 +77,9 @@ public class FileOperationProvider {
 
   public void deleteRecursively(File file) throws IOException {
     MoreFiles.deleteRecursively(file.toPath());
+  }
+
+  public List<String> readAllLines(File file) throws IOException {
+    return Files.readAllLines(file.toPath());
   }
 }

--- a/base/src/com/google/idea/blaze/base/sync/projectview/BazelIgnoreParser.java
+++ b/base/src/com/google/idea/blaze/base/sync/projectview/BazelIgnoreParser.java
@@ -40,8 +40,7 @@ public class BazelIgnoreParser {
    * @return a list of validated WorkspacePaths.
    */
   public ImmutableList<WorkspacePath> getIgnoredPaths() {
-    if (FileOperationProvider.getInstance() == null ||
-        !FileOperationProvider.getInstance().exists(bazelIgnoreFile)) {
+    if (!FileOperationProvider.getInstance().exists(bazelIgnoreFile)) {
       return ImmutableList.of();
     }
 
@@ -52,7 +51,9 @@ public class BazelIgnoreParser {
         if (path.endsWith("/")) {
           // .bazelignore allows the "/" path suffix, but WorkspacePath doesn't.
           path = path.substring(0, path.length() - 1);
-        } else if (!WorkspacePath.isValid(path)) {
+        }
+
+        if (!WorkspacePath.isValid(path)) {
           logger.warn(
               String.format(
                   "Found %s in .bazelignore, but unable to parse as relative workspace path.", path));

--- a/base/src/com/google/idea/blaze/base/sync/projectview/BazelIgnoreParser.java
+++ b/base/src/com/google/idea/blaze/base/sync/projectview/BazelIgnoreParser.java
@@ -13,6 +13,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import java.io.File;
 import javax.annotation.Nullable;
 
+/** A parser for .bazelgnore files, which tells Bazel a list of paths to ignore. */
 public class BazelIgnoreParser {
 
   Logger logger = Logger.getInstance(BazelIgnoreParser.class);
@@ -24,6 +25,10 @@ public class BazelIgnoreParser {
     this.bazelIgnoreFile = workspaceRoot.fileForPath(new WorkspacePath(".bazelignore"));
   }
 
+  /**
+   * Parse a .bazelignore file (if it exists) for workspace relative paths.
+   * @return a list of validated WorkspacePaths.
+   */
   public ImmutableList<WorkspacePath> getIgnoredPaths() {
     VirtualFile vf = VfsUtils.resolveVirtualFile(bazelIgnoreFile);
     if (vf == null || !vf.exists()) {
@@ -33,7 +38,6 @@ public class BazelIgnoreParser {
     Document document = FileDocumentManager.getInstance().getDocument(vf);
     if (document == null || document.getImmutableCharSequence().length() == 0)  {
       return ImmutableList.of();
-
     }
 
     ImmutableList.Builder<WorkspacePath> ignoredPaths = ImmutableList.builder();

--- a/base/src/com/google/idea/blaze/base/sync/projectview/BazelIgnoreParser.java
+++ b/base/src/com/google/idea/blaze/base/sync/projectview/BazelIgnoreParser.java
@@ -40,7 +40,7 @@ public class BazelIgnoreParser {
    * @return a list of validated WorkspacePaths.
    */
   public ImmutableList<WorkspacePath> getIgnoredPaths() {
-    if (FileOperationProvider.getInstance() == null &&
+    if (FileOperationProvider.getInstance() == null ||
         !FileOperationProvider.getInstance().exists(bazelIgnoreFile)) {
       return ImmutableList.of();
     }

--- a/base/src/com/google/idea/blaze/base/sync/projectview/BazelIgnoreParser.java
+++ b/base/src/com/google/idea/blaze/base/sync/projectview/BazelIgnoreParser.java
@@ -3,12 +3,12 @@ package com.google.idea.blaze.base.sync.projectview;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
+import com.google.idea.blaze.base.io.VfsUtils;
 import com.google.idea.blaze.base.model.primitives.WorkspacePath;
 import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
-import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import javax.annotation.Nullable;
 
@@ -21,10 +21,8 @@ public class BazelIgnoreParser {
 
   public BazelIgnoreParser(WorkspaceRoot workspaceRoot) {
     this.bazelIgnoreFile =
-        LocalFileSystem
-            .getInstance()
-            .findFileByIoFile(
-                workspaceRoot.fileForPath(new WorkspacePath(".bazelignore")));
+        VfsUtils.resolveVirtualFile(
+            workspaceRoot.fileForPath(new WorkspacePath(".bazelignore")));
   }
 
   public ImmutableList<WorkspacePath> getIgnoredPaths() {

--- a/base/src/com/google/idea/blaze/base/sync/projectview/BazelIgnoreParser.java
+++ b/base/src/com/google/idea/blaze/base/sync/projectview/BazelIgnoreParser.java
@@ -1,0 +1,60 @@
+package com.google.idea.blaze.base.sync.projectview;
+
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+import com.google.idea.blaze.base.model.primitives.WorkspacePath;
+import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import javax.annotation.Nullable;
+
+public class BazelIgnoreParser {
+
+  Logger logger = Logger.getInstance(BazelIgnoreParser.class);
+
+  @Nullable
+  private final VirtualFile bazelIgnoreFile;
+
+  public BazelIgnoreParser(WorkspaceRoot workspaceRoot) {
+    this.bazelIgnoreFile =
+        LocalFileSystem
+            .getInstance()
+            .findFileByIoFile(
+                workspaceRoot.fileForPath(new WorkspacePath(".bazelignore")));
+  }
+
+  public ImmutableList<WorkspacePath> getIgnoredPaths() {
+    if (bazelIgnoreFile == null || !bazelIgnoreFile.exists()) {
+      return ImmutableList.of();
+    }
+
+    Document document = FileDocumentManager.getInstance().getDocument(bazelIgnoreFile);
+    ImmutableList.Builder<WorkspacePath> ignoredPaths = ImmutableList.builder();
+
+    for (CharSequence cs : Splitter.on("\n").split(document.getImmutableCharSequence())) {
+      String path = cs.toString();
+      String validationOutcome = WorkspacePath.validate(path);
+      if (validationOutcome != null) {
+        if (validationOutcome.contains("may not end with '/'")) {
+          path = path.substring(0, path.length() - 1);
+        } else {
+          logger.warn(
+              "Found "
+                  + path
+                  + " in .bazelignore, but unable to parse as relative workspace path for reason: "
+                  + validationOutcome);
+          continue;
+        }
+      }
+
+      ignoredPaths.add(new WorkspacePath(path));
+    }
+
+    return ignoredPaths.build();
+  }
+
+}

--- a/base/src/com/google/idea/blaze/base/sync/projectview/BazelIgnoreParser.java
+++ b/base/src/com/google/idea/blaze/base/sync/projectview/BazelIgnoreParser.java
@@ -26,14 +26,12 @@ import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.vfs.VirtualFile;
 import java.io.File;
-import javax.annotation.Nullable;
 
 /** A parser for .bazelgnore files, which tells Bazel a list of paths to ignore. */
 public class BazelIgnoreParser {
 
   Logger logger = Logger.getInstance(BazelIgnoreParser.class);
 
-  @Nullable
   private final File bazelIgnoreFile;
 
   public BazelIgnoreParser(WorkspaceRoot workspaceRoot) {

--- a/base/src/com/google/idea/blaze/base/sync/projectview/BazelIgnoreParser.java
+++ b/base/src/com/google/idea/blaze/base/sync/projectview/BazelIgnoreParser.java
@@ -19,6 +19,7 @@ package com.google.idea.blaze.base.sync.projectview;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.idea.blaze.base.io.VfsUtils;
+import com.google.idea.blaze.base.io.VirtualFileSystemProvider;
 import com.google.idea.blaze.base.model.primitives.WorkspacePath;
 import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
 import com.intellij.openapi.diagnostic.Logger;
@@ -43,6 +44,10 @@ public class BazelIgnoreParser {
    * @return a list of validated WorkspacePaths.
    */
   public ImmutableList<WorkspacePath> getIgnoredPaths() {
+    if (VirtualFileSystemProvider.getInstance() == null) {
+      return ImmutableList.of();
+    }
+
     VirtualFile vf = VfsUtils.resolveVirtualFile(bazelIgnoreFile);
     if (vf == null || !vf.exists()) {
       return ImmutableList.of();

--- a/base/src/com/google/idea/blaze/base/sync/projectview/BazelIgnoreParser.java
+++ b/base/src/com/google/idea/blaze/base/sync/projectview/BazelIgnoreParser.java
@@ -40,7 +40,7 @@ public class BazelIgnoreParser {
    * @return a list of validated WorkspacePaths.
    */
   public ImmutableList<WorkspacePath> getIgnoredPaths() {
-    if (FileOperationProvider.getInstance() != null &&
+    if (FileOperationProvider.getInstance() == null &&
         !FileOperationProvider.getInstance().exists(bazelIgnoreFile)) {
       return ImmutableList.of();
     }

--- a/base/src/com/google/idea/blaze/base/sync/projectview/BazelIgnoreParser.java
+++ b/base/src/com/google/idea/blaze/base/sync/projectview/BazelIgnoreParser.java
@@ -40,7 +40,8 @@ public class BazelIgnoreParser {
    * @return a list of validated WorkspacePaths.
    */
   public ImmutableList<WorkspacePath> getIgnoredPaths() {
-    if (!FileOperationProvider.getInstance().exists(bazelIgnoreFile)) {
+    if (FileOperationProvider.getInstance() != null &&
+        !FileOperationProvider.getInstance().exists(bazelIgnoreFile)) {
       return ImmutableList.of();
     }
 

--- a/base/src/com/google/idea/blaze/base/sync/projectview/BazelIgnoreParser.java
+++ b/base/src/com/google/idea/blaze/base/sync/projectview/BazelIgnoreParser.java
@@ -10,6 +10,7 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.vfs.VirtualFile;
+import java.io.File;
 import javax.annotation.Nullable;
 
 public class BazelIgnoreParser {
@@ -17,20 +18,24 @@ public class BazelIgnoreParser {
   Logger logger = Logger.getInstance(BazelIgnoreParser.class);
 
   @Nullable
-  private final VirtualFile bazelIgnoreFile;
+  private final File bazelIgnoreFile;
 
   public BazelIgnoreParser(WorkspaceRoot workspaceRoot) {
-    this.bazelIgnoreFile =
-        VfsUtils.resolveVirtualFile(
-            workspaceRoot.fileForPath(new WorkspacePath(".bazelignore")));
+    this.bazelIgnoreFile = workspaceRoot.fileForPath(new WorkspacePath(".bazelignore"));
   }
 
   public ImmutableList<WorkspacePath> getIgnoredPaths() {
-    if (bazelIgnoreFile == null || !bazelIgnoreFile.exists()) {
+    VirtualFile vf = VfsUtils.resolveVirtualFile(bazelIgnoreFile);
+    if (vf == null || !vf.exists()) {
       return ImmutableList.of();
     }
 
-    Document document = FileDocumentManager.getInstance().getDocument(bazelIgnoreFile);
+    Document document = FileDocumentManager.getInstance().getDocument(vf);
+    if (document == null || document.getImmutableCharSequence().length() == 0)  {
+      return ImmutableList.of();
+
+    }
+
     ImmutableList.Builder<WorkspacePath> ignoredPaths = ImmutableList.builder();
 
     for (CharSequence cs : Splitter.on("\n").split(document.getImmutableCharSequence())) {

--- a/base/src/com/google/idea/blaze/base/sync/projectview/BazelIgnoreParser.java
+++ b/base/src/com/google/idea/blaze/base/sync/projectview/BazelIgnoreParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.idea.blaze.base.sync.projectview;
 
 

--- a/base/src/com/google/idea/blaze/base/sync/projectview/ImportRoots.java
+++ b/base/src/com/google/idea/blaze/base/sync/projectview/ImportRoots.java
@@ -101,6 +101,7 @@ public final class ImportRoots {
       if (buildSystem == BuildSystem.Bazel && hasWorkspaceRoot(rootDirectories)) {
         excludeBuildSystemArtifacts();
         excludeProjectDataSubDirectory();
+        excludeBazelIgnoredPaths();
       }
       ImmutableSet<WorkspacePath> minimalExcludes =
           WorkspacePathUtil.calculateMinimalWorkspacePaths(excludeDirectoriesBuilder.build());
@@ -131,6 +132,10 @@ public final class ImportRoots {
 
     private void excludeProjectDataSubDirectory() {
       excludeDirectoriesBuilder.add(new WorkspacePath(BlazeDataStorage.PROJECT_DATA_SUBDIRECTORY));
+    }
+
+    private void excludeBazelIgnoredPaths() {
+      excludeDirectoriesBuilder.addAll(new BazelIgnoreParser(workspaceRoot).getIgnoredPaths());
     }
 
     private static boolean hasWorkspaceRoot(ImmutableCollection<WorkspacePath> rootDirectories) {

--- a/base/tests/integrationtests/com/google/idea/blaze/base/sync/ImportRootsTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/sync/ImportRootsTest.java
@@ -232,4 +232,20 @@ public class ImportRootsTest extends BlazeIntegrationTestCase {
 
     assertThat(importRoots.containsWorkspacePath(new WorkspacePath("root/a/b"))).isFalse();
   }
+
+  @Test
+  public void testBazelIgnoreParser_excludesIgnoredPaths() throws Exception {
+    workspace.createFile(new WorkspacePath(".bazelignore"),  "root0");
+
+    ImportRoots importRoots =
+        ImportRoots.builder(workspaceRoot, BuildSystem.Bazel)
+            .add(DirectoryEntry.include(new WorkspacePath("")))
+            .add(DirectoryEntry.include(new WorkspacePath("root0/subdir0")))
+            .add(DirectoryEntry.include(new WorkspacePath("root0/subdir1")))
+            .add(DirectoryEntry.include(new WorkspacePath("root1")))
+            .build();
+
+    assertThat(importRoots.rootDirectories()).containsExactly(new WorkspacePath("root1"));
+    assertThat(importRoots.excludeDirectories()).containsExactly(new WorkspacePath("root0"));
+  }
 }

--- a/base/tests/integrationtests/com/google/idea/blaze/base/sync/ImportRootsTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/sync/ImportRootsTest.java
@@ -237,14 +237,14 @@ public class ImportRootsTest extends BlazeIntegrationTestCase {
   @Test
   public void testBazelIgnoreParser_worksWithoutBazelIgnore() throws Exception {
     BazelIgnoreParser parser = new BazelIgnoreParser(workspaceRoot);
-    assertThat(parser.getIgnoredPaths()).hasSize(0);
+    assertThat(parser.getIgnoredPaths()).isEmpty();
   }
 
   @Test
   public void testBazelIgnoreParser_worksWithEmptyBazelIgnore() throws Exception {
     workspace.createFile(new WorkspacePath(".bazelignore"),  "");
     BazelIgnoreParser parser = new BazelIgnoreParser(workspaceRoot);
-    assertThat(parser.getIgnoredPaths()).hasSize(0);
+    assertThat(parser.getIgnoredPaths()).isEmpty();
   }
 
   @Test
@@ -252,7 +252,7 @@ public class ImportRootsTest extends BlazeIntegrationTestCase {
     // directories cannot be absolute and cannot contain ":"
     workspace.createFile(new WorkspacePath(".bazelignore"),  "/mal:formed");
     BazelIgnoreParser parser = new BazelIgnoreParser(workspaceRoot);
-    assertThat(parser.getIgnoredPaths()).hasSize(0);
+    assertThat(parser.getIgnoredPaths()).isEmpty();
   }
 
   @Test

--- a/base/tests/utils/integration/com/google/idea/blaze/base/TestFileSystem.java
+++ b/base/tests/utils/integration/com/google/idea/blaze/base/TestFileSystem.java
@@ -17,6 +17,7 @@ package com.google.idea.blaze.base;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
@@ -37,7 +38,6 @@ import com.intellij.testFramework.LightPlatformTestCase;
 import com.intellij.testFramework.fixtures.TempDirTestFixture;
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -218,7 +218,7 @@ public class TestFileSystem {
     public List<String> readAllLines(File file) throws IOException {
       VirtualFile vf = getVirtualFile(file);
       // Assume UTF-8 here for test-only purposes.
-      String text = new String(vf.contentsToByteArray(), Charset.forName("UTF-8"));
+      String text = new String(vf.contentsToByteArray(), UTF_8);
 
       ImmutableList.Builder<String> lines = ImmutableList.builder();
       if (text.length() == 0) {

--- a/base/tests/utils/integration/com/google/idea/blaze/base/TestFileSystem.java
+++ b/base/tests/utils/integration/com/google/idea/blaze/base/TestFileSystem.java
@@ -217,19 +217,13 @@ public class TestFileSystem {
     @Override
     public List<String> readAllLines(File file) throws IOException {
       VirtualFile vf = getVirtualFile(file);
-      // Assume UTF-8 here for test-only purposes.
       String text = new String(vf.contentsToByteArray(), UTF_8);
 
-      ImmutableList.Builder<String> lines = ImmutableList.builder();
       if (text.length() == 0) {
-        return lines.build();
+        return ImmutableList.of();
       }
 
-      for (CharSequence cs : Splitter.on("\n").split(text)) {
-        lines.add(cs.toString());
-      }
-
-      return lines.build();
+      return Splitter.on("\n").splitToList(text);
     }
   }
 

--- a/java/tests/unittests/com/google/idea/blaze/java/sync/importer/BlazeJavaWorkspaceImporterTest.java
+++ b/java/tests/unittests/com/google/idea/blaze/java/sync/importer/BlazeJavaWorkspaceImporterTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertNotNull;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import com.google.idea.blaze.base.BlazeTestCase;
 import com.google.idea.blaze.base.async.executor.BlazeExecutor;
 import com.google.idea.blaze.base.async.executor.MockBlazeExecutor;
@@ -36,6 +37,7 @@ import com.google.idea.blaze.base.ideinfo.TargetIdeInfo;
 import com.google.idea.blaze.base.ideinfo.TargetKey;
 import com.google.idea.blaze.base.ideinfo.TargetMap;
 import com.google.idea.blaze.base.ideinfo.TargetMapBuilder;
+import com.google.idea.blaze.base.io.FileOperationProvider;
 import com.google.idea.blaze.base.model.LibraryKey;
 import com.google.idea.blaze.base.model.primitives.GenericBlazeRules;
 import com.google.idea.blaze.base.model.primitives.Kind;
@@ -84,6 +86,7 @@ import com.google.idea.common.experiments.MockExperimentService;
 import com.intellij.openapi.extensions.impl.ExtensionPointImpl;
 import java.io.File;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -94,6 +97,9 @@ import org.junit.runners.JUnit4;
 /** Tests for BlazeJavaWorkspaceImporter */
 @RunWith(JUnit4.class)
 public class BlazeJavaWorkspaceImporterTest extends BlazeTestCase {
+
+  private static class MockFileOperationProvider extends FileOperationProvider { }
+  private final MockFileOperationProvider fileOperationProvider = new MockFileOperationProvider();
 
   private static final String FAKE_WORKSPACE_ROOT = "/root";
   private final WorkspaceRoot workspaceRoot = new WorkspaceRoot(new File(FAKE_WORKSPACE_ROOT));
@@ -123,6 +129,7 @@ public class BlazeJavaWorkspaceImporterTest extends BlazeTestCase {
   @Override
   @SuppressWarnings("FunctionalInterfaceClash") // False positive on getDeclaredPackageOfJavaFile.
   protected void initTest(Container applicationServices, Container projectServices) {
+    applicationServices.register(FileOperationProvider.class, fileOperationProvider);
     applicationServices.register(ExperimentService.class, new MockExperimentService());
 
     ExtensionPointImpl<Kind.Provider> ep =


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/intellij/issues/421

Given a .bazelignore:

```
examples/
third_party/bazel_json/test
```

This results in the above two directories marked as excluded in IntelliJ:

![ss](https://user-images.githubusercontent.com/347918/65558083-7443b100-df03-11e9-94ec-81277a5d151e.png)
