### PR TITLE
Fix read/write lock freeze categorization with JDK 11.

### DIFF
--- a/base/src/com/google/idea/blaze/base/dependencies/AddSourceToProjectHelper.java
+++ b/base/src/com/google/idea/blaze/base/dependencies/AddSourceToProjectHelper.java
@@ -53,6 +53,7 @@ import com.intellij.notification.NotificationDisplayType;
 import com.intellij.notification.NotificationGroup;
 import com.intellij.notification.NotificationListener;
 import com.intellij.notification.NotificationType;
+import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.util.io.FileUtil;
@@ -321,6 +322,7 @@ class AddSourceToProjectHelper {
     }
     BuildSystemProvider provider = Blaze.getBuildSystemProvider(project);
     while (source != null) {
+      ProgressManager.checkCanceled();
       if (provider.findBuildFileInDirectory(pathResolver.resolveToFile(source)) != null) {
         return source;
       }

--- a/base/src/com/google/idea/blaze/base/lang/buildfile/quickfix/DeprecatedLoadQuickFix.java
+++ b/base/src/com/google/idea/blaze/base/lang/buildfile/quickfix/DeprecatedLoadQuickFix.java
@@ -27,6 +27,7 @@ import com.intellij.codeInspection.LocalQuickFix;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.history.core.Paths;
 import com.intellij.lang.ASTNode;
+import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiElement;
 import java.io.File;
@@ -94,6 +95,7 @@ public class DeprecatedLoadQuickFix implements LocalQuickFix, HighPriorityAction
     BuildSystemProvider provider = Blaze.getBuildSystemProvider(project);
     file = file.getParentFile();
     while (file != null) {
+      ProgressManager.checkCanceled();
       File buildFile = provider.findBuildFileInDirectory(file);
       if (buildFile != null) {
         return file;


### PR DESCRIPTION
Fix read/write lock freeze categorization with JDK 11.