### PR TITLE
Fix startup profiling support for ASwB 3.6

### DIFF
--- a/aswb/sdkcompat/as35/com/google/idea/blaze/android/run/binary/StartupProfilerSupport.java
+++ b/aswb/sdkcompat/as35/com/google/idea/blaze/android/run/binary/StartupProfilerSupport.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.android.run.binary;
+
+/**
+ * Indicates whether or not startup profiling is supported.
+ *
+ * <p>This can be removed once profiler support is consistent between 3.5 and 3.6.
+ */
+public class StartupProfilerSupport {
+  static final boolean SUPPORTS_STARTUP_PROFILING = false;
+
+  private StartupProfilerSupport() {}
+}

--- a/aswb/sdkcompat/as36/com/google/idea/blaze/android/run/binary/StartupProfilerSupport.java
+++ b/aswb/sdkcompat/as36/com/google/idea/blaze/android/run/binary/StartupProfilerSupport.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.android.run.binary;
+
+/**
+ * Indicates whether or not startup profiling is supported.
+ *
+ * <p>This can be removed once profiler support is consistent between 3.5 and 3.6.
+ */
+public class StartupProfilerSupport {
+  static final boolean SUPPORTS_STARTUP_PROFILING = true;
+
+  private StartupProfilerSupport() {}
+}

--- a/aswb/src/com/google/idea/blaze/android/run/binary/BlazeAndroidBinaryProgramRunner.java
+++ b/aswb/src/com/google/idea/blaze/android/run/binary/BlazeAndroidBinaryProgramRunner.java
@@ -15,6 +15,7 @@
  */
 package com.google.idea.blaze.android.run.binary;
 
+import com.android.tools.idea.profilers.ProfileRunExecutor;
 import com.android.tools.idea.run.AndroidSessionInfo;
 import com.google.idea.blaze.android.run.AndroidSessionInfoCompat;
 import com.google.idea.blaze.android.run.BlazeAndroidRunConfigurationHandler;
@@ -44,7 +45,9 @@ public class BlazeAndroidBinaryProgramRunner extends DefaultProgramRunner {
     }
     // In practice, the stock runner will probably handle all non-incremental-install configs.
     if (DefaultDebugExecutor.EXECUTOR_ID.equals(executorId)
-        || DefaultRunExecutor.EXECUTOR_ID.equals(executorId)) {
+        || DefaultRunExecutor.EXECUTOR_ID.equals(executorId)
+        || (StartupProfilerSupport.SUPPORTS_STARTUP_PROFILING
+            && ProfileRunExecutor.EXECUTOR_ID.equals(executorId))) {
       return true;
     }
     // Otherwise, the configuration must be a Blaze incremental install configuration running with


### PR DESCRIPTION
Fix startup profiling support for ASwB 3.6

Currently startup profiling doesn't work in ASwB 3.6 dev branch
because BlazeAndroidBinaryProgramRunner doesn't support it, this CL
fixes that.