### PR TITLE
Move where we reload tsconfig files.

### DIFF
--- a/base/src/com/google/idea/blaze/base/io/FileOperationProvider.java
+++ b/base/src/com/google/idea/blaze/base/io/FileOperationProvider.java
@@ -72,6 +72,10 @@ public class FileOperationProvider {
     return Files.isSymbolicLink(file.toPath());
   }
 
+  public File getCanonicalFile(File file) throws IOException {
+    return file.getCanonicalFile();
+  }
+
   public boolean mkdirs(File file) {
     return file.mkdirs();
   }

--- a/base/src/com/google/idea/blaze/base/prefetch/PrefetchService.java
+++ b/base/src/com/google/idea/blaze/base/prefetch/PrefetchService.java
@@ -16,6 +16,7 @@
 package com.google.idea.blaze.base.prefetch;
 
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.projectview.ProjectViewSet;
 import com.intellij.openapi.components.ServiceManager;
@@ -38,6 +39,7 @@ public interface PrefetchService {
    * @param refetchCachedFiles True if all files should be fetched, regardless of whether they were
    *     recently fetched.
    */
+  @CanIgnoreReturnValue
   ListenableFuture<?> prefetchFiles(
       Collection<File> files, boolean refetchCachedFiles, boolean fetchFileTypes);
 

--- a/javascript/src/com/google/idea/blaze/typescript/BlazeTypeScriptAdditionalLibraryRootsProvider.java
+++ b/javascript/src/com/google/idea/blaze/typescript/BlazeTypeScriptAdditionalLibraryRootsProvider.java
@@ -74,7 +74,7 @@ public final class BlazeTypeScriptAdditionalLibraryRootsProvider
     }
     return Stream.concat(
             filesFromTargetMap(project, projectData, importRoots),
-            filesFromTsConfig(project, projectData, importRoots))
+            filesFromTsConfig(project, importRoots))
         .collect(toImmutableList());
   }
 
@@ -93,17 +93,12 @@ public final class BlazeTypeScriptAdditionalLibraryRootsProvider
         .filter(Objects::nonNull);
   }
 
