### PR TITLE
Add tests for blaze APK build steps and BlazeApkDeployInfoProtoHelper.

### DIFF
--- a/aswb/tests/integrationtests/com/google/idea/blaze/android/functional/BlazeApkBuildStepMobileInstallIntegrationTest.java
+++ b/aswb/tests/integrationtests/com/google/idea/blaze/android/functional/BlazeApkBuildStepMobileInstallIntegrationTest.java
@@ -1,0 +1,329 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.android.functional;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.idea.blaze.android.targetmapbuilder.NbAndroidTarget.android_binary;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.android.ddmlib.IDevice;
+import com.android.ddmlib.IDevice.HardwareFeature;
+import com.android.sdklib.IAndroidTarget;
+import com.android.sdklib.devices.Abi;
+import com.android.tools.idea.run.AndroidDevice;
+import com.android.tools.idea.run.ApkProvisionException;
+import com.android.tools.idea.run.DeviceFutures;
+import com.android.tools.idea.run.LaunchCompatibility;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.devtools.build.lib.rules.android.deployinfo.AndroidDeployInfoOuterClass.AndroidDeployInfo;
+import com.google.idea.blaze.android.BlazeAndroidIntegrationTestCase;
+import com.google.idea.blaze.android.MockSdkUtil;
+import com.google.idea.blaze.android.run.binary.mobileinstall.BlazeApkBuildStepMobileInstall;
+import com.google.idea.blaze.android.run.deployinfo.BlazeAndroidDeployInfo;
+import com.google.idea.blaze.android.run.deployinfo.BlazeApkDeployInfoProtoHelper;
+import com.google.idea.blaze.android.run.deployinfo.BlazeApkDeployInfoProtoHelper.GetDeployInfoException;
+import com.google.idea.blaze.android.run.runner.BlazeAndroidDeviceSelector.DeviceSession;
+import com.google.idea.blaze.base.async.process.ExternalTask;
+import com.google.idea.blaze.base.async.process.ExternalTaskProvider;
+import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
+import com.google.idea.blaze.base.model.primitives.Label;
+import com.google.idea.blaze.base.model.primitives.WorkspacePath;
+import com.google.idea.blaze.base.scope.BlazeContext;
+import com.intellij.openapi.project.Project;
+import com.intellij.ui.SimpleColoredComponent;
+import java.io.File;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import org.jetbrains.annotations.Nullable;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Integration tests for {@link BlazeApkBuildStepMobileInstall} */
+@RunWith(JUnit4.class)
+public class BlazeApkBuildStepMobileInstallIntegrationTest extends BlazeAndroidIntegrationTestCase {
+  @Before
+  public void setupProject() {
+    setProjectView(
+        "directories:",
+        "  java/com/foo/app",
+        "targets:",
+        "  //java/com/foo/app:app",
+        "android_sdk_platform: android-27");
+    MockSdkUtil.registerSdk(workspace, "27");
+
+    workspace.createFile(
+        new WorkspacePath("java/com/foo/app/MainActivity.java"),
+        "package com.foo.app",
+        "import android.app.Activity;",
+        "public class MainActivity extends Activity {}");
+
+    setTargetMap(android_binary("//java/com/foo/app:app").src("MainActivity.java"));
+    runFullBlazeSync();
+  }
+
+  @Test
+  public void deployInfoBuiltCorrectly() throws GetDeployInfoException, ApkProvisionException {
+    Label buildTarget = Label.create("//java/com/foo/app:app");
+    BlazeContext context = new BlazeContext();
+    ImmutableList<String> blazeFlags = ImmutableList.of("some_blaze_flag", "other_blaze_flag");
+    ImmutableList<String> execFlags = ImmutableList.of("some_exec_flag", "other_exec_flag");
+
+    // Setup interceptor for fake running of blaze commands and capture details.
+    ExternalTaskInterceptor externalTaskInterceptor = new ExternalTaskInterceptor();
+    registerApplicationService(ExternalTaskProvider.class, externalTaskInterceptor);
+
+    // Mobile-install build step requires only one device be active.  DeviceFutures class is final,
+    // so we have to make one with a stub AndroidDevice.
+    DeviceFutures deviceFutures = new DeviceFutures(ImmutableList.of(new FakeDevice()));
+
+    // Return fake deploy info proto and mocked deploy info data object.
+    AndroidDeployInfo fakeProto = AndroidDeployInfo.newBuilder().build();
+    BlazeAndroidDeployInfo mockDeployInfo = mock(BlazeAndroidDeployInfo.class);
+    BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
+    when(helper.readDeployInfoProtoForTarget(eq(buildTarget), any(BuildResultHelper.class), any()))
+        .thenReturn(fakeProto);
+    when(helper.extractDeployInfoAndInvalidateManifests(
+            eq(getProject()), eq(new File(getExecRoot())), eq(fakeProto)))
+        .thenReturn(mockDeployInfo);
+
+    // Perform
+    BlazeApkBuildStepMobileInstall buildStep =
+        new BlazeApkBuildStepMobileInstall(
+            getProject(), buildTarget, blazeFlags, execFlags, helper);
+    buildStep.build(context, new DeviceSession(null, deviceFutures, null));
+
+    // Verify
+    assertThat(buildStep.getDeployInfo()).isNotNull();
+    assertThat(buildStep.getDeployInfo()).isEqualTo(mockDeployInfo);
+    assertThat(externalTaskInterceptor.context).isEqualTo(context);
+    assertThat(externalTaskInterceptor.command).containsAllIn(blazeFlags);
+    assertThat(externalTaskInterceptor.command).containsAllIn(execFlags);
+    assertThat(externalTaskInterceptor.command).contains(buildTarget.toString());
+    // Note: Invoking mobile-install does not require adding android_deploy_info output group.
+  }
+
+  @Test
+  public void moreThanOneDevice() throws GetDeployInfoException, ApkProvisionException {
+    Label buildTarget = Label.create("//java/com/foo/app:app");
+    BlazeContext context = new BlazeContext();
+
+    // Make blaze command invocation always pass.
+    registerApplicationService(ExternalTaskProvider.class, builder -> scopes -> 0);
+
+    // Mobile-install build step requires only one device be active.  DeviceFutures class is final,
+    // so we have to make one with a stub AndroidDevice.
+    DeviceFutures deviceFutures =
+        new DeviceFutures(ImmutableList.of(new FakeDevice(), new FakeDevice()));
+
+    // Return fake deploy info proto and mocked deploy info data object.
+    AndroidDeployInfo fakeProto = AndroidDeployInfo.newBuilder().build();
+    BlazeAndroidDeployInfo mockDeployInfo = mock(BlazeAndroidDeployInfo.class);
+    BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
+    when(helper.readDeployInfoProtoForTarget(eq(buildTarget), any(BuildResultHelper.class), any()))
+        .thenReturn(fakeProto);
+    when(helper.extractDeployInfoAndInvalidateManifests(
+            eq(getProject()), eq(new File(getExecRoot())), eq(fakeProto)))
+        .thenReturn(mockDeployInfo);
+
+    // Perform
+    BlazeApkBuildStepMobileInstall buildStep =
+        new BlazeApkBuildStepMobileInstall(
+            getProject(), buildTarget, ImmutableList.of(), ImmutableList.of(), helper);
+    buildStep.build(context, new DeviceSession(null, deviceFutures, null));
+
+    // Verify
+    assertThat(context.hasErrors()).isTrue();
+  }
+
+  @Test
+  public void exceptionDuringDeployInfoExtraction()
+      throws GetDeployInfoException, ApkProvisionException {
+    Label buildTarget = Label.create("//java/com/foo/app:app");
+    BlazeContext context = new BlazeContext();
+
+    // Make blaze command invocation always pass.
+    registerApplicationService(ExternalTaskProvider.class, builder -> scopes -> 0);
+
+    // Mobile-install build step requires only one device be active.  DeviceFutures class is final,
+    // so we have to make one with a stub AndroidDevice.
+    DeviceFutures deviceFutures = new DeviceFutures(ImmutableList.of(new FakeDevice()));
+
+    // Return fake deploy info proto and mocked deploy info data object.
+    AndroidDeployInfo fakeProto = AndroidDeployInfo.newBuilder().build();
+    BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
+    when(helper.readDeployInfoProtoForTarget(eq(buildTarget), any(BuildResultHelper.class), any()))
+        .thenReturn(fakeProto);
+    when(helper.extractDeployInfoAndInvalidateManifests(any(), any(), any()))
+        .thenThrow(new GetDeployInfoException("Fake Exception"));
+
+    // Perform
+    BlazeApkBuildStepMobileInstall buildStep =
+        new BlazeApkBuildStepMobileInstall(
+            getProject(), buildTarget, ImmutableList.of(), ImmutableList.of(), helper);
+    buildStep.build(context, new DeviceSession(null, deviceFutures, null));
+
+    // Verify
+    assertThat(context.hasErrors()).isTrue();
+  }
+
+  @Test
+  public void badDeployInfo() throws GetDeployInfoException, ApkProvisionException {
+    Label buildTarget = Label.create("//java/com/foo/app:app");
+    BlazeContext context = new BlazeContext();
+
+    // Return a non-zero value to indicate blaze command run failure.
+    registerApplicationService(ExternalTaskProvider.class, builder -> scopes -> 1337);
+
+    // Mobile-install build step requires only one device be active.  DeviceFutures class is final,
+    // so we have to make one with a stub AndroidDevice.
+    DeviceFutures deviceFutures = new DeviceFutures(ImmutableList.of(new FakeDevice()));
+
+    // Return fake deploy info proto and mocked deploy info data object.
+    AndroidDeployInfo fakeProto = AndroidDeployInfo.newBuilder().build();
+    BlazeAndroidDeployInfo mockDeployInfo = mock(BlazeAndroidDeployInfo.class);
+    BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
+    when(helper.readDeployInfoProtoForTarget(eq(buildTarget), any(BuildResultHelper.class), any()))
+        .thenReturn(fakeProto);
+    when(helper.extractDeployInfoAndInvalidateManifests(
+            eq(getProject()), eq(new File(getExecRoot())), eq(fakeProto)))
+        .thenReturn(mockDeployInfo);
+
+    // Perform
+    BlazeApkBuildStepMobileInstall buildStep =
+        new BlazeApkBuildStepMobileInstall(
+            getProject(), buildTarget, ImmutableList.of(), ImmutableList.of(), helper);
+    buildStep.build(context, new DeviceSession(null, deviceFutures, null));
+
+    // Verify
+    assertThat(context.hasErrors()).isTrue();
+  }
+
+  /** Saves the latest blaze command and context for later verification. */
+  private static class ExternalTaskInterceptor implements ExternalTaskProvider {
+    ImmutableList<String> command;
+    BlazeContext context;
+
+    @Override
+    public ExternalTask build(ExternalTask.Builder builder) {
+      command = builder.command.build();
+      context = builder.context;
+      return scopes -> 0;
+    }
+  }
+
+  /**
+   * A fake android device that returns a mocked launched-device. This class is required because
+   * {@link DeviceFutures} and all other implementations of {@link AndroidDevice} are final,
+   * therefore we need this to stub out a fake {@link DeviceSession}.
+   */
+  private static class FakeDevice implements AndroidDevice {
+    @Override
+    public ListenableFuture<IDevice> getLaunchedDevice() {
+      IDevice device = mock(IDevice.class);
+      when(device.getSerialNumber()).thenReturn("serial-number");
+      return Futures.immediateFuture(device);
+    }
+
+    //
+    // All methods below this point has no purpose. Please ignore.
+    //
+    @Override
+    public boolean isRunning() {
+      return false;
+    }
+
+    @Override
+    public boolean isVirtual() {
+      return false;
+    }
+
+    @Override
+    public com.android.sdklib.AndroidVersion getVersion() {
+      return null;
+    }
+
+    @Override
+    public int getDensity() {
+      return 0;
+    }
+
+    @Override
+    public List<Abi> getAbis() {
+      return null;
+    }
+
+    @Override
+    public String getSerial() {
+      return null;
+    }
+
+    @Override
+    public boolean supportsFeature(HardwareFeature hardwareFeature) {
+      return false;
+    }
+
+    @Override
+    public String getName() {
+      return null;
+    }
+
+    @Override
+    public boolean renderLabel(
+        SimpleColoredComponent simpleColoredComponent, boolean b, @Nullable String s) {
+      return false;
+    }
+
+    @Override
+    public void prepareToRenderLabel() {}
+
+    @Override
+    public LaunchCompatibility canRun(
+        com.android.sdklib.AndroidVersion androidVersion,
+        IAndroidTarget iAndroidTarget,
+        EnumSet<HardwareFeature> enumSet,
+        @Nullable Set<String> set) {
+      return null;
+    }
+
+    @Override
+    public ListenableFuture<IDevice> launch(Project project) {
+      return null;
+    }
+
+    // @Override #api 3.6
+    public ListenableFuture<IDevice> launch(Project project, String s) {
+      return null;
+    }
+
+    // @Override #api 4.0
+    public ListenableFuture<IDevice> launch(Project project, List<String> list) {
+      return null;
+    }
+
+    // @Override #api 3.6
+    public boolean isDebuggable() {
+      return false;
+    }
+  }
+}

