### PR TITLE
Be compatible with --incompatible_load_proto_rules_from_bzl

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -361,30 +361,24 @@ bazel_external_dependency_archive(
     },
 )
 
+# BEGIN-EXTERNAL-PROTO
 # LICENSE: The Apache Software License, Version 2.0
-# proto_library rules implicitly depend on @com_google_protobuf//:protoc
 http_archive(
-    name = "com_google_protobuf",
-    sha256 = "d82eb0141ad18e98de47ed7ed415daabead6d5d1bef1b8cccb6aa4d108a9008f",
-    strip_prefix = "protobuf-b4f193788c9f0f05d7e0879ea96cd738630e5d51",
-    # Commit from 2019-05-15, update to protobuf 3.8 when available.
-    url = "https://github.com/protocolbuffers/protobuf/archive/b4f193788c9f0f05d7e0879ea96cd738630e5d51.tar.gz",
+    name = "rules_proto",
+    sha256 = "4d421d51f9ecfe9bf96ab23b55c6f2b809cbaf0eea24952683e397decfbd0dd0",
+    strip_prefix = "rules_proto-f6b8d89b90a7956f6782a4a3609b2f0eee3ce965",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/f6b8d89b90a7956f6782a4a3609b2f0eee3ce965.tar.gz",
+        "https://github.com/bazelbuild/rules_proto/archive/f6b8d89b90a7956f6782a4a3609b2f0eee3ce965.tar.gz",
+    ],
 )
 
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
 
-protobuf_deps()
+rules_proto_dependencies()
 
-# LICENSE: The Apache Software License, Version 2.0
-# java_proto_library rules implicitly depend on @com_google_protobuf_java//:java_toolchain
-# It's the same repository as above, but there's no way to alias them at the moment (and both are
-# required).
-http_archive(
-    name = "com_google_protobuf_java",
-    sha256 = "d82eb0141ad18e98de47ed7ed415daabead6d5d1bef1b8cccb6aa4d108a9008f",
-    strip_prefix = "protobuf-b4f193788c9f0f05d7e0879ea96cd738630e5d51",
-    url = "https://github.com/protocolbuffers/protobuf/archive/b4f193788c9f0f05d7e0879ea96cd738630e5d51.tar.gz",
-)
+rules_proto_toolchains()
+# END-EXTERNAL-PROTO
 
 # BEGIN-EXTERNAL-SCALA
 # LICENSE: The Apache Software License, Version 2.0

--- a/aspect/testing/rules/BUILD
+++ b/aspect/testing/rules/BUILD
@@ -2,6 +2,8 @@
 
 licenses(["notice"])  # Apache 2.0
 
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
 proto_library(
     name = "intellij_aspect_test_fixture_proto",
     srcs = ["intellij_aspect_test_fixture.proto"],
@@ -27,7 +29,7 @@ java_binary(
         ":intellij_aspect_test_fixture_java_proto",
         "//aspect/testing:guava",
         "//proto:intellij_ide_info_java_proto",
-        "@com_google_protobuf_java//:protobuf_java",
+        "@com_google_protobuf//:protobuf_java",
     ],
 )
 
@@ -75,7 +77,7 @@ java_binary(
         ":fast_build_aspect_test_fixture_java_proto",
         "//aspect/testing:guava",
         "//proto:fast_build_info_java_proto",
-        "@com_google_protobuf_java//:protobuf_java",
+        "@com_google_protobuf//:protobuf_java",
     ],
 )
 

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/proto/jpl/BUILD
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/proto/jpl/BUILD
@@ -1,5 +1,6 @@
 licenses(["notice"])  # Apache 2.0
 
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load(
     "//aspect/testing/rules:intellij_aspect_test_fixture.bzl",
     "intellij_aspect_test_fixture",

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -5,6 +5,8 @@
 
 licenses(["notice"])  # Apache 2.0
 
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
 java_import(
     name = "proto_deps",
     jars = ["proto_deps.jar"],


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

This PR is required to flip `--incompatible_load_proto_rules_from_bzl` in a future release of Bazel.
It's purely build-related and not a feature or bug-fix, so I did not open an issue (https://github.com/bazelbuild/intellij/issues/1512 was automatically created to notify about the upcoming breaking change but was closed without comment). I did, however, reach out to @jin (https://bazelbuild.slack.com/archives/CHSV3RSR0/p1580932545028100) to ask whether such a change would be accepted.

# Description of this change

This change adds load statements for `proto_library` to become
compatible with https://github.com/bazelbuild/bazel/issues/8922
Also, Protobuf is updated to v3.11.3 (which also has the necessary load
statements).