### PR TITLE
Add support for running/debugging android_instrumentation_test targets.

### DIFF
--- a/aswb/src/com/google/idea/blaze/android/run/runner/BlazeInstrumentationTestApkBuildStep.java
+++ b/aswb/src/com/google/idea/blaze/android/run/runner/BlazeInstrumentationTestApkBuildStep.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.android.run.runner;
+
+import com.android.tools.idea.run.ApkProvisionException;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.devtools.build.lib.rules.android.deployinfo.AndroidDeployInfoOuterClass.AndroidDeployInfo;
+import com.google.idea.blaze.android.run.deployinfo.BlazeAndroidDeployInfo;
+import com.google.idea.blaze.android.run.deployinfo.BlazeApkDeployInfoProtoHelper;
+import com.google.idea.blaze.android.run.deployinfo.BlazeApkDeployInfoProtoHelper.GetDeployInfoException;
+import com.google.idea.blaze.base.async.process.ExternalTask;
+import com.google.idea.blaze.base.async.process.LineProcessingOutputStream;
+import com.google.idea.blaze.base.command.BlazeCommand;
+import com.google.idea.blaze.base.command.BlazeCommandName;
+import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
+import com.google.idea.blaze.base.command.buildresult.BuildResultHelperProvider;
+import com.google.idea.blaze.base.console.BlazeConsoleLineProcessorProvider;
+import com.google.idea.blaze.base.filecache.FileCaches;
+import com.google.idea.blaze.base.ideinfo.AndroidIdeInfo;
+import com.google.idea.blaze.base.ideinfo.AndroidInstrumentationInfo;
+import com.google.idea.blaze.base.ideinfo.TargetIdeInfo;
+import com.google.idea.blaze.base.ideinfo.TargetKey;
+import com.google.idea.blaze.base.ideinfo.TargetMap;
+import com.google.idea.blaze.base.model.BlazeProjectData;
+import com.google.idea.blaze.base.model.primitives.Label;
+import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
+import com.google.idea.blaze.base.scope.BlazeContext;
+import com.google.idea.blaze.base.scope.output.IssueOutput;
+import com.google.idea.blaze.base.scope.output.StatusOutput;
+import com.google.idea.blaze.base.settings.Blaze;
+import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
+import com.google.idea.blaze.base.util.SaveUtil;
+import com.google.idea.blaze.java.AndroidBlazeRules.RuleTypes;
+import com.intellij.openapi.project.Project;
+import java.io.File;
+import javax.annotation.Nullable;
+
+/** Builds the APKs required for an android instrumentation test. */
+public class BlazeInstrumentationTestApkBuildStep implements BlazeApkBuildStep {
+
+  /** Subject to change with changes to android build rules. */
+  private static final String DEPLOY_INFO_FILE_SUFFIX = ".deployinfo.pb";
+
+  private final Project project;
+  private final Label instrumentationTestLabel;
+  private final ImmutableList<String> buildFlags;
+  private final BlazeApkDeployInfoProtoHelper deployInfoHelper;
+  private BlazeAndroidDeployInfo deployInfo = null;
+
+  /**
+   * Note: Target kind of {@param instrumentationTestlabel} must be "android_instrumentation_test".
+   */
+  public BlazeInstrumentationTestApkBuildStep(
+      Project project, Label instrumentationTestLabel, ImmutableList<String> buildFlags) {
+    this(project, instrumentationTestLabel, buildFlags, new BlazeApkDeployInfoProtoHelper());
+  }
+
+  @VisibleForTesting
+  public BlazeInstrumentationTestApkBuildStep(
+      Project project,
+      Label instrumentationTestLabel,
+      ImmutableList<String> buildFlags,
+      BlazeApkDeployInfoProtoHelper deployInfoHelper) {
+    this.project = project;
+    this.instrumentationTestLabel = instrumentationTestLabel;
+    this.buildFlags = buildFlags;
+    this.deployInfoHelper = deployInfoHelper;
+  }
+
+  @Override
+  public void build(BlazeContext context, BlazeAndroidDeviceSelector.DeviceSession deviceSession) {
+    BlazeProjectData projectData =
+        BlazeProjectDataManager.getInstance(project).getBlazeProjectData();
+    if (projectData == null) {
+      IssueOutput.error("Invalid project data. Please sync the project.").submit(context);
+      return;
+    }
+
+    InstrumentorToTarget testComponents = getInstrumentorToTargetPair(context, projectData);
+    if (testComponents == null) {
+      return;
+    }
+
+    BlazeCommand.Builder command =
+        BlazeCommand.builder(
+            Blaze.getBuildSystemProvider(project).getBinaryPath(project), BlazeCommandName.BUILD);
+    WorkspaceRoot workspaceRoot = WorkspaceRoot.fromProject(project);
+    File executionRoot = projectData.getBlazeInfo().getExecutionRoot();
+
+    try (BuildResultHelper buildResultHelper = BuildResultHelperProvider.create(project)) {
+      command
+          .addTargets(testComponents.instrumentor, testComponents.target)
+          .addBlazeFlags("--output_groups=+android_deploy_info")
+          .addBlazeFlags(buildFlags)
+          .addBlazeFlags(buildResultHelper.getBuildFlags());
+
+      SaveUtil.saveAllFiles();
+      int retVal =
+          ExternalTask.builder(workspaceRoot)
+              .addBlazeCommand(command.build())
+              .context(context)
+              .stderr(
+                  LineProcessingOutputStream.of(
+                      BlazeConsoleLineProcessorProvider.getAllStderrLineProcessors(context)))
+              .build()
+              .run();
+      FileCaches.refresh(project, context);
+
+      if (retVal != 0) {
+        IssueOutput.error("Blaze build failed. See Blaze Console for details.").submit(context);
+        return;
+      }
+      try {
+        context.output(new StatusOutput("Reading deployment information..."));
+        AndroidDeployInfo instrumentorDeployInfoProto =
+            deployInfoHelper.readDeployInfoProtoForTarget(
+                testComponents.instrumentor,
+                buildResultHelper,
+                fileName -> fileName.endsWith(DEPLOY_INFO_FILE_SUFFIX));
+        AndroidDeployInfo targetDeployInfoProto =
+            deployInfoHelper.readDeployInfoProtoForTarget(
+                testComponents.target,
+                buildResultHelper,
+                fileName -> fileName.endsWith(DEPLOY_INFO_FILE_SUFFIX));
+        deployInfo =
+            deployInfoHelper.extractInstrumentationTestDeployInfoAndInvalidateManifests(
+                project, executionRoot, instrumentorDeployInfoProto, targetDeployInfoProto);
+      } catch (GetDeployInfoException e) {
+        IssueOutput.error("Could not read apk deploy info from build: " + e.getMessage())
+            .submit(context);
+      }
+    }
+  }
+
+  @Override
+  public BlazeAndroidDeployInfo getDeployInfo() throws ApkProvisionException {
+    if (deployInfo != null) {
+      return deployInfo;
+    }
+    throw new ApkProvisionException(
+        "Failed to read APK deploy info.  Either build step hasn't been executed or there was an"
+            + " error obtaining deploy info after build.");
+  }
+
+  /**
+   * Extracts test instrumentor and instrumentation target labels from the target map.
+   *
+   * @return The labels contained in an {@link InstrumentorToTarget} object.
+   */
+  @Nullable
+  @VisibleForTesting
+  public InstrumentorToTarget getInstrumentorToTargetPair(
+      BlazeContext context, BlazeProjectData projectData) {
+    // The following extracts the dependency info required during an instrumentation test.
+    // To disambiguate, the following terms are used:
+    // - test: The android_instrumentation_test target.
+    // - instrumentor: The target of kind android_binary that's used as the binary that
+    // orchestrates the instrumentation test.
+    // - app: The android_binary app that's being tested in this instrumentation test through
+    // the instrumentor.
+    TargetMap targetMap = projectData.getTargetMap();
+    TargetIdeInfo testTarget = targetMap.get(TargetKey.forPlainTarget(instrumentationTestLabel));
+    if (testTarget == null
+        || testTarget.getKind() != RuleTypes.ANDROID_INSTRUMENTATION_TEST.getKind()) {
+      IssueOutput.error(
+              "Unable to identify target \""
+                  + instrumentationTestLabel
+                  + "\". Please sync the project and try again.")
+          .submit(context);
+      return null;
+    }
+    AndroidInstrumentationInfo testInstrumentationInfo = testTarget.getAndroidInstrumentationInfo();
+    if (testInstrumentationInfo == null) {
+      IssueOutput.error(
+              "Required target data missing for \""
+                  + instrumentationTestLabel
+                  + "\".  Has the target definition changed recently? Please sync the project and"
+                  + " try again.")
+          .submit(context);
+      return null;
+    }
+
+    Label instrumentorLabel = testInstrumentationInfo.getTestApp();
+    if (instrumentorLabel == null) {
+      IssueOutput.error(
+              "No \"test_app\" in target definition for "
+                  + testTarget.getKey().getLabel()
+                  + ". Please ensure \"test_app\" attribute is set.  See"
+                  + " https://docs.bazel.build/versions/master/be/android.html#android_instrumentation_test.test_app"
+                  + " for more information.")
+          .submit(context);
+      return null;
+    }
+
+    TargetIdeInfo instrumentorTarget = targetMap.get(TargetKey.forPlainTarget(instrumentorLabel));
+    if (instrumentorTarget == null) {
+      IssueOutput.error(
+              "Unable to identify target \""
+                  + instrumentorLabel
+                  + "\". Please sync the project and try again.")
+          .submit(context);
+      return null;
+    }
+    AndroidIdeInfo instrumentorAndroidInfo = instrumentorTarget.getAndroidIdeInfo();
+    if (instrumentorAndroidInfo == null) {
+      IssueOutput.error(
+              "Required target data missing for \""
+                  + instrumentorLabel
+                  + "\".  Has the target definition changed recently? Please sync the project and"
+                  + " try again.")
+          .submit(context);
+      return null;
+    }
+    Label appLabel = instrumentorAndroidInfo.getInstruments();
+    if (appLabel == null) {
+      IssueOutput.error(
+              "No \"instruments\" in target definition for "
+                  + instrumentorLabel
+                  + ". Please ensure a instrumentation target is defined via the \"instruments\""
+                  + " attribute.  See"
+                  + " https://docs.bazel.build/versions/master/be/android.html#android_binary.instruments"
+                  + " for more information.")
+          .submit(context);
+      return null;
+    }
+
+    return new InstrumentorToTarget(appLabel, instrumentorLabel);
+  }
+
+  /** A container for a instrumentation test instrumentor and the target app it instruments. */
+  @VisibleForTesting
+  public static class InstrumentorToTarget {
+    public final Label target;
+    public final Label instrumentor;
+
+    InstrumentorToTarget(Label target, Label instrumentor) {
+      this.target = target;
+      this.instrumentor = instrumentor;
+    }
+  }
+}