--- a/aswb/tests/integrationtests/com/google/idea/blaze/android/functional/BlazeApkBuildStepNormalBuildIntegrationTest.java
+++ b/aswb/tests/integrationtests/com/google/idea/blaze/android/functional/BlazeApkBuildStepNormalBuildIntegrationTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.android.functional;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.idea.blaze.android.targetmapbuilder.NbAndroidTarget.android_binary;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.android.tools.idea.run.ApkProvisionException;
+import com.google.common.collect.ImmutableList;
+import com.google.devtools.build.lib.rules.android.deployinfo.AndroidDeployInfoOuterClass.AndroidDeployInfo;
+import com.google.idea.blaze.android.BlazeAndroidIntegrationTestCase;
+import com.google.idea.blaze.android.MockSdkUtil;
+import com.google.idea.blaze.android.run.deployinfo.BlazeAndroidDeployInfo;
+import com.google.idea.blaze.android.run.deployinfo.BlazeApkDeployInfoProtoHelper;
+import com.google.idea.blaze.android.run.deployinfo.BlazeApkDeployInfoProtoHelper.GetDeployInfoException;
+import com.google.idea.blaze.android.run.runner.BlazeAndroidDeviceSelector.DeviceSession;
+import com.google.idea.blaze.android.run.runner.BlazeApkBuildStepNormalBuild;
+import com.google.idea.blaze.base.async.process.ExternalTask;
+import com.google.idea.blaze.base.async.process.ExternalTaskProvider;
+import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
+import com.google.idea.blaze.base.model.primitives.Label;
+import com.google.idea.blaze.base.model.primitives.WorkspacePath;
+import com.google.idea.blaze.base.scope.BlazeContext;
+import java.io.File;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Integration tests for {@link BlazeApkBuildStepNormalBuild} */
+@RunWith(JUnit4.class)
+public class BlazeApkBuildStepNormalBuildIntegrationTest extends BlazeAndroidIntegrationTestCase {
+  @Before
+  public void setupProject() {
+    setProjectView(
+        "directories:",
+        "  java/com/foo/app",
+        "targets:",
+        "  //java/com/foo/app:app",
+        "android_sdk_platform: android-27");
+    MockSdkUtil.registerSdk(workspace, "27");
+
+    workspace.createFile(
+        new WorkspacePath("java/com/foo/app/MainActivity.java"),
+        "package com.foo.app",
+        "import android.app.Activity;",
+        "public class MainActivity extends Activity {}");
+
+    setTargetMap(android_binary("//java/com/foo/app:app").src("MainActivity.java"));
+    runFullBlazeSync();
+  }
+
+  @Test
+  public void deployInfoBuiltCorrectly() throws GetDeployInfoException, ApkProvisionException {
+    Label buildTarget = Label.create("//java/com/foo/app:app");
+    BlazeContext context = new BlazeContext();
+    ImmutableList<String> blazeFlags = ImmutableList.of("some_blaze_flag", "some_other_flag");
+
+    // Setup interceptor for fake running of blaze commands and capture details.
+    ExternalTaskInterceptor externalTaskInterceptor = new ExternalTaskInterceptor();
+    registerApplicationService(ExternalTaskProvider.class, externalTaskInterceptor);
+
+    // Return fake deploy info proto and mocked deploy info data object.
+    AndroidDeployInfo fakeProto = AndroidDeployInfo.newBuilder().build();
+    BlazeAndroidDeployInfo mockDeployInfo = mock(BlazeAndroidDeployInfo.class);
+    BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
+    when(helper.readDeployInfoProtoForTarget(eq(buildTarget), any(BuildResultHelper.class), any()))
+        .thenReturn(fakeProto);
+    when(helper.extractDeployInfoAndInvalidateManifests(
+            eq(getProject()), eq(new File(getExecRoot())), eq(fakeProto)))
+        .thenReturn(mockDeployInfo);
+
+    // Perform
+    BlazeApkBuildStepNormalBuild buildStep =
+        new BlazeApkBuildStepNormalBuild(getProject(), buildTarget, blazeFlags, helper);
+    buildStep.build(context, new DeviceSession(null, null, null));
+
+    // Verify
+    assertThat(buildStep.getDeployInfo()).isNotNull();
+    assertThat(buildStep.getDeployInfo()).isEqualTo(mockDeployInfo);
+    assertThat(externalTaskInterceptor.context).isEqualTo(context);
+    assertThat(externalTaskInterceptor.command).contains(buildTarget.toString());
+    assertThat(externalTaskInterceptor.command).contains("--output_groups=+android_deploy_info");
+    assertThat(externalTaskInterceptor.command).containsAllIn(blazeFlags);
+  }
+
+  @Test
+  public void exceptionDuringDeployInfoExtraction()
+      throws GetDeployInfoException, ApkProvisionException {
+    Label buildTarget = Label.create("//java/com/foo/app:app");
+    BlazeContext context = new BlazeContext();
+
+    // Make blaze command invocation always pass.
+    registerApplicationService(ExternalTaskProvider.class, builder -> scopes -> 0);
+
+    // Return fake deploy info proto and mocked deploy info data object.
+    AndroidDeployInfo fakeProto = AndroidDeployInfo.newBuilder().build();
+    BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
+    when(helper.readDeployInfoProtoForTarget(eq(buildTarget), any(BuildResultHelper.class), any()))
+        .thenReturn(fakeProto);
+    when(helper.extractDeployInfoAndInvalidateManifests(any(), any(), any()))
+        .thenThrow(new GetDeployInfoException("Fake Exception"));
+
+    // Perform
+    BlazeApkBuildStepNormalBuild buildStep =
+        new BlazeApkBuildStepNormalBuild(getProject(), buildTarget, ImmutableList.of(), helper);
+    buildStep.build(context, new DeviceSession(null, null, null));
+
+    // Verify
+    assertThat(context.hasErrors()).isTrue();
+  }
+
+  @Test
+  public void badDeployInfo() throws GetDeployInfoException, ApkProvisionException {
+    Label buildTarget = Label.create("//java/com/foo/app:app");
+    BlazeContext context = new BlazeContext();
+
+    // Return a non-zero value to indicate blaze command run failure.
+    registerApplicationService(ExternalTaskProvider.class, builder -> scopes -> 1337);
+
+    // Return fake deploy info proto and mocked deploy info data object.
+    AndroidDeployInfo fakeProto = AndroidDeployInfo.newBuilder().build();
+    BlazeAndroidDeployInfo mockDeployInfo = mock(BlazeAndroidDeployInfo.class);
+    BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
+    when(helper.readDeployInfoProtoForTarget(eq(buildTarget), any(BuildResultHelper.class), any()))
+        .thenReturn(fakeProto);
+    when(helper.extractDeployInfoAndInvalidateManifests(
+            eq(getProject()), eq(new File(getExecRoot())), eq(fakeProto)))
+        .thenReturn(mockDeployInfo);
+
+    // Perform
+    BlazeApkBuildStepNormalBuild buildStep =
+        new BlazeApkBuildStepNormalBuild(getProject(), buildTarget, ImmutableList.of(), helper);
+    buildStep.build(context, new DeviceSession(null, null, null));
+
+    // Verify
+    assertThat(context.hasErrors()).isTrue();
+  }
+
+  /** Saves the latest blaze command and context for later verification. */
+  private static class ExternalTaskInterceptor implements ExternalTaskProvider {
+    ImmutableList<String> command;
+    BlazeContext context;
+
+    @Override
+    public ExternalTask build(ExternalTask.Builder builder) {
+      command = builder.command.build();
+      context = builder.context;
+      return scopes -> 0;
+    }
+  }
+}

