### PR TITLE
Fix code style manager support in 2019.3

### DIFF
--- a/common/formatter/src/com/google/idea/common/formatter/DelegatingCodeStyleManager.java
+++ b/common/formatter/src/com/google/idea/common/formatter/DelegatingCodeStyleManager.java
@@ -15,6 +15,7 @@
  */
 package com.google.idea.common.formatter;
 
+import com.google.idea.sdkcompat.openapi.DelegatingCodeStyleManagerCompat;
 import com.intellij.formatting.FormattingMode;
 import com.intellij.lang.ASTNode;
 import com.intellij.openapi.editor.Document;
@@ -34,12 +35,13 @@ import java.util.Collection;
 import javax.annotation.Nullable;
 
 /** A delegating {@link CodeStyleManager}. */
-public abstract class DelegatingCodeStyleManager extends CodeStyleManager
+public abstract class DelegatingCodeStyleManager extends DelegatingCodeStyleManagerCompat
     implements FormattingModeAwareIndentAdjuster {
 
-  protected CodeStyleManager delegate;
+  protected final CodeStyleManager delegate;
 
   protected DelegatingCodeStyleManager(CodeStyleManager delegate) {
+    super(delegate);
     this.delegate = delegate;
   }
 

--- a/sdkcompat/v191/com/google/idea/sdkcompat/openapi/DelegatingCodeStyleManagerCompat.java
+++ b/sdkcompat/v191/com/google/idea/sdkcompat/openapi/DelegatingCodeStyleManagerCompat.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.sdkcompat.openapi;
+
+import com.intellij.psi.codeStyle.CodeStyleManager;
+
+/**
+ * Adapter to bridge different SDK versions. Contains only methods not present in all supported
+ * versions. #api192
+ */
+public abstract class DelegatingCodeStyleManagerCompat extends CodeStyleManager {
+
+  protected DelegatingCodeStyleManagerCompat(CodeStyleManager delegate) {}
+}

--- a/sdkcompat/v192/com/google/idea/sdkcompat/openapi/DelegatingCodeStyleManagerCompat.java
+++ b/sdkcompat/v192/com/google/idea/sdkcompat/openapi/DelegatingCodeStyleManagerCompat.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.sdkcompat.openapi;
+
+import com.intellij.psi.codeStyle.CodeStyleManager;
+
+/**
+ * Adapter to bridge different SDK versions. Contains only methods not present in all supported
+ * versions. #api192
+ */
+public abstract class DelegatingCodeStyleManagerCompat extends CodeStyleManager {
+
+  protected DelegatingCodeStyleManagerCompat(CodeStyleManager delegate) {}
+}

--- a/sdkcompat/v193/com/google/idea/sdkcompat/openapi/DelegatingCodeStyleManagerCompat.java
+++ b/sdkcompat/v193/com/google/idea/sdkcompat/openapi/DelegatingCodeStyleManagerCompat.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.sdkcompat.openapi;
+
+import com.intellij.openapi.editor.Document;
+import com.intellij.psi.codeStyle.CodeStyleManager;
+
+/**
+ * Adapter to bridge different SDK versions. Contains only methods not present in all supported
+ * versions. #api192
+ */
+public abstract class DelegatingCodeStyleManagerCompat extends CodeStyleManager {
+
+  private final CodeStyleManager delegate;
+
+  protected DelegatingCodeStyleManagerCompat(CodeStyleManager delegate) {
+    this.delegate = delegate;
+  }
+
+  /** #api192: method added in 2019.3 */
+  @Override
+  public void scheduleIndentAdjustment(Document document, int offset) {
+    delegate.scheduleIndentAdjustment(document, offset);
+  }
+}


### PR DESCRIPTION
Fix code style manager support in 2019.3

GitHub issue: https://github.com/bazelbuild/intellij/issues/1548
