### PR TITLE
compat: Add compat class for (Java)ResolveTestCase

### DIFF
--- a/testing/BUILD
+++ b/testing/BUILD
@@ -28,7 +28,10 @@ java_library(
         "android-studio-3.5": glob(["testcompat/v192/**/*.java"]),
         "android-studio-3.6": glob(["testcompat/v192/**/*.java"]),
         "android-studio-4.0": glob(["testcompat/v192/**/*.java"]),
-        "clion-2019.2": glob(["testcompat/v192/**/*.java"]),
+        "clion-2019.2": glob(
+            ["testcompat/v192/**/*.java"],
+            exclude = ["testcompat/v192/com/google/idea/sdkcompat/testframework/JavaResolveTestCase.java"],
+        ),
         "intellij-2019.2": glob(["testcompat/v192/**/*.java"]),
         "intellij-ue-2019.2": glob(["testcompat/v192/**/*.java"]),
         "default": glob(["testcompat/v193/**/*.java"]),

--- a/testing/testcompat/v192/com/google/idea/sdkcompat/testframework/JavaResolveTestCase.java
+++ b/testing/testcompat/v192/com/google/idea/sdkcompat/testframework/JavaResolveTestCase.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.sdkcompat.testframework;
+
+import com.intellij.testFramework.ResolveTestCase;
+
+/** #api192: class renamed in 2019.3 */
+public abstract class JavaResolveTestCase extends ResolveTestCase {}

--- a/testing/testcompat/v193/com/google/idea/sdkcompat/testframework/JavaResolveTestCase.java
+++ b/testing/testcompat/v193/com/google/idea/sdkcompat/testframework/JavaResolveTestCase.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.sdkcompat.testframework;
+
+/** #api192: class renamed in 2019.3 */
+public abstract class JavaResolveTestCase extends com.intellij.testFramework.JavaResolveTestCase {}


### PR DESCRIPTION
compat: Add compat class for (Java)ResolveTestCase

api193 renames ResolveTestCase to JavaResolveTestCase. This CL creates a compat class to provide a consistent name.
