### PR TITLE
Allow coverage to search for files if workspace is not in folder root

### DIFF
--- a/java/src/com/google/idea/blaze/java/run/coverage/BlazeCoverageRunner.java
+++ b/java/src/com/google/idea/blaze/java/run/coverage/BlazeCoverageRunner.java
@@ -31,6 +31,7 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.rt.coverage.data.ClassData;
 import com.intellij.rt.coverage.data.LineData;
 import com.intellij.rt.coverage.data.ProjectData;
+import java.io.*;
 import java.util.HashSet;
 import javax.annotation.Nullable;
 


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: https://github.com/bazelbuild/intellij/issues/1372

# Description of this change

I have had https://github.com/bazelbuild/intellij/issues/1372 open for months now with no comments, so just opening this PR. 

It should change no functionality for people that coverage current works for, but allows to search for the files if it does not find coverage in root. 