### PR TITLE
Create intellij-canary and intellij-ue-canary to bring in EAP releases

### DIFF
--- a/intellij_platform_sdk/BUILD
+++ b/intellij_platform_sdk/BUILD
@@ -38,6 +38,20 @@ config_setting(
 )
 
 config_setting(
+    name = "intellij-canary",
+    values = {
+        "define": "ij_product=intellij-canary",
+    },
+)
+
+config_setting(
+    name = "intellij-ue-canary",
+    values = {
+        "define": "ij_product=intellij-ue-canary",
+    },
+)
+
+config_setting(
     name = "intellij-2019.1",
     values = {
         "define": "ij_product=intellij-2019.1",

--- a/intellij_platform_sdk/build_defs.bzl
+++ b/intellij_platform_sdk/build_defs.bzl
@@ -4,8 +4,10 @@
 INDIRECT_IJ_PRODUCTS = {
     "intellij-latest": "intellij-2019.1",
     "intellij-beta": "intellij-2019.2",
+    "intellij-canary": "intellij-2019.2",  # TODO(b/141539619): switch to 2019.3 after drop
     "intellij-ue-latest": "intellij-ue-2019.1",
     "intellij-ue-beta": "intellij-ue-2019.2",
+    "intellij-ue-canary": "intellij-2019.2",  # TODO(b/141539619): switch to 2019.3 after drop
     "android-studio-latest": "android-studio-3.5",
     "android-studio-beta": "android-studio-3.5",
     "android-studio-beta-mac": "android-studio-3.5-mac",


### PR DESCRIPTION
Create intellij-canary and intellij-ue-canary to bring in EAP releases

https://blog.jetbrains.com/idea/2019/09/intellij-idea-starts-2019-3-early-access-program/