### PR TITLE
Prioritzie scala and kt providers before JavaInfo

### DIFF
--- a/aspect/intellij_info_impl.bzl
+++ b/aspect/intellij_info_impl.bzl
@@ -498,6 +498,10 @@ def collect_c_toolchain_info(target, ctx, semantics, ide_info, ide_info_file, ou
 
 def get_java_provider(target):
     """Find a provider exposing java compilation/outputs data."""
+
+    # Check for scala and kt providers before JavaInfo. e.g. scala targets have
+    # JavaInfo, but their data lives in the "scala" provider and not JavaInfo.
+    # See https://github.com/bazelbuild/intellij/pull/1202
     if hasattr(target, "scala"):
         return target.scala
     if hasattr(target, "kt") and hasattr(target.kt, "outputs"):

--- a/aspect/intellij_info_impl.bzl
+++ b/aspect/intellij_info_impl.bzl
@@ -498,12 +498,12 @@ def collect_c_toolchain_info(target, ctx, semantics, ide_info, ide_info_file, ou
 
 def get_java_provider(target):
     """Find a provider exposing java compilation/outputs data."""
-    if JavaInfo in target:
-        return target[JavaInfo]
     if hasattr(target, "scala"):
         return target.scala
     if hasattr(target, "kt") and hasattr(target.kt, "outputs"):
         return target.kt
+    if JavaInfo in target:
+        return target[JavaInfo]
     return None
 
 def collect_java_info(target, ctx, semantics, ide_info, ide_info_file, output_groups):


### PR DESCRIPTION
While `scala_library` / other Scala rules have `JavaInfo` as well, their Scala-specific data lives in the `scala` provider. Proritizing `JavaInfo` over `scala` causes the plugin to assume that there are no outputs, hence causing all Scala workspaces to fail to resolve ("No Scala SDK added") https://github.com/bazelbuild/intellij/issues/1183

Instead, prioritize `kt` and `scala` providers over `JavaInfo`. 

This wasn't an issue previously because we c[hecked for the legacy "java" provider first](https://github.com/bazelbuild/intellij/commit/5f03bde0f02f5d1693a4567dc129230420a30372), which Scala targets do not have, and the conditional successfully fell through.

This fixes https://github.com/bazelbuild/intellij/issues/1183.