### PR TITLE
[JavaInfo] use transitive_runtime_jars if compilation_info is None

### DIFF
--- a/aspect/java_classpath.bzl
+++ b/aspect/java_classpath.bzl
@@ -19,7 +19,10 @@ def _runtime_classpath_impl(target, ctx):
 
 def _get_runtime_jars(target):
     if JavaInfo in target:
-        return target[JavaInfo].compilation_info.runtime_classpath
+        if (target[JavaInfo].compilation_info == None):
+            return target[JavaInfo].transitive_runtime_jars
+        else :
+            return target[JavaInfo].compilation_info.runtime_classpath
     return depset()
 
 def _aspect_def(impl):


### PR DESCRIPTION
# Checklist

- [V ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ X] I have received the approval from the maintainers to make this change.
- [V ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: https://github.com/bazelbuild/intellij/issues/1281

# Description of this change
Use transitive_runtime_jars if compilation_info is None 