--- a/aswb/tests/unittests/com/google/idea/blaze/android/run/deployinfo/BlazeApkDeployInfoProtoHelperTest.java
+++ b/aswb/tests/unittests/com/google/idea/blaze/android/run/deployinfo/BlazeApkDeployInfoProtoHelperTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2018 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.android.run.deployinfo;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.devtools.build.lib.rules.android.deployinfo.AndroidDeployInfoOuterClass;
+import com.google.devtools.build.lib.rules.android.deployinfo.AndroidDeployInfoOuterClass.AndroidDeployInfo;
+import com.google.devtools.build.lib.rules.android.deployinfo.AndroidDeployInfoOuterClass.Artifact;
+import com.google.idea.blaze.android.manifest.ManifestParser.ParsedManifest;
+import com.google.idea.blaze.android.manifest.ParsedManifestService;
+import com.google.idea.blaze.base.BlazeTestCase;
+import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
+import com.google.idea.blaze.base.model.primitives.Label;
+import java.io.File;
+import java.util.function.Predicate;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+/**
+ * Unit tests for {@link BlazeApkDeployInfoProtoHelper}.
+ *
+ * <p>{@link BlazeApkDeployInfoProtoHelper#readDeployInfoProtoForTarget(Label, BuildResultHelper,
+ * Predicate)} requires a integration test to test properly and is handled by {@link
+ * com.google.idea.blaze.android.google3.run.deployinfo.BlazeApkDeployInfoTest}.
+ */
+@RunWith(JUnit4.class)
+public class BlazeApkDeployInfoProtoHelperTest extends BlazeTestCase {
+  private final ParsedManifestService mockParsedManifestService =
+      Mockito.mock(ParsedManifestService.class);
+
+  /**
+   * Registers a mocked {@link ParsedManifestService} to return predetermined matching parsed
+   * manifests and for verifying that manifest refreshes are called correctly.
+   */
+  @Override
+  protected void initTest(Container applicationServices, Container projectServices) {
+    projectServices.register(ParsedManifestService.class, mockParsedManifestService);
+  }
+
+  @Test
+  public void readDeployInfoForNormalBuild_onlyMainManifest() throws Exception {
+    // setup
+    AndroidDeployInfo deployInfoProto =
+        AndroidDeployInfo.newBuilder()
+            .setMergedManifest(makeArtifact("path/to/manifest"))
+            .addApksToDeploy(makeArtifact("path/to/apk"))
+            .build();
+
+    File mainApk = new File("execution_root/path/to/apk");
+    File mainManifestFile = new File("execution_root/path/to/manifest");
+    ParsedManifest parsedMainManifest = new ParsedManifest("main", null, null);
+    when(mockParsedManifestService.getParsedManifest(mainManifestFile))
+        .thenReturn(parsedMainManifest);
+
+    // perform
+    BlazeAndroidDeployInfo deployInfo =
+        new BlazeApkDeployInfoProtoHelper()
+            .extractDeployInfoAndInvalidateManifests(
+                getProject(), new File("execution_root"), deployInfoProto);
+
+    // verify
+    assertThat(deployInfo.getApksToDeploy()).containsExactly(mainApk);
+    assertThat(deployInfo.getMergedManifest()).isEqualTo(parsedMainManifest);
+    assertThat(deployInfo.getTestTargetMergedManifest()).isNull();
+    verify(mockParsedManifestService, times(1)).invalidateCachedManifest(mainManifestFile);
+  }
+
+  @Test
+  public void readDeployInfoForNormalBuild_withTestTargetManifest() throws Exception {
+    // setup
+    AndroidDeployInfo deployInfoProto =
+        AndroidDeployInfo.newBuilder()
+            .setMergedManifest(makeArtifact("path/to/manifest"))
+            .addAdditionalMergedManifests(makeArtifact("path/to/testtarget/manifest"))
+            .addApksToDeploy(makeArtifact("path/to/apk"))
+            .addApksToDeploy(makeArtifact("path/to/testtarget/apk"))
+            .build();
+
+    File mainApk = new File("execution_root/path/to/apk");
+    File testApk = new File("execution_root/path/to/testtarget/apk");
+    File mainManifest = new File("execution_root/path/to/manifest");
+    File testTargetManifest = new File("execution_root/path/to/testtarget/manifest");
+    ParsedManifest parsedMainManifest = new ParsedManifest("main", null, null);
+    ParsedManifest parsedTestManifest = new ParsedManifest("testtarget", null, null);
+    when(mockParsedManifestService.getParsedManifest(mainManifest)).thenReturn(parsedMainManifest);
+    when(mockParsedManifestService.getParsedManifest(testTargetManifest))
+        .thenReturn(parsedTestManifest);
+
+    // perform
+    BlazeAndroidDeployInfo deployInfo =
+        new BlazeApkDeployInfoProtoHelper()
+            .extractDeployInfoAndInvalidateManifests(
+                getProject(), new File("execution_root"), deployInfoProto);
+
+    // verify
+    assertThat(deployInfo.getApksToDeploy()).containsExactly(mainApk, testApk).inOrder();
+    assertThat(deployInfo.getMergedManifest()).isEqualTo(parsedMainManifest);
+    assertThat(deployInfo.getTestTargetMergedManifest()).isEqualTo(parsedTestManifest);
+
+    ArgumentCaptor<File> expectedArgs = ArgumentCaptor.forClass(File.class);
+    verify(mockParsedManifestService, times(2)).invalidateCachedManifest(expectedArgs.capture());
+    expectedArgs.getAllValues().containsAll(ImmutableList.of(mainManifest, testTargetManifest));
+  }
+
+  private static Artifact makeArtifact(String execRootPath) {
+    return AndroidDeployInfoOuterClass.Artifact.newBuilder().setExecRootPath(execRootPath).build();
+  }
+}

