### PR TITLE
Drop the noStrictGenericChecks: true compiler setting.

### DIFF
--- a/javascript/tests/integrationtests/com/google/idea/blaze/typescript/BlazeTypeScriptConfigTest.java
+++ b/javascript/tests/integrationtests/com/google/idea/blaze/typescript/BlazeTypeScriptConfigTest.java
@@ -93,7 +93,6 @@ public class BlazeTypeScriptConfigTest extends BlazeIntegrationTestCase {
           "        \"noImplicitThis\": true,",
           "        \"noLib\": true,",
           "        \"noResolve\": false,",
-          "        \"noStrictGenericChecks\": true,",
           "        \"paths\": {",
           "            \"workspace/*\": [",
           "                \"./tsconfig.runfiles/workspace/*\"",


### PR DESCRIPTION
Drop the noStrictGenericChecks: true compiler setting.

We're removing this globally for google3.
