### PR TITLE
Use ManifestParser.ParsedManifest in BlazeAndroidDeployInfo

### DIFF
--- a/aswb/src/com/google/idea/blaze/android/run/binary/BlazeAndroidBinaryApplicationIdProvider.java
+++ b/aswb/src/com/google/idea/blaze/android/run/binary/BlazeAndroidBinaryApplicationIdProvider.java
@@ -35,12 +35,10 @@ public class BlazeAndroidBinaryApplicationIdProvider implements ApplicationIdPro
     BlazeAndroidDeployInfo deployInfo = buildStep.getDeployInfo();
     ManifestParser.ParsedManifest parsedManifest = deployInfo.getMergedManifest();
     if (parsedManifest == null) {
-      throw new ApkProvisionException(
-          "Could not find merged manifest: " + deployInfo.getMergedManifestFile());
+      throw new ApkProvisionException("Could not find merged manifest.");
     }
     if (parsedManifest.packageName == null) {
-      throw new ApkProvisionException(
-          "No application id in merged manifest: " + deployInfo.getMergedManifestFile());
+      throw new ApkProvisionException("No application id in merged manifest.");
     }
     return parsedManifest.packageName;
   }

--- a/aswb/src/com/google/idea/blaze/android/run/deployinfo/BlazeAndroidDeployInfo.java
+++ b/aswb/src/com/google/idea/blaze/android/run/deployinfo/BlazeAndroidDeployInfo.java
@@ -15,86 +15,52 @@
  */
 package com.google.idea.blaze.android.run.deployinfo;
 
-import com.google.common.collect.Lists;
-import com.google.devtools.build.lib.rules.android.deployinfo.AndroidDeployInfoOuterClass;
 import com.google.idea.blaze.android.manifest.ManifestParser;
-import com.google.idea.blaze.android.manifest.ParsedManifestService;
-import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.openapi.project.Project;
+import com.google.idea.blaze.android.manifest.ManifestParser.ParsedManifest;
 import java.io.File;
