### PR TITLE
Create test case to test sync with BlazeSdkProivder

### DIFF
--- a/aswb/BUILD
+++ b/aswb/BUILD
@@ -50,6 +50,17 @@ stamped_plugin_xml(
 )
 
 java_library(
+    name = "unit_test_utils",
+    testonly = 1,
+    srcs = glob(["tests/utils/unit/**/*.java"]),
+    deps = [
+        ":aswb_lib",
+        "//intellij_platform_sdk:plugin_api_for_tests",
+        "//intellij_platform_sdk:test_libs",
+    ],
+)
+
+java_library(
     name = "integration_test_utils",
     testonly = 1,
     srcs = glob(["tests/utils/integration/**/*.java"]),
@@ -92,6 +103,7 @@ intellij_unit_test_suite(
     test_package_root = "com.google.idea.blaze.android",
     deps = [
         ":aswb_lib",
+        ":unit_test_utils",
         "//base",
         "//base:unit_test_utils",
         "//common/experiments",
@@ -133,6 +145,7 @@ intellij_integration_test_suite(
     deps = [
         ":aswb_lib",
         ":integration_test_utils",
+        ":unit_test_utils",
         "//base",
         "//base:integration_test_utils",
         "//base:unit_test_utils",

--- a/aswb/src/META-INF/aswb.xml
+++ b/aswb/src/META-INF/aswb.xml
@@ -35,8 +35,7 @@
     <projectService serviceImplementation="com.google.idea.blaze.android.projectsystem.BlazeProjectSystemSyncManager$LastSyncResultCache"/>
     <applicationService serviceImplementation="com.google.idea.blaze.android.settings.BlazeAndroidUserSettings"/>
     <applicationService serviceInterface="com.google.idea.blaze.android.sdk.BlazeSdkProvider"
-      serviceImplementation="com.google.idea.blaze.android.sdk.BlazeSdkProviderImpl"
-      testServiceImplementation="com.google.idea.blaze.android.sdk.MockBlazeSdkProvider"/>
+      serviceImplementation="com.google.idea.blaze.android.sdk.BlazeSdkProviderImpl"/>
     <dom.fileDescription implementation="com.google.idea.blaze.android.resources.BlazeResourcesDomFileDescription"/>
     <moduleService serviceImplementation="com.google.idea.blaze.android.projectsystem.BlazeModuleSystem"/>
     <runConfigurationProducer

--- a/aswb/src/com/google/idea/blaze/android/sdk/MockBlazeSdkProvider.java
+++ b/aswb/src/com/google/idea/blaze/android/sdk/MockBlazeSdkProvider.java
@@ -24,7 +24,7 @@ import java.util.Map.Entry;
 import javax.annotation.Nullable;
 
 /** Indirection to Sdks for testing purposes. */
-public class MockBlazeSdkProvider extends BlazeSdkProviderImpl {
+public class MockBlazeSdkProvider implements BlazeSdkProvider {
   Map<String, Sdk> sdks = Maps.newHashMap();
 
   public void addSdk(String targetHash, Sdk sdk) {

--- a/aswb/src/com/google/idea/blaze/android/sync/sdk/AndroidSdkFromProjectView.java
+++ b/aswb/src/com/google/idea/blaze/android/sync/sdk/AndroidSdkFromProjectView.java
@@ -37,6 +37,13 @@ import org.jetbrains.android.sdk.AndroidSdkAdditionalData;
 
 /** Calculates AndroidSdkPlatform. */
 public class AndroidSdkFromProjectView {
+  private static final Joiner COMMA_JOINER = Joiner.on(", ");
+  public static final String NO_SDK_ERROR_TEMPLATE =
+      "No such android_sdk_platform: '%s'. "
+          + "Available android_sdk_platforms are: %s. "
+          + "Please change android_sdk_platform or run SDK manager "
+          + "to download missing SDK platforms.";
+
   @Nullable
   public static AndroidSdkPlatform getAndroidSdkPlatform(
       BlazeContext context, ProjectViewSet projectViewSet) {
@@ -85,14 +92,7 @@ public class AndroidSdkFromProjectView {
     if (sdk == null) {
       ProjectViewFile projectViewFile = projectViewSet.getTopLevelProjectViewFile();
       IssueOutput.error(
-              ("No such android_sdk_platform: '"
-                  + androidSdk
-                  + "'. "
-                  + "Available android_sdk_platforms are: "
-                  + getAvailableTargetHashesAsList(sdks)
-                  + ". "
-                  + "Please change android_sdk_platform or run SDK manager "
-                  + "to download missing SDK platforms."))
+              String.format(NO_SDK_ERROR_TEMPLATE, androidSdk, getAllAvailableTargetHashes()))
           .inFile(projectViewFile != null ? projectViewFile.projectViewFile : null)
           .submit(context);
       return null;
@@ -118,7 +118,12 @@ public class AndroidSdkFromProjectView {
   }
 
   private static String getAvailableTargetHashesAsList(Collection<Sdk> sdks) {
-    return Joiner.on(", ").join(getAvailableSdkTargetHashes(sdks));
+    return COMMA_JOINER.join(getAvailableSdkTargetHashes(sdks));
+  }
+
+  private static String getAllAvailableTargetHashes() {
+    return COMMA_JOINER.join(
+        getAvailableSdkTargetHashes(BlazeSdkProvider.getInstance().getAllAndroidSdks()));
   }
 
   private static int getAndroidSdkApiLevel(Sdk sdk) {

--- a/aswb/src/com/google/idea/blaze/android/sync/sdk/SdkUtil.java
+++ b/aswb/src/com/google/idea/blaze/android/sync/sdk/SdkUtil.java
@@ -78,7 +78,7 @@ public class SdkUtil {
     ShowSettingsUtil.getInstance().showSettingsDialog(null, configurable.getClass());
   }
 
-  private static boolean containsJarAndRes(Sdk sdk) {
+  public static boolean containsJarAndRes(Sdk sdk) {
     VirtualFile[] classes = sdk.getRootProvider().getFiles(OrderRootType.CLASSES);
     // A valid sdk must contains path to android.jar and res
     if (classes.length < 2) {

--- a/aswb/tests/integrationtests/com/google/idea/blaze/android/AswbGotoDeclarationTest.java
+++ b/aswb/tests/integrationtests/com/google/idea/blaze/android/AswbGotoDeclarationTest.java
@@ -49,7 +49,7 @@ public class AswbGotoDeclarationTest extends BlazeAndroidIntegrationTestCase {
         "targets:",
         "  //java/com/foo/gallery/activities:activities",
         "android_sdk_platform: android-27");
-    mockSdk("android-27", "Android 27 SDK");
+    MockSdkUtil.registerSdk(workspace, "27");
   }
 
   @After

--- a/aswb/tests/integrationtests/com/google/idea/blaze/android/functional/AswbMergedManifestTest.java
+++ b/aswb/tests/integrationtests/com/google/idea/blaze/android/functional/AswbMergedManifestTest.java
@@ -22,6 +22,7 @@ import static com.google.idea.blaze.android.targetmapbuilder.NbAndroidTarget.and
 import com.android.tools.idea.model.MergedManifestManager;
 import com.android.tools.lint.checks.PermissionHolder;
 import com.google.idea.blaze.android.BlazeAndroidIntegrationTestCase;
+import com.google.idea.blaze.android.MockSdkUtil;
 import com.google.idea.blaze.base.model.primitives.WorkspacePath;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleManager;
@@ -44,7 +45,7 @@ public class AswbMergedManifestTest extends BlazeAndroidIntegrationTestCase {
         "targets:",
         "  //java/com/example/...:all",
         "android_sdk_platform: android-27");
-    mockSdk("android-27", "Android 27 SDK");
+    MockSdkUtil.registerSdk(workspace, "27");
   }
 
   @Test

--- a/aswb/tests/integrationtests/com/google/idea/blaze/android/functional/BlazeModuleSystemDependentLibrariesIntegrationTest.java
+++ b/aswb/tests/integrationtests/com/google/idea/blaze/android/functional/BlazeModuleSystemDependentLibrariesIntegrationTest.java
@@ -29,6 +29,7 @@ import com.android.projectmodel.SelectiveResourceFolder;
 import com.android.tools.idea.projectsystem.GoogleMavenArtifactId;
 import com.google.common.collect.ImmutableList;
 import com.google.idea.blaze.android.BlazeAndroidIntegrationTestCase;
+import com.google.idea.blaze.android.MockSdkUtil;
 import com.google.idea.blaze.android.libraries.AarLibraryFileBuilder;
 import com.google.idea.blaze.android.libraries.UnpackedAars;
 import com.google.idea.blaze.android.projectsystem.BlazeModuleSystem;
@@ -117,8 +118,7 @@ public class BlazeModuleSystemDependentLibrariesIntegrationTest
         "targets:",
         "  //java/com/google:app",
         "android_sdk_platform: android-27");
-
-    mockSdk("android-27", "Android 27 SDK");
+    MockSdkUtil.registerSdk(workspace, "27");
 
     NbAarTarget aarTarget =
         aar_import(aarFile)

--- a/aswb/tests/integrationtests/com/google/idea/blaze/android/functional/BlazeModuleSystemExternalDependencyIntegrationTest.java
+++ b/aswb/tests/integrationtests/com/google/idea/blaze/android/functional/BlazeModuleSystemExternalDependencyIntegrationTest.java
@@ -22,6 +22,7 @@ import com.android.ide.common.repository.GradleCoordinate;
 import com.android.tools.idea.projectsystem.GoogleMavenArtifactId;
 import com.google.common.collect.ImmutableMap;
 import com.google.idea.blaze.android.BlazeAndroidIntegrationTestCase;
+import com.google.idea.blaze.android.MockSdkUtil;
 import com.google.idea.blaze.android.projectsystem.BlazeModuleSystem;
 import com.google.idea.blaze.android.projectsystem.MavenArtifactLocator;
 import com.google.idea.blaze.base.model.primitives.Label;
@@ -74,7 +75,7 @@ public class BlazeModuleSystemExternalDependencyIntegrationTest
         "targets:",
         "  //java/com/foo/gallery/activities:activities",
         "android_sdk_platform: android-27");
-    mockSdk("android-27", "Android 27 SDK");
+    MockSdkUtil.registerSdk(workspace, "27");
 
     workspace.createFile(
         new WorkspacePath("java/com/foo/gallery/activities/MainActivity.java"),

--- a/aswb/tests/integrationtests/com/google/idea/blaze/android/projectsystem/BlazeSampleDataDirectoryProviderTest.java
+++ b/aswb/tests/integrationtests/com/google/idea/blaze/android/projectsystem/BlazeSampleDataDirectoryProviderTest.java
@@ -23,6 +23,7 @@ import static com.google.idea.blaze.android.targetmapbuilder.NbAndroidTarget.and
 
 import com.android.ide.common.util.PathString;
 import com.google.idea.blaze.android.BlazeAndroidIntegrationTestCase;
+import com.google.idea.blaze.android.MockSdkUtil;
 import com.google.idea.blaze.base.model.primitives.WorkspacePath;
 import com.intellij.openapi.application.WriteAction;
 import com.intellij.openapi.module.Module;
@@ -50,7 +51,7 @@ public class BlazeSampleDataDirectoryProviderTest extends BlazeAndroidIntegratio
         "targets:",
         "  //com/google/example:main",
         "android_sdk_platform: android-25");
-    mockSdk("android-25", "Android 25 SDK");
+    MockSdkUtil.registerSdk(workspace, "25");
 
     workspaceDir = workspace.createDirectory(new WorkspacePath("com/google/example"));
     resDir = workspace.createFile(new WorkspacePath("com/google/example/res"));

--- a/aswb/tests/utils/integration/com/google/idea/blaze/android/BlazeAndroidIntegrationTestCase.java
+++ b/aswb/tests/utils/integration/com/google/idea/blaze/android/BlazeAndroidIntegrationTestCase.java
@@ -16,11 +16,7 @@
 package com.google.idea.blaze.android;
 
 import static com.google.idea.blaze.android.targetmapbuilder.NbTargetBuilder.targetMap;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
-import com.google.idea.blaze.android.sdk.BlazeSdkProvider;
-import com.google.idea.blaze.android.sdk.MockBlazeSdkProvider;
 import com.google.idea.blaze.android.targetmapbuilder.NbTargetBuilder;
 import com.google.idea.blaze.base.ideinfo.TargetMap;
 import com.google.idea.blaze.base.settings.BuildSystem;
@@ -29,8 +25,6 @@ import com.google.idea.blaze.base.sync.BlazeSyncIntegrationTestCase;
 import com.google.idea.blaze.base.sync.BlazeSyncParams;
 import com.google.idea.blaze.base.sync.JdepsFileWriter;
 import com.google.idea.blaze.base.sync.SyncMode;
-import com.intellij.openapi.projectRoots.Sdk;
-import com.intellij.openapi.projectRoots.SdkTypeId;
 import org.junit.Rule;
 
 /** Base class for integration tests that require an ASwB project setup. */
@@ -53,16 +47,6 @@ public class BlazeAndroidIntegrationTestCase extends BlazeSyncIntegrationTestCas
     TargetMap targetMap = targetMap(builders);
     setTargetMap(targetMap);
     JdepsFileWriter.writeDefaultJdepsFiles(getExecRoot(), fileSystem, targetMap);
-  }
-
-  public static void mockSdk(String targetHash, String sdkName) {
-    SdkTypeId sdkType = mock(SdkTypeId.class);
-    when(sdkType.getName()).thenReturn("Android SDK");
-    Sdk sdk = mock(Sdk.class);
-    when(sdk.getName()).thenReturn(sdkName);
-    when(sdk.getSdkType()).thenReturn(sdkType);
-    MockBlazeSdkProvider sdkProvider = (MockBlazeSdkProvider) BlazeSdkProvider.getInstance();
-    sdkProvider.addSdk(targetHash, sdk);
   }
 
   protected void runFullBlazeSync() {

--- a/aswb/tests/utils/integration/com/google/idea/blaze/android/MockSdkUtil.java
+++ b/aswb/tests/utils/integration/com/google/idea/blaze/android/MockSdkUtil.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.android;
+
+import com.google.idea.blaze.base.WorkspaceFileSystem;
+import com.google.idea.blaze.base.model.primitives.WorkspacePath;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.projectRoots.ProjectJdkTable;
+import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.openapi.projectRoots.impl.MockSdk;
+import com.intellij.openapi.roots.OrderRootType;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.testFramework.EdtTestUtil;
+import com.intellij.util.containers.MultiMap;
+import org.jetbrains.android.sdk.AndroidSdkAdditionalData;
+import org.jetbrains.android.sdk.AndroidSdkType;
+
+/**
+ * Helper to create mock SDKs.
+ *
+ * <p>Sync tests need register SDKs to {link @ProjectJdkTable} for their test projects since the SDK
+ * is needed during sync. However, {link @ProjectJdkTable} will only treat a SDK as valid if it can
+ * access expected SDK files with expected content in disk. {link #registerSdkWithJdkTable} is
+ * provided to handle all files creation and registration to mock a SDK.
+ */
+public class MockSdkUtil {
+
+  private static final WorkspacePath SDK_DIR = new WorkspacePath("sdk");
+  private static final WorkspacePath PLATFORM_DIR = new WorkspacePath(SDK_DIR, "platforms");
+  private static final String TARGET_HASH = "android-%s";
+  private static final String SDK_NAME = "Android %s SDK";
+
+  private MockSdkUtil() {}
+
+  /**
+   * Creates a mock SDK and register it in {@link ProjectJdkTable}.
+   *
+   * <p>All dummy files will be created in disks which are used by {@link
+   * com.android.tools.idea.sdk.AndroidSdks#tryToCreate} or {@link
+   * com.android.tools.idea.sdk.IdeSdks#getEligibleAndroidSdks}. It helps {@link ProjectJdkTable} to
+   * make sure a SDK is valid. All sync test with heavy test fixture are recommended to use this
+   * method to improve coverage.
+   *
+   * @param workspace test file system
+   * @param major major version of SDK
+   * @return a mock sdk for the given target and name. The sdk is registered with the {@link
+   *     ProjectJdkTable}.
+   */
+  public static Sdk registerSdk(WorkspaceFileSystem workspace, String major) {
+    String targetHash = String.format(TARGET_HASH, major);
+    MultiMap<OrderRootType, VirtualFile> roots = MultiMap.create();
+    roots.putValue(
+        OrderRootType.CLASSES,
+        workspace.createFile(new WorkspacePath(PLATFORM_DIR, targetHash + "/android.jar")));
+    roots.putValue(
+        OrderRootType.CLASSES,
+        workspace.createDirectory(new WorkspacePath(PLATFORM_DIR, targetHash + "/data/res")));
+
+    return registerSdk(workspace, major, "0", roots, true);
+  }
+
+  /**
+   * Creates a mock SDK and register it in {@link ProjectJdkTable}.
+   *
+   * <p>Same as {link #registerSdk} but provides user ability to customize root content of SDK and
+   * dummy files to create. It can be used to mock corrupt {@link ProjectJdkTable}/ missing SDK in
+   * local.
+   *
+   * @param workspace test file system
+   * @param major major version of SDK
+   * @param minor minor version of SDK
+   * @param roots root content of SDK
+   * @param createSubFiles whether create subdirectory and files in file system for SDK. Set this to
+   *     false would lead to fail to add SDK to Jdk table and cannot retrieve its repo package
+   * @return a mock sdk for the given target and name. The sdk is registered with the {@link
+   *     ProjectJdkTable}.
+   */
+  public static Sdk registerSdk(
+      WorkspaceFileSystem workspace,
+      String major,
+      String minor,
+      MultiMap<OrderRootType, VirtualFile> roots,
+      boolean createSubFiles) {
+    String targetHash = String.format(TARGET_HASH, major);
+    String sdkName = String.format(SDK_NAME, major);
+    WorkspacePath workspacePathToAndroid = new WorkspacePath(PLATFORM_DIR, targetHash);
+
+    if (createSubFiles) {
+      workspace.createFile(
+          new WorkspacePath(workspacePathToAndroid, "package.xml"),
+          "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>",
+          "<ns2:repository xmlns:ns2=\"http://schemas.android.com/repository/android/common/01\"",
+          " xmlns:ns3=\"http://schemas.android.com/repository/android/generic/01\"",
+          " xmlns:ns4=\"http://schemas.android.com/sdk/android/repo/addon2/01\"",
+          " xmlns:ns5=\"http://schemas.android.com/sdk/android/repo/repository2/01\"",
+          " xmlns:ns6=\"http://schemas.android.com/sdk/android/repo/sys-img2/01\">",
+          "<localPackage path=\"platforms;" + targetHash + "\" obsolete=\"false\">",
+          "<type-details xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\""
+              + " xsi:type=\"ns5:platformDetailsType\">",
+          "<api-level>",
+          major,
+          "</api-level>",
+          "<layoutlib api=\"15\"/>",
+          "</type-details>",
+          "<revision>",
+          " <major>",
+          major,
+          " </major>",
+          " <minor>",
+          minor,
+          " </minor>",
+          " <micro>",
+          "0",
+          " </micro>",
+          "</revision>",
+          "<display-name>",
+          sdkName,
+          "</display-name>",
+          "</localPackage>",
+          "</ns2:repository>");
+      workspace.createFile(new WorkspacePath(workspacePathToAndroid, "build.prop"));
+      workspace.createFile(new WorkspacePath(workspacePathToAndroid, "android.jar"));
+      workspace.createDirectory(new WorkspacePath(workspacePathToAndroid, "data/res"));
+      workspace.createFile(new WorkspacePath(workspacePathToAndroid, "data/annotations.zip"));
+    }
+    MockSdk sdk =
+        new MockSdk(
+            sdkName,
+            workspace.createDirectory(SDK_DIR).getPath(),
+            String.format("%s.%s.0", major, minor),
+            roots,
+            AndroidSdkType.getInstance());
+    AndroidSdkAdditionalData data = new AndroidSdkAdditionalData(sdk);
+    data.setBuildTargetHashString(targetHash);
+    sdk.setSdkAdditionalData(data);
+    EdtTestUtil.runInEdtAndWait(
+        () ->
+            ApplicationManager.getApplication()
+                .runWriteAction(() -> ProjectJdkTable.getInstance().addJdk(sdk)));
+    return sdk;
+  }
+}

--- a/aswb/tests/utils/unit/com/google/idea/blaze/android/LightWeightMockSdkUtil.java
+++ b/aswb/tests/utils/unit/com/google/idea/blaze/android/LightWeightMockSdkUtil.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.android;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.idea.blaze.android.sdk.BlazeSdkProvider;
+import com.google.idea.blaze.android.sdk.BlazeSdkProviderImpl;
+import com.google.idea.blaze.android.sdk.MockBlazeSdkProvider;
+import com.intellij.openapi.projectRoots.ProjectJdkTable;
+import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.openapi.projectRoots.SdkTypeId;
+
+/**
+ * Helper to create mock SDKs for light test case.
+ *
+ * <p>Consider light test case cannot create files in disk, they cannot create register SDK by using
+ * {link MockSdkUtil#registerSdk}. This helper class provide alternative method to register mock
+ * SDK.
+ */
+public class LightWeightMockSdkUtil {
+
+  private LightWeightMockSdkUtil() {}
+
+  /**
+   * A light weight way to mock SDK.
+   *
+   * <p>This method help light sync test cases to retrieve sdk of project without creating dummy sdk
+   * files. SDK will be maintained by {@link MockBlazeSdkProvider} instead of {@link
+   * ProjectJdkTable}. But all functions in {@link BlazeSdkProviderImpl} cannot be test due to
+   * override by {@link MockBlazeSdkProvider}
+   *
+   * <p>Note that user is expected to register MockBlazeSdkProvider as application service before
+   * this method.
+   *
+   * @param targetHash code name of SDK
+   * @param sdkName display name of SDK
+   * @param sdkProvider the MockBlazeSdkProvider to register mock sdk
+   * @return a mock sdk for the given target and name. The sdk is registered with the {@link
+   *     MockBlazeSdkProvider}. Note that this SDK is not added to {@link ProjectJdkTable}
+   */
+  public static Sdk registerSdk(
+      String targetHash, String sdkName, MockBlazeSdkProvider sdkProvider) {
+    SdkTypeId sdkType = mock(SdkTypeId.class);
+    when(sdkType.getName()).thenReturn("Android SDK");
+    Sdk sdk = mock(Sdk.class);
+    when(sdk.getName()).thenReturn(sdkName);
+    when(sdk.getSdkType()).thenReturn(sdkType);
+    assert sdkProvider.equals(BlazeSdkProvider.getInstance());
+    sdkProvider.addSdk(targetHash, sdk);
+    return sdk;
+  }
+}

--- a/base/tests/utils/unit/com/google/idea/blaze/base/TestUtils.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/TestUtils.java
@@ -138,4 +138,22 @@ public class TestUtils {
           }
         });
   }
+
+  /**
+   * Sets a system property, reverting to the previous value when the supplied parent disposable is
+   * disposed.
+   */
+  public static void setSystemProperties(Disposable parentDisposable, String key, String value) {
+    String prevValue = System.getProperty(key);
+    System.setProperty(key, value);
+    Disposer.register(
+        parentDisposable,
+        () -> {
+          if (prevValue != null) {
+            System.setProperty(key, value);
+          } else {
+            System.clearProperty(key);
+          }
+        });
+  }
 }


### PR DESCRIPTION
Create test case to test sync with BlazeSdkProivder

Previous, we mock sdk by using Mockito and MockBlazeSdkProvider which is quick but bypass BlazeSdkProivder. So we cannot verify the part that IDE retrieve Sdk from jdk table. 