### PR TITLE
Improve automatic source jar redirection.

### DIFF
--- a/java/src/com/google/idea/blaze/java/libraries/BlazeAttachSourceProvider.java
+++ b/java/src/com/google/idea/blaze/java/libraries/BlazeAttachSourceProvider.java
@@ -95,13 +95,11 @@ public class BlazeAttachSourceProvider implements AttachSourcesProvider {
     // Hack: When sources are requested and we have them, we attach them automatically in the
     // background.
     if (attachAutomatically.getValue()) {
-      ActionCallback callback = new ActionCallback().doWhenDone(() -> navigateToSource(psiFile));
       TransactionGuard.getInstance()
           .submitTransactionLater(
               project,
               () -> {
                 attachSources(project, blazeProjectData, librariesToAttachSourceTo);
-                callback.setDone();
               });
       return ImmutableList.of();
     }


### PR DESCRIPTION
Improve automatic source jar redirection.

The plugin now just attaches the source jar automatically. Once that's done, IntelliJ will automatically navigate to the correct position in the source jar.