### PR TITLE
Fix IJwB UE integration test on prefetched extensions

### DIFF
--- a/ijwb/tests/integrationtests/com/google/idea/blaze/ijwb/prefetch/IntelliJBazelPrefetchFileSourceTest.java
+++ b/ijwb/tests/integrationtests/com/google/idea/blaze/ijwb/prefetch/IntelliJBazelPrefetchFileSourceTest.java
@@ -30,6 +30,6 @@ public class IntelliJBazelPrefetchFileSourceTest extends BlazeIntegrationTestCas
   @Test
   public void testPrefetchedExtensions() {
     assertThat(PrefetchFileSource.getAllPrefetchFileExtensions())
-        .containsExactly("java", "proto", "dart");
+        .containsExactly("java", "proto", "dart", "html", "css", "gss", "ts", "tsx", "java");
   }
 }


### PR DESCRIPTION
See test failure in #1292 

https://storage.googleapis.com/bazel-untrusted-buildkite-artifacts/074be68b-756b-4778-8be2-03e9c8a43f06/ijwb/integration_tests/attempt_1.log

```
exec ${PAGER:-/usr/bin/less} "$0" || exit 1
Executing tests from //ijwb:integration_tests
-----------------------------------------------------------------------------
JUnit4 Test Runner
.log4j:WARN No appenders could be found for logger (#com.intellij.application.impl.ApplicationImpl).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
Oct 18, 2019 6:57:56 PM java.util.prefs.FileSystemPreferences$1 run
INFO: Created user preferences directory.
.E
Time: 6.556
There was 1 failure:
1) testPrefetchedExtensions(com.google.idea.blaze.ijwb.prefetch.IntelliJBazelPrefetchFileSourceTest)
unexpected (6): js, html, css, gss, ts, tsx
---
expected      : [java, proto, dart]
but was       : [proto, dart, js, html, css, gss, ts, tsx, java]
	at com.google.idea.blaze.ijwb.prefetch.IntelliJBazelPrefetchFileSourceTest.testPrefetchedExtensions(IntelliJBazelPrefetchFileSourceTest.java:33)

FAILURES!!!
Tests run: 2,  Failures: 1


BazelTestRunner exiting with a return value of 1
JVM shutdown hooks (if any) will run now.
The JVM will exit once they complete.

-- JVM shutdown starting at 2019-10-18 18:57:58 --
```