### PR TITLE
Associate an ID with each blaze build during sync, and communicate it to SyncListener along with the synced targets.

### DIFF
--- a/aswb/src/com/google/idea/blaze/android/cppimpl/BlazeNdkSupportEnabler.java
+++ b/aswb/src/com/google/idea/blaze/android/cppimpl/BlazeNdkSupportEnabler.java
@@ -18,6 +18,7 @@ package com.google.idea.blaze.android.cppimpl;
 import static com.jetbrains.cidr.lang.OCLanguage.LANGUAGE_SUPPORT_DISABLED;
 
 import com.android.tools.ndk.NdkHelper;
+import com.google.common.collect.ImmutableSet;
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.primitives.LanguageClass;
 import com.google.idea.blaze.base.projectview.ProjectViewSet;
@@ -39,6 +40,7 @@ final class BlazeNdkSupportEnabler implements SyncListener {
       BlazeContext context,
       BlazeImportSettings importSettings,
       ProjectViewSet projectViewSet,
+      ImmutableSet<Integer> buildIds,
       BlazeProjectData blazeProjectData,
       SyncMode syncMode,
       SyncResult syncResult) {

--- a/aswb/src/com/google/idea/blaze/android/manifest/ParsedManifestService.java
+++ b/aswb/src/com/google/idea/blaze/android/manifest/ParsedManifestService.java
@@ -17,6 +17,7 @@ package com.google.idea.blaze.android.manifest;
 
 import static com.google.idea.blaze.android.manifest.ManifestParser.parseManifestFromInputStream;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.projectview.ProjectViewSet;
@@ -79,6 +80,7 @@ public class ParsedManifestService {
         BlazeContext context,
         BlazeImportSettings importSettings,
         ProjectViewSet projectViewSet,
+        ImmutableSet<Integer> buildIds,
         BlazeProjectData blazeProjectData,
         SyncMode syncMode,
         SyncResult syncResult) {

--- a/aswb/src/com/google/idea/blaze/android/projectsystem/BlazeProjectSystemSyncManager.java
+++ b/aswb/src/com/google/idea/blaze/android/projectsystem/BlazeProjectSystemSyncManager.java
@@ -19,6 +19,7 @@ import static com.android.tools.idea.projectsystem.ProjectSystemSyncUtil.PROJECT
 
 import com.android.annotations.VisibleForTesting;
 import com.android.tools.idea.projectsystem.ProjectSystemSyncManager;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.idea.blaze.base.scope.BlazeContext;
@@ -138,7 +139,8 @@ public class BlazeProjectSystemSyncManager implements ProjectSystemSyncManager {
         Project project,
         BlazeContext context,
         SyncMode syncMode,
-        com.google.idea.blaze.base.sync.SyncResult syncResult) {
+        com.google.idea.blaze.base.sync.SyncResult syncResult,
+        ImmutableSet<Integer> buildIds) {
 
       LastSyncResultCache lastSyncResultCache = LastSyncResultCache.getInstance(project);
 

--- a/aswb/src/com/google/idea/blaze/android/sync/BlazeAndroidSyncListener.java
+++ b/aswb/src/com/google/idea/blaze/android/sync/BlazeAndroidSyncListener.java
@@ -16,6 +16,7 @@
 package com.google.idea.blaze.android.sync;
 
 import com.android.tools.idea.res.ResourceFolderRegistry;
+import com.google.common.collect.ImmutableSet;
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.sync.SyncListener;
 import com.google.idea.blaze.base.sync.SyncMode;
@@ -27,7 +28,11 @@ import com.intellij.openapi.project.Project;
 public class BlazeAndroidSyncListener implements SyncListener {
   @Override
   public void afterSync(
-      Project project, BlazeContext context, SyncMode syncMode, SyncResult syncResult) {
+      Project project,
+      BlazeContext context,
+      SyncMode syncMode,
+      SyncResult syncResult,
+      ImmutableSet<Integer> buildIds) {
     if (syncResult.successful()) {
       DumbService dumbService = DumbService.getInstance(project);
       dumbService.queueTask(new ResourceFolderRegistry.PopulateCachesTask(project));

--- a/base/src/com/google/idea/blaze/base/dependencies/ExternalFileProjectManagementHelper.java
+++ b/base/src/com/google/idea/blaze/base/dependencies/ExternalFileProjectManagementHelper.java
@@ -16,6 +16,7 @@
 package com.google.idea.blaze.base.dependencies;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -189,6 +190,7 @@ public class ExternalFileProjectManagementHelper
         BlazeContext context,
         BlazeImportSettings importSettings,
         ProjectViewSet projectViewSet,
+        ImmutableSet<Integer> buildIds,
         BlazeProjectData blazeProjectData,
         SyncMode syncMode,
         SyncResult syncResult) {

--- a/base/src/com/google/idea/blaze/base/run/BlazeRunConfigurationSyncListener.java
+++ b/base/src/com/google/idea/blaze/base/run/BlazeRunConfigurationSyncListener.java
@@ -15,6 +15,7 @@
  */
 package com.google.idea.blaze.base.run;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.primitives.Label;
@@ -57,6 +58,7 @@ public class BlazeRunConfigurationSyncListener implements SyncListener {
       BlazeContext context,
       BlazeImportSettings importSettings,
       ProjectViewSet projectViewSet,
+      ImmutableSet<Integer> buildIds,
       BlazeProjectData blazeProjectData,
       SyncMode syncMode,
       SyncResult syncResult) {

--- a/base/src/com/google/idea/blaze/base/sync/BlazeSyncModificationTracker.java
+++ b/base/src/com/google/idea/blaze/base/sync/BlazeSyncModificationTracker.java
@@ -15,6 +15,7 @@
  */
 package com.google.idea.blaze.base.sync;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.project.Project;
@@ -38,7 +39,11 @@ public final class BlazeSyncModificationTracker {
   static class Updater implements SyncListener {
     @Override
     public void afterSync(
-        Project project, BlazeContext context, SyncMode syncMode, SyncResult syncResult) {
+        Project project,
+        BlazeContext context,
+        SyncMode syncMode,
+        SyncResult syncResult,
+        ImmutableSet<Integer> buildIds) {
       ((SimpleModificationTracker) getInstance(project)).incModificationCount();
     }
   }

--- a/base/src/com/google/idea/blaze/base/sync/SimpleSyncListenerService.java
+++ b/base/src/com/google/idea/blaze/base/sync/SimpleSyncListenerService.java
@@ -15,6 +15,7 @@
  */
 package com.google.idea.blaze.base.sync;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.intellij.openapi.project.Project;
 
@@ -22,7 +23,11 @@ import com.intellij.openapi.project.Project;
 public class SimpleSyncListenerService implements SyncListener {
   @Override
   public void afterSync(
-      Project project, BlazeContext context, SyncMode syncMode, SyncResult syncResult) {
+      Project project,
+      BlazeContext context,
+      SyncMode syncMode,
+      SyncResult syncResult,
+      ImmutableSet<Integer> buildIds) {
     for (SimpleSyncListener listener : SimpleSyncListener.EP_NAME.getExtensions()) {
       listener.syncFinished(project, syncMode, syncResult);
     }

--- a/base/src/com/google/idea/blaze/base/sync/SyncCache.java
+++ b/base/src/com/google/idea/blaze/base/sync/SyncCache.java
@@ -16,6 +16,7 @@
 package com.google.idea.blaze.base.sync;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.projectview.ProjectViewSet;
@@ -75,6 +76,7 @@ public class SyncCache {
         BlazeContext context,
         BlazeImportSettings importSettings,
         ProjectViewSet projectViewSet,
+        ImmutableSet<Integer> buildIds,
         BlazeProjectData blazeProjectData,
         SyncMode syncMode,
         SyncResult syncResult) {

--- a/base/src/com/google/idea/blaze/base/sync/SyncListener.java
+++ b/base/src/com/google/idea/blaze/base/sync/SyncListener.java
@@ -15,7 +15,10 @@
  */
 package com.google.idea.blaze.base.sync;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.idea.blaze.base.model.BlazeProjectData;
+import com.google.idea.blaze.base.model.primitives.TargetExpression;
 import com.google.idea.blaze.base.projectview.ProjectViewSet;
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.settings.BlazeImportSettings;
@@ -30,17 +33,34 @@ public interface SyncListener {
   /** Called after open documents have been saved, prior to starting the blaze sync. */
   default void onSyncStart(Project project, BlazeContext context, SyncMode syncMode) {}
 
+  /**
+   * Called just prior to starting a blaze build during sync.
+   *
+   * @param buildId a unique ID associated with each sync build. {@link #afterSync} is guaranteed to
+   *     be called with this build ID at some point.
+   */
+  default void buildStarted(
+      Project project,
+      BlazeContext context,
+      int buildId,
+      ImmutableList<TargetExpression> targets) {}
+
   /** Called on successful (or partially successful) completion of a sync */
   default void onSyncComplete(
       Project project,
       BlazeContext context,
       BlazeImportSettings importSettings,
       ProjectViewSet projectViewSet,
+      ImmutableSet<Integer> buildIds,
       BlazeProjectData blazeProjectData,
       SyncMode syncMode,
       SyncResult syncResult) {}
 
   /** Guaranteed to be called once per sync, regardless of whether it successfully completed */
   default void afterSync(
-      Project project, BlazeContext context, SyncMode syncMode, SyncResult syncResult) {}
+      Project project,
+      BlazeContext context,
+      SyncMode syncMode,
+      SyncResult syncResult,
+      ImmutableSet<Integer> buildIds) {}
 }

--- a/base/src/com/google/idea/blaze/base/sync/libraries/ExternalLibraryManager.java
+++ b/base/src/com/google/idea/blaze/base/sync/libraries/ExternalLibraryManager.java
@@ -20,6 +20,7 @@ import static com.google.common.collect.ImmutableMap.toImmutableMap;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
@@ -119,7 +120,11 @@ public class ExternalLibraryManager {
 
     @Override
     public void afterSync(
-        Project project, BlazeContext context, SyncMode syncMode, SyncResult syncResult) {
+        Project project,
+        BlazeContext context,
+        SyncMode syncMode,
+        SyncResult syncResult,
+        ImmutableSet<Integer> buildIds) {
       ExternalLibraryManager manager = ExternalLibraryManager.getInstance(project);
       if (syncMode == SyncMode.STARTUP) {
         BlazeProjectData blazeProjectData =

--- a/base/src/com/google/idea/blaze/base/sync/projectview/WorkspaceFileFinderImpl.java
+++ b/base/src/com/google/idea/blaze/base/sync/projectview/WorkspaceFileFinderImpl.java
@@ -15,6 +15,7 @@
  */
 package com.google.idea.blaze.base.sync.projectview;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.primitives.WorkspacePath;
 import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
@@ -45,6 +46,7 @@ class WorkspaceFileFinderImpl implements SyncListener, WorkspaceFileFinder {
       BlazeContext context,
       BlazeImportSettings importSettings,
       ProjectViewSet projectViewSet,
+      ImmutableSet<Integer> buildIds,
       BlazeProjectData blazeProjectData,
       SyncMode syncMode,
       SyncResult syncResult) {

--- a/base/src/com/google/idea/blaze/base/sync/status/BlazeSyncStatusListener.java
+++ b/base/src/com/google/idea/blaze/base/sync/status/BlazeSyncStatusListener.java
@@ -15,6 +15,7 @@
  */
 package com.google.idea.blaze.base.sync.status;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.sync.SyncListener;
 import com.google.idea.blaze.base.sync.SyncMode;
@@ -34,7 +35,11 @@ public class BlazeSyncStatusListener implements SyncListener {
 
   @Override
   public void afterSync(
-      Project project, BlazeContext context, SyncMode syncMode, SyncResult syncResult) {
+      Project project,
+      BlazeContext context,
+      SyncMode syncMode,
+      SyncResult syncResult,
+      ImmutableSet<Integer> buildIds) {
     BlazeSyncStatusImpl.getImpl(project).syncEnded(syncMode, syncResult);
   }
 }

--- a/base/tests/unittests/com/google/idea/blaze/base/sync/libraries/ExternalLibraryManagerTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/sync/libraries/ExternalLibraryManagerTest.java
@@ -19,6 +19,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.idea.blaze.base.BlazeTestCase;
 import com.google.idea.blaze.base.io.VirtualFileSystemProvider;
@@ -172,7 +173,8 @@ public final class ExternalLibraryManagerTest extends BlazeTestCase {
         null);
     assertThat(libraryProvider.getAdditionalProjectLibraries(project)).isNotEmpty();
 
-    syncListener.afterSync(project, context, SyncMode.INCREMENTAL, SyncResult.SUCCESS);
+    syncListener.afterSync(
+        project, context, SyncMode.INCREMENTAL, SyncResult.SUCCESS, ImmutableSet.of());
     assertThat(libraryProvider.getAdditionalProjectLibraries(project)).isNotEmpty();
   }
 
@@ -189,7 +191,8 @@ public final class ExternalLibraryManagerTest extends BlazeTestCase {
     syncListener.onSyncStart(project, context, SyncMode.INCREMENTAL);
     assertThat(libraryProvider.getAdditionalProjectLibraries(project)).isEmpty();
 
-    syncListener.afterSync(project, context, SyncMode.INCREMENTAL, SyncResult.FAILURE);
+    syncListener.afterSync(
+        project, context, SyncMode.INCREMENTAL, SyncResult.FAILURE, ImmutableSet.of());
     assertThat(libraryProvider.getAdditionalProjectLibraries(project)).isNotEmpty();
   }
 
@@ -208,7 +211,7 @@ public final class ExternalLibraryManagerTest extends BlazeTestCase {
           null,
           null);
     }
-    syncListener.afterSync(project, context, SyncMode.INCREMENTAL, syncResult);
+    syncListener.afterSync(project, context, SyncMode.INCREMENTAL, syncResult, ImmutableSet.of());
   }
 
   private SyntheticLibrary getExternalLibrary() {

--- a/cpp/src/com/google/idea/blaze/cpp/BulkSymbolTableBuildingChangeListener.java
+++ b/cpp/src/com/google/idea/blaze/cpp/BulkSymbolTableBuildingChangeListener.java
@@ -16,6 +16,7 @@
 package com.google.idea.blaze.cpp;
 
 import com.google.common.base.Stopwatch;
+import com.google.common.collect.ImmutableSet;
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.primitives.LanguageClass;
 import com.google.idea.blaze.base.model.primitives.WorkspacePath;
@@ -203,6 +204,7 @@ public class BulkSymbolTableBuildingChangeListener implements BulkFileListener {
         BlazeContext context,
         BlazeImportSettings importSettings,
         ProjectViewSet projectViewSet,
+        ImmutableSet<Integer> buildIds,
         BlazeProjectData blazeProjectData,
         SyncMode syncMode,
         SyncResult syncResult) {

--- a/golang/src/com/google/idea/blaze/golang/sync/BlazeGoSdkUpdater.java
+++ b/golang/src/com/google/idea/blaze/golang/sync/BlazeGoSdkUpdater.java
@@ -19,6 +19,7 @@ import com.goide.project.GoModuleSettings;
 import com.goide.sdk.GoSdk;
 import com.goide.sdk.GoSdkService;
 import com.goide.sdk.GoSdkUtil;
+import com.google.common.collect.ImmutableSet;
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.primitives.LanguageClass;
 import com.google.idea.blaze.base.projectview.ProjectViewSet;
@@ -49,6 +50,7 @@ public class BlazeGoSdkUpdater implements SyncListener {
       BlazeContext context,
       BlazeImportSettings importSettings,
       ProjectViewSet projectViewSet,
+      ImmutableSet<Integer> buildIds,
       BlazeProjectData blazeProjectData,
       SyncMode syncMode,
       SyncResult syncResult) {

--- a/java/src/com/google/idea/blaze/java/libraries/DetachAllSourceJarsAction.java
+++ b/java/src/com/google/idea/blaze/java/libraries/DetachAllSourceJarsAction.java
@@ -15,6 +15,7 @@
  */
 package com.google.idea.blaze.java.libraries;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.idea.blaze.base.actions.BlazeProjectAction;
 import com.google.idea.blaze.base.model.BlazeProjectData;
@@ -97,6 +98,7 @@ class DetachAllSourceJarsAction extends BlazeProjectAction {
         BlazeContext context,
         BlazeImportSettings importSettings,
         ProjectViewSet projectViewSet,
+        ImmutableSet<Integer> buildIds,
         BlazeProjectData blazeProjectData,
         SyncMode syncMode,
         SyncResult syncResult) {

--- a/javascript/src/com/google/idea/blaze/typescript/BlazeTypeScriptConfigServiceImpl.java
+++ b/javascript/src/com/google/idea/blaze/typescript/BlazeTypeScriptConfigServiceImpl.java
@@ -196,6 +196,7 @@ class BlazeTypeScriptConfigServiceImpl implements TypeScriptConfigServiceCompat 
         BlazeContext context,
         BlazeImportSettings importSettings,
         ProjectViewSet projectViewSet,
+        ImmutableSet<Integer> buildIds,
         BlazeProjectData blazeProjectData,
         SyncMode syncMode,
         SyncResult syncResult) {

--- a/kotlin/src/com/google/idea/blaze/kotlin/sync/BlazeKotlinSyncPlugin.java
+++ b/kotlin/src/com/google/idea/blaze/kotlin/sync/BlazeKotlinSyncPlugin.java
@@ -301,7 +301,11 @@ public class BlazeKotlinSyncPlugin implements BlazeSyncPlugin {
   static class Listener implements SyncListener {
     @Override
     public void afterSync(
-        Project project, BlazeContext context, SyncMode syncMode, SyncResult syncResult) {
+        Project project,
+        BlazeContext context,
+        SyncMode syncMode,
+        SyncResult syncResult,
+        ImmutableSet<Integer> buildIds) {
       BlazeProjectData blazeProjectData =
           BlazeProjectDataManager.getInstance(project).getBlazeProjectData();
       if (blazeProjectData == null


### PR DESCRIPTION
Associate an ID with each blaze build during sync, and communicate it to SyncListener along with the synced targets.