### PR TITLE
Update IDE info classes to support android_instrumentation_test.

### DIFF
--- a/aswb/tests/integrationtests/com/google/idea/blaze/android/functional/InstrumentationTestTargetIntegrationTest.java
+++ b/aswb/tests/integrationtests/com/google/idea/blaze/android/functional/InstrumentationTestTargetIntegrationTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.android.functional;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.idea.blaze.android.targetmapbuilder.NbAndroidInstrumentationTestTarget.android_instrumentation_test;
+import static com.google.idea.blaze.android.targetmapbuilder.NbAndroidTarget.android_binary;
+
+import com.google.idea.blaze.android.BlazeAndroidIntegrationTestCase;
+import com.google.idea.blaze.android.MockSdkUtil;
+import com.google.idea.blaze.base.ideinfo.TargetIdeInfo;
+import com.google.idea.blaze.base.ideinfo.TargetKey;
+import com.google.idea.blaze.base.ideinfo.TargetMap;
+import com.google.idea.blaze.base.model.BlazeProjectData;
+import com.google.idea.blaze.base.model.primitives.Label;
+import com.google.idea.blaze.base.model.primitives.WorkspacePath;
+import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
+import com.google.idea.blaze.java.AndroidBlazeRules.RuleTypes;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Integration tests for android_instrumentation_test dependencies.
+ *
+ * <p>Note: Technically this test should be an invoking blaze integration test to truly verify that
+ * instrumentation test dependencies work as expected. However, this test is still useful for
+ * verifying that instrumentation test related IDE info work correctly.
+ *
+ * <p>TODO(b/141650036): Change this test into an invoking blaze integration test.
+ */
+@RunWith(JUnit4.class)
+public class InstrumentationTestTargetIntegrationTest extends BlazeAndroidIntegrationTestCase {
+  @Before
+  public void setup() {
+    setProjectView(
+        "directories:",
+        "  java/com/foo/app",
+        "targets:",
+        "  //java/com/foo/app:instrumentation_test",
+        "android_sdk_platform: android-27");
+    MockSdkUtil.registerSdk(workspace, "27");
+
+    workspace.createFile(
+        new WorkspacePath("java/com/foo/app/MainActivity.java"),
+        "package com.foo.app",
+        "import android.app.Activity;",
+        "public class MainActivity extends Activity {}");
+
+    workspace.createFile(
+        new WorkspacePath("java/com/foo/app/Test.java"),
+        "package com.foo.app",
+        "public class Test {}");
+
+    setTargetMap(
+        android_binary("//java/com/foo/app:app").src("MainActivity.java"),
+        android_binary("//java/com/foo/app:test_app")
+            .src("Test.java")
+            .instruments("//java/com/foo/app:app"),
+        android_instrumentation_test("//java/com/foo/app:instrumentation_test")
+            .test_app("//java/com/foo/app:test_app"));
+    runFullBlazeSync();
+  }
+
+  @Test
+  public void findInstrumentorAndTestTargets() {
+    BlazeProjectData projectData =
+        BlazeProjectDataManager.getInstance(getProject()).getBlazeProjectData();
+    assertThat(projectData).isNotNull();
+
+    // The following extracts the dependency info required during an instrumentation test.
+    // To disambiguate, the following terms are used:
+    // test: The android_instrumentation_test target.
+    // instrumentor: The android app that instruments the UI test.
+    // app: The android app under test.
+    Label testLabel = Label.create("//java/com/foo/app:instrumentation_test");
+    Label instrumentorLabel = Label.create("//java/com/foo/app:test_app");
+    Label appLabel = Label.create("//java/com/foo/app:app");
+
+    TargetMap targetMap = projectData.getTargetMap();
+    TargetIdeInfo testTarget = targetMap.get(TargetKey.forPlainTarget(testLabel));
+    assertThat(testTarget).isNotNull();
+    assertThat(testTarget.getKind()).isEqualTo(RuleTypes.ANDROID_INSTRUMENTATION_TEST.getKind());
+    assertThat(testTarget.getAndroidInstrumentationInfo().getTestApp())
+        .isEqualTo(instrumentorLabel);
+
+    TargetIdeInfo instrumentorTarget = targetMap.get(TargetKey.forPlainTarget(instrumentorLabel));
+    assertThat(instrumentorTarget).isNotNull();
+    assertThat(instrumentorTarget.getKind()).isEqualTo(RuleTypes.ANDROID_BINARY.getKind());
+    assertThat(instrumentorTarget.getAndroidIdeInfo().getInstruments()).isEqualTo(appLabel);
+
+    TargetIdeInfo appTarget = targetMap.get(TargetKey.forPlainTarget(appLabel));
+    assertThat(appTarget).isNotNull();
+    assertThat(appTarget.getKind()).isEqualTo(RuleTypes.ANDROID_BINARY.getKind());
+  }
+}