-import java.io.IOException;
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
-/** Info about the android_binary/android_test to deploy. */
+/** Info about the deployment phase. */
 public class BlazeAndroidDeployInfo {
-  private static final Logger log = Logger.getInstance(BlazeAndroidDeployInfo.class);
-  private final Project project;
-  private final File executionRoot;
-  private final AndroidDeployInfoOuterClass.AndroidDeployInfo deployInfo;
+  private final ParsedManifest mergedManifest;
+  @Nullable private final ParsedManifest testTargetMergedManifest;
+  private final List<File> apksToDeploy;
 
+  /**
+   * Note: Not every deployment has a test target, so {@param testTargetMergedManifest} can be null.
+   */
   public BlazeAndroidDeployInfo(
-      Project project,
-      File executionRoot,
-      AndroidDeployInfoOuterClass.AndroidDeployInfo deployInfo) {
-    this.project = project;
-    this.executionRoot = executionRoot;
-    this.deployInfo = deployInfo;
+      ParsedManifest mergedManifest,
+      @Nullable ParsedManifest testTargetMergedManifest,
+      List<File> apksToDeploy) {
+    this.mergedManifest = mergedManifest;
+    this.testTargetMergedManifest = testTargetMergedManifest;
+    this.apksToDeploy = apksToDeploy;
   }
 
-  public File getMergedManifestFile() {
-    return new File(executionRoot, deployInfo.getMergedManifest().getExecRootPath());
-  }
-
-  @Nullable
+  /**
+   * Returns parsed manifest of the main target for this deployment. During normal app deployment,
+   * the main target is the android_binary that builds the app itself. During instrumentation tests
+   * the main target is the android_binary/android_test target responsible for instrumenting the
+   * app, while the merged manifest of the app under test can be obtained through {@link
+   * BlazeAndroidDeployInfo#getTestTargetMergedManifest()}.
+   */
   public ManifestParser.ParsedManifest getMergedManifest() {
-    File manifestFile = getMergedManifestFile();
-    try {
-      return ParsedManifestService.getInstance(project).getParsedManifest(manifestFile);
-    } catch (IOException e) {
-      log.warn("Could not read merged manifest file: " + manifestFile);
-      return null;
-    }
+    return mergedManifest;
   }
 
-  private List<File> getAdditionalMergedManifestFiles() {
-    return deployInfo
-        .getAdditionalMergedManifestsList()
-        .stream()
-        .map(artifact -> new File(executionRoot, artifact.getExecRootPath()))
-        .collect(Collectors.toList());
-  }
-
-  public List<ManifestParser.ParsedManifest> getAdditionalMergedManifest() {
-    return getAdditionalMergedManifestFiles().stream()
-        .map(
-            file -> {
-              try {
-                return ParsedManifestService.getInstance(project).getParsedManifest(file);
-              } catch (IOException e) {
-                log.warn("Could not read merged manifest file: " + file);
-                return null;
-              }
-            })
-        .filter(Objects::nonNull)
-        .collect(Collectors.toList());
-  }
-
-  public List<File> getManifestFiles() {
-    List<File> result = Lists.newArrayList();
-    result.add(getMergedManifestFile());
-    result.addAll(getAdditionalMergedManifestFiles());
-    return result;
+  /**
+   * Returns parsed manifest of the app under test during an instrumentation test. This method
+   * returns null in all other scenarios.
+   */
+  @Nullable
+  public ManifestParser.ParsedManifest getTestTargetMergedManifest() {
+    return testTargetMergedManifest;
   }
 
   /** Returns the full list of apks to deploy, if any. */
-  public List<File> getApksToDeploy() {
-    return deployInfo
-        .getApksToDeployList()
-        .stream()
-        .map(artifact -> new File(executionRoot, artifact.getExecRootPath()))
-        .collect(Collectors.toList());
+  List<File> getApksToDeploy() {
+    return apksToDeploy;
   }
 }

--- a/aswb/src/com/google/idea/blaze/android/run/test/ConnectBlazeTestDebuggerTask.java
+++ b/aswb/src/com/google/idea/blaze/android/run/test/ConnectBlazeTestDebuggerTask.java
@@ -80,7 +80,7 @@ class ConnectBlazeTestDebuggerTask extends ConnectDebuggerTask {
       @NotNull ProcessHandlerLaunchStatus state,
       @NotNull ProcessHandlerConsolePrinter printer) {
     try {
-      String packageName = applicationIdProvider.getPackageName();
+      String packageName = applicationIdProvider.getTestPackageName();
       setUpForReattachingDebugger(packageName, launchInfo, state, printer);
     } catch (ApkProvisionException e) {
       LOG.error(e);

--- a/aswb/tests/unittests/com/google/idea/blaze/android/run/binary/BlazeAndroidBinaryApplicationIdProviderTest.java
+++ b/aswb/tests/unittests/com/google/idea/blaze/android/run/binary/BlazeAndroidBinaryApplicationIdProviderTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.android.run.binary;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.when;
+
+import com.android.tools.idea.run.ApkProvisionException;
+import com.google.common.collect.ImmutableList;
+import com.google.idea.blaze.android.manifest.ManifestParser.ParsedManifest;
+import com.google.idea.blaze.android.run.deployinfo.BlazeAndroidDeployInfo;
+import com.google.idea.blaze.android.run.runner.BlazeApkBuildStep;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+
+/**
+ * Unit tests for {@link
+ * com.google.idea.blaze.android.run.binary.BlazeAndroidBinaryApplicationIdProvider}
+ */
+@RunWith(JUnit4.class)
+public class BlazeAndroidBinaryApplicationIdProviderTest {
+  @Test
+  public void getApplicationId() throws Exception {
+    ParsedManifest manifest = new ParsedManifest("package.name", ImmutableList.of(), null);
+    BlazeAndroidDeployInfo deployInfo =
+        new BlazeAndroidDeployInfo(manifest, null, ImmutableList.of());
+    BlazeApkBuildStep mockBuildStep = Mockito.mock(BlazeApkBuildStep.class);
+    when(mockBuildStep.getDeployInfo()).thenReturn(deployInfo);
+
+    BlazeAndroidBinaryApplicationIdProvider provider =
+        new BlazeAndroidBinaryApplicationIdProvider(mockBuildStep);
+    assertThat(provider.getPackageName()).isEqualTo("package.name");
+  }
+
+  @Test
+  public void getApplicationId_noPackageNameInMergedManifest() throws Exception {
+    ParsedManifest manifest = new ParsedManifest(null, ImmutableList.of(), null);
+    BlazeAndroidDeployInfo deployInfo =
+        new BlazeAndroidDeployInfo(manifest, null, ImmutableList.of());
+    BlazeApkBuildStep mockBuildStep = Mockito.mock(BlazeApkBuildStep.class);
+    when(mockBuildStep.getDeployInfo()).thenReturn(deployInfo);
+
+    BlazeAndroidBinaryApplicationIdProvider provider =
+        new BlazeAndroidBinaryApplicationIdProvider(mockBuildStep);
+
+    // An exception should be thrown if the package name is not available because it's a
+    // serious error and should not fail silently.
+    assertThrows(ApkProvisionException.class, provider::getPackageName);
+  }
+
+  @Test
+  public void getApplicationId_noMergedManifest() throws Exception {
+    BlazeAndroidDeployInfo deployInfo = new BlazeAndroidDeployInfo(null, null, ImmutableList.of());
+    BlazeApkBuildStep mockBuildStep = Mockito.mock(BlazeApkBuildStep.class);
+    when(mockBuildStep.getDeployInfo()).thenReturn(deployInfo);
+
+    BlazeAndroidBinaryApplicationIdProvider provider =
+        new BlazeAndroidBinaryApplicationIdProvider(mockBuildStep);
+
+    // An exception should be thrown if the merged manifest not available because it's a
+    // serious error and should not fail silently.
+    assertThrows(ApkProvisionException.class, provider::getPackageName);
+  }
+}

--- a/aswb/tests/unittests/com/google/idea/blaze/android/run/test/BlazeAndroidTestApplicationIdProviderTest.java
+++ b/aswb/tests/unittests/com/google/idea/blaze/android/run/test/BlazeAndroidTestApplicationIdProviderTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.android.run.test;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.when;
+
+import com.android.tools.idea.run.ApkProvisionException;
+import com.google.common.collect.ImmutableList;
+import com.google.idea.blaze.android.manifest.ManifestParser.ParsedManifest;
+import com.google.idea.blaze.android.run.deployinfo.BlazeAndroidDeployInfo;
+import com.google.idea.blaze.android.run.runner.BlazeApkBuildStep;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+
+/**
+ * Unit tests for {@link
+ * com.google.idea.blaze.android.run.test.BlazeAndroidTestApplicationIdProvider}
+ */
+@RunWith(JUnit4.class)
+public class BlazeAndroidTestApplicationIdProviderTest {
+  @Test
+  public void getTestPackageName() throws Exception {
+    ParsedManifest targetManifest = new ParsedManifest("package.name", ImmutableList.of(), null);
+    ParsedManifest testManifest = new ParsedManifest("test.package.name", ImmutableList.of(), null);
+    BlazeAndroidDeployInfo deployInfo =
+        new BlazeAndroidDeployInfo(testManifest, targetManifest, ImmutableList.of());
+    BlazeApkBuildStep mockBuildStep = Mockito.mock(BlazeApkBuildStep.class);
+    when(mockBuildStep.getDeployInfo()).thenReturn(deployInfo);
+
+    BlazeAndroidTestApplicationIdProvider provider =
+        new BlazeAndroidTestApplicationIdProvider(mockBuildStep);
+    assertThat(provider.getTestPackageName()).isEqualTo("test.package.name");
+  }
+
+  @Test
+  public void getTestPackageName_noPackageNameInMergedManifest() throws Exception {
+    ParsedManifest targetManifest = new ParsedManifest("package.name", ImmutableList.of(), null);
+    ParsedManifest testManifest = new ParsedManifest(null, ImmutableList.of(), null);
+    BlazeAndroidDeployInfo deployInfo =
+        new BlazeAndroidDeployInfo(testManifest, targetManifest, ImmutableList.of());
+    BlazeApkBuildStep mockBuildStep = Mockito.mock(BlazeApkBuildStep.class);
+    when(mockBuildStep.getDeployInfo()).thenReturn(deployInfo);
+
+    BlazeAndroidTestApplicationIdProvider provider =
+        new BlazeAndroidTestApplicationIdProvider(mockBuildStep);
+
+    // An exception should be thrown if the package name is not available because it's a
+    // serious error and should not fail silently. In this case we shouldn't fallback to
+    // the main package name, because the test package will be invalid as long as test
+    // manifest is missing package name.
+    assertThrows(ApkProvisionException.class, provider::getTestPackageName);
+  }
+
+  @Test
+  public void getTestPackageName_noMergedManifest() throws Exception {
+    ParsedManifest targetManifest = new ParsedManifest("package.name", ImmutableList.of(), null);
+    BlazeAndroidDeployInfo deployInfo =
+        new BlazeAndroidDeployInfo(null, targetManifest, ImmutableList.of());
+    BlazeApkBuildStep mockBuildStep = Mockito.mock(BlazeApkBuildStep.class);
+    when(mockBuildStep.getDeployInfo()).thenReturn(deployInfo);
+
+    BlazeAndroidTestApplicationIdProvider provider =
+        new BlazeAndroidTestApplicationIdProvider(mockBuildStep);
+    assertThat(provider.getTestPackageName()).isEqualTo("package.name");
+  }
+
+  @Test
+  public void getPackageName() throws Exception {
+    ParsedManifest targetManifest = new ParsedManifest("package.name", ImmutableList.of(), null);
+    ParsedManifest testManifest = new ParsedManifest("test.package.name", ImmutableList.of(), null);
+    BlazeAndroidDeployInfo deployInfo =
+        new BlazeAndroidDeployInfo(testManifest, targetManifest, ImmutableList.of());
+    BlazeApkBuildStep mockBuildStep = Mockito.mock(BlazeApkBuildStep.class);
+    when(mockBuildStep.getDeployInfo()).thenReturn(deployInfo);
+
+    BlazeAndroidTestApplicationIdProvider provider =
+        new BlazeAndroidTestApplicationIdProvider(mockBuildStep);
+    assertThat(provider.getPackageName()).isEqualTo("package.name");
+  }
+
+  @Test
+  public void getPackageName_noPackageNameInMergedManifest() throws Exception {
+    ParsedManifest targetManifest = new ParsedManifest(null, ImmutableList.of(), null);
+    ParsedManifest testManifest = new ParsedManifest("test.package.name", ImmutableList.of(), null);
+    BlazeAndroidDeployInfo deployInfo =
+        new BlazeAndroidDeployInfo(testManifest, targetManifest, ImmutableList.of());
+    BlazeApkBuildStep mockBuildStep = Mockito.mock(BlazeApkBuildStep.class);
+    when(mockBuildStep.getDeployInfo()).thenReturn(deployInfo);
+
+    BlazeAndroidTestApplicationIdProvider provider =
+        new BlazeAndroidTestApplicationIdProvider(mockBuildStep);
+
+    // An exception should be thrown if the package name is not available because it's a
+    // serious error and should not fail silently. In this case we shouldn't fallback to
+    // the main package name, because the test package will be invalid as long as test
+    // manifest is missing package name.
+    assertThrows(ApkProvisionException.class, provider::getPackageName);
+  }
+
+  @Test
+  public void getPackageName_noMergedManifest() throws Exception {
+    ParsedManifest testManifest = new ParsedManifest("test.package.name", ImmutableList.of(), null);
+    BlazeAndroidDeployInfo deployInfo =
+        new BlazeAndroidDeployInfo(testManifest, null, ImmutableList.of());
+    BlazeApkBuildStep mockBuildStep = Mockito.mock(BlazeApkBuildStep.class);
+    when(mockBuildStep.getDeployInfo()).thenReturn(deployInfo);
+
+    BlazeAndroidTestApplicationIdProvider provider =
+        new BlazeAndroidTestApplicationIdProvider(mockBuildStep);
+
+    // An exception should be thrown if the merged manifest not available because it's a
+    // serious error and should not fail silently.
+    assertThrows(ApkProvisionException.class, provider::getPackageName);
+  }
+}


### PR DESCRIPTION
Use ManifestParser.ParsedManifest in BlazeAndroidDeployInfo

Currently BlazeAndroidDeployInfo is a wrapper around AndroidDeployInfo
proto and contains it's own extraction logic for manifest values. This
is unecessarily complex and inflexible, so this CL extracts the logic
out of BlazeAndroidDeployInfo so it's now just a data-class. This added
flexibility also aids the upcoming android_instrumentation_test support
feature, where manifests values are extracted differently depending on
the build step.