### PR TITLE
Remove reference to MissingDependencyTargetProviderImpl in the plug-in configuration file which has been previously removed.

### DIFF
--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -272,9 +272,6 @@
     <codeInsight.lineMarkerProvider
         language="BUILD"
       implementationClass="com.google.idea.blaze.base.query.MacroLineMarkerProvider"/>
-
-    <projectService serviceInterface="com.google.idea.blaze.base.dependencies.MissingDependencyTargetProvider"
-        serviceImplementation="com.google.idea.blaze.base.dependencies.MissingDependencyTargetProviderImpl"/>
   </extensions>
 
   <extensions defaultExtensionNs="com.intellij">


### PR DESCRIPTION
Remove reference to MissingDependencyTargetProviderImpl in the plug-in configuration file which has been previously removed.