### PR TITLE
clion-2019.3 compat: Support test frameworks being in separate plugins

### DIFF
--- a/clwb/src/com/google/idea/blaze/clwb/run/producers/NonBlazeProducerSuppressor.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/producers/NonBlazeProducerSuppressor.java
@@ -21,6 +21,7 @@ import com.intellij.execution.RunConfigurationProducerService;
 import com.intellij.execution.actions.RunConfigurationProducer;
 import com.intellij.openapi.components.ProjectComponent;
 import com.intellij.openapi.project.Project;
+import com.jetbrains.cidr.cpp.execution.testing.boost.CMakeBoostTestRunConfigurationProducer;
 import com.jetbrains.cidr.cpp.execution.testing.google.CMakeGoogleTestRunConfigurationProducer;
 import com.jetbrains.cidr.cpp.execution.testing.tcatch.CMakeCatchTestRunConfigurationProducer;
 
@@ -31,7 +32,8 @@ public class NonBlazeProducerSuppressor implements ProjectComponent {
       PRODUCERS_TO_SUPPRESS =
           ImmutableList.of(
               CMakeGoogleTestRunConfigurationProducer.class,
-              CMakeCatchTestRunConfigurationProducer.class);
+              CMakeCatchTestRunConfigurationProducer.class,
+              CMakeBoostTestRunConfigurationProducer.class);
 
   private final Project project;
 

--- a/intellij_platform_sdk/BUILD.clion193
+++ b/intellij_platform_sdk/BUILD.clion193
@@ -10,6 +10,8 @@ java_import(
         [
             "clion-*/lib/*.jar",
             "clion-*/plugins/clion-test-google/lib/*.jar",
+            "clion-*/plugins/clion-test-catch/lib/*.jar",
+            "clion-*/plugins/clion-test-boost/lib/*.jar",
         ]),
     tags = ["intellij-provided-by-sdk"],
     deps = ["@error_prone_annotations//jar"],


### PR DESCRIPTION
clion-2019.3 compat: Support test frameworks being in separate plugins