### PR TITLE
Add more flexible BUILD file target name matching.

### DIFF
--- a/base/src/com/google/idea/blaze/base/actions/BuildFileUtils.java
+++ b/base/src/com/google/idea/blaze/base/actions/BuildFileUtils.java
@@ -15,6 +15,12 @@
  */
 package com.google.idea.blaze.base.actions;
 
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.idea.blaze.base.lang.buildfile.psi.BuildFile;
+import com.google.idea.blaze.base.lang.buildfile.psi.FuncallExpression;
+import com.google.idea.blaze.base.lang.buildfile.psi.LoadStatement;
 import com.google.idea.blaze.base.lang.buildfile.references.BuildReferenceManager;
 import com.google.idea.blaze.base.lang.buildfile.search.BlazePackage;
 import com.google.idea.blaze.base.model.BlazeProjectData;
@@ -22,17 +28,23 @@ import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.model.primitives.WorkspacePath;
 import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
 import com.google.idea.blaze.base.targetmaps.SourceToTargetMap;
+import com.google.idea.common.experiments.BoolExperiment;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFileSystemItem;
 import com.intellij.psi.PsiManager;
 import java.io.File;
+import java.util.Arrays;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /** BUILD-file utility methods used by actions. */
 final class BuildFileUtils {
   private BuildFileUtils() {}
+
+  static final BoolExperiment enableMacroPrefixMatching =
+      new BoolExperiment("buildfile.macro.prefix.matching.enabled", true);
 
   @Nullable
   static BlazePackage getBuildFile(Project project, @Nullable VirtualFile vf) {
@@ -63,15 +75,54 @@ final class BuildFileUtils {
       return null;
     }
     Label label =
-        SourceToTargetMap.getInstance(project)
-            .getTargetsToBuildForSourceFile(file)
-            .stream()
+        SourceToTargetMap.getInstance(project).getTargetsToBuildForSourceFile(file).stream()
             .filter(l -> l.blazePackage().equals(packagePath))
             .findFirst()
             .orElse(null);
     if (label == null) {
       return null;
     }
-    return BuildReferenceManager.getInstance(project).resolveLabel(label);
+
+    PsiElement targetElement = BuildReferenceManager.getInstance(project).resolveLabel(label);
+    if (targetElement != null) {
+      return targetElement;
+    }
+
+    if (enableMacroPrefixMatching.getValue()) {
+      Label macroWithMatchingPrefix = findMacroWithMatchingPrefix(parentPackage.buildFile, label);
+      if (macroWithMatchingPrefix != null) {
+        return BuildReferenceManager.getInstance(project).resolveLabel(macroWithMatchingPrefix);
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Returns the label of a macro with name prefixing the target name of a given label with a '_' or
+   * '-' delimiter.
+   */
+  @Nullable
+  @VisibleForTesting
+  static Label findMacroWithMatchingPrefix(BuildFile buildFile, Label label) {
+    Set<String> loadedSymbols =
+        Arrays.stream(buildFile.findChildrenByClass(LoadStatement.class))
+            .flatMap(l -> Arrays.stream(l.getVisibleSymbolNames()))
+            .collect(toImmutableSet());
+
+    String nameToMatch = label.targetName().toString();
+    for (FuncallExpression expr : buildFile.findChildrenByClass(FuncallExpression.class)) {
+      String name = expr.getNameArgumentValue();
+      if (loadedSymbols.contains(expr.getFunctionName())
+          && name != null
+          && name.length() < nameToMatch.length()
+          && nameToMatch.startsWith(name)
+          && (nameToMatch.charAt(name.length()) == '_'
+              || nameToMatch.charAt(name.length()) == '-')) {
+        return label.withTargetName(name);
+      }
+    }
+
+    return null;
   }
 }

--- a/base/tests/integrationtests/com/google/idea/blaze/base/actions/BuildFileUtilsTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/actions/BuildFileUtilsTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.actions;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.idea.blaze.base.lang.buildfile.BuildFileIntegrationTestCase;
+import com.google.idea.blaze.base.lang.buildfile.psi.BuildFile;
+import com.google.idea.blaze.base.model.primitives.Label;
+import com.google.idea.blaze.base.model.primitives.WorkspacePath;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link com.google.idea.blaze.base.actions.BuildFileUtils} */
+@RunWith(JUnit4.class)
+public class BuildFileUtilsTest extends BuildFileIntegrationTestCase {
+  @Before
+  public void setupMacroDefinitionFile() {
+    workspace.createPsiFile(new WorkspacePath("foo/bar/BUILD"));
+    workspace.createPsiFile(new WorkspacePath("foo/bar/build_defs.bzl"));
+  }
+
+  @Test
+  public void findMacroWithMatchingPrefix_onlyMatchMacros() {
+    BuildFile buildFile =
+        createBuildFile(
+            new WorkspacePath("java/com/google/BUILD"),
+            "load('//foo/bar:build_defs.bzl', 'symbol')",
+            "java_test(",
+            "    name = \"my_lib_test\"",
+            ")",
+            "symbol(",
+            "    name = \"my_lib\"",
+            ")");
+
+    Label foundMacro =
+        BuildFileUtils.findMacroWithMatchingPrefix(
+            buildFile, Label.create("//java/com/google:my_lib_test_some_suffix"));
+
+    assertThat(foundMacro).isEqualTo(Label.create("//java/com/google:my_lib"));
+  }
+
+  @Test
+  public void findMacroWithMatchingPrefix_delimitedByDash() {
+    BuildFile buildFile =
+        createBuildFile(
+            new WorkspacePath("java/com/google/BUILD"),
+            "load('//foo/bar:build_defs.bzl', 'symbol')",
+            "symbol(",
+            "    name = \"my_lib\"",
+            ")");
+
+    Label foundMacro =
+        BuildFileUtils.findMacroWithMatchingPrefix(
+            buildFile, Label.create("//java/com/google:my_lib-test_some_suffix"));
+
+    assertThat(foundMacro).isEqualTo(Label.create("//java/com/google:my_lib"));
+  }
+
+  @Test
+  public void findMacroWithMatchingPrefix_notDelimitedByDashOrUnderscore() {
+    BuildFile buildFile =
+        createBuildFile(
+            new WorkspacePath("java/com/google/BUILD"),
+            "load('//foo/bar:build_defs.bzl', 'symbol')",
+            "symbol(",
+            "    name = \"my_lib\"",
+            ")");
+
+    Label foundMacro =
+        BuildFileUtils.findMacroWithMatchingPrefix(
+            buildFile, Label.create("//java/com/google:my_lib.some_suffix"));
+
+    assertThat(foundMacro).isNull();
+  }
+
+  @Test
+  public void findMacroWithMatchingPrefix_noMatchingMacro() {
+    BuildFile buildFile =
+        createBuildFile(
+            new WorkspacePath("java/com/google/BUILD"),
+            "java_test(",
+            "    name = \"my_lib_test\"",
+            ")");
+
+    Label foundMacro =
+        BuildFileUtils.findMacroWithMatchingPrefix(
+            buildFile, Label.create("//java/com/google:my_lib_test_some_suffix"));
+
+    assertThat(foundMacro).isNull();
+  }
+}


### PR DESCRIPTION
Add more flexible BUILD file target name matching.

kt_jvm_library currently produces java IDE info with target names
plus a "_DO_NOT_DEPEND_JVM" at the end. This breaks BUILD file target
name matching.  

This CL fixes issues like these by augmenting BuildFileUtils#findBuildTarget
to look for a macro with matching prefix when the target isn't in the BUILD
file.

When a label is calculated, #findBuildTarget first checks to see if the
label actually points to a target in the corresponding BUILD file.
If it doesn't, then it iterates through the named macros in the BUILD
file until it finds one with name matching the beginning of the label.

The new macro prefix matching mechanism is enabled by the flag 
"buildfile.macro.prefix.matching.enabled"