### PR TITLE
compat: CreateDesktopEntryAction no longer contains `getLauncherScript()` method in api193. It is replaced by `Restarter.getIdeStarter()`

### DIFF
--- a/sdkcompat/v191/BUILD
+++ b/sdkcompat/v191/BUILD
@@ -14,6 +14,7 @@ java_library(
         "com/google/idea/sdkcompat/run/**",
         "com/google/idea/sdkcompat/testframework/*.java",
         "com/google/idea/sdkcompat/vcs/**",
+        "com/google/idea/sdkcompat/util/**",
         "com/intellij/serviceContainer/*.java",
     ]) + select_for_ide(
         android_studio = glob([

--- a/sdkcompat/v191/com/google/idea/sdkcompat/util/CreateDesktopEntryActionCompat.java
+++ b/sdkcompat/v191/com/google/idea/sdkcompat/util/CreateDesktopEntryActionCompat.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.sdkcompat.util;
+
+import com.intellij.ide.actions.CreateDesktopEntryAction;
+import javax.annotation.Nullable;
+
+/**
+ * Compat for {@link com.intellij.ide.actions.CreateDesktopEntryAction}. Remove when #api192 is no
+ * longer supported.
+ */
+public class CreateDesktopEntryActionCompat {
+  private CreateDesktopEntryActionCompat() {}
+
+  @Nullable
+  public static String getLauncherScript() {
+    return CreateDesktopEntryAction.getLauncherScript();
+  }
+}

--- a/sdkcompat/v192/BUILD
+++ b/sdkcompat/v192/BUILD
@@ -12,6 +12,7 @@ java_library(
         "com/google/idea/sdkcompat/platform/**",
         "com/google/idea/sdkcompat/python/*.java",
         "com/google/idea/sdkcompat/run/**",
+        "com/google/idea/sdkcompat/util/**",
         "com/google/idea/sdkcompat/testframework/*.java",
         "com/google/idea/sdkcompat/vcs/**",
         "com/intellij/serviceContainer/*.java",

--- a/sdkcompat/v192/com/google/idea/sdkcompat/util/CreateDesktopEntryActionCompat.java
+++ b/sdkcompat/v192/com/google/idea/sdkcompat/util/CreateDesktopEntryActionCompat.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.sdkcompat.util;
+
+import com.intellij.ide.actions.CreateDesktopEntryAction;
+import javax.annotation.Nullable;
+
+/**
+ * Compat for {@link com.intellij.ide.actions.CreateDesktopEntryAction}. Remove when #api192 is no
+ * longer supported.
+ */
+public class CreateDesktopEntryActionCompat {
+  private CreateDesktopEntryActionCompat() {}
+
+  @Nullable
+  public static String getLauncherScript() {
+    return CreateDesktopEntryAction.getLauncherScript();
+  }
+}

--- a/sdkcompat/v193/BUILD
+++ b/sdkcompat/v193/BUILD
@@ -11,6 +11,7 @@ java_library(
         "com/google/idea/sdkcompat/openapi/**",
         "com/google/idea/sdkcompat/platform/**",
         "com/google/idea/sdkcompat/python/*.java",
+        "com/google/idea/sdkcompat/util/**",
         "com/google/idea/sdkcompat/run/**",
         "com/google/idea/sdkcompat/testframework/*.java",
         "com/google/idea/sdkcompat/vcs/**",

--- a/sdkcompat/v193/com/google/idea/sdkcompat/util/CreateDesktopEntryActionCompat.java
+++ b/sdkcompat/v193/com/google/idea/sdkcompat/util/CreateDesktopEntryActionCompat.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.sdkcompat.util;
+
+import com.intellij.openapi.diagnostic.Logger;
+import java.io.File;
+import java.lang.reflect.Method;
+import javax.annotation.Nullable;
+
+/**
+ * Compat for {@link com.intellij.ide.actions.CreateDesktopEntryAction}. Remove when #api192 is no
+ * longer supported.
+ */
+public class CreateDesktopEntryActionCompat {
+  private static final Logger logger = Logger.getInstance(CreateDesktopEntryActionCompat.class);
+
+  private CreateDesktopEntryActionCompat() {}
+
+  @Nullable
+  public static String getLauncherScript() {
+    // TODO (arakesh): Remove hack once IJ gets updated to use new plugin api.
+    // Hack for IJ2019.3 which uses an older api193 which doesn't contain the Restarter class.
+    try {
+      // Should raise ClassNotFoundException if Class not found.
+      Class<?> cls = Class.forName("com.intellij.ide.actions.CreateDesktopEntryAction");
+      // Should throw NoSuchMethodException in new PluginSDK.
+      Method method = cls.getMethod("getLauncherScript");
+      return (String) method.invoke(null);
+    } catch (ReflectiveOperationException e) {
+      // Ignore exceptions. We default to using the new Class.
+      logger.info(
+          "Error Calling `CreateDesktopEntryAction.getLauncherScript()`. Using default"
+              + " `Restarter.getIdeStarter()`",
+          e);
+    }
+
+    try {
+      Class<?> cls = Class.forName("com.intellij.util.Restarter");
+      Method method = cls.getMethod("getIdeStarter");
+      File startFile = (File) method.invoke(null);
+      if (startFile == null) {
+        return null;
+      }
+
+      return startFile.getPath();
+    } catch (ReflectiveOperationException e) {
+      logger.error("Error calling `Restarter.getIdeStarter()`", e);
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
compat: CreateDesktopEntryAction no longer contains `getLauncherScript()` method in api193. It is replaced by `Restarter.getIdeStarter()`
