### PR TITLE
Remove comments from vmoptions before using it inside a run config

### DIFF
--- a/plugin_dev/src/com/google/idea/blaze/plugin/run/BlazeIntellijPluginConfigurationType.java
+++ b/plugin_dev/src/com/google/idea/blaze/plugin/run/BlazeIntellijPluginConfigurationType.java
@@ -145,7 +145,7 @@ public class BlazeIntellijPluginConfigurationType implements ConfigurationType {
       if (vmoptions == null) {
         return null;
       }
-      vmoptions = vmoptions.replaceAll("#.+", "").replaceAll("\\s+", " ").trim();
+      vmoptions = vmoptions.replaceAll("#.*", "").replaceAll("\\s+", " ").trim();
       String vmoptionsFile = System.getProperty("jb.vmOptionsFile");
       if (vmoptionsFile != null) {
         vmoptions += String.format(" -Djb.vmOptionsFile=\"%s\"", vmoptionsFile);

--- a/plugin_dev/src/com/google/idea/blaze/plugin/run/BlazeIntellijPluginConfigurationType.java
+++ b/plugin_dev/src/com/google/idea/blaze/plugin/run/BlazeIntellijPluginConfigurationType.java
@@ -145,7 +145,7 @@ public class BlazeIntellijPluginConfigurationType implements ConfigurationType {
       if (vmoptions == null) {
         return null;
       }
-      vmoptions = vmoptions.replaceAll("\\s+", " ").trim();
+      vmoptions = vmoptions.replaceAll("#.+", "").replaceAll("\\s+", " ").trim();
       String vmoptionsFile = System.getProperty("jb.vmOptionsFile");
       if (vmoptionsFile != null) {
         vmoptions += String.format(" -Djb.vmOptionsFile=\"%s\"", vmoptionsFile);


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #1438 

# Description of this change

Simple change to remove commented lines from the inferred `vmoptions` file.


