### PR TITLE
BuildRabbit syncing: stream BEP output in batches, don't read it all into memory at once.

### DIFF
--- a/base/src/com/google/idea/blaze/base/command/buildresult/BuildEventProtocolOutputReader.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/BuildEventProtocolOutputReader.java
@@ -42,11 +42,6 @@ public final class BuildEventProtocolOutputReader {
 
   private BuildEventProtocolOutputReader() {}
 
-  /** Parses a BEP input stream, returning a {@link ParsedBepOutput}. */
-  public static ParsedBepOutput parseBepOutput(InputStream inputStream) throws IOException {
-    return ParsedBepOutput.parseBepArtifacts(inputStream);
-  }
-
   /**
    * Returns all test results from a BEP-formatted {@link InputStream}.
    *

--- a/base/src/com/google/idea/blaze/base/command/buildresult/BuildEventStreamProvider.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/BuildEventStreamProvider.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.command.buildresult;
+
+import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos;
+import java.io.IOException;
+import java.io.InputStream;
+import javax.annotation.Nullable;
+
+/** Provides {@link BuildEventStreamProtos.BuildEvent} */
+public interface BuildEventStreamProvider {
+
+  /** An exception parsing a stream of build events. */
+  class BuildEventStreamException extends Exception {
+    public BuildEventStreamException(String message, Exception e) {
+      super(message, e);
+    }
+  }
+
+  @Nullable
+  static BuildEventStreamProtos.BuildEvent parseNextEventFromStream(InputStream stream)
+      throws BuildEventStreamException {
+    try {
+      return BuildEventStreamProtos.BuildEvent.parseDelimitedFrom(stream);
+    } catch (IOException e) {
+      throw new BuildEventStreamException(e.getMessage(), e);
+    }
+  }
+
+  static BuildEventStreamProvider fromInputStream(InputStream stream) {
+    return () -> parseNextEventFromStream(stream);
+  }
+
+  /** Returns the next build event in the stream, or null if there are none remaining. */
+  @Nullable
+  BuildEventStreamProtos.BuildEvent getNext() throws BuildEventStreamException;
+}

--- a/base/src/com/google/idea/blaze/base/command/buildresult/BuildResultHelperBep.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/BuildResultHelperBep.java
@@ -15,6 +15,7 @@
  */
 package com.google.idea.blaze.base.command.buildresult;
 
+import com.google.idea.blaze.base.command.buildresult.BuildEventStreamProvider.BuildEventStreamException;
 import com.google.idea.blaze.base.command.info.BlazeInfo;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
@@ -49,8 +50,8 @@ class BuildResultHelperBep implements BuildResultHelper {
   @Override
   public ParsedBepOutput getBuildOutput() throws GetArtifactsException {
     try (InputStream inputStream = new BufferedInputStream(new FileInputStream(outputFile))) {
-      return BuildEventProtocolOutputReader.parseBepOutput(inputStream);
-    } catch (IOException e) {
+      return ParsedBepOutput.parseBepArtifacts(inputStream);
+    } catch (IOException | BuildEventStreamException e) {
       logger.error(e);
       throw new GetArtifactsException(e.getMessage());
     }


### PR DESCRIPTION
BuildRabbit syncing: stream BEP output in batches, don't read it all into memory at once.