### PR TITLE
Remove BlazeJsCompletionService in v193, since JsCompletionService is now final.

### DIFF
--- a/javascript/BUILD
+++ b/javascript/BUILD
@@ -5,6 +5,7 @@ load(
     "optional_plugin_xml",
     "stamped_plugin_xml",
 )
+load("//intellij_platform_sdk:build_defs.bzl", "select_for_plugin_api")
 load(
     "//testing:test_defs.bzl",
     "intellij_integration_test_suite",
@@ -34,9 +35,20 @@ optional_plugin_xml(
     plugin_xml = "src/META-INF/javascript-contents.xml",
 )
 
+optional_plugin_xml(
+    name = "pre-v193_xml",
+    module = "JavaScript",
+    plugin_xml = "src/META-INF/pre-v193.xml",
+)
+
 intellij_plugin_library(
     name = "plugin_library",
-    optional_plugin_xmls = [":optional_xml"],
+    optional_plugin_xmls = [":optional_xml"] + select_for_plugin_api({
+        "intellij-2019.3": [],
+        "intellij-ue-2019.3": [],
+        "clion-2019.3": [],
+        "default": [":pre-v193_xml"],
+    }),
     plugin_xmls = ["src/META-INF/blaze-javascript.xml"],
     visibility = ["//visibility:public"],
     deps = [":javascript"],

--- a/javascript/src/META-INF/javascript-contents.xml
+++ b/javascript/src/META-INF/javascript-contents.xml
@@ -35,10 +35,6 @@
         language="JavaScript"/>
     <editorNotificationProvider
         implementation="com.google.idea.blaze.typescript.AddTsConfigNotificationProvider"/>
-    <projectService
-        serviceInterface="com.intellij.lang.javascript.completion.JSCompletionService"
-        serviceImplementation="com.google.idea.blaze.javascript.BlazeJsCompletionService"
-        overrides="true"/>
   </extensions>
 
   <extensions defaultExtensionNs="com.google.idea.blaze">

--- a/javascript/src/META-INF/pre-v193.xml
+++ b/javascript/src/META-INF/pre-v193.xml
@@ -1,0 +1,23 @@
+<!--
+  ~ Copyright 2020 The Bazel Authors. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<idea-plugin>
+  <extensions>
+    <projectService
+          serviceInterface="com.intellij.lang.javascript.completion.JSCompletionService"
+          serviceImplementation="com.google.idea.sdkcompat.javascript.BlazeJsCompletionService"
+          overrides="true"/>
+  </extensions>
+</idea-plugin>

--- a/sdkcompat/v191/com/google/idea/sdkcompat/javascript/BlazeJsCompletionService.java
+++ b/sdkcompat/v191/com/google/idea/sdkcompat/javascript/BlazeJsCompletionService.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.idea.blaze.javascript;
+package com.google.idea.sdkcompat.javascript;
 
 import com.intellij.codeInsight.lookup.LookupManager;
 import com.intellij.lang.javascript.completion.JSCompletionService;
@@ -22,7 +22,11 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-/** Replacement {@link JSCompletionService} that fixes a buggy timeout implementation. */
+/**
+ * Replacement {@link JSCompletionService} that fixes a buggy timeout implementation.
+ *
+ * #api192 : JSCompletionService is final in 193.
+ */
 public class BlazeJsCompletionService extends JSCompletionService {
   public BlazeJsCompletionService(LookupManager lookupManager) {
     super(lookupManager);

--- a/sdkcompat/v192/com/google/idea/sdkcompat/javascript/BlazeJsCompletionService.java
+++ b/sdkcompat/v192/com/google/idea/sdkcompat/javascript/BlazeJsCompletionService.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.sdkcompat.javascript;
+
+import com.intellij.codeInsight.lookup.LookupManager;
+import com.intellij.lang.javascript.completion.JSCompletionService;
+import com.intellij.openapi.application.ApplicationManager;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Replacement {@link JSCompletionService} that fixes a buggy timeout implementation.
+ *
+ * #api192 : JSCompletionService is final in 193.
+ */
+public class BlazeJsCompletionService extends JSCompletionService {
+  public BlazeJsCompletionService(LookupManager lookupManager) {
+    super(lookupManager);
+  }
+
+  /**
+   * Upstream uses {@link java.util.concurrent.ForkJoinPool#awaitQuiescence(long, TimeUnit)}, which
+   * executes tasks directly on the caller thread (EDT) and could ignore the hard coded 100ms
+   * timeout.
+   */
+  @Override
+  public boolean awaitWithTimeout() {
+    try {
+      return ApplicationManager.getApplication()
+          .executeOnPooledThread(super::awaitWithTimeout)
+          .get(100L, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
Remove BlazeJsCompletionService in v193, since JsCompletionService is now final.
