### PR TITLE
Move scoping logic out of build steps.

### DIFF
--- a/aswb/src/com/google/idea/blaze/android/run/runner/BlazeApkBuildStep.java
+++ b/aswb/src/com/google/idea/blaze/android/run/runner/BlazeApkBuildStep.java
@@ -19,14 +19,13 @@ import com.android.tools.idea.run.ApkProvisionException;
 import com.google.idea.blaze.android.run.deployinfo.BlazeAndroidDeployInfo;
 import com.google.idea.blaze.base.scope.BlazeContext;
 
-/** Builds the APK. */
+/** Builds the APK and optionally installs the APK. */
 public interface BlazeApkBuildStep {
   /**
-   * Builds and optionally installs the APK.
-   *
-   * @return True to continue the launch.
+   * Builds and optionally installs the APK. Errors and messages are bubbled up to the caller via
+   * the given {@link BlazeContext}.
    */
-  boolean build(BlazeContext context, BlazeAndroidDeviceSelector.DeviceSession deviceSession);
+  void build(BlazeContext context, BlazeAndroidDeviceSelector.DeviceSession deviceSession);
 
   BlazeAndroidDeployInfo getDeployInfo() throws ApkProvisionException;
 }

--- a/aswb/src/com/google/idea/blaze/android/run/runner/BlazeApkBuildStepNormalBuild.java
+++ b/aswb/src/com/google/idea/blaze/android/run/runner/BlazeApkBuildStepNormalBuild.java
@@ -18,12 +18,9 @@ package com.google.idea.blaze.android.run.runner;
 import com.android.tools.idea.run.ApkProvisionException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
 import com.google.devtools.build.lib.rules.android.deployinfo.AndroidDeployInfoOuterClass.AndroidDeployInfo;
 import com.google.idea.blaze.android.run.deployinfo.BlazeAndroidDeployInfo;
 import com.google.idea.blaze.android.run.deployinfo.BlazeApkDeployInfoProtoHelper;
-import com.google.idea.blaze.base.async.executor.ProgressiveTaskWithProgressIndicator;
 import com.google.idea.blaze.base.async.process.ExternalTask;
 import com.google.idea.blaze.base.async.process.LineProcessingOutputStream;
 import com.google.idea.blaze.base.command.BlazeCommand;
@@ -41,17 +38,14 @@ import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
 import com.google.idea.blaze.base.scope.BlazeContext;
-import com.google.idea.blaze.base.scope.ScopedTask;
 import com.google.idea.blaze.base.scope.output.IssueOutput;
 import com.google.idea.blaze.base.scope.output.StatusOutput;
 import com.google.idea.blaze.base.settings.Blaze;
 import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
 import com.google.idea.blaze.base.util.SaveUtil;
 import com.google.idea.blaze.java.AndroidBlazeRules;
-import com.intellij.execution.ExecutionException;
 import com.intellij.openapi.project.Project;
 import java.io.File;
