### PR TITLE
Update maven URLs to HTTPS.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -186,7 +186,7 @@ jvm_maven_import_external(
     artifact = "junit:junit:4.12",
     artifact_sha256 = "59721f0805e223d84b90677887d9ff567dc534d7c502ca903c0c2b17f05c116a",
     licenses = ["notice"],  # Common Public License 1.0
-    server_urls = ["http://central.maven.org/maven2"],
+    server_urls = ["https://repo1.maven.org/maven2"],
 )
 
 jvm_maven_import_external(
@@ -194,7 +194,7 @@ jvm_maven_import_external(
     artifact = "com.google.code.findbugs:jsr305:3.0.2",
     artifact_sha256 = "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
     licenses = ["notice"],  # Apache 2.0
-    server_urls = ["http://central.maven.org/maven2"],
+    server_urls = ["https://repo1.maven.org/maven2"],
 )
 
 jvm_maven_import_external(
@@ -202,7 +202,7 @@ jvm_maven_import_external(
     artifact = "com.google.truth:truth:0.42",
     artifact_sha256 = "dd652bdf0c4427c59848ac0340fd6b6d20c2cbfaa3c569a8366604dbcda5214c",
     licenses = ["notice"],  # Apache 2.0
-    server_urls = ["http://central.maven.org/maven2"],
+    server_urls = ["https://repo1.maven.org/maven2"],
 )
 
 jvm_maven_import_external(
@@ -210,7 +210,7 @@ jvm_maven_import_external(
     artifact = "com.google.truth.extensions:truth-java8-extension:0.42",
     artifact_sha256 = "cf9e095a6763bc33633b8844c3ebadffe3b082c81dd97a4d79b64ad88d305bc1",
     licenses = ["notice"],  # Apache 2.0
-    server_urls = ["http://central.maven.org/maven2"],
+    server_urls = ["https://repo1.maven.org/maven2"],
 )
 
 jvm_maven_import_external(
@@ -218,7 +218,7 @@ jvm_maven_import_external(
     artifact = "org.mockito:mockito-core:1.10.19",
     artifact_sha256 = "d5831ee4f71055800821a34a3051cf1ed5b3702f295ffebd50f65fb5d81a71b8",
     licenses = ["notice"],  # Apache 2.0
-    server_urls = ["http://central.maven.org/maven2"],
+    server_urls = ["https://repo1.maven.org/maven2"],
 )
 
 jvm_maven_import_external(
@@ -226,7 +226,7 @@ jvm_maven_import_external(
     artifact = "org.objenesis:objenesis:1.3",
     artifact_sha256 = "dd4ef3d3091063a4fec578cbb2bbe6c1f921c00091ba2993dcd9afd25ff9444a",
     licenses = ["notice"],  # Apache 2.0
-    server_urls = ["http://central.maven.org/maven2"],
+    server_urls = ["https://repo1.maven.org/maven2"],
 )
 
 jvm_maven_import_external(
@@ -234,7 +234,7 @@ jvm_maven_import_external(
     artifact = "com.googlecode.jarjar:jarjar:1.3",
     artifact_sha256 = "4225c8ee1bf3079c4b07c76fe03c3e28809a22204db6249c9417efa4f804b3a7",
     licenses = ["notice"],  # Apache 2.0
-    server_urls = ["http://central.maven.org/maven2"],
+    server_urls = ["https://repo1.maven.org/maven2"],
 )
 
 jvm_maven_import_external(
@@ -242,7 +242,7 @@ jvm_maven_import_external(
     artifact = "com.google.auto.value:auto-value:1.6.2",
     artifact_sha256 = "edbe65a5c53e3d4f5cb10b055d4884ae7705a7cd697be4b2a5d8427761b8ba12",
     licenses = ["notice"],  # Apache 2.0
-    server_urls = ["http://central.maven.org/maven2"],
+    server_urls = ["https://repo1.maven.org/maven2"],
 )
 
 jvm_maven_import_external(
@@ -250,7 +250,7 @@ jvm_maven_import_external(
     artifact = "com.google.auto.value:auto-value-annotations:1.6.2",
     artifact_sha256 = "b48b04ddba40e8ac33bf036f06fc43995fc5084bd94bdaace807ce27d3bea3fb",
     licenses = ["notice"],  # Apache 2.0
-    server_urls = ["http://central.maven.org/maven2"],
+    server_urls = ["https://repo1.maven.org/maven2"],
 )
 
 jvm_maven_import_external(
@@ -258,7 +258,7 @@ jvm_maven_import_external(
     artifact = "com.google.errorprone:error_prone_annotations:2.3.0",
     artifact_sha256 = "524b43ea15ca97c68f10d5f417c4068dc88144b620d2203f0910441a769fd42f",
     licenses = ["notice"],  # Apache 2.0
-    server_urls = ["http://central.maven.org/maven2"],
+    server_urls = ["https://repo1.maven.org/maven2"],
 )
 
 http_archive(
@@ -330,10 +330,10 @@ http_archive(
 # LICENSE: The Apache Software License, Version 2.0
 http_archive(
     name = "io_bazel_rules_scala",
-    sha256 = "ccd4693c5f5a302b8c145ce87792c6fca1cb956b94c15b569ddd0809f5f617d1",
-    strip_prefix = "rules_scala-96176ae9e0be8582918a5212a7d4b44d885db8f6",
+    sha256 = "b8b18d0fe3f6c3401b4f83f78f536b24c7fb8b92c593c1dcbcd01cc2b3e85c9a",
+    strip_prefix = "rules_scala-a676633dc14d8239569affb2acafbef255df3480",
     type = "zip",
-    url = "https://github.com/bazelbuild/rules_scala/archive/96176ae9e0be8582918a5212a7d4b44d885db8f6.zip",
+    url = "https://github.com/bazelbuild/rules_scala/archive/a676633dc14d8239569affb2acafbef255df3480.zip",
 )
 
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repositories")


### PR DESCRIPTION
Update maven URLs to HTTPS.

See https://support.sonatype.com/hc/en-us/articles/360041287334.