--- a/aswb/tests/utils/integration/com/google/idea/blaze/android/targetmapbuilder/NbAndroidInstrumentationTestTarget.java
+++ b/aswb/tests/utils/integration/com/google/idea/blaze/android/targetmapbuilder/NbAndroidInstrumentationTestTarget.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.android.targetmapbuilder;
+
+import static com.google.idea.blaze.android.targetmapbuilder.NbTargetMapUtils.makeSourceArtifact;
+
+import com.google.idea.blaze.base.ideinfo.AndroidInstrumentationInfo;
+import com.google.idea.blaze.base.ideinfo.ArtifactLocation;
+import com.google.idea.blaze.base.ideinfo.TargetIdeInfo;
+import com.google.idea.blaze.base.model.primitives.Label;
+import com.google.idea.blaze.base.model.primitives.WorkspacePath;
+import com.google.idea.blaze.java.AndroidBlazeRules.RuleTypes;
+
+/** Builder for a blaze android instrumentation test target's IDE info. */
+public class NbAndroidInstrumentationTestTarget extends NbBaseTargetBuilder {
+  private final TargetIdeInfo.Builder targetIdeInfoBuilder;
+  private final AndroidInstrumentationInfo.Builder androidInstrumentationInfoBuilder;
+  private final WorkspacePath blazePackage;
+
+  public static NbAndroidInstrumentationTestTarget android_instrumentation_test(String label) {
+    return new NbAndroidInstrumentationTestTarget(BlazeInfoData.DEFAULT, label);
+  }
+
+  public NbAndroidInstrumentationTestTarget test_app(String relativeLabel) {
+    if (relativeLabel.startsWith("//")) {
+      androidInstrumentationInfoBuilder.setTestApp(Label.create(relativeLabel));
+    } else {
+      androidInstrumentationInfoBuilder.setTestApp(
+          Label.create("//" + blazePackage + relativeLabel));
+    }
+    return this;
+  }
+
+  NbAndroidInstrumentationTestTarget(BlazeInfoData blazeInfoData, String label) {
+    super(blazeInfoData);
+    this.blazePackage = NbTargetMapUtils.blazePackageForLabel(label);
+    this.androidInstrumentationInfoBuilder = new AndroidInstrumentationInfo.Builder();
+    this.targetIdeInfoBuilder = new TargetIdeInfo.Builder();
+
+    targetIdeInfoBuilder
+        .setKind(RuleTypes.ANDROID_INSTRUMENTATION_TEST.getKind())
+        .setLabel(label)
+        .setBuildFile(inferBuildFileLocation(label));
+  }
+
+  @Override
+  TargetIdeInfo.Builder getIdeInfoBuilder() {
+    return targetIdeInfoBuilder.setAndroidInstrumentationInfo(
+        androidInstrumentationInfoBuilder.build());
+  }
+
+  private static ArtifactLocation inferBuildFileLocation(String label) {
+    return makeSourceArtifact(NbTargetMapUtils.blazePackageForLabel(label) + "/BUILD");
+  }
+}

