### PR TITLE
Add MissingDependencyTargetProvider to find the Blaze targets that are missing from the dependency set of the rules building a given source file.

### DIFF
--- a/base/BUILD
+++ b/base/BUILD
@@ -199,6 +199,8 @@ java_library(
 java_library(
     name = "dep_finder_api",
     srcs = [
+        "src/com/google/idea/blaze/base/dependencies/MissingDependencyData.java",
+        "src/com/google/idea/blaze/base/dependencies/MissingDependencyTargetProvider.java",
         "src/com/google/idea/blaze/base/dependencies/SourceToTargetProvider.java",
         "src/com/google/idea/blaze/base/dependencies/TargetInfo.java",
         "src/com/google/idea/blaze/base/dependencies/TestSize.java",
@@ -212,6 +214,7 @@ java_library(
         ":proto_wrapper",
         "//intellij_platform_sdk:jsr305",
         "//intellij_platform_sdk:plugin_api",
+        "//third_party/auto_value",
     ],
 )
 

--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -270,7 +270,10 @@
     <consoleFilterProvider implementation="com.google.idea.blaze.base.run.filter.TestLogFilter$Provider"/>
     <codeInsight.lineMarkerProvider
         language="BUILD"
-        implementationClass="com.google.idea.blaze.base.query.MacroLineMarkerProvider"/>
+      implementationClass="com.google.idea.blaze.base.query.MacroLineMarkerProvider"/>
+
+    <projectService serviceInterface="com.google.idea.blaze.base.dependencies.MissingDependencyTargetProvider"
+        serviceImplementation="com.google.idea.blaze.base.dependencies.MissingDependencyTargetProviderImpl"/>
   </extensions>
 
   <extensions defaultExtensionNs="com.intellij">

--- a/base/src/com/google/idea/blaze/base/dependencies/MissingDependencyData.java
+++ b/base/src/com/google/idea/blaze/base/dependencies/MissingDependencyData.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.dependencies;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.idea.blaze.base.model.primitives.Label;
+import com.intellij.psi.PsiReference;
+
+/**
+ * A mapping between a PSI reference in a specific source file and the rules building the source
+ * file that are missing dependencies for the PSI reference. A list of eligible Blaze target rules
+ * to fix the missing dependency is provided for each source file rule.
+ */
+@AutoValue
+public abstract class MissingDependencyData {
+  /** Returns the PSI reference in the source file. */
+  public abstract PsiReference reference();
+
+  /**
+   * Returns the Blaze targets that can be added to each source file rule to fix the dependency.
+   *
+   * <p>The key of the multimap is the label of the source file rule and the value is the Blaze
+   * target to fix the dependency.
+   */
+  public abstract ImmutableListMultimap<Label, Label> dependencyTargets();
+
+  public static Builder builder() {
+    return new AutoValue_MissingDependencyData.Builder();
+  }
+
+  /** Builder for {@link MissingDependencyData}. */
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder setReference(PsiReference value);
+
+    public abstract Builder setDependencyTargets(
+        ImmutableListMultimap<Label, Label> dependencyTargets);
+
+    public abstract MissingDependencyData build();
+  }
+}

--- a/base/src/com/google/idea/blaze/base/dependencies/MissingDependencyTargetProvider.java
+++ b/base/src/com/google/idea/blaze/base/dependencies/MissingDependencyTargetProvider.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.dependencies;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiReference;
+
+/**
+ * Provides the missing Blaze targets that can be added as dependencies to the target rules building
+ * the given source file.
+ */
+public interface MissingDependencyTargetProvider {
+
+  static MissingDependencyTargetProvider getInstance(Project project) {
+    return ServiceManager.getService(project, MissingDependencyTargetProvider.class);
+  }
+
+  /**
+   * Returns the missing dependency targets containing the given referenced elements in their
+   * transitive closures that can be added to the targets building the given source file.
+   *
+   * <p>Each given {@link PsiReference} is a PSI element reference in the specified source file.
+   * Specifically, the referenced element is an element in another source file or library. Here are
+   * some examples for a Java source file:
+   *
+   * <ul>
+   *   <li>A reference to another class or one of the members of another class from an import
+   *       statement.
+   *   <li>A reference to another class or one of the members of another class from the code block
+   *       itself (such as an inline fully qualified class reference).
+   * </ul>
+   *
+   * <p>If one or more Blaze rules building the given source file are missing the dependency for a
+   * {@link PsiReference}, this method returns the list of eligible Blaze target labels that can be
+   * added to the affected rule to fix the dependency encapsulated in {@link MissingDependencyData}
+   * instance.
+   */
+  ImmutableList<MissingDependencyData> getMissingDependencyTargets(
+      PsiFile sourceFile, ImmutableSet<PsiReference> references);
+}

--- a/base/src/com/google/idea/blaze/base/dependencies/MissingDependencyTargetProviderImpl.java
+++ b/base/src/com/google/idea/blaze/base/dependencies/MissingDependencyTargetProviderImpl.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.dependencies;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.Sets;
+import com.google.idea.blaze.base.model.primitives.Label;
+import com.google.idea.blaze.base.targetmaps.SourceToTargetMap;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Computable;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiReference;
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+
+/**
+ * Provides the missing Blaze targets that can be added as dependencies to the target rules building
+ * the given source file.
+ */
+public class MissingDependencyTargetProviderImpl implements MissingDependencyTargetProvider {
+
+  @Override
+  public ImmutableList<MissingDependencyData> getMissingDependencyTargets(
+      PsiFile sourceFile, ImmutableSet<PsiReference> references) {
+    Project project = sourceFile.getProject();
+    ImmutableSetMultimap<Label, Label> dependencies =
+        getDependenciesForSourceFile(project, sourceFile);
+    if (dependencies.isEmpty()) {
+      return ImmutableList.of();
+    }
+    ImmutableList.Builder<MissingDependencyData> result = ImmutableList.builder();
+    references.forEach(
+        reference -> {
+          ImmutableListMultimap<Label, Label> missingDependencyTargets =
+              getMissingDependencyTargets(project, dependencies, reference);
+          if (!missingDependencyTargets.isEmpty()) {
+            result.add(
+                MissingDependencyData.builder()
+                    .setReference(reference)
+                    .setDependencyTargets(missingDependencyTargets)
+                    .build());
+          }
+        });
+    return result.build();
+  }
+
+  private static ImmutableListMultimap<Label, Label> getMissingDependencyTargets(
+      Project project, ImmutableSetMultimap<Label, Label> dependencies, PsiReference reference) {
+    ImmutableListMultimap.Builder<Label, Label> result = ImmutableListMultimap.builder();
+    // TODO(b/138926172): Support libraries in project.
+    File referencedSourceFile = getReferencedSourceFile(reference);
+    if (referencedSourceFile == null) {
+      return ImmutableListMultimap.of();
+    }
+    ImmutableSet<Label> referencedSourceFileTargets =
+        ImmutableSet.copyOf(getTargetsBuildingSourceFile(project, referencedSourceFile));
+    if (referencedSourceFileTargets.isEmpty()) {
+      return ImmutableListMultimap.of();
+    }
+    for (Label sourceTarget : dependencies.keySet()) {
+      // TODO(b/138926172): Check whether the dependency set for the source rule also contains
+      //  targets exporting any of the targets in the "referencedSourceFileTargets" set.
+      Set<Label> existingDependencies =
+          Sets.intersection(referencedSourceFileTargets, dependencies.get(sourceTarget));
+      if (existingDependencies.isEmpty()) {
+        result.putAll(sourceTarget, referencedSourceFileTargets);
+      }
+    }
+    return result.build();
+  }
+
+  @Nullable
+  private static File getReferencedSourceFile(PsiReference reference) {
+    PsiElement resolvedElement =
+        ApplicationManager.getApplication()
+            .runReadAction((Computable<PsiElement>) () -> reference.resolve());
+    if (resolvedElement == null) {
+      return null;
+    }
+    PsiFile containingFile = resolvedElement.getContainingFile();
+    if (containingFile == null) {
+      return null;
+    }
+    return new File(containingFile.getVirtualFile().getPath());
+  }
+
+  private static ImmutableList<Label> getTargetsBuildingSourceFile(Project project, File file) {
+    // TODO(b/138926172): Support Herb/Blaze queries for finding all the targets building a source
+    //  file to take into account the user's local changes.
+    return SourceToTargetMap.getInstance(project).getTargetsToBuildForSourceFile(file);
+  }
+
+  @Nullable
+  private static ImmutableList<Label> getDependencies(Project project, Label target) {
+    List<TargetInfo> dependencies =
+        DependencyFinder.getCompileTimeDependencyTargets(project, target);
+    if (dependencies == null) {
+      return null;
+    }
+    return dependencies.stream()
+        .map(targetInfo -> targetInfo.label)
+        .collect(ImmutableList.toImmutableList());
+  }
+
+  private static ImmutableSetMultimap<Label, Label> getDependenciesForSourceFile(
+      Project project, PsiFile file) {
+    ImmutableList<Label> targets =
+        getTargetsBuildingSourceFile(
+            project, new File(file.getViewProvider().getVirtualFile().getPath()));
+    Map<Label, ImmutableList<Label>> map =
+        targets.stream()
+            .collect(
+                Collectors.toMap(Function.identity(), target -> getDependencies(project, target)));
+    return map.entrySet().stream()
+        .filter(entry -> entry.getValue() != null)
+        .collect(
+            ImmutableSetMultimap.flatteningToImmutableSetMultimap(
+                Map.Entry::getKey, entry -> entry.getValue().stream()));
+  }
+}

--- a/base/tests/integrationtests/com/google/idea/blaze/base/dependencies/MissingDependencyTargetProviderImplTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/dependencies/MissingDependencyTargetProviderImplTest.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.dependencies;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.idea.blaze.base.BlazeIntegrationTestCase;
+import com.google.idea.blaze.base.WorkspaceFileSystem;
+import com.google.idea.blaze.base.ideinfo.ArtifactLocation;
+import com.google.idea.blaze.base.ideinfo.TargetIdeInfo;
+import com.google.idea.blaze.base.ideinfo.TargetMap;
+import com.google.idea.blaze.base.model.BlazeProjectData;
+import com.google.idea.blaze.base.model.MockBlazeProjectDataBuilder;
+import com.google.idea.blaze.base.model.primitives.Label;
+import com.google.idea.blaze.base.model.primitives.WorkspacePath;
+import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
+import com.google.idea.testing.ServiceHelper;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiImportStatement;
+import com.intellij.psi.PsiRecursiveElementWalkingVisitor;
+import com.intellij.psi.PsiReference;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/** Tests for {@link MissingDependencyTargetProviderImpl}. */
+@RunWith(JUnit4.class)
+public class MissingDependencyTargetProviderImplTest extends BlazeIntegrationTestCase {
+
+  private static final String ANIMAL_SOURCE_FILE_RELATIVE_PATH = "java/com/google/test/Animal.java";
+  private static final String[] ANIMAL_SOURCE_FILE_CONTENTS =
+      new String[] {
+        "package com.google.test;",
+        "",
+        "import com.google.test.pet.Cat;",
+        "import com.google.test.pet.Dog;",
+        "import com.google.test.pet.Pig;",
+        "",
+        "public class Animal {",
+        "  public void doSomething() {",
+        "    Dog dog = new Dog();",
+        "    Pig pig = new Pig();",
+        "    Cat cat = new Cat();",
+        "  }",
+        "}"
+      };
+  private static final String CAT_SOURCE_FILE_RELATIVE_PATH = "java/com/google/test/pet/Cat.java";
+  private static final String[] CAT_SOURCE_FILE_CONTENTS =
+      new String[] {"package com.google.test.pet;", "", "public class Cat {}"};
+  private static final String DOG_SOURCE_FILE_RELATIVE_PATH = "java/com/google/test/pet/Dog.java";
+  private static final String[] DOG_SOURCE_FILE_CONTENTS =
+      new String[] {"package com.google.test.pet;", "", "public class Dog {}"};
+  private static final String PIG_SOURCE_FILE_RELATIVE_PATH = "java/com/google/test/pet/Pig.java";
+  private static final String[] PIG_SOURCE_FILE_CONTENTS =
+      new String[] {"package com.google.test.pet;", "", "public class Pig {}"};
+  private static final ImmutableMap<String, String[]> SOURCE_FILE_RELATIVE_PATH_TO_CONTENTS =
+      ImmutableMap.<String, String[]>builder()
+          .put(ANIMAL_SOURCE_FILE_RELATIVE_PATH, ANIMAL_SOURCE_FILE_CONTENTS)
+          .put(CAT_SOURCE_FILE_RELATIVE_PATH, CAT_SOURCE_FILE_CONTENTS)
+          .put(DOG_SOURCE_FILE_RELATIVE_PATH, DOG_SOURCE_FILE_CONTENTS)
+          .put(PIG_SOURCE_FILE_RELATIVE_PATH, PIG_SOURCE_FILE_CONTENTS)
+          .build();
+
+  @Mock private BlazeProjectDataManager mockProjectDataManager;
+
+  private MissingDependencyTargetProviderImpl underTest;
+
+  @Before
+  public void initTest() {
+    MockitoAnnotations.initMocks(this);
+    ServiceHelper.registerProjectService(
+        testFixture.getProject(),
+        BlazeProjectDataManager.class,
+        mockProjectDataManager,
+        getTestRootDisposable());
+    underTest = new MissingDependencyTargetProviderImpl();
+  }
+
+  @Test
+  public void getMissingDependencyTargets_singleTargetBuildingSourceFile() {
+    ImmutableMap<String, PsiFile> sourceFiles = initializeSourceFiles(workspace);
+    ImmutableMap<String, ArtifactLocation> sourceLocations = createSourceLocations();
+    ImmutableList<TargetIdeInfo> ideInfos =
+        ImmutableList.of(
+            createTargetIdeInfo(
+                "//test:animal",
+                sourceLocations.get(ANIMAL_SOURCE_FILE_RELATIVE_PATH),
+                "//test:cat",
+                "//test:pig"),
+            createTargetIdeInfo("//test:cat", sourceLocations.get(CAT_SOURCE_FILE_RELATIVE_PATH)),
+            createTargetIdeInfo(
+                "//test:dog", sourceLocations.get(DOG_SOURCE_FILE_RELATIVE_PATH), "//test:pig"));
+    BlazeProjectData projectData =
+        MockBlazeProjectDataBuilder.builder(workspaceRoot)
+            .setTargetMap(
+                new TargetMap(
+                    ideInfos.stream()
+                        .collect(
+                            ImmutableMap.toImmutableMap(
+                                TargetIdeInfo::getKey, ideInfo -> ideInfo))))
+            .build();
+    PsiFile mainSourceFile = sourceFiles.get(ANIMAL_SOURCE_FILE_RELATIVE_PATH);
+    ImmutableSet<PsiReference> references = getImportReferences(mainSourceFile);
+
+    when(mockProjectDataManager.getBlazeProjectData()).thenReturn(projectData);
+
+    ImmutableList<MissingDependencyData> actual =
+        underTest.getMissingDependencyTargets(mainSourceFile, references);
+
+    PsiReference expectedReference = getReference(references, "Dog");
+    assertThat(actual)
+        .containsExactly(
+            MissingDependencyData.builder()
+                .setReference(expectedReference)
+                .setDependencyTargets(
+                    ImmutableListMultimap.of(
+                        Label.create("//test:animal"), Label.create("//test:dog")))
+                .build());
+  }
+
+  @Test
+  public void getMissingDependencyTargets_multipleTargetsBuildingSourceFile() {
+    ImmutableMap<String, PsiFile> sourceFiles = initializeSourceFiles(workspace);
+    ImmutableMap<String, ArtifactLocation> sourceLocations = createSourceLocations();
+    ImmutableList<TargetIdeInfo> ideInfos =
+        ImmutableList.of(
+            createTargetIdeInfo(
+                "//test1:animal",
+                sourceLocations.get(ANIMAL_SOURCE_FILE_RELATIVE_PATH),
+                "//test2:cat",
+                "//test1:pig"),
+            createTargetIdeInfo(
+                "//test2:animal",
+                sourceLocations.get(ANIMAL_SOURCE_FILE_RELATIVE_PATH),
+                "//test1:cat"),
+            createTargetIdeInfo("//test1:cat", sourceLocations.get(CAT_SOURCE_FILE_RELATIVE_PATH)),
+            createTargetIdeInfo("//test2:cat", sourceLocations.get(CAT_SOURCE_FILE_RELATIVE_PATH)),
+            createTargetIdeInfo("//test1:dog", sourceLocations.get(DOG_SOURCE_FILE_RELATIVE_PATH)),
+            createTargetIdeInfo("//test2:dog", sourceLocations.get(DOG_SOURCE_FILE_RELATIVE_PATH)),
+            createTargetIdeInfo("//test1:pig", sourceLocations.get(PIG_SOURCE_FILE_RELATIVE_PATH)),
+            createTargetIdeInfo("//test2:pig", sourceLocations.get(PIG_SOURCE_FILE_RELATIVE_PATH)));
+    BlazeProjectData projectData =
+        MockBlazeProjectDataBuilder.builder(workspaceRoot)
+            .setTargetMap(
+                new TargetMap(
+                    ideInfos.stream()
+                        .collect(
+                            ImmutableMap.toImmutableMap(
+                                TargetIdeInfo::getKey, ideInfo -> ideInfo))))
+            .build();
+    PsiFile mainSourceFile = sourceFiles.get(ANIMAL_SOURCE_FILE_RELATIVE_PATH);
+    ImmutableSet<PsiReference> references = getImportReferences(mainSourceFile);
+
+    when(mockProjectDataManager.getBlazeProjectData()).thenReturn(projectData);
+
+    ImmutableList<MissingDependencyData> actual =
+        underTest.getMissingDependencyTargets(mainSourceFile, references);
+
+    PsiReference expectedDogReference = getReference(references, "Dog");
+    PsiReference expectedPigReference = getReference(references, "Pig");
+    assertThat(actual)
+        .containsExactly(
+            MissingDependencyData.builder()
+                .setReference(expectedDogReference)
+                .setDependencyTargets(
+                    ImmutableListMultimap.<Label, Label>builder()
+                        .putAll(
+                            Label.create("//test1:animal"),
+                            Label.create("//test1:dog"),
+                            Label.create("//test2:dog"))
+                        .putAll(
+                            Label.create("//test2:animal"),
+                            Label.create("//test1:dog"),
+                            Label.create("//test2:dog"))
+                        .build())
+                .build(),
+            MissingDependencyData.builder()
+                .setReference(expectedPigReference)
+                .setDependencyTargets(
+                    ImmutableListMultimap.<Label, Label>builder()
+                        .putAll(
+                            Label.create("//test2:animal"),
+                            Label.create("//test1:pig"),
+                            Label.create("//test2:pig"))
+                        .build())
+                .build());
+  }
+
+  private static PsiReference getReference(ImmutableSet<PsiReference> references, String text) {
+    return references.stream()
+        .filter(reference -> reference.getCanonicalText().contains(text))
+        .findFirst()
+        .get();
+  }
+
+  private static ImmutableSet<PsiReference> getImportReferences(PsiFile file) {
+    ImmutableSet.Builder<PsiReference> references = ImmutableSet.builder();
+    file.accept(
+        new PsiRecursiveElementWalkingVisitor() {
+          @Override
+          public void visitElement(PsiElement element) {
+            if (element.getParent() instanceof PsiImportStatement) {
+              references.add(element.getReferences());
+            }
+            super.visitElement(element);
+          }
+        });
+    return references.build();
+  }
+
+  private static ImmutableMap<String, PsiFile> initializeSourceFiles(
+      WorkspaceFileSystem workspace) {
+    return SOURCE_FILE_RELATIVE_PATH_TO_CONTENTS.entrySet().stream()
+        .collect(
+            ImmutableMap.toImmutableMap(
+                Map.Entry::getKey,
+                entry -> createSourceFile(workspace, entry.getKey(), entry.getValue())));
+  }
+
+  private static PsiFile createSourceFile(
+      WorkspaceFileSystem workspace, String relativePath, String... contents) {
+    return workspace.createPsiFile(new WorkspacePath(relativePath), contents);
+  }
+
+  private static ImmutableMap<String, ArtifactLocation> createSourceLocations() {
+    return SOURCE_FILE_RELATIVE_PATH_TO_CONTENTS.keySet().stream()
+        .collect(
+            ImmutableMap.toImmutableMap(
+                relativePath -> relativePath,
+                relativePath ->
+                    ArtifactLocation.builder()
+                        .setIsExternal(false)
+                        .setIsSource(true)
+                        .setRelativePath(relativePath)
+                        .build()));
+  }
+
+  private static TargetIdeInfo createTargetIdeInfo(
+      String label, ArtifactLocation sourceLocation, String... dependencies) {
+    // We use "proto_library" here to avoid packaging Java-specific rule classes in the test.
+    TargetIdeInfo.Builder ideInfo =
+        TargetIdeInfo.builder().setLabel(label).setKind("proto_library").addSource(sourceLocation);
+    Arrays.stream(dependencies).forEach(dependency -> ideInfo.addDependency(dependency));
+    return ideInfo.build();
+  }
+}


### PR DESCRIPTION
Add MissingDependencyTargetProvider to find the Blaze targets that are missing from the dependency set of the rules building a given source file.