-  private static Stream<File> filesFromTsConfig(
-      Project project, BlazeProjectData projectData, ImportRoots importRoots) {
+  private static Stream<File> filesFromTsConfig(Project project, ImportRoots importRoots) {
     if (!moveTsconfigFilesToAdditionalLibrary.getValue()) {
       return Stream.of();
     }
-    TypeScriptConfigService typeScriptConfigService = TypeScriptConfigService.Provider.get(project);
-    if (typeScriptConfigService instanceof DelegatingTypeScriptConfigService) {
-      ((DelegatingTypeScriptConfigService) typeScriptConfigService).update(projectData);
-    }
     WorkspaceRoot workspaceRoot = WorkspaceRoot.fromProject(project);
-    return typeScriptConfigService.getConfigs().stream()
+    return TypeScriptConfigService.Provider.get(project).getConfigs().stream()
         .map(TypeScriptConfig::getFileList)
         .flatMap(Collection::stream)
         .map(VfsUtil::virtualToIoFile)

--- a/javascript/src/com/google/idea/blaze/typescript/BlazeTypeScriptConfig.java
+++ b/javascript/src/com/google/idea/blaze/typescript/BlazeTypeScriptConfig.java
@@ -17,6 +17,7 @@ package com.google.idea.blaze.typescript;
 
 import com.google.common.base.Ascii;
 import com.google.common.base.Charsets;
+import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -25,7 +26,6 @@ import com.google.idea.blaze.base.command.info.BlazeInfo;
 import com.google.idea.blaze.base.io.FileOperationProvider;
 import com.google.idea.blaze.base.io.InputStreamProvider;
 import com.google.idea.blaze.base.io.VfsUtils;
-import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
 import com.google.idea.blaze.base.settings.Blaze;
@@ -62,6 +62,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
 /**
@@ -118,39 +120,78 @@ class BlazeTypeScriptConfig implements TypeScriptConfigCompat {
   private final NotNullLazyValue<List<VirtualFile>> files;
 
   @Nullable
-  static TypeScriptConfig getInstance(Project project, BlazeProjectData projectData, Label label) {
+  static TypeScriptConfig getInstance(Project project, Label label, File tsconfig) {
     WorkspaceRoot workspaceRoot = WorkspaceRoot.fromProject(project);
 
     // as seen by the project
-    VirtualFile configFile =
-        VfsUtils.resolveVirtualFile(
-            new File(workspaceRoot.fileForPath(label.blazePackage()), "tsconfig.json"));
+    VirtualFile configFile = VfsUtils.resolveVirtualFile(tsconfig);
     if (configFile == null) {
       return null;
     }
 
-    // TODO: handle remote output artifacts, and not rely on blaze-out/blaze-bin location
-    File blazeBin;
+    File tsconfigEditor;
     try {
-      blazeBin = projectData.getBlazeInfo().getBlazeBinDirectory().getCanonicalFile();
+      JsonObject object =
+          new JsonParser()
+              .parse(
+                  new InputStreamReader(
+                      InputStreamProvider.getInstance().forFile(tsconfig), Charsets.UTF_8))
+              .getAsJsonObject();
+      tsconfigEditor =
+          FileOperationProvider.getInstance()
+              .getCanonicalFile(
+                  new File(tsconfig.getParentFile(), object.get("extends").getAsString()));
     } catch (IOException e) {
+      logger.warn(e);
       return null;
     }
-    File tsconfigDirectory = new File(blazeBin, label.blazePackage().relativePath());
-    // contains the actual content of the tsconfig
-    File tsconfigEditor = new File(tsconfigDirectory, "tsconfig_editor.json");
 
-    // need these two to replace workspace relative paths from the blaze-bin symlink in the
-    // workspace root with workspace relative paths from the actual blaze-bin.
-    String workspacePrefix =
-        tsconfigDirectory.toPath().relativize(blazeBin.getParentFile().toPath()).toString();
+    // When a path in the tsconfig_editor refers to a file in the workspace, they'll have this
+    // prefix. This assumes that blaze-bin is just a subdirectory in the workspace root.
+    String workspacePrefix = buildWorkspacePrefix(label.blazePackage().relativePath());
+
+    // We must use this prefix instead after resolving the location of the tsconfig_editor. In this
+    // case blaze-bin is a completely unrelated directory to the workspace root. This prefix will ..
+    // all the way to the system root directory, then follow the absolute path to the workspace.
     String workspaceRelativePath =
-        tsconfigDirectory.toPath().relativize(workspaceRoot.directory().toPath()).toString();
+        tsconfigEditor
+            .getParentFile()
+            .toPath()
+            .relativize(workspaceRoot.directory().toPath())
+            .toString();
 
     return FileOperationProvider.getInstance().exists(tsconfigEditor)
         ? new BlazeTypeScriptConfig(
             project, label, configFile, tsconfigEditor, workspacePrefix, workspaceRelativePath)
         : null;
+  }
+
+  /**
+   * This is the prefix used by paths in the tsconfig to refer to files in the workspace.
+   *
+   * <p>E.g., the tsconfig file located in
+   *
+   * <pre>blaze-bin/foo/bar/tsconfig_editor.json</pre>
+   *
+   * referring to the workspace file
+   *
+   * <pre>foo/bar/foo.ts</pre>
+   *
+   * would look like
+   *
+   * <pre>../../../foo/bar/foo.ts</pre>
+   *
+   * One set of ".." for each component in the blaze package plus one for blaze-bin directory at the
+   * workspace root.
+   */
+  private static String buildWorkspacePrefix(String blazePackage) {
+    if (blazePackage.isEmpty()) {
+      return "..";
+    }
+    return Stream.concat(
+            Stream.of(".."),
+            Splitter.on('/').splitToList(blazePackage).stream().map(component -> ".."))
+        .collect(Collectors.joining("/"));
   }
 
   private BlazeTypeScriptConfig(

--- a/javascript/src/com/google/idea/blaze/typescript/DelegatingTypeScriptConfigService.java
+++ b/javascript/src/com/google/idea/blaze/typescript/DelegatingTypeScriptConfigService.java
@@ -15,7 +15,8 @@
  */
 package com.google.idea.blaze.typescript;
 
-import com.google.idea.blaze.base.model.BlazeProjectData;
+import com.google.common.collect.ImmutableMap;
+import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.settings.Blaze;
 import com.google.idea.common.experiments.BoolExperiment;
 import com.google.idea.sdkcompat.typescript.TypeScriptConfigServiceCompat;
@@ -31,6 +32,7 @@ import com.intellij.openapi.util.Condition;
 import com.intellij.openapi.util.ModificationTracker;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiManager;
+import java.io.File;
 import java.util.List;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -62,9 +64,9 @@ class DelegatingTypeScriptConfigService implements TypeScriptConfigServiceCompat
     }
   }
 
-  void update(BlazeProjectData projectData) {
+  void update(ImmutableMap<Label, File> tsconfigs) {
     if (impl instanceof BlazeTypeScriptConfigServiceImpl) {
-      ((BlazeTypeScriptConfigServiceImpl) impl).update(projectData);
+      ((BlazeTypeScriptConfigServiceImpl) impl).update(tsconfigs);
     }
   }
 


### PR DESCRIPTION
Move where we reload tsconfig files.

After cl/282411077, we always reload the tsconfig whenever we read the
file list to avoid having stale configs, but that causes file resolving
to happen on the EDT when we want to rebuild the external libraries for
TypeScript.

This CL moves tsconfig reloading to immediately follow the place where
we rebuild the tsconfig rules. It is off the EDT, and guarantees that
the TypeScript service always has an up to date view of the tsconfig
files.