--- a/aswb/tests/utils/integration/com/google/idea/blaze/android/targetmapbuilder/NbAndroidTarget.java
+++ b/aswb/tests/utils/integration/com/google/idea/blaze/android/targetmapbuilder/NbAndroidTarget.java
@@ -22,6 +22,7 @@ import com.google.idea.blaze.base.ideinfo.AndroidIdeInfo;
 import com.google.idea.blaze.base.ideinfo.AndroidResFolder;
 import com.google.idea.blaze.base.ideinfo.TargetIdeInfo;
 import com.google.idea.blaze.base.model.primitives.Kind;
+import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.model.primitives.WorkspacePath;
 import com.google.idea.blaze.java.AndroidBlazeRules;
 import java.util.Collection;
@@ -68,6 +69,7 @@ public class NbAndroidTarget extends NbBaseTargetBuilder {
     if (kind.equals(AndroidBlazeRules.RuleTypes.ANDROID_BINARY.getKind())) {
       // The android_binary rule requires a manifest.
       setDefaultManifest();
+      setGenerateResourceClass();
     }
 
     // blaze java packages all take the form "java/<actual_package_here>".
@@ -173,6 +175,15 @@ public class NbAndroidTarget extends NbBaseTargetBuilder {
 
   public NbAndroidTarget java_toolchain_version(String version) {
     javaTarget.java_toolchain_version(version);
+    return this;
+  }
+
+  public NbAndroidTarget instruments(String relativeLabel) {
+    if (relativeLabel.startsWith("//")) {
+      androidIdeInfoBuilder.setInstruments(Label.create(relativeLabel));
+    } else {
+      androidIdeInfoBuilder.setInstruments(Label.create("//" + blazePackage + relativeLabel));
+    }
     return this;
   }
 }

--- a/base/src/com/google/idea/blaze/base/ideinfo/AndroidIdeInfo.java
+++ b/base/src/com/google/idea/blaze/base/ideinfo/AndroidIdeInfo.java
@@ -45,6 +45,7 @@ public final class AndroidIdeInfo implements ProtoWrapper<IntellijIdeInfo.Androi
   @Nullable private final String resourceJavaPackage;
   private final boolean generateResourceClass;
   @Nullable private final Label legacyResources;
+  @Nullable private final Label instruments;
 
   private AndroidIdeInfo(
       List<AndroidResFolder> resources,
@@ -55,7 +56,8 @@ public final class AndroidIdeInfo implements ProtoWrapper<IntellijIdeInfo.Androi
       @Nullable LibraryArtifact idlJar,
       @Nullable LibraryArtifact resourceJar,
       boolean hasIdlSources,
-      @Nullable Label legacyResources) {
+      @Nullable Label legacyResources,
+      @Nullable Label instruments) {
     this.resources = ImmutableList.copyOf(resources);
     this.resourceJavaPackage = resourceJavaPackage;
     this.generateResourceClass = generateResourceClass;
@@ -65,6 +67,7 @@ public final class AndroidIdeInfo implements ProtoWrapper<IntellijIdeInfo.Androi
     this.resourceJar = resourceJar;
     this.hasIdlSources = hasIdlSources;
     this.legacyResources = legacyResources;
+    this.instruments = instruments;
   }
 
   static AndroidIdeInfo fromProto(IntellijIdeInfo.AndroidIdeInfo proto) {
@@ -81,6 +84,9 @@ public final class AndroidIdeInfo implements ProtoWrapper<IntellijIdeInfo.Androi
         proto.getHasIdlSources(),
         !Strings.isNullOrEmpty(proto.getLegacyResources())
             ? Label.create(proto.getLegacyResources())
+            : null,
+        !Strings.isNullOrEmpty(proto.getInstruments())
+            ? Label.create(proto.getInstruments())
             : null);
   }
 
@@ -97,6 +103,7 @@ public final class AndroidIdeInfo implements ProtoWrapper<IntellijIdeInfo.Androi
     ProtoWrapper.unwrapAndSetIfNotNull(builder::setIdlJar, idlJar);
     ProtoWrapper.unwrapAndSetIfNotNull(builder::setResourceJar, resourceJar);
     ProtoWrapper.unwrapAndSetIfNotNull(builder::setLegacyResources, legacyResources);
