### PR TITLE
Expand and collapse all buttons for Blaze Problems

### DIFF
--- a/base/src/com/google/idea/blaze/base/ui/problems/BlazeProblemsViewPanel.java
+++ b/base/src/com/google/idea/blaze/base/ui/problems/BlazeProblemsViewPanel.java
@@ -43,6 +43,8 @@ import com.intellij.openapi.util.ActionCallback;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.pom.Navigatable;
 import com.intellij.ui.AutoScrollToSourceHandler;
+import com.intellij.ui.treeStructure.actions.CollapseAllAction;
+import com.intellij.ui.treeStructure.actions.ExpandAllAction;
 import com.intellij.util.OpenSourceUtil;
 import java.awt.BorderLayout;
 import java.awt.Component;
@@ -101,6 +103,8 @@ class BlazeProblemsViewPanel extends NewErrorTreeViewPanel {
     super.fillRightToolbarGroup(group);
     group.add(new AutoscrollToConsoleAction());
     group.add(new ShowWarningsAction());
+    group.add(new ExpandAllAction(myTree));
+    group.add(new CollapseAllAction(myTree));
   }
 
   @Override


### PR DESCRIPTION
Expand and collapse all buttons for Blaze Problems

The CL adds expand all and collapse all buttons for the tree of errors
in the Blaze Problems view.