-import java.util.concurrent.CancellationException;
 
 /** Builds the APK using normal blaze build. */
 public class BlazeApkBuildStepNormalBuild implements BlazeApkBuildStep {
@@ -92,80 +86,56 @@ public class BlazeApkBuildStepNormalBuild implements BlazeApkBuildStep {
   }
 
   @Override
-  public boolean build(
-      BlazeContext context, BlazeAndroidDeviceSelector.DeviceSession deviceSession) {
-    ScopedTask<Void> buildTask =
-        new ScopedTask<Void>(context) {
-          @Override
-          protected Void execute(BlazeContext context) {
-            BlazeProjectData projectData =
-                BlazeProjectDataManager.getInstance(project).getBlazeProjectData();
+  public void build(BlazeContext context, BlazeAndroidDeviceSelector.DeviceSession deviceSession) {
+    BlazeProjectData projectData =
+        BlazeProjectDataManager.getInstance(project).getBlazeProjectData();
 
-            if (projectData == null) {
-              IssueOutput.error("Missing project data. Please sync and try again.").submit(context);
-              return null;
-            }
-
-            BlazeCommand.Builder command =
-                BlazeCommand.builder(
-                    Blaze.getBuildSystemProvider(project).getBinaryPath(project),
-                    BlazeCommandName.BUILD);
-            WorkspaceRoot workspaceRoot = WorkspaceRoot.fromProject(project);
-            File executionRoot = projectData.getBlazeInfo().getExecutionRoot();
-
-            try (BuildResultHelper buildResultHelper = BuildResultHelperProvider.create(project)) {
-              command
-                  .addTargets(getTargetToBuild(projectData, label))
-                  .addBlazeFlags("--output_groups=+android_deploy_info")
-                  .addBlazeFlags(buildFlags)
-                  .addBlazeFlags(buildResultHelper.getBuildFlags());
-
-              SaveUtil.saveAllFiles();
-              int retVal =
-                  ExternalTask.builder(workspaceRoot)
-                      .addBlazeCommand(command.build())
-                      .context(context)
-                      .stderr(
-                          LineProcessingOutputStream.of(
-                              BlazeConsoleLineProcessorProvider.getAllStderrLineProcessors(
-                                  context)))
-                      .build()
-                      .run();
-              FileCaches.refresh(project, context);
-
-              if (retVal != 0) {
-                context.setHasError();
-                return null;
-              }
-
-              context.output(new StatusOutput("Reading deployment information..."));
-              AndroidDeployInfo deployInfoProto =
-                  BlazeApkDeployInfoProtoHelper.readDeployInfoProtoForTarget(
-                      label, buildResultHelper, fileName -> fileName.endsWith(DEPLOY_INFO_SUFFIX));
-              deployInfo =
-                  BlazeApkDeployInfoProtoHelper.extractDeployInfoAndInvalidateManifests(
-                      project, executionRoot, deployInfoProto);
-            } catch (GetArtifactsException e) {
-              IssueOutput.error("Could not read apk deploy info from build: " + e.getMessage())
-                  .submit(context);
-            }
-            return null;
-          }
-        };
-
-    ListenableFuture<Void> buildFuture =
-        ProgressiveTaskWithProgressIndicator.builder(
-                project, String.format("Executing %s apk build", Blaze.buildSystemName(project)))
-            .submitTaskWithResult(buildTask);
-
-    try {
-      Futures.getChecked(buildFuture, ExecutionException.class);
-    } catch (ExecutionException e) {
-      context.setHasError();
-    } catch (CancellationException e) {
-      context.setCancelled();
+    if (projectData == null) {
+      IssueOutput.error("Missing project data. Please sync and try again.").submit(context);
+      return;
     }
-    return context.shouldContinue();
+
+    BlazeCommand.Builder command =
+        BlazeCommand.builder(
+            Blaze.getBuildSystemProvider(project).getBinaryPath(project), BlazeCommandName.BUILD);
+    WorkspaceRoot workspaceRoot = WorkspaceRoot.fromProject(project);
+    File executionRoot = projectData.getBlazeInfo().getExecutionRoot();
+
+    try (BuildResultHelper buildResultHelper = BuildResultHelperProvider.create(project)) {
+      command
+          .addTargets(getTargetToBuild(projectData, label))
+          .addBlazeFlags("--output_groups=+android_deploy_info")
+          .addBlazeFlags(buildFlags)
+          .addBlazeFlags(buildResultHelper.getBuildFlags());
+
+      SaveUtil.saveAllFiles();
+      int retVal =
+          ExternalTask.builder(workspaceRoot)
+              .addBlazeCommand(command.build())
+              .context(context)
+              .stderr(
+                  LineProcessingOutputStream.of(
+                      BlazeConsoleLineProcessorProvider.getAllStderrLineProcessors(context)))
+              .build()
+              .run();
+      FileCaches.refresh(project, context);
+
+      if (retVal != 0) {
+        context.setHasError();
+        return;
+      }
+
+      context.output(new StatusOutput("Reading deployment information..."));
+      AndroidDeployInfo deployInfoProto =
+          BlazeApkDeployInfoProtoHelper.readDeployInfoProtoForTarget(
+              label, buildResultHelper, fileName -> fileName.endsWith(DEPLOY_INFO_SUFFIX));
+      deployInfo =
+          BlazeApkDeployInfoProtoHelper.extractDeployInfoAndInvalidateManifests(
+              project, executionRoot, deployInfoProto);
+    } catch (GetArtifactsException e) {
+      IssueOutput.error("Could not read apk deploy info from build: " + e.getMessage())
+          .submit(context);
+    }
   }
 
   @Override


### PR DESCRIPTION
Move scoping logic out of build steps.

Currently, every build step has a section that creates a scoped task and
starts itself in a progressive task with indicator.  

These sections are identical, the scoping logic adds annoying nesting
in an already crowded method, and the future task logic makes these 
build step classes hard to test.  It should be extracted out to the caller 
where it's better suited anyway.  

TEST:
I've manually verified that both mobile-install and normal build works the same way as before.
