### PR TITLE
Fix ExecRootUtil.getExecutionRoot always falling through.

### DIFF
--- a/aswb/src/com/google/idea/blaze/android/run/runner/ExecRootUtil.java
+++ b/aswb/src/com/google/idea/blaze/android/run/runner/ExecRootUtil.java
@@ -55,7 +55,9 @@ public final class ExecRootUtil {
       BlazeContext context)
       throws GetArtifactsException {
     String executionRoot = buildResultHelper.getBuildOutput().getLocalExecRoot();
-    if (executionRoot == null && !useBlazeInfoAsExecrootFallback.getValue()) {
+    if (executionRoot != null) {
+      return executionRoot;
+    } else if (!useBlazeInfoAsExecrootFallback.getValue()) {
       return null;
     }
 


### PR DESCRIPTION
Fix ExecRootUtil.getExecutionRoot always falling through.

ExecRootUtil.getExecutionRoot gets the execroot but doesn't actually
return it.  This CL fixes that.
