### PR TITLE
Allow insecure delete for test resources when configured

### DIFF
--- a/base/src/com/google/idea/blaze/base/io/FileOperationProvider.java
+++ b/base/src/com/google/idea/blaze/base/io/FileOperationProvider.java
@@ -16,6 +16,7 @@
 package com.google.idea.blaze.base.io;
 
 import com.google.common.io.MoreFiles;
+import com.google.common.io.RecursiveDeleteOption;
 import com.intellij.openapi.components.ServiceManager;
 import java.io.File;
 import java.io.IOException;
@@ -76,7 +77,21 @@ public class FileOperationProvider {
   }
 
   public void deleteRecursively(File file) throws IOException {
-    MoreFiles.deleteRecursively(file.toPath());
+    deleteRecursively(file, false);
+  }
+
+  /**
+   * Deletes the file or directory at the given path recursively, allowing insecure delete according
+   * to {@code allowInsecureDelete}.
+   *
+   * @see RecursiveDeleteOption#ALLOW_INSECURE
+   */
+  public void deleteRecursively(File file, boolean allowInsecureDelete) throws IOException {
+    if (allowInsecureDelete) {
+      MoreFiles.deleteRecursively(file.toPath(), RecursiveDeleteOption.ALLOW_INSECURE);
+    } else {
+      MoreFiles.deleteRecursively(file.toPath());
+    }
   }
 
   // If the file is too big, this method can blow up RAM as it reads the file contents

--- a/java/src/com/google/idea/blaze/java/run/fastbuild/FastBuildTestEnvironmentCreator.java
+++ b/java/src/com/google/idea/blaze/java/run/fastbuild/FastBuildTestEnvironmentCreator.java
@@ -52,6 +52,8 @@ abstract class FastBuildTestEnvironmentCreator implements BuildSystemExtensionPo
   private static final String TEMP_DIRECTORY_VARIABLE = "TEST_TMPDIR";
   private static final String TEST_FILTER_VARIABLE = "TESTBRIDGE_TEST_ONLY";
   private static final String WORKSPACE_VARIABLE = "TEST_WORKSPACE";
+  private static final String ALLOW_INSECURE_TEST_DIAGNOSTICS_DELETION_KEY =
+      "blaze.fastBuild.allowInsecureTestDiagnosticsDeletion";
 
   private static final ExtensionPointName<FastBuildTestEnvironmentCreator> EP_NAME =
       ExtensionPointName.create("com.google.idea.blaze.FastBuildTestEnvironmentCreator");
@@ -242,7 +244,7 @@ abstract class FastBuildTestEnvironmentCreator implements BuildSystemExtensionPo
 
       try {
         if (testDiagnosticsDir.exists()) {
-          files.deleteRecursively(testDiagnosticsDir);
+          files.deleteRecursively(testDiagnosticsDir, shouldAllowInsecureTestDiagnosticsDeletion());
         }
       } catch (IOException e) {
         throw new ExecutionException(e);
@@ -251,6 +253,11 @@ abstract class FastBuildTestEnvironmentCreator implements BuildSystemExtensionPo
       commandBuilder.addEnvironmentVariable(
           "TEST_DIAGNOSTICS_OUTPUT_DIR", testDiagnosticsDir.toString());
     }
+  }
+
+  /** Should we allow insecure deletion of test resources? */
+  private static boolean shouldAllowInsecureTestDiagnosticsDeletion() {
+    return Boolean.getBoolean(ALLOW_INSECURE_TEST_DIAGNOSTICS_DELETION_KEY);
   }
 
   private static void addJvmOptsFromBlazeFlags(


### PR DESCRIPTION
Allow insecure delete for test resources when configured

Fast-run/debug fails when using a file system that does not support secure deletion. This is the case when we connect over an SSHFS, for example. This change provides configuration through a system property that allows insecure delete, in the sense described in [RecursiveDeleteOption#ALLOW_INSECURE](https://guava.dev/releases/23.0/api/docs/com/google/common/io/RecursiveDeleteOption.html#ALLOW_INSECURE). The default case in unchanged.
