### PR TITLE
Fix sharded syncs not properly removing explicitly-excluded targets when deriving targets from directories.

### DIFF
--- a/base/src/com/google/idea/blaze/base/sync/projectview/TargetExpressionList.java
+++ b/base/src/com/google/idea/blaze/base/sync/projectview/TargetExpressionList.java
@@ -74,6 +74,13 @@ public final class TargetExpressionList {
     this.directories = directories;
   }
 
+  /** Returns the original list of targets with trivially-excluded targets removed. */
+  public ImmutableList<TargetExpression> getTargets() {
+    return reversedTargets.reverse().stream()
+        .map(t -> t.originalExpression)
+        .collect(toImmutableList());
+  }
+
   /** Returns true if the entire package is covered by the target expressions. */
   public boolean includesPackage(WorkspacePath packagePath) {
     // the last target expression to cover this label overrides all previous expressions


### PR DESCRIPTION
Fix sharded syncs not properly removing explicitly-excluded targets when deriving targets from directories.