+    ProtoWrapper.unwrapAndSetIfNotNull(builder::setInstruments, instruments);
     return builder.build();
   }
 
@@ -146,6 +153,11 @@ public final class AndroidIdeInfo implements ProtoWrapper<IntellijIdeInfo.Androi
     return legacyResources;
   }
 
+  @Nullable
+  public Label getInstruments() {
+    return instruments;
+  }
+
   public static Builder builder() {
     return new Builder();
   }
@@ -161,6 +173,7 @@ public final class AndroidIdeInfo implements ProtoWrapper<IntellijIdeInfo.Androi
     private String resourceJavaPackage;
     private boolean generateResourceClass;
     private Label legacyResources;
+    private Label instruments;
 
     public Builder setManifestFile(ArtifactLocation artifactLocation) {
       this.manifest = artifactLocation;
@@ -211,6 +224,11 @@ public final class AndroidIdeInfo implements ProtoWrapper<IntellijIdeInfo.Androi
       return this;
     }
 
+    public Builder setInstruments(@Nullable Label instruments) {
+      this.instruments = instruments;
+      return this;
+    }
+
     public AndroidIdeInfo build() {
       if (!resources.isEmpty() || manifest != null) {
         if (!generateResourceClass) {
@@ -228,7 +246,8 @@ public final class AndroidIdeInfo implements ProtoWrapper<IntellijIdeInfo.Androi
           idlJar,
           resourceJar,
           hasIdlSources,
-          legacyResources);
+          legacyResources,
+          instruments);
     }
   }
 
@@ -249,7 +268,8 @@ public final class AndroidIdeInfo implements ProtoWrapper<IntellijIdeInfo.Androi
         && Objects.equals(idlJar, that.idlJar)
         && Objects.equals(resourceJar, that.resourceJar)
         && Objects.equals(resourceJavaPackage, that.resourceJavaPackage)
-        && Objects.equals(legacyResources, that.legacyResources);
+        && Objects.equals(legacyResources, that.legacyResources)
+        && Objects.equals(instruments, that.instruments);
   }
 
   @Override
@@ -263,6 +283,7 @@ public final class AndroidIdeInfo implements ProtoWrapper<IntellijIdeInfo.Androi
         hasIdlSources,
         resourceJavaPackage,
         generateResourceClass,
-        legacyResources);
+        legacyResources,
+        instruments);
   }
 }

--- a/base/src/com/google/idea/blaze/base/ideinfo/AndroidInstrumentationInfo.java
+++ b/base/src/com/google/idea/blaze/base/ideinfo/AndroidInstrumentationInfo.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.ideinfo;
+
+import com.google.common.base.Strings;
+import com.google.devtools.intellij.ideinfo.IntellijIdeInfo;
+import com.google.idea.blaze.base.model.primitives.Label;
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/** Ide info specific to android instrumentation tests */
+public class AndroidInstrumentationInfo
+    implements ProtoWrapper<IntellijIdeInfo.AndroidInstrumentationInfo> {
+
+  @Nullable
+  public Label getTestApp() {
+    return testApp;
+  }
+
+  @Nullable private final Label testApp;
+
+  private AndroidInstrumentationInfo(@Nullable Label testApp) {
+    this.testApp = testApp;
+  }
+
+  static AndroidInstrumentationInfo fromProto(IntellijIdeInfo.AndroidInstrumentationInfo proto) {
+    return new AndroidInstrumentationInfo(
+        !Strings.isNullOrEmpty(proto.getTestApp()) ? Label.create(proto.getTestApp()) : null);
+  }
+
+  @Override
+  public IntellijIdeInfo.AndroidInstrumentationInfo toProto() {
+    IntellijIdeInfo.AndroidInstrumentationInfo.Builder builder =
+        IntellijIdeInfo.AndroidInstrumentationInfo.newBuilder();
+    ProtoWrapper.unwrapAndSetIfNotNull(builder::setTestApp, testApp);
+    return builder.build();
+  }
+
+  /** Builder for android instrumentation test rule */
+  public static class Builder {
+    private Label testApp;
+
+    public Builder setTestApp(Label testApp) {
+      this.testApp = testApp;
+      return this;
+    }
+
+    public AndroidInstrumentationInfo build() {
+      return new AndroidInstrumentationInfo(testApp);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof Builder)) {
+        return false;
+      }
+      if (!(o instanceof AndroidInstrumentationInfo)) {
+        return false;
+      }
+      AndroidInstrumentationInfo that = (AndroidInstrumentationInfo) o;
+      return testApp.equals(that.getTestApp());
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(testApp);
+    }
+  }
+}