--- a/base/src/com/google/idea/blaze/base/async/process/ExternalTask.java
+++ b/base/src/com/google/idea/blaze/base/async/process/ExternalTask.java
@@ -53,10 +53,10 @@ public interface ExternalTask {
 
   /** A builder for an external task */
   class Builder {
-    final ImmutableList.Builder<String> command = ImmutableList.builder();
+    @VisibleForTesting public final ImmutableList.Builder<String> command = ImmutableList.builder();
     final File workingDirectory;
     final Map<String, String> environmentVariables = Maps.newHashMap();
-    @Nullable BlazeContext context;
+    @VisibleForTesting @Nullable public BlazeContext context;
     @Nullable OutputStream stdout;
     @Nullable OutputStream stderr;
     @Nullable BlazeCommand blazeCommand;

--- a/base/src/com/google/idea/blaze/base/async/process/ExternalTaskProvider.java
+++ b/base/src/com/google/idea/blaze/base/async/process/ExternalTaskProvider.java
@@ -15,6 +15,7 @@
  */
 package com.google.idea.blaze.base.async.process;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.idea.blaze.base.async.process.ExternalTask.Builder;
 import com.google.idea.blaze.base.async.process.ExternalTask.ExternalTaskImpl;
 import com.intellij.openapi.components.ServiceManager;
@@ -23,7 +24,8 @@ import com.intellij.openapi.components.ServiceManager;
  * Constructs an {@link ExternalTask} from a builder instance. This indirection exists to allow easy
  * redirection in blaze-invoking integration tests.
  */
-interface ExternalTaskProvider {
+@VisibleForTesting
+public interface ExternalTaskProvider {
 
   static ExternalTaskProvider getInstance() {
     return ServiceManager.getService(ExternalTaskProvider.class);
@@ -31,8 +33,8 @@ interface ExternalTaskProvider {
 
   ExternalTask build(ExternalTask.Builder builder);
 
+  /** Default implementation returning an {@link ExternalTaskImpl}. */
   class Impl implements ExternalTaskProvider {
-
     @Override
     public ExternalTask build(Builder builder) {
       return new ExternalTaskImpl(


### PR DESCRIPTION
Add tests for blaze APK build steps and BlazeApkDeployInfoProtoHelper.

There are currently no test coverage for blaze APK build steps. The
build steps are a critical part of run/deploy pipeline and regressions
in this area are guaranteed to be severe.

This CL adds tests tha cover the existing build steps.  This CL also
includes updates to BlazeApkDeployInfoProtoHelper to make it more
testable, as well as a unit test for the proto helper itself.

Expanded visibility on some blaze-intellij classes because they were
required to write these tests.
