### PR TITLE
2019.3 sdkcompat: Workaround for change to PluginInstaller.prepareToUninstall()

### DIFF
--- a/sdkcompat/v191/com/google/idea/sdkcompat/platform/PluginInstallerCompat.java
+++ b/sdkcompat/v191/com/google/idea/sdkcompat/platform/PluginInstallerCompat.java
@@ -1,0 +1,15 @@
+package com.google.idea.sdkcompat.platform;
+
+import com.intellij.ide.plugins.IdeaPluginDescriptor;
+import com.intellij.ide.plugins.PluginInstaller;
+import java.io.IOException;
+
+/** * Compat for PluginInstaller. Remove when #api192 is no longer supported. */
+public class PluginInstallerCompat {
+
+  private PluginInstallerCompat() {}
+
+  public static void prepareToUninstall(IdeaPluginDescriptor pluginDescriptor) throws IOException {
+    PluginInstaller.prepareToUninstall(pluginDescriptor.getPluginId());
+  }
+}

--- a/sdkcompat/v192/com/google/idea/sdkcompat/platform/PluginInstallerCompat.java
+++ b/sdkcompat/v192/com/google/idea/sdkcompat/platform/PluginInstallerCompat.java
@@ -1,0 +1,15 @@
+package com.google.idea.sdkcompat.platform;
+
+import com.intellij.ide.plugins.IdeaPluginDescriptor;
+import com.intellij.ide.plugins.PluginInstaller;
+import java.io.IOException;
+
+/** * Compat for PluginInstaller. Remove when #api192 is no longer supported. */
+public class PluginInstallerCompat {
+
+  private PluginInstallerCompat() {}
+
+  public static void prepareToUninstall(IdeaPluginDescriptor pluginDescriptor) throws IOException {
+    PluginInstaller.prepareToUninstall(pluginDescriptor.getPluginId());
+  }
+}

--- a/sdkcompat/v193/com/google/idea/sdkcompat/platform/PluginInstallerCompat.java
+++ b/sdkcompat/v193/com/google/idea/sdkcompat/platform/PluginInstallerCompat.java
@@ -1,0 +1,15 @@
+package com.google.idea.sdkcompat.platform;
+
+import com.intellij.ide.plugins.IdeaPluginDescriptor;
+import com.intellij.ide.plugins.PluginInstaller;
+import java.io.IOException;
+
+/** * Compat for PluginInstaller. Remove when #api192 is no longer supported. */
+public class PluginInstallerCompat {
+
+  private PluginInstallerCompat() {}
+
+  public static void prepareToUninstall(IdeaPluginDescriptor pluginDescriptor) throws IOException {
+    PluginInstaller.prepareToUninstall(pluginDescriptor);
+  }
+}


### PR DESCRIPTION
2019.3 sdkcompat: Workaround for change to PluginInstaller.prepareToUninstall()