--- a/base/src/com/google/idea/blaze/base/ideinfo/TargetIdeInfo.java
+++ b/base/src/com/google/idea/blaze/base/ideinfo/TargetIdeInfo.java
@@ -44,6 +44,7 @@ public final class TargetIdeInfo implements ProtoWrapper<IntellijIdeInfo.TargetI
   @Nullable private final AndroidIdeInfo androidIdeInfo;
   @Nullable private final AndroidSdkIdeInfo androidSdkIdeInfo;
   @Nullable private final AndroidAarIdeInfo androidAarIdeInfo;
+  @Nullable private final AndroidInstrumentationInfo androidInstrumentationInfo;
   @Nullable private final PyIdeInfo pyIdeInfo;
   @Nullable private final GoIdeInfo goIdeInfo;
   @Nullable private final JsIdeInfo jsIdeInfo;
@@ -67,6 +68,7 @@ public final class TargetIdeInfo implements ProtoWrapper<IntellijIdeInfo.TargetI
       @Nullable AndroidIdeInfo androidIdeInfo,
       @Nullable AndroidSdkIdeInfo androidSdkIdeInfo,
       @Nullable AndroidAarIdeInfo androidAarIdeInfo,
+      @Nullable AndroidInstrumentationInfo androidInstrumentationInfo,
       @Nullable PyIdeInfo pyIdeInfo,
       @Nullable GoIdeInfo goIdeInfo,
       @Nullable JsIdeInfo jsIdeInfo,
@@ -88,6 +90,7 @@ public final class TargetIdeInfo implements ProtoWrapper<IntellijIdeInfo.TargetI
     this.androidIdeInfo = androidIdeInfo;
     this.androidSdkIdeInfo = androidSdkIdeInfo;
     this.androidAarIdeInfo = androidAarIdeInfo;
+    this.androidInstrumentationInfo = androidInstrumentationInfo;
     this.pyIdeInfo = pyIdeInfo;
     this.goIdeInfo = goIdeInfo;
     this.jsIdeInfo = jsIdeInfo;
@@ -176,6 +179,9 @@ public final class TargetIdeInfo implements ProtoWrapper<IntellijIdeInfo.TargetI
         proto.hasAndroidAarIdeInfo()
             ? AndroidAarIdeInfo.fromProto(proto.getAndroidAarIdeInfo())
             : null,
+        proto.hasAndroidInstrumentationInfo()
+            ? AndroidInstrumentationInfo.fromProto(proto.getAndroidInstrumentationInfo())
+            : null,
         pyIdeInfo,
         goIdeInfo,
         jsIdeInfo,
@@ -206,6 +212,8 @@ public final class TargetIdeInfo implements ProtoWrapper<IntellijIdeInfo.TargetI
     ProtoWrapper.unwrapAndSetIfNotNull(builder::setAndroidIdeInfo, androidIdeInfo);
     ProtoWrapper.unwrapAndSetIfNotNull(builder::setAndroidSdkIdeInfo, androidSdkIdeInfo);
     ProtoWrapper.unwrapAndSetIfNotNull(builder::setAndroidAarIdeInfo, androidAarIdeInfo);
