### PR TITLE
Update IntelliJ plugin SDKs to 4.0 Canary 1 (4.0.0.1)

### DIFF
--- a/intellij_platform_sdk/BUILD
+++ b/intellij_platform_sdk/BUILD
@@ -142,6 +142,13 @@ config_setting(
 )
 
 config_setting(
+    name = "android-studio-4.0",
+    values = {
+        "define": "ij_product=android-studio-4.0",
+    },
+)
+
+config_setting(
     name = "android-studio-beta-mac",
     values = {
         "cpu": "darwin_x86_64",


### PR DESCRIPTION
Update IntelliJ plugin SDKs to 4.0 Canary 1 (4.0.0.1)