### PR TITLE
compat: ProjectPackageIndexImpl is package private in api193. This CL creates a compat class that delegates it's methods to that of ProjectPackageIndexImpl

### DIFF
--- a/sdkcompat/v191/BUILD
+++ b/sdkcompat/v191/BUILD
@@ -15,6 +15,7 @@ java_library(
         "com/google/idea/sdkcompat/testframework/*.java",
         "com/google/idea/sdkcompat/vcs/**",
         "com/intellij/serviceContainer/*.java",
+        "com/intellij/openapi/roots/impl/**",
     ]) + select_for_ide(
         android_studio = glob([
             "com/google/idea/sdkcompat/cidr/**",

--- a/sdkcompat/v191/com/intellij/openapi/roots/impl/ProjectPackageIndexImplCompat.java
+++ b/sdkcompat/v191/com/intellij/openapi/roots/impl/ProjectPackageIndexImplCompat.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.openapi.roots.impl;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.PackageIndex;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.util.Query;
+import org.jetbrains.annotations.NotNull;
+
+/** Compat class overriding {@link ProjectPackageIndexImpl} */
+public final class ProjectPackageIndexImplCompat extends PackageIndex {
+  private final ProjectPackageIndexImpl delegate;
+
+  public ProjectPackageIndexImplCompat(
+      @NotNull Project project, @NotNull DirectoryIndex directoryIndex) {
+    delegate = new ProjectPackageIndexImpl(directoryIndex);
+  }
+
+  @NotNull
+  @Override
+  public VirtualFile[] getDirectoriesByPackageName(
+      @NotNull String packageName, boolean includeLibrarySources) {
+    return delegate.getDirectoriesByPackageName(packageName, includeLibrarySources);
+  }
+
+  @NotNull
+  @Override
+  public Query<VirtualFile> getDirsByPackageName(@NotNull String s, boolean b) {
+    return delegate.getDirsByPackageName(s, b);
+  }
+}

--- a/sdkcompat/v192/BUILD
+++ b/sdkcompat/v192/BUILD
@@ -15,6 +15,7 @@ java_library(
         "com/google/idea/sdkcompat/testframework/*.java",
         "com/google/idea/sdkcompat/vcs/**",
         "com/intellij/serviceContainer/*.java",
+        "com/intellij/openapi/roots/impl/**",
     ]) + select_for_ide(
         android_studio = glob([
             "com/google/idea/sdkcompat/cidr/**",

--- a/sdkcompat/v192/com/intellij/openapi/roots/impl/ProjectPackageIndexImplCompat.java
+++ b/sdkcompat/v192/com/intellij/openapi/roots/impl/ProjectPackageIndexImplCompat.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.openapi.roots.impl;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.PackageIndex;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.util.Query;
+import org.jetbrains.annotations.NotNull;
+
+/** Compat class overriding {@link ProjectPackageIndexImpl} */
+public final class ProjectPackageIndexImplCompat extends PackageIndex {
+  private final ProjectPackageIndexImpl delegate;
+
+  public ProjectPackageIndexImplCompat(
+      @NotNull Project project, @NotNull DirectoryIndex directoryIndex) {
+    delegate = new ProjectPackageIndexImpl(directoryIndex);
+  }
+
+  @NotNull
+  @Override
+  public VirtualFile[] getDirectoriesByPackageName(
+      @NotNull String packageName, boolean includeLibrarySources) {
+    return delegate.getDirectoriesByPackageName(packageName, includeLibrarySources);
+  }
+
+  @NotNull
+  @Override
+  public Query<VirtualFile> getDirsByPackageName(@NotNull String s, boolean b) {
+    return delegate.getDirsByPackageName(s, b);
+  }
+}

--- a/sdkcompat/v193/BUILD
+++ b/sdkcompat/v193/BUILD
@@ -14,6 +14,7 @@ java_library(
         "com/google/idea/sdkcompat/run/**",
         "com/google/idea/sdkcompat/testframework/*.java",
         "com/google/idea/sdkcompat/vcs/**",
+        "com/intellij/openapi/roots/impl/**",
     ]) + select_for_ide(
         android_studio = glob([
             "com/google/idea/sdkcompat/cidr/**",

--- a/sdkcompat/v193/com/intellij/openapi/roots/impl/ProjectPackageIndexImplCompat.java
+++ b/sdkcompat/v193/com/intellij/openapi/roots/impl/ProjectPackageIndexImplCompat.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.openapi.roots.impl;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.PackageIndex;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.util.Query;
+import org.jetbrains.annotations.NotNull;
+
+/** Compat class overriding {@link ProjectPackageIndexImpl} */
+public final class ProjectPackageIndexImplCompat extends PackageIndex {
+  private final ProjectPackageIndexImpl delegate;
+
+  public ProjectPackageIndexImplCompat(
+      @NotNull Project project, @NotNull DirectoryIndex directoryIndex) {
+    delegate = new ProjectPackageIndexImpl(project);
+  }
+
+  @NotNull
+  @Override
+  public VirtualFile[] getDirectoriesByPackageName(
+      @NotNull String packageName, boolean includeLibrarySources) {
+    return delegate.getDirectoriesByPackageName(packageName, includeLibrarySources);
+  }
+
+  @NotNull
+  @Override
+  public Query<VirtualFile> getDirsByPackageName(@NotNull String s, boolean b) {
+    return delegate.getDirsByPackageName(s, b);
+  }
+}


### PR DESCRIPTION
compat: ProjectPackageIndexImpl is package private in api193. This CL creates a compat class that delegates it's methods to that of ProjectPackageIndexImpl
