### PR TITLE
Use ManifestParser.ParsedManifest in BlazeAndroidDeployInfo

### DIFF
--- a/aswb/src/com/google/idea/blaze/android/run/binary/BlazeAndroidBinaryApplicationIdProvider.java
+++ b/aswb/src/com/google/idea/blaze/android/run/binary/BlazeAndroidBinaryApplicationIdProvider.java
@@ -34,13 +34,8 @@ public class BlazeAndroidBinaryApplicationIdProvider implements ApplicationIdPro
   public String getPackageName() throws ApkProvisionException {
     BlazeAndroidDeployInfo deployInfo = buildStep.getDeployInfo();
     ManifestParser.ParsedManifest parsedManifest = deployInfo.getMergedManifest();
-    if (parsedManifest == null) {
-      throw new ApkProvisionException(
-          "Could not find merged manifest: " + deployInfo.getMergedManifestFile());
-    }
     if (parsedManifest.packageName == null) {
-      throw new ApkProvisionException(
-          "No application id in merged manifest: " + deployInfo.getMergedManifestFile());
+      throw new ApkProvisionException("No application id in merged manifest.");
     }
     return parsedManifest.packageName;
   }

--- a/aswb/src/com/google/idea/blaze/android/run/binary/mobileinstall/BlazeApkBuildStepMobileInstall.java
+++ b/aswb/src/com/google/idea/blaze/android/run/binary/mobileinstall/BlazeApkBuildStepMobileInstall.java
@@ -24,7 +24,6 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.google.devtools.build.lib.rules.android.deployinfo.AndroidDeployInfoOuterClass.AndroidDeployInfo;
-import com.google.idea.blaze.android.manifest.ParsedManifestService;
 import com.google.idea.blaze.android.run.deployinfo.BlazeAndroidDeployInfo;
 import com.google.idea.blaze.android.run.deployinfo.BlazeApkDeployInfoProtoHelper;
 import com.google.idea.blaze.android.run.runner.BlazeAndroidDeviceSelector;
