### PR TITLE
Guard against NPE when validating instrumentation binary.

### DIFF
--- a/aswb/src/com/google/idea/blaze/android/run/test/BlazeAndroidTestRunConfigurationHandler.java
+++ b/aswb/src/com/google/idea/blaze/android/run/test/BlazeAndroidTestRunConfigurationHandler.java
@@ -104,6 +104,9 @@ public class BlazeAndroidTestRunConfigurationHandler
     }
     TargetMap targetMap = projectData.getTargetMap();
     TargetIdeInfo instrumentationTest = targetMap.get(TargetKey.forPlainTarget(label));
+    if (instrumentationTest == null) {
+      return null;
+    }
     for (Dependency dependency : instrumentationTest.getDependencies()) {
       TargetIdeInfo dependencyInfo = targetMap.get(dependency.getTargetKey());
       // Should exist via test_app attribute, and be unique.


### PR DESCRIPTION
Guard against NPE when validating instrumentation binary.

Validating a android test run config in ASwB involves obtaining the
instrumentation binary of the test through project target map.  It's
possible for a run config to have stale information and cause it to
NPE when a matching target can't be found.  