### PR TITLE
Use correct execroot to obtain deployment files.

### DIFF
--- a/aswb/src/com/google/idea/blaze/android/run/runner/ExecRootUtil.java
+++ b/aswb/src/com/google/idea/blaze/android/run/runner/ExecRootUtil.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.android.run.runner;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
+import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtifactsException;
+import com.google.idea.blaze.base.command.info.BlazeInfo;
+import com.google.idea.blaze.base.command.info.BlazeInfoRunner;
+import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
+import com.google.idea.blaze.base.scope.BlazeContext;
+import com.google.idea.blaze.base.scope.output.IssueOutput;
+import com.google.idea.blaze.base.scope.output.StatusOutput;
+import com.google.idea.blaze.base.settings.Blaze;
+import com.google.idea.common.experiments.BoolExperiment;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+import java.util.concurrent.ExecutionException;
+import javax.annotation.Nullable;
+
+/** Utility for fetching execroot. */
+public final class ExecRootUtil {
+  /** Enables using blaze info as fallback for fetching execroot. */
+  private static final BoolExperiment useBlazeInfoAsExecrootFallback =
+      new BoolExperiment("enable.execroot.fallback", false);
+
+  private static final Logger log = Logger.getInstance(ExecRootUtil.class);
+
+  /**
+   * Returns the execroot of the given project.
+   *
+   * <p>This method tries to get the execroot from BEP output. In the event where BEP isn't reliable
+   * for obtaining the execroot, enabling {@link #useBlazeInfoAsExecrootFallback} will cause this
+   * method to also obtain the execroot using blaze info.
+   */
+  @Nullable
+  public static String getExecutionRoot(
+      BuildResultHelper buildResultHelper,
+      Project project,
+      ImmutableList<String> buildFlags,
+      BlazeContext context)
+      throws GetArtifactsException {
+    String executionRoot = buildResultHelper.getBuildOutput().getLocalExecRoot();
+    if (executionRoot == null && !useBlazeInfoAsExecrootFallback.getValue()) {
+      return null;
+    }
+
+    log.warn("Could not get execroot from BEP. Falling back to using blaze info.");
+    context.output(new StatusOutput("Fetching project output directory..."));
+    ListenableFuture<String> execRootFuture =
+        BlazeInfoRunner.getInstance()
+            .runBlazeInfo(
+                context,
+                Blaze.getBuildSystemProvider(project).getBinaryPath(project),
+                WorkspaceRoot.fromProject(project),
+                buildFlags,
+                BlazeInfo.EXECUTION_ROOT_KEY);
+    try {
+      return execRootFuture.get();
+    } catch (InterruptedException e) {
+      IssueOutput.warn("Build cancelled.").submit(context);
+      context.setCancelled();
+    } catch (ExecutionException e) {
+      IssueOutput.error(e.getMessage()).submit(context);
+      context.setHasError();
+    }
+    return null;
+  }
+
+  private ExecRootUtil() {}
+}

--- a/aswb/tests/utils/integration/com/google/idea/blaze/android/MessageCollector.java
+++ b/aswb/tests/utils/integration/com/google/idea/blaze/android/MessageCollector.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.android;
+
+import com.google.idea.blaze.base.scope.OutputSink;
+import com.google.idea.blaze.base.scope.output.IssueOutput;
+import java.util.ArrayList;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+
+/** An issue output sink that collects the messages outputted to it. */
+public class MessageCollector implements OutputSink<IssueOutput> {
+  private final ArrayList<String> messages = new ArrayList<>();
+
+  @Override
+  public Propagation onOutput(@NotNull IssueOutput output) {
+    messages.add(output.getMessage());
+    return Propagation.Continue;
+  }
+
+  public List<String> getMessages() {
+    return messages;
+  }
+}


### PR DESCRIPTION
Use correct execroot to obtain deployment files.

Currently ASwB assumes a project will only have one execroot.  As a
result the build process will attempt to save time by reusing the
execroot fetched during initial project sync.  This is not always correct
and caused a bug where the build process will use a remote execroot 
as it's local blaze execroot and failed due to "missing files".

This CL fixes this by parsing BEP for the execroot, which should 
always be present after a build anyway.  

This change modifies the critical path for running/debugging 
android apps from the IDE. Fetching execroot from BEP output
hasn't been done before so a fallback mechanism guarded by
"enable.execroot.fallback" flag will automatically enable the old
way of obtaining the execroot through blaze info if fetching
through BEP fails.

"enable.execroot.fallback" is disabled by default and the fallback
can be removed once fetching through execroot through BEP proves
to be reliable.
