### PR TITLE
api193: cleanup services during teardown

### DIFF
--- a/base/tests/integrationtests/com/google/idea/blaze/base/dependencies/DependencyFinderTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/dependencies/DependencyFinderTest.java
@@ -27,7 +27,6 @@ import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.MockBlazeProjectDataBuilder;
 import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
-import com.google.idea.testing.ServiceHelper;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
@@ -45,11 +44,8 @@ public final class DependencyFinderTest extends BlazeIntegrationTestCase {
   @Before
   public void initTest() {
     MockitoAnnotations.initMocks(this);
-    ServiceHelper.registerProjectService(
-        testFixture.getProject(),
-        BlazeProjectDataManager.class,
-        mockProjectDataManager,
-        getTestRootDisposable());
+    registerProjectService(
+        BlazeProjectDataManager.class, mockProjectDataManager, getTestRootDisposable());
   }
 
   @Test


### PR DESCRIPTION
api193: cleanup services during teardown

api193 registers project and application services with project and application disposables respectively. Both project and applications can be reused between test cases. This means services registered in one test can leak over to other tests. This CL adds logic to replace the services with their defaults during tear down. 

This CL also modifies any `BlazeIntegrationTest` that directly called `ServiceHelper` to register services to call `BlazeIntegrationTest#registerProjectService`