--- a/aswb/src/com/google/idea/blaze/android/run/test/BlazeAndroidTestProgramRunner.java
+++ b/aswb/src/com/google/idea/blaze/android/run/test/BlazeAndroidTestProgramRunner.java
@@ -19,7 +19,6 @@ import com.android.tools.idea.run.AndroidSessionInfo;
 import com.google.idea.blaze.android.run.AndroidSessionInfoCompat;
 import com.google.idea.blaze.android.run.BlazeAndroidRunConfigurationHandler;
 import com.google.idea.blaze.base.run.BlazeCommandRunConfiguration;
-import com.google.idea.blaze.java.AndroidBlazeRules;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.RunConfiguration;
 import com.intellij.execution.configurations.RunConfigurationBase;
@@ -44,13 +43,8 @@ public class BlazeAndroidTestProgramRunner extends DefaultProgramRunner {
     if (!(profile instanceof BlazeCommandRunConfiguration)) {
       return false;
     }
-    BlazeCommandRunConfiguration configuration = (BlazeCommandRunConfiguration) profile;
-    // Debugging android_instrumentation_test doesn't work yet.
-    if (DefaultDebugExecutor.EXECUTOR_ID.equals(executorId)) {
-      return configuration.getTargetKind()
-          != AndroidBlazeRules.RuleTypes.ANDROID_INSTRUMENTATION_TEST.getKind();
-    }
-    return DefaultRunExecutor.EXECUTOR_ID.equals(executorId);
+    return DefaultRunExecutor.EXECUTOR_ID.equals(executorId)
+        || DefaultDebugExecutor.EXECUTOR_ID.equals(executorId);
   }
 
   @Override