+    ProtoWrapper.unwrapAndSetIfNotNull(
+        builder::setAndroidInstrumentationInfo, androidInstrumentationInfo);
     ProtoWrapper.unwrapAndSetIfNotNull(builder::setPyIdeInfo, pyIdeInfo);
     ProtoWrapper.unwrapAndSetIfNotNull(builder::setGoIdeInfo, goIdeInfo);
     ProtoWrapper.unwrapAndSetIfNotNull(builder::setJsIdeInfo, jsIdeInfo);
@@ -240,6 +248,7 @@ public final class TargetIdeInfo implements ProtoWrapper<IntellijIdeInfo.TargetI
         androidIdeInfo,
         androidSdkIdeInfo,
         androidAarIdeInfo,
+        androidInstrumentationInfo,
         pyIdeInfo,
         goIdeInfo,
         jsIdeInfo,
@@ -304,6 +313,11 @@ public final class TargetIdeInfo implements ProtoWrapper<IntellijIdeInfo.TargetI
   @Nullable
   public AndroidAarIdeInfo getAndroidAarIdeInfo() {
     return androidAarIdeInfo;
+  }
+
+  @Nullable
+  public AndroidInstrumentationInfo getAndroidInstrumentationInfo() {
+    return androidInstrumentationInfo;
   }
 
   @Nullable
@@ -395,6 +409,7 @@ public final class TargetIdeInfo implements ProtoWrapper<IntellijIdeInfo.TargetI
     private JavaIdeInfo javaIdeInfo;
     private AndroidIdeInfo androidIdeInfo;
     private AndroidAarIdeInfo androidAarIdeInfo;
+    private AndroidInstrumentationInfo androidInstrumentationInfo;
     private PyIdeInfo pyIdeInfo;
     private GoIdeInfo goIdeInfo;
     private JsIdeInfo jsIdeInfo;
@@ -464,6 +479,11 @@ public final class TargetIdeInfo implements ProtoWrapper<IntellijIdeInfo.TargetI
 
     public Builder setAndroidAarInfo(AndroidAarIdeInfo aarInfo) {
       this.androidAarIdeInfo = aarInfo;
+      return this;
+    }
+
+    public Builder setAndroidInstrumentationInfo(AndroidInstrumentationInfo instrumentationInfo) {
+      this.androidInstrumentationInfo = instrumentationInfo;
       return this;
     }
 
@@ -551,6 +571,7 @@ public final class TargetIdeInfo implements ProtoWrapper<IntellijIdeInfo.TargetI
           androidIdeInfo,
           null,
           androidAarIdeInfo,
+          androidInstrumentationInfo,
           pyIdeInfo,
           goIdeInfo,
           jsIdeInfo,
@@ -584,6 +605,7 @@ public final class TargetIdeInfo implements ProtoWrapper<IntellijIdeInfo.TargetI
         && Objects.equals(androidIdeInfo, that.androidIdeInfo)
         && Objects.equals(androidSdkIdeInfo, that.androidSdkIdeInfo)
         && Objects.equals(androidAarIdeInfo, that.androidAarIdeInfo)
+        && Objects.equals(androidInstrumentationInfo, that.androidInstrumentationInfo)
         && Objects.equals(pyIdeInfo, that.pyIdeInfo)
         && Objects.equals(goIdeInfo, that.goIdeInfo)
         && Objects.equals(jsIdeInfo, that.jsIdeInfo)
@@ -610,6 +632,7 @@ public final class TargetIdeInfo implements ProtoWrapper<IntellijIdeInfo.TargetI
         androidIdeInfo,
         androidSdkIdeInfo,
         androidAarIdeInfo,
+        androidInstrumentationInfo,
         pyIdeInfo,
         goIdeInfo,
         jsIdeInfo,


### PR DESCRIPTION
Update IDE info classes to support android_instrumentation_test.

android_ide_info now exposes information required to support
android_instrumentation_test.  This CL does the necessary IDE side
changes to consume these newly exposed aspect fields.

TEST INFRA:
Added new NB target map builders for android_instrumentation_test.
