### PR TITLE
api193: Java integration test fixes.

### DIFF
--- a/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/findusages/LocalVariableUsagesTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/findusages/LocalVariableUsagesTest.java
@@ -30,6 +30,9 @@ import com.google.idea.blaze.base.lang.buildfile.search.FindUsages;
 import com.google.idea.blaze.base.model.primitives.WorkspacePath;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiReference;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -86,7 +89,9 @@ public class LocalVariableUsagesTest extends BuildFileIntegrationTestCase {
     PsiReference[] references = FindUsages.findAllReferences(target);
     assertThat(references).hasLength(2);
 
-    assertThat(references[0]).isInstanceOf(LocalReference.class);
-    assertThat(references[1]).isInstanceOf(TargetReference.class);
+    // We cannot guarantee order of references.
+    List<Class<?>> referenceClasses =
+        Arrays.stream(references).map(Object::getClass).collect(Collectors.toList());
+    assertThat(referenceClasses).containsExactly(TargetReference.class, LocalReference.class);
   }
 }

--- a/java/tests/integrationtests/com/google/idea/blaze/java/run/CombinedTestHeuristicTest.java
+++ b/java/tests/integrationtests/com/google/idea/blaze/java/run/CombinedTestHeuristicTest.java
@@ -56,9 +56,11 @@ public class CombinedTestHeuristicTest extends BlazeIntegrationTestCase {
             + "    Class<? extends Runner> value();"
             + "}");
     workspace.createPsiFile(
-        new WorkspacePath("org/junit/Test"), "package org.junit;", "public @interface Test {}");
+        new WorkspacePath("org/junit/Test.java"),
+        "package org.junit;",
+        "public @interface Test {}");
     workspace.createPsiFile(
-        new WorkspacePath("org/junit/runners/JUnit4"),
+        new WorkspacePath("org/junit/runners/JUnit4.java"),
         "package org.junit.runners;",
         "public class JUnit4 {}");
   }

--- a/java/tests/integrationtests/com/google/idea/blaze/java/run/JUnitTestHeuristicTest.java
+++ b/java/tests/integrationtests/com/google/idea/blaze/java/run/JUnitTestHeuristicTest.java
@@ -42,9 +42,11 @@ public class JUnitTestHeuristicTest extends BlazeIntegrationTestCase {
             + "    Class<? extends Runner> value();"
             + "}");
     workspace.createPsiFile(
-        new WorkspacePath("org/junit/Test"), "package org.junit;", "public @interface Test {}");
+        new WorkspacePath("org/junit/Test.java"),
+        "package org.junit;",
+        "public @interface Test {}");
     workspace.createPsiFile(
-        new WorkspacePath("org/junit/runners/JUnit4"),
+        new WorkspacePath("org/junit/runners/JUnit4.java"),
         "package org.junit.runners;",
         "public class JUnit4 {}");
   }

--- a/java/tests/integrationtests/com/google/idea/blaze/java/run/producers/BlazeJUnitTestFilterFlagsIntegrationTest.java
+++ b/java/tests/integrationtests/com/google/idea/blaze/java/run/producers/BlazeJUnitTestFilterFlagsIntegrationTest.java
@@ -51,9 +51,11 @@ public class BlazeJUnitTestFilterFlagsIntegrationTest extends BlazeIntegrationTe
             + "    Class<? extends Runner> value();"
             + "}");
     workspace.createPsiFile(
-        new WorkspacePath("org/junit/Test"), "package org.junit;", "public @interface Test {}");
+        new WorkspacePath("org/junit/Test.java"),
+        "package org.junit;",
+        "public @interface Test {}");
     workspace.createPsiFile(
-        new WorkspacePath("org/junit/runners/JUnit4"),
+        new WorkspacePath("org/junit/runners/JUnit4.java"),
         "package org.junit.runners;",
         "public class JUnit4 {}");
   }

