### PR TITLE
Add sdkcompat for deprecated Extensions.cleanRootArea

### DIFF
--- a/base/tests/utils/unit/com/google/idea/blaze/base/BlazeTestCase.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/BlazeTestCase.java
@@ -15,6 +15,7 @@
  */
 package com.google.idea.blaze.base;
 
+import com.google.idea.sdkcompat.openapi.ExtensionsCompat;
 import com.intellij.mock.MockProject;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
@@ -91,7 +92,7 @@ public class BlazeTestCase {
         (MutablePicoContainer) ApplicationManager.getApplication().getPicoContainer();
     MockProject mockProject = TestUtils.mockProject(applicationContainer, testDisposable);
 
-    Extensions.cleanRootArea(testDisposable);
+    ExtensionsCompat.cleanRootArea(testDisposable);
     extensionsArea = (ExtensionsAreaImpl) Extensions.getRootArea();
 
     this.project = mockProject;

--- a/sdkcompat/v191/com/google/idea/sdkcompat/openapi/ExtensionsCompat.java
+++ b/sdkcompat/v191/com/google/idea/sdkcompat/openapi/ExtensionsCompat.java
@@ -1,0 +1,11 @@
+package com.google.idea.sdkcompat.openapi;
+
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.extensions.Extensions;
+
+/** Extensions.cleanRootArea removed in 193.* #api192 */
+public class ExtensionsCompat {
+  public static void cleanRootArea(Disposable disposable) {
+    Extensions.cleanRootArea(disposable);
+  }
+}

--- a/sdkcompat/v192/com/google/idea/sdkcompat/openapi/ExtensionsCompat.java
+++ b/sdkcompat/v192/com/google/idea/sdkcompat/openapi/ExtensionsCompat.java
@@ -1,0 +1,11 @@
+package com.google.idea.sdkcompat.openapi;
+
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.extensions.Extensions;
+
+/** Extensions.cleanRootArea removed in 193.* #api192 */
+public class ExtensionsCompat {
+  public static void cleanRootArea(Disposable disposable) {
+    Extensions.cleanRootArea(disposable);
+  }
+}

--- a/sdkcompat/v193/com/google/idea/sdkcompat/openapi/ExtensionsCompat.java
+++ b/sdkcompat/v193/com/google/idea/sdkcompat/openapi/ExtensionsCompat.java
@@ -1,0 +1,10 @@
+package com.google.idea.sdkcompat.openapi;
+
+import com.intellij.openapi.Disposable;
+
+/** Extensions.cleanRootArea removed in 193.* #api192 */
+public class ExtensionsCompat {
+  public static void cleanRootArea(Disposable disposable) {
+    // do nothing
+  }
+}

--- a/testing/BUILD
+++ b/testing/BUILD
@@ -25,13 +25,10 @@ java_library(
         "default": [],
     }),
     deps = [
+        "//sdkcompat",
         "//intellij_platform_sdk:plugin_api_for_tests",
         "//intellij_platform_sdk:test_libs",
         "//intellij_platform_sdk:jsr305",
         "@junit//jar",
-    ] + select_for_ide(
-        android_studio = ["//sdkcompat"],
-        clion = ["//sdkcompat"],
-        default = [],
-    ),
+    ],
 )

--- a/testing/src/com/google/idea/testing/IntellijRule.java
+++ b/testing/src/com/google/idea/testing/IntellijRule.java
@@ -15,11 +15,11 @@
  */
 package com.google.idea.testing;
 
+import com.google.idea.sdkcompat.openapi.ExtensionsCompat;
 import com.intellij.mock.MockProject;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.extensions.ExtensionPointName;
-import com.intellij.openapi.extensions.Extensions;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Disposer;
 import org.junit.rules.ExternalResource;
@@ -42,7 +42,7 @@ public final class IntellijRule extends ExternalResource {
     project =
         TestUtils.mockProject(
             ApplicationManager.getApplication().getPicoContainer(), testDisposable);
-    Extensions.cleanRootArea(testDisposable);
+    ExtensionsCompat.cleanRootArea(testDisposable);
   }
 
   @Override


### PR DESCRIPTION
See deprecated notice in https://upsource.jetbrains.com/idea-ce/file/idea-ce-4eb65aaf9c76f558e7954ac589507831f67cd70d/platform/extensions/src/com/intellij/openapi/extensions/Extensions.java?nav=2088:2101:focused&line=65&preview=false

`@deprecated Extension area is a part of component manager, no need to clean extension area - dispose component manager instead`

This method is going to be removed in 193.