### PR TITLE
Fix go debug path resolving.

### DIFF
--- a/golang/src/META-INF/go-contents.xml
+++ b/golang/src/META-INF/go-contents.xml
@@ -21,7 +21,8 @@
         order="before default"/>
     <packageFactory implementation="com.google.idea.blaze.golang.resolve.BlazeGoPackageFactory"/>
     <dlv.positionConverterFactory
-        implementation="com.google.idea.blaze.golang.run.BlazeDlvPositionConverter$Factory"/>
+        implementation="com.google.idea.blaze.golang.run.BlazeDlvPositionConverter$Factory"
+        order="first"/>
   </extensions>
 
   <extensions defaultExtensionNs="com.google.idea.blaze">


### PR DESCRIPTION
Fix go debug path resolving.

1. Move the extension first. There's a new position converter
   extension that moved in front of the blaze one.
2. Fix resolving to GOROOT paths.