### PR TITLE
compat: Add compat class for PlatformTestCase.createProject

### DIFF
--- a/testing/testcompat/v192/com/google/idea/sdkcompat/testframework/PlatformTestCaseCompat.java
+++ b/testing/testcompat/v192/com/google/idea/sdkcompat/testframework/PlatformTestCaseCompat.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.sdkcompat.testframework;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.testFramework.PlatformTestCase;
+import java.io.File;
+
+/** Compat class for {@link PlatformTestCase}. #api192: changed in 2019.3 */
+public final class PlatformTestCaseCompat {
+  private PlatformTestCaseCompat() {}
+
+  public static Project createProject(File projectFile, String creationPlace) {
+    return PlatformTestCase.createProject(projectFile, creationPlace);
+  }
+}

--- a/testing/testcompat/v193/com/google/idea/sdkcompat/testframework/PlatformTestCaseCompat.java
+++ b/testing/testcompat/v193/com/google/idea/sdkcompat/testframework/PlatformTestCaseCompat.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.sdkcompat.testframework;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.testFramework.PlatformTestCase;
+import java.io.File;
+
+/** Compat class for {@link PlatformTestCase}. #api192: changed in 2019.3 */
+public final class PlatformTestCaseCompat {
+  private PlatformTestCaseCompat() {}
+
+  public static Project createProject(File projectFile, String creationPlace) {
+    return PlatformTestCase.createProject(projectFile.toPath());
+  }
+}


### PR DESCRIPTION
compat: Add compat class for PlatformTestCase.createProject

PlatformTestCase.createProject has changed signature in v193. This CL adds a compat class for a consistent signature.
