### PR TITLE
Adds support for $(location) expansion in aspect for C++ targets.

### DIFF
--- a/aspect/make_variables.bzl
+++ b/aspect/make_variables.bzl
@@ -87,6 +87,13 @@ def expand_make_variables(attr_name, expression, ctx, additional_subs = {}):
         # odd number of '$', but integer division will provide correct count
         rv = rv + "$" * ((end_dollars - begin_dollars) // 2)
         varname = expression[end_dollars + 1:end_parens]
+
+        # Handle $(location) expansion
+        if varname.startswith("location"):
+            varname = varname[len("location"):].strip()
+            rv = rv + ctx.expand_location(varname)
+            continue
+
         if not _is_valid_make_var(varname):
             # invalid make variable name
             fail("expand_make_variables: $(%s) invalid name" % varname, attr_name)


### PR DESCRIPTION
The aspect implementation goes around the deprecation of
`ctx.expand_make_variable` by providing its own implementation. However
support for `$(location)` expansion was not supported in the orifinal
fix which leads to errors being generated in targets which use this
expansion.

This patch addresses this issue by adding support for $(location)
expansion.

# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `522`

# Description of this change
The aspect implementation goes around the deprecation of
`ctx.expand_make_variable` by providing its own implementation. However
support for `$(location)` expansion was not supported in the orifinal
fix which leads to errors being generated in targets which use this
expansion.

This patch addresses this issue by adding support for $(location)
expansion.
