### PR TITLE
Don't let plugins forcibly override the user's $PATH in Terminal after rc files are run.

### DIFF
--- a/terminal/src/META-INF/terminal-contents.xml
+++ b/terminal/src/META-INF/terminal-contents.xml
@@ -15,6 +15,6 @@
   -->
 <idea-plugin>
   <extensions defaultExtensionNs="org.jetbrains.plugins.terminal">
-    <localTerminalCustomizer implementation="com.google.idea.blaze.terminal.DefaultTerminalLocationCustomizer"/>
+    <localTerminalCustomizer implementation="com.google.idea.blaze.terminal.TerminalCustomizer" order="last"/>
   </extensions>
 </idea-plugin>


### PR DESCRIPTION
Don't let plugins forcibly override the user's $PATH in Terminal after rc files are run.