@@ -167,9 +166,9 @@ public class BlazeApkBuildStepMobileInstall implements BlazeApkBuildStep {
               AndroidDeployInfo deployInfoProto =
                   BlazeApkDeployInfoProtoHelper.readDeployInfoProtoForTarget(
                       label, buildResultHelper, fileName -> fileName.endsWith(deployInfoSuffix));
-              deployInfo = new BlazeAndroidDeployInfo(project, executionRoot, deployInfoProto);
-              ParsedManifestService.getInstance(project)
-                  .invalidateCachedManifests(deployInfo.getManifestFiles());
+              deployInfo =
+                  BlazeApkDeployInfoProtoHelper.extractDeployInfoAndInvalidateManifests(
+                      project, executionRoot, deployInfoProto);
             } catch (GetArtifactsException e) {
               IssueOutput.error("Could not read apk deploy info from build: " + e.getMessage())
                   .submit(context);

--- a/aswb/src/com/google/idea/blaze/android/run/runner/BlazeApkBuildStepNormalBuild.java
+++ b/aswb/src/com/google/idea/blaze/android/run/runner/BlazeApkBuildStepNormalBuild.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.devtools.build.lib.rules.android.deployinfo.AndroidDeployInfoOuterClass.AndroidDeployInfo;
-import com.google.idea.blaze.android.manifest.ParsedManifestService;
 import com.google.idea.blaze.android.run.deployinfo.BlazeAndroidDeployInfo;
 import com.google.idea.blaze.android.run.deployinfo.BlazeApkDeployInfoProtoHelper;
 import com.google.idea.blaze.base.async.executor.ProgressiveTaskWithProgressIndicator;
@@ -143,9 +142,9 @@ public class BlazeApkBuildStepNormalBuild implements BlazeApkBuildStep {
               AndroidDeployInfo deployInfoProto =
                   BlazeApkDeployInfoProtoHelper.readDeployInfoProtoForTarget(
                       label, buildResultHelper, fileName -> fileName.endsWith(DEPLOY_INFO_SUFFIX));
-              deployInfo = new BlazeAndroidDeployInfo(project, executionRoot, deployInfoProto);
-              ParsedManifestService.getInstance(project)
-                  .invalidateCachedManifests(deployInfo.getManifestFiles());
+              deployInfo =
+                  BlazeApkDeployInfoProtoHelper.extractDeployInfoAndInvalidateManifests(
+                      project, executionRoot, deployInfoProto);
             } catch (GetArtifactsException e) {
               IssueOutput.error("Could not read apk deploy info from build: " + e.getMessage())
                   .submit(context);

--- a/aswb/src/com/google/idea/blaze/android/run/test/BlazeAndroidTestApplicationIdProvider.java
+++ b/aswb/src/com/google/idea/blaze/android/run/test/BlazeAndroidTestApplicationIdProvider.java
@@ -17,12 +17,11 @@ package com.google.idea.blaze.android.run.test;
 
 import com.android.tools.idea.run.ApkProvisionException;
 import com.android.tools.idea.run.ApplicationIdProvider;
-import com.google.common.collect.Iterables;
 import com.google.idea.blaze.android.manifest.ManifestParser;
 import com.google.idea.blaze.android.run.deployinfo.BlazeAndroidDeployInfo;
 import com.google.idea.blaze.android.run.runner.BlazeApkBuildStep;
 
-/** Application id provider for android_binary. */
+/** Application id provider for android_test and android_instrumentation_test. */
 public class BlazeAndroidTestApplicationIdProvider implements ApplicationIdProvider {
   private final BlazeApkBuildStep buildStep;
 
@@ -30,33 +29,29 @@ public class BlazeAndroidTestApplicationIdProvider implements ApplicationIdProvi
     this.buildStep = buildStep;
   }
 
+  /** Returns the package name of the target APK under test. */
   @Override
   public String getPackageName() throws ApkProvisionException {
     BlazeAndroidDeployInfo deployInfo = buildStep.getDeployInfo();
-    ManifestParser.ParsedManifest parsedManifest =
-        Iterables.getFirst(deployInfo.getAdditionalMergedManifest(), null);
+    ManifestParser.ParsedManifest parsedManifest = deployInfo.getTestTargetMergedManifest();
     if (parsedManifest == null) {
-      // The application may not have a separate package,
-      // and can instead be in the same package as the tests.
+      // The test instrumentor may not have a separate package,
+      // and can instead be in the same package as the test target package.
       return getTestPackageName();
     }
     if (parsedManifest.packageName == null) {
-      throw new ApkProvisionException("No application id in manifest under test");
+      throw new ApkProvisionException("No application id in test target manifest.");
     }
     return parsedManifest.packageName;
   }
 
+  /** Returns the package name of the test instrumentor. */
   @Override
   public String getTestPackageName() throws ApkProvisionException {
     BlazeAndroidDeployInfo deployInfo = buildStep.getDeployInfo();
     ManifestParser.ParsedManifest parsedManifest = deployInfo.getMergedManifest();
-    if (parsedManifest == null) {
-      throw new ApkProvisionException(
-          "Could not find merged manifest: " + deployInfo.getMergedManifestFile());
-    }
     if (parsedManifest.packageName == null) {
-      throw new ApkProvisionException(
-          "No application id in merged manifest: " + deployInfo.getMergedManifestFile());
+      throw new ApkProvisionException("No application id in test instrumentor manifest");
     }
     return parsedManifest.packageName;
   }

--- a/aswb/tests/unittests/com/google/idea/blaze/android/run/binary/BlazeAndroidBinaryApplicationIdProviderTest.java
+++ b/aswb/tests/unittests/com/google/idea/blaze/android/run/binary/BlazeAndroidBinaryApplicationIdProviderTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.android.run.binary;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.android.tools.idea.run.ApkProvisionException;
+import com.google.common.collect.ImmutableList;
+import com.google.idea.blaze.android.manifest.ManifestParser.ParsedManifest;
+import com.google.idea.blaze.android.run.deployinfo.BlazeAndroidDeployInfo;
+import com.google.idea.blaze.android.run.runner.BlazeApkBuildStep;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Unit tests for {@link
+ * com.google.idea.blaze.android.run.binary.BlazeAndroidBinaryApplicationIdProvider}
+ */
+@RunWith(JUnit4.class)
+public class BlazeAndroidBinaryApplicationIdProviderTest {
+  @Test
+  public void getApplicationId() throws Exception {
+    ParsedManifest manifest = new ParsedManifest("package.name", ImmutableList.of(), null);
+    BlazeAndroidDeployInfo deployInfo =
+        new BlazeAndroidDeployInfo(manifest, null, ImmutableList.of());
+    BlazeApkBuildStep mockBuildStep = mock(BlazeApkBuildStep.class);
+    when(mockBuildStep.getDeployInfo()).thenReturn(deployInfo);
+
+    BlazeAndroidBinaryApplicationIdProvider provider =
+        new BlazeAndroidBinaryApplicationIdProvider(mockBuildStep);
+    assertThat(provider.getPackageName()).isEqualTo("package.name");
+  }
+
+  @Test
+  public void getApplicationId_noPackageNameInMergedManifest() throws Exception {
+    ParsedManifest manifest = new ParsedManifest(null, ImmutableList.of(), null);
+    BlazeAndroidDeployInfo deployInfo =
+        new BlazeAndroidDeployInfo(manifest, null, ImmutableList.of());
+    BlazeApkBuildStep mockBuildStep = mock(BlazeApkBuildStep.class);
+    when(mockBuildStep.getDeployInfo()).thenReturn(deployInfo);
+
+    BlazeAndroidBinaryApplicationIdProvider provider =
+        new BlazeAndroidBinaryApplicationIdProvider(mockBuildStep);
+
+    try {
+      provider.getPackageName();
+      fail();
+    } catch (ApkProvisionException ex) {
+      // An exception should be thrown if the package name is not available because it's a
+      // serious error and should not fail silently.
+    }
+  }
+}

--- a/aswb/tests/unittests/com/google/idea/blaze/android/run/test/BlazeAndroidTestApplicationIdProviderTest.java
+++ b/aswb/tests/unittests/com/google/idea/blaze/android/run/test/BlazeAndroidTestApplicationIdProviderTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.android.run.test;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.android.tools.idea.run.ApkProvisionException;
+import com.google.common.collect.ImmutableList;
+import com.google.idea.blaze.android.manifest.ManifestParser.ParsedManifest;
+import com.google.idea.blaze.android.run.deployinfo.BlazeAndroidDeployInfo;
+import com.google.idea.blaze.android.run.runner.BlazeApkBuildStep;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Unit tests for {@link
+ * com.google.idea.blaze.android.run.test.BlazeAndroidTestApplicationIdProvider}
+ */
+@RunWith(JUnit4.class)
+public class BlazeAndroidTestApplicationIdProviderTest {
+  @Test
+  public void getTestPackageName() throws Exception {
+    BlazeAndroidDeployInfo deployInfo =
+        new BlazeAndroidDeployInfo(
+            stubManifest("test.package.name"), stubManifest("package.name"), ImmutableList.of());
+    BlazeApkBuildStep mockBuildStep = mock(BlazeApkBuildStep.class);
+    when(mockBuildStep.getDeployInfo()).thenReturn(deployInfo);
+
+    BlazeAndroidTestApplicationIdProvider provider =
+        new BlazeAndroidTestApplicationIdProvider(mockBuildStep);
+    assertThat(provider.getTestPackageName()).isEqualTo("test.package.name");
+  }
+
+  @Test
+  public void getTestPackageName_noPackageNameInMergedManifest() throws Exception {
+    BlazeAndroidDeployInfo deployInfo =
+        new BlazeAndroidDeployInfo(
+            stubManifest(null), stubManifest("package.name"), ImmutableList.of());
+    BlazeApkBuildStep mockBuildStep = mock(BlazeApkBuildStep.class);
+    when(mockBuildStep.getDeployInfo()).thenReturn(deployInfo);
+
+    BlazeAndroidTestApplicationIdProvider provider =
+        new BlazeAndroidTestApplicationIdProvider(mockBuildStep);
+
+    try {
+      provider.getTestPackageName();
+      fail();
+    } catch (ApkProvisionException ex) {
+      // An exception should be thrown if the package name is not available because it's a
+      // serious error and should not fail silently. In this case we shouldn't fallback to
+      // the main package name, because the test package will be invalid as long as test
+      // manifest is missing package name.
+    }
+  }
+
+  @Test
+  public void getPackageName() throws Exception {
+    BlazeAndroidDeployInfo deployInfo =
+        new BlazeAndroidDeployInfo(
+            stubManifest("test.package.name"), stubManifest("package.name"), ImmutableList.of());
+    BlazeApkBuildStep mockBuildStep = mock(BlazeApkBuildStep.class);
+    when(mockBuildStep.getDeployInfo()).thenReturn(deployInfo);
+
+    BlazeAndroidTestApplicationIdProvider provider =
+        new BlazeAndroidTestApplicationIdProvider(mockBuildStep);
+    assertThat(provider.getPackageName()).isEqualTo("package.name");
+  }
+
+  @Test
+  public void getPackageName_noPackageNameInMergedManifest() throws Exception {
+    BlazeAndroidDeployInfo deployInfo =
+        new BlazeAndroidDeployInfo(
+            stubManifest("test.package.name"), stubManifest(null), ImmutableList.of());
+    BlazeApkBuildStep mockBuildStep = mock(BlazeApkBuildStep.class);
+    when(mockBuildStep.getDeployInfo()).thenReturn(deployInfo);
+
+    BlazeAndroidTestApplicationIdProvider provider =
+        new BlazeAndroidTestApplicationIdProvider(mockBuildStep);
+
+    try {
+      provider.getPackageName();
+      fail();
+    } catch (ApkProvisionException ex) {
+      // An exception should be thrown if the package name is not available because it's a
+      // serious error and should not fail silently. In this case we shouldn't fallback to
+      // the main package name, because the test package will be invalid as long as test
+      // manifest is missing package name.
+    }
+  }
+
+  @Test
+  public void getPackageName_noMergedManifest() throws Exception {
+    BlazeAndroidDeployInfo deployInfo =
+        new BlazeAndroidDeployInfo(stubManifest("test.package.name"), null, ImmutableList.of());
+    BlazeApkBuildStep mockBuildStep = mock(BlazeApkBuildStep.class);
+    when(mockBuildStep.getDeployInfo()).thenReturn(deployInfo);
+
+    BlazeAndroidTestApplicationIdProvider provider =
+        new BlazeAndroidTestApplicationIdProvider(mockBuildStep);
+    assertThat(provider.getPackageName()).isEqualTo("test.package.name");
+  }
+
+  private static ParsedManifest stubManifest(String packageName) {
+    return new ParsedManifest(packageName, ImmutableList.of(), null);
+  }
+}


### PR DESCRIPTION
Use ManifestParser.ParsedManifest in BlazeAndroidDeployInfo

Currently BlazeAndroidDeployInfo is a wrapper around AndroidDeployInfo
proto and contains it's own extraction logic for manifest values. This
is unecessarily complex and inflexible, so this CL extracts the logic
out of BlazeAndroidDeployInfo so it's now just a data-class. This added
flexibility also aids the upcoming android_instrumentation_test support
feature, where manifests values are extracted differently depending on
the build step.