### PR TITLE
Remove comments from vmoptions before using it inside a run config

### DIFF
--- a/plugin_dev/src/com/google/idea/blaze/plugin/run/BlazeIntellijPluginConfigurationType.java
+++ b/plugin_dev/src/com/google/idea/blaze/plugin/run/BlazeIntellijPluginConfigurationType.java
@@ -145,7 +145,7 @@ public class BlazeIntellijPluginConfigurationType implements ConfigurationType {
       if (vmoptions == null) {
         return null;
       }
-      vmoptions = vmoptions.replaceAll("\\s+", " ").trim();
+      vmoptions = vmoptions.replaceAll("#.*", "").replaceAll("\\s+", " ").trim();
       String vmoptionsFile = System.getProperty("jb.vmOptionsFile");
       if (vmoptionsFile != null) {
         vmoptions += String.format(" -Djb.vmOptionsFile=\"%s\"", vmoptionsFile);


### PR DESCRIPTION
Remove comments from vmoptions before using it inside a run config

Merges https://github.com/bazelbuild/intellij/pull/1439 from mtoader.
