### PR TITLE
Add support for empty lines and non-root views in bazelignore

### DIFF
--- a/base/src/com/google/idea/blaze/base/sync/projectview/BazelIgnoreParser.java
+++ b/base/src/com/google/idea/blaze/base/sync/projectview/BazelIgnoreParser.java
@@ -48,6 +48,10 @@ public class BazelIgnoreParser {
 
     try {
       for (String path : FileOperationProvider.getInstance().readAllLines(bazelIgnoreFile)) {
+        if (!isEmptyLine(path)) {
+          continue;
+        }
+
         if (path.endsWith("/")) {
           // .bazelignore allows the "/" path suffix, but WorkspacePath doesn't.
           path = path.substring(0, path.length() - 1);
@@ -68,5 +72,9 @@ public class BazelIgnoreParser {
     }
 
     return ignoredPaths.build();
+  }
+
+  private boolean isEmptyLine(String ignore) {
+    return !ignore.trim().isEmpty();
   }
 }

--- a/base/src/com/google/idea/blaze/base/sync/projectview/ImportRoots.java
+++ b/base/src/com/google/idea/blaze/base/sync/projectview/ImportRoots.java
@@ -98,11 +98,14 @@ public final class ImportRoots {
 
     public ImportRoots build() {
       ImmutableCollection<WorkspacePath> rootDirectories = rootDirectoriesBuilder.build();
-      if (buildSystem == BuildSystem.Bazel && hasWorkspaceRoot(rootDirectories)) {
-        excludeBuildSystemArtifacts();
-        excludeProjectDataSubDirectory();
+      if (buildSystem == BuildSystem.Bazel) {
+        if(hasWorkspaceRoot(rootDirectories)) {
+          excludeBuildSystemArtifacts();
+          excludeProjectDataSubDirectory();
+        }
         excludeBazelIgnoredPaths();
       }
+
       ImmutableSet<WorkspacePath> minimalExcludes =
           WorkspacePathUtil.calculateMinimalWorkspacePaths(excludeDirectoriesBuilder.build());
 

--- a/base/tests/integrationtests/com/google/idea/blaze/base/sync/ImportRootsTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/sync/ImportRootsTest.java
@@ -270,4 +270,40 @@ public class ImportRootsTest extends BlazeIntegrationTestCase {
         .containsExactly(
             new WorkspacePath("root0"), new WorkspacePath(new WorkspacePath("root1"), "dir"));
   }
+
+  @Test
+  public void testBazelIgnoreParser_skipsEmptyLines() throws Exception {
+    workspace.createFile(new WorkspacePath(".bazelignore"), "root0\n     \n\nroot1/dir/\n\n");
+    BazelIgnoreParser parser = new BazelIgnoreParser(workspaceRoot);
+    assertThat(parser.getIgnoredPaths())
+        .containsExactly(
+             new WorkspacePath("root0"), new WorkspacePath(new WorkspacePath("root1"), "dir"));
+  }
+
+  @Test
+  public void testBlazeBuildsDoNotUseBazelIgnore() throws Exception {
+    workspace.createFile(new WorkspacePath(".bazelignore"), "root1/a/b");
+
+    ImportRoots importRoots =
+        ImportRoots.builder(workspaceRoot, BuildSystem.Blaze)
+            .add(DirectoryEntry.include(new WorkspacePath("root0")))
+            .add(DirectoryEntry.include(new WorkspacePath("root1/a/b/c")))
+            .build();
+
+    assertThat(importRoots.containsWorkspacePath(new WorkspacePath("root1/a/b/c"))).isTrue();
+  }
+
+
+  @Test
+  public void testIgnoresPathsFromBazelIgnore() throws Exception {
+    workspace.createFile(new WorkspacePath(".bazelignore"), "root1/a/b");
+
+    ImportRoots importRoots =
+        ImportRoots.builder(workspaceRoot, BuildSystem.Bazel)
+            .add(DirectoryEntry.include(new WorkspacePath("root0")))
+            .add(DirectoryEntry.include(new WorkspacePath("root1/a/b/c")))
+            .build();
+
+    assertThat(importRoots.containsWorkspacePath(new WorkspacePath("root1/a/b/c"))).isFalse();
+  }
 }

--- a/cpp/tests/unittests/com/google/idea/blaze/cpp/BlazeConfigurationResolverTest.java
+++ b/cpp/tests/unittests/com/google/idea/blaze/cpp/BlazeConfigurationResolverTest.java
@@ -33,6 +33,7 @@ import com.google.idea.blaze.base.ideinfo.TargetIdeInfo;
 import com.google.idea.blaze.base.ideinfo.TargetKey;
 import com.google.idea.blaze.base.ideinfo.TargetMap;
 import com.google.idea.blaze.base.ideinfo.TargetMapBuilder;
+import com.google.idea.blaze.base.io.FileOperationProvider;
 import com.google.idea.blaze.base.io.VirtualFileSystemProvider;
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.MockBlazeProjectDataBuilder;
@@ -92,6 +93,7 @@ public class BlazeConfigurationResolverTest extends BlazeTestCase {
     applicationServices.register(ProgressManager.class, new ProgressManagerImpl());
     applicationServices.register(CompilerWrapperProvider.class, new CompilerWrapperProviderImpl());
     applicationServices.register(VirtualFileManager.class, mock(VirtualFileManager.class));
+    applicationServices.register(FileOperationProvider.class, new FileOperationProvider());
     mockFileSystem = mock(LocalFileSystem.class);
     applicationServices.register(
         VirtualFileSystemProvider.class, mock(VirtualFileSystemProvider.class));

--- a/cpp/tests/unittests/com/google/idea/blaze/cpp/BlazeResolveConfigurationEquivalenceTest.java
+++ b/cpp/tests/unittests/com/google/idea/blaze/cpp/BlazeResolveConfigurationEquivalenceTest.java
@@ -35,6 +35,7 @@ import com.google.idea.blaze.base.ideinfo.CToolchainIdeInfo;
 import com.google.idea.blaze.base.ideinfo.TargetIdeInfo;
 import com.google.idea.blaze.base.ideinfo.TargetMap;
 import com.google.idea.blaze.base.ideinfo.TargetMapBuilder;
+import com.google.idea.blaze.base.io.FileOperationProvider;
 import com.google.idea.blaze.base.io.VirtualFileSystemProvider;
 import com.google.idea.blaze.base.model.MockBlazeProjectDataBuilder;
 import com.google.idea.blaze.base.model.primitives.ExecutionRootPath;
@@ -96,6 +97,7 @@ public class BlazeResolveConfigurationEquivalenceTest extends BlazeTestCase {
     applicationServices.register(ProgressManager.class, new ProgressManagerImpl());
     applicationServices.register(CompilerWrapperProvider.class, new CompilerWrapperProviderImpl());
     applicationServices.register(VirtualFileManager.class, mock(VirtualFileManager.class));
+    applicationServices.register(FileOperationProvider.class, new FileOperationProvider());
     mockFileSystem = mock(LocalFileSystem.class);
     applicationServices.register(
         VirtualFileSystemProvider.class, mock(VirtualFileSystemProvider.class));

--- a/scala/tests/unittests/com/google/idea/blaze/java/sync/source/ScalaSourceDirectoryCalculatorTest.java
+++ b/scala/tests/unittests/com/google/idea/blaze/java/sync/source/ScalaSourceDirectoryCalculatorTest.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.idea.blaze.base.BlazeTestCase;
 import com.google.idea.blaze.base.ideinfo.ArtifactLocation;
 import com.google.idea.blaze.base.ideinfo.TargetKey;
+import com.google.idea.blaze.base.io.FileOperationProvider;
 import com.google.idea.blaze.base.io.InputStreamProvider;
 import com.google.idea.blaze.base.io.MockInputStreamProvider;
 import com.google.idea.blaze.base.model.primitives.Label;
@@ -73,7 +74,7 @@ public class ScalaSourceDirectoryCalculatorTest extends BlazeTestCase {
     applicationServices.register(JavaSourcePackageReader.class, new JavaSourcePackageReader());
     applicationServices.register(PackageManifestReader.class, new PackageManifestReader());
     applicationServices.register(PrefetchService.class, new MockPrefetchService());
-
+    applicationServices.register(FileOperationProvider.class, new FileOperationProvider());
 
 
     ExtensionPoint<JavaLikeLanguage> javaLikeLanguages =

--- a/scala/tests/unittests/com/google/idea/blaze/scala/sync/importer/BlazeScalaWorkspaceImporterTest.java
+++ b/scala/tests/unittests/com/google/idea/blaze/scala/sync/importer/BlazeScalaWorkspaceImporterTest.java
@@ -26,6 +26,7 @@ import com.google.idea.blaze.base.ideinfo.LibraryArtifact;
 import com.google.idea.blaze.base.ideinfo.TargetIdeInfo;
 import com.google.idea.blaze.base.ideinfo.TargetMap;
 import com.google.idea.blaze.base.ideinfo.TargetMapBuilder;
+import com.google.idea.blaze.base.io.FileOperationProvider;
 import com.google.idea.blaze.base.model.LibraryKey;
 import com.google.idea.blaze.base.model.primitives.GenericBlazeRules;
 import com.google.idea.blaze.base.model.primitives.Kind;
@@ -111,6 +112,7 @@ public class BlazeScalaWorkspaceImporterTest extends BlazeTestCase {
     applicationServices.register(PrefetchService.class, new MockPrefetchService());
     applicationServices.register(PackageManifestReader.class, new PackageManifestReader());
     applicationServices.register(ExperimentService.class, new MockExperimentService());
+    applicationServices.register(FileOperationProvider.class, new FileOperationProvider());
 
     // will silently fall back to FilePathJavaPackageReader
     applicationServices.register(


### PR DESCRIPTION
Adds:
- parsing of `.bazelignore` file ignores empty lines
- fix bazelignore support in case project view does not contain workspace root
- moves parser tests to a separate class
