### PR TITLE
Do not inject services via the constructor

### DIFF
--- a/java/src/com/google/idea/blaze/java/fastbuild/FastBuildChangedFilesService.java
+++ b/java/src/com/google/idea/blaze/java/fastbuild/FastBuildChangedFilesService.java
@@ -41,6 +41,7 @@ import com.intellij.openapi.vfs.VirtualFileManager;
 import com.intellij.openapi.vfs.newvfs.BulkFileListener;
 import com.intellij.openapi.vfs.newvfs.events.VFileDeleteEvent;
 import com.intellij.openapi.vfs.newvfs.events.VFileEvent;
+import com.intellij.serviceContainer.NonInjectable;
 import com.intellij.util.ConcurrencyUtil;
 import com.intellij.util.messages.MessageBusConnection;
 import java.io.File;
@@ -89,6 +90,7 @@ final class FastBuildChangedFilesService implements Disposable {
                 FastBuildChangedFilesService.class.getSimpleName() + "-" + project.getName())));
   }
 
+  @NonInjectable
   private FastBuildChangedFilesService(
       Project project,
       BlazeProjectDataManager projectDataManager,

--- a/java/src/com/google/idea/blaze/java/fastbuild/FastBuildCompilerFactoryImpl.java
+++ b/java/src/com/google/idea/blaze/java/fastbuild/FastBuildCompilerFactoryImpl.java
@@ -43,6 +43,7 @@ import com.intellij.ide.plugins.IdeaPluginDescriptor;
 import com.intellij.ide.plugins.PluginManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.serviceContainer.NonInjectable;
 import java.io.File;
 import java.io.PrintWriter;
 import java.lang.reflect.Constructor;
@@ -74,6 +75,7 @@ final class FastBuildCompilerFactoryImpl implements FastBuildCompilerFactory {
   private final Supplier<EventLoggingService> eventLoggerSupplier;
   private final Supplier<File> fastBuildJavacJarSupplier;
 
+  @NonInjectable
   private FastBuildCompilerFactoryImpl(
       BlazeProjectDataManager projectDataManager,
       Supplier<EventLoggingService> eventLoggerSupplier,

--- a/sdkcompat/v191/BUILD
+++ b/sdkcompat/v191/BUILD
@@ -12,6 +12,7 @@ java_library(
         "com/google/idea/sdkcompat/platform/**",
         "com/google/idea/sdkcompat/run/**",
         "com/google/idea/sdkcompat/vcs/**",
+        "com/intellij/serviceContainer/*.java",
     ]) + select_for_ide(
         android_studio = glob([
             "com/google/idea/sdkcompat/cidr/**",

--- a/sdkcompat/v191/com/intellij/serviceContainer/NonInjectable.java
+++ b/sdkcompat/v191/com/intellij/serviceContainer/NonInjectable.java
@@ -1,0 +1,10 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0
+// license that can be found in the LICENSE file.
+package com.intellij.serviceContainer;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/** Marks constructor as not applicable for constructor injection. */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NonInjectable {}

--- a/sdkcompat/v192/BUILD
+++ b/sdkcompat/v192/BUILD
@@ -12,6 +12,7 @@ java_library(
         "com/google/idea/sdkcompat/platform/**",
         "com/google/idea/sdkcompat/run/**",
         "com/google/idea/sdkcompat/vcs/**",
+        "com/intellij/serviceContainer/*.java",
     ]) + select_for_ide(
         android_studio = glob([
             "com/google/idea/sdkcompat/cidr/**",

--- a/sdkcompat/v192/com/intellij/serviceContainer/NonInjectable.java
+++ b/sdkcompat/v192/com/intellij/serviceContainer/NonInjectable.java
@@ -1,0 +1,10 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0
+// license that can be found in the LICENSE file.
+package com.intellij.serviceContainer;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/** Marks constructor as not applicable for constructor injection. */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NonInjectable {}


### PR DESCRIPTION
Do not inject services via the constructor

One restriction with sdk v193 is that services should not be injected
via the constructor. There is also a new annotation (@NonInjectable)
that needs to be placed on constructors that are not supposed to be
used by picocontainers.