### PR TITLE
Don't display warning messages during sync when java source files can't be found.

### DIFF
--- a/java/src/com/google/idea/blaze/java/sync/source/JavaSourcePackageReader.java
+++ b/java/src/com/google/idea/blaze/java/sync/source/JavaSourcePackageReader.java
@@ -20,6 +20,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import com.google.idea.blaze.base.io.InputStreamProvider;
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.scope.output.IssueOutput;
+import com.google.idea.blaze.base.scope.output.PrintOutput;
 import com.google.idea.blaze.base.sync.workspace.ArtifactLocationDecoder;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.Logger;
@@ -74,9 +75,7 @@ public class JavaSourcePackageReader extends JavaPackageReader {
           .submit(context);
       return null;
     } catch (FileNotFoundException e) {
-      IssueOutput.warn("No source file found for: " + sourceFile)
-          .inFile(sourceFile)
-          .submit(context);
+      context.output(PrintOutput.log("No source file found for: " + sourceFile));
       return null;
     } catch (IOException e) {
       logger.error(e);

--- a/java/src/com/google/idea/blaze/java/sync/source/SourceDirectoryCalculator.java
+++ b/java/src/com/google/idea/blaze/java/sync/source/SourceDirectoryCalculator.java
@@ -38,7 +38,7 @@ import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
 import com.google.idea.blaze.base.prefetch.FetchExecutor;
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.scope.Scope;
-import com.google.idea.blaze.base.scope.output.IssueOutput;
+import com.google.idea.blaze.base.scope.output.PrintOutput;
 import com.google.idea.blaze.base.scope.scopes.TimingScope;
 import com.google.idea.blaze.base.scope.scopes.TimingScope.EventType;
 import com.google.idea.blaze.base.sync.projectview.ImportRoots;
@@ -440,11 +440,10 @@ public final class SourceDirectoryCalculator {
       }
     }
     if (declaredPackage == null) {
-      IssueOutput.warn(
+      context.output(
+          PrintOutput.log(
               "Failed to inspect the package name of java source file: "
-                  + sourceArtifact.artifactLocation)
-          .inFile(decoder.resolveSource(sourceArtifact.artifactLocation))
-          .submit(context);
+                  + sourceArtifact.artifactLocation));
       return null;
     }
     String parentPath = new File(sourceArtifact.artifactLocation.getRelativePath()).getParent();


### PR DESCRIPTION
Don't display warning messages during sync when java source files can't be found.

It's an expected situation during partial syncs, when previously-synced data may not be up-to-date.
