### PR TITLE
Skip out-of-date targets building a source file when searching for the missing BUILD dependencies of a class reference in the source file.

### DIFF
--- a/base/tests/utils/integration/com/google/idea/blaze/base/TestFileSystem.java
+++ b/base/tests/utils/integration/com/google/idea/blaze/base/TestFileSystem.java
@@ -206,6 +206,15 @@ public class TestFileSystem {
       return Arrays.stream(vf.getChildren()).map((f) -> new File(f.getPath())).toArray(File[]::new);
     }
 
+    @Override
+    public long getFileModifiedTime(File file) {
+      VirtualFile vf = getVirtualFile(file);
+      if (vf == null) {
+        return super.getFileModifiedTime(file);
+      }
+      return vf.getTimeStamp();
+    }
+
     private VirtualFile getVirtualFile(File file) {
       return fileSystem.findFileByPath(file.getPath());
     }


### PR DESCRIPTION
Skip out-of-date targets building a source file when searching for the missing BUILD dependencies of a class reference in the source file.