--- a/java/tests/integrationtests/com/google/idea/blaze/java/run/producers/BlazeJavaAbstractTestCaseConfigurationProducerTest.java
+++ b/java/tests/integrationtests/com/google/idea/blaze/java/run/producers/BlazeJavaAbstractTestCaseConfigurationProducerTest.java
@@ -37,6 +37,7 @@ import com.intellij.psi.PsiClassOwner;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiMethod;
 import java.util.List;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -45,6 +46,25 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class BlazeJavaAbstractTestCaseConfigurationProducerTest
     extends BlazeRunConfigurationProducerTestCase {
+
+  @Before
+  public final void setup() {
+    // required for IntelliJ to recognize annotations, JUnit version, etc.
+    workspace.createPsiFile(
+        new WorkspacePath("org/junit/runner/RunWith.java"),
+        "package org.junit.runner;"
+            + "public @interface RunWith {"
+            + "    Class<? extends Runner> value();"
+            + "}");
+    workspace.createPsiFile(
+        new WorkspacePath("org/junit/Test.java"),
+        "package org.junit;",
+        "public @interface Test {}");
+    workspace.createPsiFile(
+        new WorkspacePath("org/junit/runners/JUnit4.java"),
+        "package org.junit.runners;",
+        "public class JUnit4 {}");
+  }
 
   @Test
   public void testIgnoreTestClassWithNoTestSubclasses() {

--- a/java/tests/integrationtests/com/google/idea/blaze/java/run/producers/BlazeJavaTestClassConfigurationProducerTest.java
+++ b/java/tests/integrationtests/com/google/idea/blaze/java/run/producers/BlazeJavaTestClassConfigurationProducerTest.java
@@ -38,6 +38,7 @@ import com.intellij.psi.PsiClassOwner;
 import com.intellij.psi.PsiFile;
 import java.util.ArrayList;
 import java.util.List;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -46,6 +47,25 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class BlazeJavaTestClassConfigurationProducerTest
     extends BlazeRunConfigurationProducerTestCase {
+
+  @Before
+  public final void setup() {
+    // required for IntelliJ to recognize annotations, JUnit version, etc.
+    workspace.createPsiFile(
+        new WorkspacePath("org/junit/runner/RunWith.java"),
+        "package org.junit.runner;"
+            + "public @interface RunWith {"
+            + "    Class<? extends Runner> value();"
+            + "}");
+    workspace.createPsiFile(
+        new WorkspacePath("org/junit/Test.java"),
+        "package org.junit;",
+        "public @interface Test {}");
+    workspace.createPsiFile(
+        new WorkspacePath("org/junit/runners/JUnit4.java"),
+        "package org.junit.runners;",
+        "public class JUnit4 {}");
+  }
 
   @Test
   public void testProducedFromPsiFile() {

--- a/java/tests/integrationtests/com/google/idea/blaze/java/run/producers/BlazeJavaTestMethodConfigurationProducerTest.java
+++ b/java/tests/integrationtests/com/google/idea/blaze/java/run/producers/BlazeJavaTestMethodConfigurationProducerTest.java
@@ -38,6 +38,7 @@ import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiMethod;
 import java.util.ArrayList;
 import java.util.List;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -46,6 +47,25 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class BlazeJavaTestMethodConfigurationProducerTest
     extends BlazeRunConfigurationProducerTestCase {
+
+  @Before
+  public final void setup() {
+    // required for IntelliJ to recognize annotations, JUnit version, etc.
+    workspace.createPsiFile(
+        new WorkspacePath("org/junit/runner/RunWith.java"),
+        "package org.junit.runner;"
+            + "public @interface RunWith {"
+            + "    Class<? extends Runner> value();"
+            + "}");
+    workspace.createPsiFile(
+        new WorkspacePath("org/junit/Test.java"),
+        "package org.junit;",
+        "public @interface Test {}");
+    workspace.createPsiFile(
+        new WorkspacePath("org/junit/runners/JUnit4.java"),
+        "package org.junit.runners;",
+        "public class JUnit4 {}");
+  }
 
   @Test
   public void testProducedFromPsiMethod() {

--- a/java/tests/integrationtests/com/google/idea/blaze/java/run/producers/MultipleJavaClassesTestContextProviderTest.java
+++ b/java/tests/integrationtests/com/google/idea/blaze/java/run/producers/MultipleJavaClassesTestContextProviderTest.java
@@ -74,6 +74,22 @@ public class MultipleJavaClassesTestContextProviderTest
     registerProjectService(BlazeProjectDataManager.class, mockProjectDataManager);
     registerProjectService(
         WorkspaceFileFinder.Provider.class, () -> file -> file.getPath().contains("test"));
+
+    // required for IntelliJ to recognize annotations, JUnit version, etc.
+    workspace.createPsiFile(
+        new WorkspacePath("org/junit/runner/RunWith.java"),
+        "package org.junit.runner;"
+            + "public @interface RunWith {"
+            + "    Class<? extends Runner> value();"
+            + "}");
+    workspace.createPsiFile(
+        new WorkspacePath("org/junit/Test.java"),
+        "package org.junit;",
+        "public @interface Test {}");
+    workspace.createPsiFile(
+        new WorkspacePath("org/junit/runners/JUnit4.java"),
+        "package org.junit.runners;",
+        "public class JUnit4 {}");
   }
 
   @After


### PR DESCRIPTION
api193: Java integration test fixes.

api193 expects `org.junit.Test` and `org.junit.runners.JUnit4` classes to be present in the project to classify it as a JUnit4 project. CombinedTestHeuristic.java already added the relevant classes, but missed the `.java` extension which caused the tests to fail in 193. This CL adds the mentioned classes to the tests that need it.
