### PR TITLE
clion 2019.3 compat: IMPORT_GROUP_BEGIN move from PyBlock to PythonCodeStyleService

### DIFF
--- a/sdkcompat/v191/com/google/idea/sdkcompat/python/PythonCodeStyleServiceAdapter.java
+++ b/sdkcompat/v191/com/google/idea/sdkcompat/python/PythonCodeStyleServiceAdapter.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.sdkcompat.python;
+
+import com.intellij.openapi.util.Key;
+import com.jetbrains.python.formatter.PyBlock;
+
+/** IMPORT_GROUP_BEGIN moved to PythonCodeStyleService in 2019.3 #api192 */
+public class PythonCodeStyleServiceAdapter {
+
+  public static final Key<Boolean> IMPORT_GROUP_BEGIN = PyBlock.IMPORT_GROUP_BEGIN;
+
+  private PythonCodeStyleServiceAdapter() {}
+}

--- a/sdkcompat/v192/com/google/idea/sdkcompat/python/PythonCodeStyleServiceAdapter.java
+++ b/sdkcompat/v192/com/google/idea/sdkcompat/python/PythonCodeStyleServiceAdapter.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.sdkcompat.python;
+
+import com.intellij.openapi.util.Key;
+import com.jetbrains.python.formatter.PyBlock;
+
+/** IMPORT_GROUP_BEGIN moved to PythonCodeStyleService in 2019.3 #api192 */
+public class PythonCodeStyleServiceAdapter {
+
+  public static final Key<Boolean> IMPORT_GROUP_BEGIN = PyBlock.IMPORT_GROUP_BEGIN;
+
+  private PythonCodeStyleServiceAdapter() {}
+}

--- a/sdkcompat/v193/com/google/idea/sdkcompat/python/PythonCodeStyleServiceAdapter.java
+++ b/sdkcompat/v193/com/google/idea/sdkcompat/python/PythonCodeStyleServiceAdapter.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.sdkcompat.python;
+
+import com.intellij.openapi.util.Key;
+import com.jetbrains.python.PythonCodeStyleService;
+
+/** IMPORT_GROUP_BEGIN moved to PythonCodeStyleService in 2019.3 #api192 */
+public class PythonCodeStyleServiceAdapter {
+
+  public static final Key<Boolean> IMPORT_GROUP_BEGIN = PythonCodeStyleService.IMPORT_GROUP_BEGIN;
+
+  private PythonCodeStyleServiceAdapter() {}
+}


### PR DESCRIPTION
clion 2019.3 compat: IMPORT_GROUP_BEGIN move from PyBlock to PythonCodeStyleService