### PR TITLE
Fix running main methods in scala_library directly

### DIFF
--- a/scala/src/com/google/idea/blaze/scala/run/producers/GenerateDeployableJarTaskProvider.java
+++ b/scala/src/com/google/idea/blaze/scala/run/producers/GenerateDeployableJarTaskProvider.java
@@ -183,7 +183,8 @@ class GenerateDeployableJarTaskProvider
 
       List<File> outputs =
           BlazeArtifact.getLocalFiles(
-              buildResultHelper.getBuildArtifactsForTarget(target, file -> true));
+              buildResultHelper.getBuildArtifactsForTarget(
+                  target.withTargetName(target.targetName() + "_deploy.jar"), file -> true));
       if (outputs.isEmpty()) {
         throw new ExecutionException(
             String.format("Failed to find deployable jar when building %s", target));

--- a/scala/src/com/google/idea/blaze/scala/run/producers/GenerateDeployableJarTaskProvider.java
+++ b/scala/src/com/google/idea/blaze/scala/run/producers/GenerateDeployableJarTaskProvider.java
@@ -28,7 +28,6 @@ import com.google.idea.blaze.base.command.buildresult.BlazeArtifact;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtifactsException;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelperProvider;
-import com.google.idea.blaze.base.command.buildresult.OutputArtifact;
 import com.google.idea.blaze.base.console.BlazeConsoleLineProcessorProvider;
 import com.google.idea.blaze.base.issueparser.IssueOutputFilter;
 import com.google.idea.blaze.base.model.primitives.Label;
@@ -182,14 +181,10 @@ class GenerateDeployableJarTaskProvider
         throw new ExecutionException(e);
       }
 
-      ImmutableList<OutputArtifact> deployJars =
-          buildResultHelper.getBuildArtifactsForTarget(
-              target.withTargetName(target.targetName() + "_deploy.jar"), file -> true);
-      ImmutableList<OutputArtifact> regularFiles =
-          buildResultHelper.getBuildArtifactsForTarget(target, file -> true);
       List<File> outputs =
           BlazeArtifact.getLocalFiles(
-              deployJars);
+              buildResultHelper.getBuildArtifactsForTarget(
+                  target.withTargetName(target.targetName() + "_deploy.jar"), file -> true));
       if (outputs.isEmpty()) {
         throw new ExecutionException(
             String.format("Failed to find deployable jar when building %s", target));

--- a/scala/src/com/google/idea/blaze/scala/run/producers/GenerateDeployableJarTaskProvider.java
+++ b/scala/src/com/google/idea/blaze/scala/run/producers/GenerateDeployableJarTaskProvider.java
@@ -28,6 +28,7 @@ import com.google.idea.blaze.base.command.buildresult.BlazeArtifact;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtifactsException;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelperProvider;
+import com.google.idea.blaze.base.command.buildresult.OutputArtifact;
 import com.google.idea.blaze.base.console.BlazeConsoleLineProcessorProvider;
 import com.google.idea.blaze.base.issueparser.IssueOutputFilter;
 import com.google.idea.blaze.base.model.primitives.Label;
@@ -181,10 +182,14 @@ class GenerateDeployableJarTaskProvider
         throw new ExecutionException(e);
       }
 
+      ImmutableList<OutputArtifact> deployJars =
+          buildResultHelper.getBuildArtifactsForTarget(
+              target.withTargetName(target.targetName() + "_deploy.jar"), file -> true);
+      ImmutableList<OutputArtifact> regularFiles =
+          buildResultHelper.getBuildArtifactsForTarget(target, file -> true);
       List<File> outputs =
           BlazeArtifact.getLocalFiles(
-              buildResultHelper.getBuildArtifactsForTarget(
-                  target.withTargetName(target.targetName() + "_deploy.jar"), file -> true));
+              deployJars);
       if (outputs.isEmpty()) {
         throw new ExecutionException(
             String.format("Failed to find deployable jar when building %s", target));


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/intellij/issues/1172

Before https://github.com/bazelbuild/intellij/commit/98d0504fa70b3536184f610f5cee00391f772543#diff-c924e38cec968aa15f096048cb42b57fR185, the deployable jar was not filtered against any label. If the scala library is `//:foo`, the deployable is `//:foo_deploy.jar` according to the parsed bep output, and because they don't match and the deploy jar isn't found, the action fails.

Fix this by searching for `<label>_deploy.jar` instead.