### PR TITLE
Fix python plugin to work with IJ v193

### DIFF
--- a/sdkcompat/v191/BUILD
+++ b/sdkcompat/v191/BUILD
@@ -1,8 +1,8 @@
 # Description: Indirections for SDK changes to the underlying platform library.
 
-licenses(["notice"])  # Apache 2.0
-
 load("//intellij_platform_sdk:build_defs.bzl", "select_for_ide")
+
+licenses(["notice"])  # Apache 2.0
 
 java_library(
     name = "v191",
@@ -10,6 +10,7 @@ java_library(
         "com/google/idea/sdkcompat/configuration/**",
         "com/google/idea/sdkcompat/openapi/**",
         "com/google/idea/sdkcompat/platform/**",
+        "com/google/idea/sdkcompat/python/*.java",
         "com/google/idea/sdkcompat/run/**",
         "com/google/idea/sdkcompat/testframework/*.java",
         "com/google/idea/sdkcompat/vcs/**",

--- a/sdkcompat/v191/com/google/idea/sdkcompat/python/PyInspectionExtensionCompat.java
+++ b/sdkcompat/v191/com/google/idea/sdkcompat/python/PyInspectionExtensionCompat.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.sdkcompat.python;
+
+import com.jetbrains.python.inspections.unresolvedReference.PyUnresolvedReferenceSkipperExtPoint;
+import com.jetbrains.python.psi.PyImportedNameDefiner;
+import org.jetbrains.annotations.NotNull;
+
+/** PyUnresolvedReferenceSkipperExtPoint has been removed in v193. #api192 */
+public abstract class PyInspectionExtensionCompat implements PyUnresolvedReferenceSkipperExtPoint {
+  @Override
+  public boolean unusedImportShouldBeSkipped(PyImportedNameDefiner pyImportedNameDefiner) {
+    return ignoreUnusedImports(pyImportedNameDefiner);
+  }
+
+  public abstract boolean ignoreUnusedImports(@NotNull PyImportedNameDefiner importNameDefiner);
+}

--- a/sdkcompat/v191/com/google/idea/sdkcompat/python/PythonVisitorFilterCompat.java
+++ b/sdkcompat/v191/com/google/idea/sdkcompat/python/PythonVisitorFilterCompat.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.sdkcompat.python;
+
+import com.jetbrains.python.inspections.PythonVisitorFilter;
+
+/** Compat interface bridging the different locations of {@link PythonVisitorFilter}. #api192 */
+public interface PythonVisitorFilterCompat extends PythonVisitorFilter {}

--- a/sdkcompat/v192/BUILD
+++ b/sdkcompat/v192/BUILD
@@ -1,8 +1,8 @@
 # Description: Indirections for SDK changes to the underlying platform library.
 
-licenses(["notice"])  # Apache 2.0
-
 load("//intellij_platform_sdk:build_defs.bzl", "select_for_ide")
+
+licenses(["notice"])  # Apache 2.0
 
 java_library(
     name = "v192",
@@ -10,6 +10,7 @@ java_library(
         "com/google/idea/sdkcompat/configuration/**",
         "com/google/idea/sdkcompat/openapi/**",
         "com/google/idea/sdkcompat/platform/**",
+        "com/google/idea/sdkcompat/python/*.java",
         "com/google/idea/sdkcompat/run/**",
         "com/google/idea/sdkcompat/testframework/*.java",
         "com/google/idea/sdkcompat/vcs/**",

--- a/sdkcompat/v192/com/google/idea/sdkcompat/python/PyInspectionExtensionCompat.java
+++ b/sdkcompat/v192/com/google/idea/sdkcompat/python/PyInspectionExtensionCompat.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.sdkcompat.python;
+
+import com.jetbrains.python.inspections.unresolvedReference.PyUnresolvedReferenceSkipperExtPoint;
+import com.jetbrains.python.psi.PyImportedNameDefiner;
+import org.jetbrains.annotations.NotNull;
+
+/** PyUnresolvedReferenceSkipperExtPoint has been removed in v193. #api192 */
+public abstract class PyInspectionExtensionCompat implements PyUnresolvedReferenceSkipperExtPoint {
+  @Override
+  public boolean unusedImportShouldBeSkipped(PyImportedNameDefiner pyImportedNameDefiner) {
+    return ignoreUnusedImports(pyImportedNameDefiner);
+  }
+
+  public abstract boolean ignoreUnusedImports(@NotNull PyImportedNameDefiner importNameDefiner);
+}

--- a/sdkcompat/v192/com/google/idea/sdkcompat/python/PythonVisitorFilterCompat.java
+++ b/sdkcompat/v192/com/google/idea/sdkcompat/python/PythonVisitorFilterCompat.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.sdkcompat.python;
+
+import com.jetbrains.python.inspections.PythonVisitorFilter;
+
+/** Compat interface bridging the different locations of {@link PythonVisitorFilter}. #api192 */
+public interface PythonVisitorFilterCompat extends PythonVisitorFilter {}

--- a/sdkcompat/v193/BUILD
+++ b/sdkcompat/v193/BUILD
@@ -10,6 +10,7 @@ java_library(
         "com/google/idea/sdkcompat/configuration/**",
         "com/google/idea/sdkcompat/openapi/**",
         "com/google/idea/sdkcompat/platform/**",
+        "com/google/idea/sdkcompat/python/*.java",
         "com/google/idea/sdkcompat/run/**",
         "com/google/idea/sdkcompat/testframework/*.java",
         "com/google/idea/sdkcompat/vcs/**",

--- a/sdkcompat/v193/com/google/idea/sdkcompat/python/PyInspectionExtensionCompat.java
+++ b/sdkcompat/v193/com/google/idea/sdkcompat/python/PyInspectionExtensionCompat.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.sdkcompat.python;
+
+import com.jetbrains.python.inspections.PyInspectionExtension;
+
+/** PyUnresolvedReferenceSkipperExtPoint has been removed in v193. #api192 */
+public abstract class PyInspectionExtensionCompat extends PyInspectionExtension {}

--- a/sdkcompat/v193/com/google/idea/sdkcompat/python/PythonVisitorFilterCompat.java
+++ b/sdkcompat/v193/com/google/idea/sdkcompat/python/PythonVisitorFilterCompat.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.sdkcompat.python;
+
+import com.jetbrains.python.psi.PythonVisitorFilter;
+
+/** Compat interface bridging the different locations of {@link PythonVisitorFilter}. #api192 */
+public interface PythonVisitorFilterCompat extends PythonVisitorFilter {}


### PR DESCRIPTION
Fix python plugin to work with IJ v193

* PyUnresolvedReferenceSkipperExtPoint has been removed in favor of
  PyInspectionExtension
* PythonVisitorFilter has moved from com.jetbrains.python.inspections to
  com.jetbrains.python.psi