### PR TITLE
Eagerly attach sources for android support libraries.

### DIFF
--- a/java/src/META-INF/java-contents.xml
+++ b/java/src/META-INF/java-contents.xml
@@ -163,5 +163,7 @@
                     interface="com.google.idea.blaze.java.run.fastbuild.FastBuildTestEnvironmentModifier"/>
     <extensionPoint qualifiedName="com.google.idea.blaze.FastBuildCompilationModification"
                     interface="com.google.idea.blaze.java.fastbuild.FastBuildCompilationModification"/>
+    <extensionPoint qualifiedName="com.google.idea.blaze.AttachSourcesFilter"
+                    interface="com.google.idea.blaze.java.sync.model.AttachSourcesFilter"/>
   </extensionPoints>
 </idea-plugin>

--- a/java/src/com/google/idea/blaze/java/sync/model/AttachSourcesFilter.java
+++ b/java/src/com/google/idea/blaze/java/sync/model/AttachSourcesFilter.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.java.sync.model;
+
+import com.intellij.openapi.extensions.ExtensionPointName;
+
+/** Decides if a library should have it's source jar attached by default. */
+public interface AttachSourcesFilter {
+  ExtensionPointName<AttachSourcesFilter> EP_NAME =
+      ExtensionPointName.create("com.google.idea.blaze.AttachSourcesFilter");
+
+  boolean shouldAlwaysAttachSourceJar(BlazeJarLibrary library);
+}

--- a/java/src/com/google/idea/blaze/java/sync/model/BlazeJarLibrary.java
+++ b/java/src/com/google/idea/blaze/java/sync/model/BlazeJarLibrary.java
@@ -37,7 +37,6 @@ import javax.annotation.concurrent.Immutable;
 /** An immutable reference to a .jar required by a rule. */
 @Immutable
 public final class BlazeJarLibrary extends BlazeLibrary {
-
   private static final Logger logger = Logger.getInstance(BlazeJarLibrary.class);
 
   public final LibraryArtifact libraryArtifact;
@@ -79,6 +78,12 @@ public final class BlazeJarLibrary extends BlazeLibrary {
     }
 
     AttachedSourceJarManager sourceJarManager = AttachedSourceJarManager.getInstance(project);
+    for (AttachSourcesFilter decider : AttachSourcesFilter.EP_NAME.getExtensions()) {
+      if (decider.shouldAlwaysAttachSourceJar(this)) {
+        sourceJarManager.setHasSourceJarAttached(key, true);
+      }
+    }
+
     if (!sourceJarManager.hasSourceJarAttached(key)) {
       return;
     }


### PR DESCRIPTION
Eagerly attach sources for android support libraries.

DejetifiedGotoDeclarationHandler requires the presence of indexed
support lib source jars to work.  Specifically, so that the source files
can be found using the FilenameIndex.

This CL adds the extension SourceJarAttachmentDecider to allow
implementers control which libraries to attach source jars.