--- a/aswb/tests/integrationtests/com/google/idea/blaze/android/functional/BlazeInstrumentationTestApkBuildStepIntegrationTest.java
+++ b/aswb/tests/integrationtests/com/google/idea/blaze/android/functional/BlazeInstrumentationTestApkBuildStepIntegrationTest.java
@@ -1,0 +1,353 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.android.functional;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.idea.blaze.android.targetmapbuilder.NbAndroidInstrumentationTestTarget.android_instrumentation_test;
+import static com.google.idea.blaze.android.targetmapbuilder.NbAndroidTarget.android_binary;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.android.tools.idea.run.ApkProvisionException;
+import com.google.common.collect.ImmutableList;
+import com.google.devtools.build.lib.rules.android.deployinfo.AndroidDeployInfoOuterClass.AndroidDeployInfo;
+import com.google.idea.blaze.android.BlazeAndroidIntegrationTestCase;
+import com.google.idea.blaze.android.MockSdkUtil;
+import com.google.idea.blaze.android.run.deployinfo.BlazeAndroidDeployInfo;
+import com.google.idea.blaze.android.run.deployinfo.BlazeApkDeployInfoProtoHelper;
+import com.google.idea.blaze.android.run.deployinfo.BlazeApkDeployInfoProtoHelper.GetDeployInfoException;
+import com.google.idea.blaze.android.run.runner.BlazeAndroidDeviceSelector.DeviceSession;
+import com.google.idea.blaze.android.run.runner.BlazeInstrumentationTestApkBuildStep;
+import com.google.idea.blaze.android.run.runner.BlazeInstrumentationTestApkBuildStep.InstrumentorToTarget;
+import com.google.idea.blaze.base.async.process.ExternalTask;
+import com.google.idea.blaze.base.async.process.ExternalTaskProvider;
+import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
+import com.google.idea.blaze.base.model.primitives.Label;
+import com.google.idea.blaze.base.model.primitives.WorkspacePath;
+import com.google.idea.blaze.base.scope.BlazeContext;
+import com.google.idea.blaze.base.scope.OutputSink;
+import com.google.idea.blaze.base.scope.output.IssueOutput;
+import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
+import java.io.File;
+import java.util.ArrayList;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Integration tests for {@link BlazeInstrumentationTestApkBuildStep} */
+@RunWith(JUnit4.class)
+public class BlazeInstrumentationTestApkBuildStepIntegrationTest
+    extends BlazeAndroidIntegrationTestCase {
+
+  void setupProject() {
+    setProjectView(
+        "directories:",
+        "  java/com/foo/app",
+        "targets:",
+        "  //java/com/foo/app:instrumentation_test",
+        "android_sdk_platform: android-27");
+    MockSdkUtil.registerSdk(workspace, "27");
+
+    workspace.createFile(
+        new WorkspacePath("java/com/foo/app/MainActivity.java"),
+        "package com.foo.app",
+        "import android.app.Activity;",
+        "public class MainActivity extends Activity {}");
+
+    workspace.createFile(
+        new WorkspacePath("java/com/foo/app/Test.java"),
+        "package com.foo.app",
+        "public class Test {}");
+
+    setTargetMap(
+        android_binary("//java/com/foo/app:app").src("MainActivity.java"),
+        android_binary("//java/com/foo/app:test_app")
+            .src("Test.java")
+            .instruments("//java/com/foo/app:app"),
+        android_instrumentation_test("//java/com/foo/app:instrumentation_test")
+            .test_app("//java/com/foo/app:test_app"));
+    runFullBlazeSync();
+  }
+
+  @Test
+  public void deployInfoBuiltCorrectly() throws GetDeployInfoException, ApkProvisionException {
+    setupProject();
+    Label testTarget = Label.create("//java/com/foo/app:instrumentation_test");
+    Label instrumentorTarget = Label.create("//java/com/foo/app:test_app");
+    Label appTarget = Label.create("//java/com/foo/app:app");
+    BlazeContext context = new BlazeContext();
+    ImmutableList<String> blazeFlags = ImmutableList.of("some_blaze_flag", "some_other_flag");
+
+    // Setup interceptor for fake running of blaze commands and capture details.
+    ExternalTaskInterceptor externalTaskInterceptor = new ExternalTaskInterceptor();
+    registerApplicationService(ExternalTaskProvider.class, externalTaskInterceptor);
+
+    // Return fake deploy info proto and mocked deploy info data object.
+    BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
+
+    AndroidDeployInfo fakeInstrumentorProto = AndroidDeployInfo.newBuilder().build();
+    AndroidDeployInfo fakeAppProto = AndroidDeployInfo.newBuilder().build();
+    BlazeAndroidDeployInfo mockDeployInfo = mock(BlazeAndroidDeployInfo.class);
+    when(helper.readDeployInfoProtoForTarget(
+            eq(instrumentorTarget), any(BuildResultHelper.class), any()))
+        .thenReturn(fakeInstrumentorProto);
+    when(helper.readDeployInfoProtoForTarget(eq(appTarget), any(BuildResultHelper.class), any()))
+        .thenReturn(fakeAppProto);
+    when(helper.extractInstrumentationTestDeployInfoAndInvalidateManifests(
+            eq(getProject()),
+            eq(new File(getExecRoot())),
+            eq(fakeInstrumentorProto),
+            eq(fakeAppProto)))
+        .thenReturn(mockDeployInfo);
+
+    // Perform
+    BlazeInstrumentationTestApkBuildStep buildStep =
+        new BlazeInstrumentationTestApkBuildStep(getProject(), testTarget, blazeFlags, helper);
+    buildStep.build(context, new DeviceSession(null, null, null));
+
+    // Verify
+    assertThat(buildStep.getDeployInfo()).isNotNull();
+    assertThat(buildStep.getDeployInfo()).isEqualTo(mockDeployInfo);
+    assertThat(externalTaskInterceptor.context).isEqualTo(context);
+    assertThat(externalTaskInterceptor.command).contains(instrumentorTarget.toString());
+    assertThat(externalTaskInterceptor.command).contains(appTarget.toString());
+    assertThat(externalTaskInterceptor.command).contains("--output_groups=+android_deploy_info");
+    assertThat(externalTaskInterceptor.command).containsAllIn(blazeFlags);
+  }
+
+  @Test
+  public void exceptionDuringDeployInfoExtraction() throws GetDeployInfoException {
+    setupProject();
+    Label testTarget = Label.create("//java/com/foo/app:instrumentation_test");
+    Label instrumentorTarget = Label.create("//java/com/foo/app:test_app");
+    Label appTarget = Label.create("//java/com/foo/app:app");
+
+    MessageCollector messageCollector = new MessageCollector();
+    BlazeContext context = new BlazeContext();
+    context.addOutputSink(IssueOutput.class, messageCollector);
+
+    // Make blaze command invocation always pass.
+    registerApplicationService(ExternalTaskProvider.class, builder -> scopes -> 0);
+
+    // Return fake deploy info proto and mocked deploy info data object.
+    BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
+
+    AndroidDeployInfo fakeInstrumentorProto = AndroidDeployInfo.newBuilder().build();
+    AndroidDeployInfo fakeAppProto = AndroidDeployInfo.newBuilder().build();
+    when(helper.readDeployInfoProtoForTarget(
+            eq(instrumentorTarget), any(BuildResultHelper.class), any()))
+        .thenReturn(fakeInstrumentorProto);
+    when(helper.readDeployInfoProtoForTarget(eq(appTarget), any(BuildResultHelper.class), any()))
+        .thenReturn(fakeAppProto);
+    when(helper.extractInstrumentationTestDeployInfoAndInvalidateManifests(
+            any(), any(), any(), any()))
+        .thenThrow(new GetDeployInfoException("Fake Exception"));
+
+    // Perform
+    BlazeInstrumentationTestApkBuildStep buildStep =
+        new BlazeInstrumentationTestApkBuildStep(
+            getProject(), testTarget, ImmutableList.of(), helper);
+    buildStep.build(context, new DeviceSession(null, null, null));
+
+    // Verify
+    assertThat(context.hasErrors()).isTrue();
+    assertThat(messageCollector.messages)
+        .contains("Could not read apk deploy info from build: Fake Exception");
+  }
+
+  @Test
+  public void badDeployInfo() throws GetDeployInfoException {
+    setupProject();
+    Label testTarget = Label.create("//java/com/foo/app:instrumentation_test");
+    Label instrumentorTarget = Label.create("//java/com/foo/app:test_app");
+    Label appTarget = Label.create("//java/com/foo/app:app");
+
+    MessageCollector messageCollector = new MessageCollector();
+    BlazeContext context = new BlazeContext();
+    context.addOutputSink(IssueOutput.class, messageCollector);
+
+    // Return a non-zero value to indicate blaze command run failure.
+    registerApplicationService(ExternalTaskProvider.class, builder -> scopes -> 1337);
+
+    // Return fake deploy info proto and mocked deploy info data object.
+    BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
+
+    AndroidDeployInfo fakeInstrumentorProto = AndroidDeployInfo.newBuilder().build();
+    AndroidDeployInfo fakeAppProto = AndroidDeployInfo.newBuilder().build();
+    BlazeAndroidDeployInfo mockDeployInfo = mock(BlazeAndroidDeployInfo.class);
+    when(helper.readDeployInfoProtoForTarget(
+            eq(instrumentorTarget), any(BuildResultHelper.class), any()))
+        .thenReturn(fakeInstrumentorProto);
+    when(helper.readDeployInfoProtoForTarget(eq(appTarget), any(BuildResultHelper.class), any()))
+        .thenReturn(fakeAppProto);
+    when(helper.extractInstrumentationTestDeployInfoAndInvalidateManifests(
+            eq(getProject()),
+            eq(new File(getExecRoot())),
+            eq(fakeInstrumentorProto),
+            eq(fakeAppProto)))
+        .thenReturn(mockDeployInfo);
+
+    // Perform
+    BlazeInstrumentationTestApkBuildStep buildStep =
+        new BlazeInstrumentationTestApkBuildStep(
+            getProject(), testTarget, ImmutableList.of(), helper);
+    buildStep.build(context, new DeviceSession(null, null, null));
+
+    // Verify
+    assertThat(context.hasErrors()).isTrue();
+    assertThat(messageCollector.messages)
+        .contains("Blaze build failed. See Blaze Console for details.");
+  }
+
+  @Test
+  public void noInstrumentsSpecified() {
+    setProjectView(
+        "directories:",
+        "  java/com/foo/app",
+        "targets:",
+        "  //java/com/foo/app:instrumentation_test",
+        "android_sdk_platform: android-27");
+    MockSdkUtil.registerSdk(workspace, "27");
+
+    workspace.createFile(
+        new WorkspacePath("java/com/foo/app/MainActivity.java"),
+        "package com.foo.app",
+        "import android.app.Activity;",
+        "public class MainActivity extends Activity {}");
+
+    workspace.createFile(
+        new WorkspacePath("java/com/foo/app/Test.java"),
+        "package com.foo.app",
+        "public class Test {}");
+
+    setTargetMap(
+        android_binary("//java/com/foo/app:app").src("MainActivity.java"),
+        android_binary("//java/com/foo/app:test_app").src("Test.java"),
+        android_instrumentation_test("//java/com/foo/app:instrumentation_test")
+            .test_app("//java/com/foo/app:test_app"));
+    runFullBlazeSync();
+
+    MessageCollector messageCollector = new MessageCollector();
+    BlazeContext context = new BlazeContext();
+    context.addOutputSink(IssueOutput.class, messageCollector);
+
+    BlazeInstrumentationTestApkBuildStep buildStep =
+        new BlazeInstrumentationTestApkBuildStep(
+            getProject(),
+            Label.create("//java/com/foo/app:instrumentation_test"),
+            ImmutableList.of());
+    InstrumentorToTarget pair =
+        buildStep.getInstrumentorToTargetPair(
+            context, BlazeProjectDataManager.getInstance(getProject()).getBlazeProjectData());
+
+    assertThat(pair).isNull();
+    assertThat(messageCollector.messages).hasSize(1);
+    assertThat(messageCollector.messages.get(0))
+        .contains("No \"instruments\" in target definition for //java/com/foo/app:test_app.");
+  }
+
+  @Test
+  public void noTestAppSpecified() {
+    setProjectView(
+        "directories:",
+        "  java/com/foo/app",
+        "targets:",
+        "  //java/com/foo/app:instrumentation_test",
+        "android_sdk_platform: android-27");
+    MockSdkUtil.registerSdk(workspace, "27");
+
+    workspace.createFile(
+        new WorkspacePath("java/com/foo/app/MainActivity.java"),
+        "package com.foo.app",
+        "import android.app.Activity;",
+        "public class MainActivity extends Activity {}");
+
+    workspace.createFile(
+        new WorkspacePath("java/com/foo/app/Test.java"),
+        "package com.foo.app",
+        "public class Test {}");
+
+    setTargetMap(
+        android_binary("//java/com/foo/app:app").src("MainActivity.java"),
+        android_binary("//java/com/foo/app:test_app")
+            .src("Test.java")
+            .instruments("//java/com/foo/app:app"),
+        android_instrumentation_test("//java/com/foo/app:instrumentation_test"));
+    runFullBlazeSync();
+
+    MessageCollector messageCollector = new MessageCollector();
+    BlazeContext context = new BlazeContext();
+    context.addOutputSink(IssueOutput.class, messageCollector);
+
+    BlazeInstrumentationTestApkBuildStep buildStep =
+        new BlazeInstrumentationTestApkBuildStep(
+            getProject(),
+            Label.create("//java/com/foo/app:instrumentation_test"),
+            ImmutableList.of());
+    InstrumentorToTarget pair =
+        buildStep.getInstrumentorToTargetPair(
+            context, BlazeProjectDataManager.getInstance(getProject()).getBlazeProjectData());
+
+    assertThat(pair).isNull();
+    assertThat(messageCollector.messages).hasSize(1);
+    assertThat(messageCollector.messages.get(0))
+        .contains(
+            "No \"test_app\" in target definition for //java/com/foo/app:instrumentation_test.");
+  }
+
+  /** Saves the latest blaze command and context for later verification. */
+  private static class ExternalTaskInterceptor implements ExternalTaskProvider {
+    ImmutableList<String> command;
+    BlazeContext context;
+
+    @Override
+    public ExternalTask build(ExternalTask.Builder builder) {
+      command = builder.command.build();
+      context = builder.context;
+      return scopes -> 0;
+    }
+  }
+
+  @Test
+  public void findInstrumentorAndTestTargets() {
+    setupProject();
+    BlazeInstrumentationTestApkBuildStep buildStep =
+        new BlazeInstrumentationTestApkBuildStep(
+            getProject(),
+            Label.create("//java/com/foo/app:instrumentation_test"),
+            ImmutableList.of());
+
+    InstrumentorToTarget pair =
+        buildStep.getInstrumentorToTargetPair(
+            new BlazeContext(),
+            BlazeProjectDataManager.getInstance(getProject()).getBlazeProjectData());
+    assertThat(pair.instrumentor).isEqualTo(Label.create("//java/com/foo/app:test_app"));
+    assertThat(pair.target).isEqualTo(Label.create("//java/com/foo/app:app"));
+  }
+
+  private static class MessageCollector implements OutputSink<IssueOutput> {
+    ArrayList<String> messages = new ArrayList<>();
+
+    @Override
+    public Propagation onOutput(@NotNull IssueOutput output) {
+      messages.add(output.getMessage());
+      return Propagation.Continue;
+    }
+  }
+}


### PR DESCRIPTION
Add support for running/debugging android_instrumentation_test targets.

Currently ASwB has poor support for migrated android_test targets 
(files aren't sync'd correctly and only run action is shown) as well as no
support for android_instrumentation_test targets.  This CL adds support
to these two so they work seamlessly as android_test did before.

The following are required to support android_instrumentation_test:

* BlazeApkBuildStepInstrumentation is added to specifically handle 
  android_instrumentation_test targets. Doing this also simplifies 
  BlazeApkBuildStepNormalBuild as it doesn't have to have separate logic 
  for building multiple APKs just for instrumentation tests.

* BlazeApkDeployInfoProtoHelper is updated to handle two scenarios: 
  normal deployment, and instrumentation test deployment.  Normal 
  deployment handles existing usages, while instrumentation test 
  deployment handles the case where there are two deploy info files to 
  process (info for both instrumentor and target-app APKs).

* BlazeAndroidTestProgramRunner is updated to support 
  android_instrumentation_tests.  
 

TEST: Added test for instrumentation build step.  Manually verified with test
project on both before and after migration scenarios on stable, beta, and
canary channels.
