### PR TITLE
Don't include AAR libraries in BlazeAndroidLibrarySource#getLibraries

### DIFF
--- a/aswb/src/com/google/idea/blaze/android/sync/BlazeAndroidLibrarySource.java
+++ b/aswb/src/com/google/idea/blaze/android/sync/BlazeAndroidLibrarySource.java
@@ -49,7 +49,6 @@ public class BlazeAndroidLibrarySource extends LibrarySource.Adapter {
     for (BlazeJarLibrary javacJarLibrary : syncData.importResult.javacJarLibraries) {
       libraries.add(javacJarLibrary);
     }
-    libraries.addAll(syncData.importResult.aarLibraries.values());
     return libraries.build();
   }
 


### PR DESCRIPTION
Don't include AAR libraries in BlazeAndroidLibrarySource#getLibraries

getLibraries() is only ever called by BlazeLibraryCollector, which immediately
turns around and filters out any AAR libraries using the AarJarFilter returned by BlazeAndroidLibrarySource#getLibraryFilter. So there's no reason to waste time by including these and then filtering them out.
