### PR TITLE
Don't build unnecessary jars.

### DIFF
--- a/aspect/intellij_info_impl.bzl
+++ b/aspect/intellij_info_impl.bzl
@@ -168,9 +168,11 @@ def jars_from_output(output):
     """Collect jars for intellij-resolve-files from Java output."""
     if output == None:
         return []
+    source_jars = get_source_jars(output)
+    jars = source_jars
     return [
         jar
-        for jar in ([output.class_jar, output.ijar] + get_source_jars(output))
+        for jar in ([output.ijar if len(source_jars) > 0 and output.ijar else output.class_jar] + source_jars)
         if jar != None and not jar.is_source
     ]
 
@@ -664,12 +666,12 @@ def build_filtered_gen_jar(ctx, target, java, gen_java_sources, srcjars):
     for jar in java.outputs.jars:
         if jar.ijar:
             jar_artifacts.append(jar.ijar)
-        elif jar.class_jar:
-            jar_artifacts.append(jar.class_jar)
         if hasattr(jar, "source_jars") and jar.source_jars:
             source_jar_artifacts.extend(jar.source_jars)
         elif hasattr(jar, "source_jar") and jar.source_jar:
             source_jar_artifacts.append(jar.source_jar)
+    if len(source_jar_artifacts) == 0 or len(jar_artifacts) == 0:
+        jar_artifacts.extend([jar.class_jar for jar in java.outputs.jars if jar.class_jar])
 
     filtered_jar = ctx.actions.declare_file(target.label.name + "-filtered-gen.jar")
     filtered_source_jar = ctx.actions.declare_file(target.label.name + "-filtered-gen-src.jar")

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/general/noide/NoIdeTest.java
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/general/noide/NoIdeTest.java
@@ -38,7 +38,6 @@ public class NoIdeTest extends BazelIntellijAspectTest {
             testRelative("foo.java-manifest"), testRelative(intellijInfoFileName("foo")));
     assertThat(getOutputGroupFiles(testFixture, "intellij-resolve-java"))
         .containsExactly(
-            testRelative("libfoo.jar"),
             testRelative("libfoo-hjar.jar"),
             testRelative("libfoo-src.jar"),
             testRelative("libfoo.jdeps"));

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/java/dependencies/DependenciesTest.java
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/java/dependencies/DependenciesTest.java
@@ -54,13 +54,10 @@ public class DependenciesTest extends BazelIntellijAspectTest {
             testRelative(intellijInfoFileName("transitive_dep")));
     assertThat(getOutputGroupFiles(testFixture, "intellij-resolve-java"))
         .containsAllOf(
-            testRelative("libfoo.jar"),
             testRelative("libfoo-hjar.jar"),
             testRelative("libfoo-src.jar"),
-            testRelative("libsingle_dep.jar"),
             testRelative("libsingle_dep-hjar.jar"),
             testRelative("libsingle_dep-src.jar"),
-            testRelative("libtransitive_dep.jar"),
             testRelative("libtransitive_dep-hjar.jar"),
             testRelative("libtransitive_dep-src.jar"));
     assertThat(getOutputGroupFiles(testFixture, "intellij-compile-java"))
@@ -103,13 +100,10 @@ public class DependenciesTest extends BazelIntellijAspectTest {
             testRelative(intellijInfoFileName("export_consumer")));
     assertThat(getOutputGroupFiles(testFixture, "intellij-resolve-java"))
         .containsAllOf(
-            testRelative("libfoo.jar"),
             testRelative("libfoo-hjar.jar"),
             testRelative("libfoo-src.jar"),
-            testRelative("libfoo_exporter.jar"),
             testRelative("libfoo_exporter-hjar.jar"),
             testRelative("libfoo_exporter-src.jar"),
-            testRelative("libexport_consumer.jar"),
             testRelative("libexport_consumer-hjar.jar"),
             testRelative("libexport_consumer-src.jar"));
     assertThat(getOutputGroupFiles(testFixture, "intellij-compile-java"))

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/java/javabinary/JavaBinaryTest.java
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/java/javabinary/JavaBinaryTest.java
@@ -58,10 +58,8 @@ public class JavaBinaryTest extends BazelIntellijAspectTest {
             testRelative(intellijInfoFileName("foo")));
     assertThat(getOutputGroupFiles(testFixture, "intellij-resolve-java"))
         .containsAllOf(
-            testRelative("libfoolib.jar"),
             testRelative("libfoolib-hjar.jar"),
             testRelative("libfoolib-src.jar"),
-            testRelative("foo.jar"),
             testRelative("foo-src.jar"));
     assertThat(getOutputGroupFiles(testFixture, "intellij-compile-java"))
         .containsExactly(testRelative("libfoolib.jar"), testRelative("foo.jar"));

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/java/javalibrary/JavaLibraryTest.java
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/java/javalibrary/JavaLibraryTest.java
@@ -123,40 +123,33 @@ public class JavaLibraryTest extends BazelIntellijAspectTest {
     assertThat(getOutputGroupFiles(testFixture, "intellij-resolve-java"))
         .containsExactly(
             // foo
-            testRelative("libfoo.jar"),
             testRelative("libfoo-hjar.jar"),
             testRelative("libfoo-src.jar"),
             testRelative("libfoo.jdeps"),
             // direct
-            testRelative("libdirect.jar"),
             testRelative("libdirect-hjar.jar"),
             testRelative("libdirect-src.jar"),
             testRelative("libdirect.jdeps"),
             // indirect
-            testRelative("libindirect.jar"),
             testRelative("libindirect-hjar.jar"),
             testRelative("libindirect-src.jar"),
             testRelative("libindirect.jdeps"),
             // distant
-            testRelative("libdistant.jar"),
             testRelative("libdistant-hjar.jar"),
             testRelative("libdistant-src.jar"),
             testRelative("libdistant.jdeps"));
     assertThat(getOutputGroupFiles(testFixture, "intellij-resolve-java-outputs"))
         .containsExactly(
-            testRelative("libfoo.jar"),
             testRelative("libfoo-hjar.jar"),
             testRelative("libfoo-src.jar"),
             testRelative("libfoo.jdeps"));
     assertThat(getOutputGroupFiles(testFixture, "intellij-resolve-java-direct-deps"))
         .containsExactly(
             // foo
-            testRelative("libfoo.jar"),
             testRelative("libfoo-hjar.jar"),
             testRelative("libfoo-src.jar"),
             testRelative("libfoo.jdeps"),
             // direct
-            testRelative("libdirect.jar"),
             testRelative("libdirect-hjar.jar"),
             testRelative("libdirect-src.jar"),
             testRelative("libdirect.jdeps"),

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/proto/jpl/JavaProtoLibraryTest.java
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/proto/jpl/JavaProtoLibraryTest.java
@@ -106,33 +106,27 @@ public class JavaProtoLibraryTest extends BazelIntellijAspectTest {
     assertThat(getOutputGroupFiles(testFixture, "intellij-resolve-java"))
         .containsExactly(
             // lib
-            testRelative("liblib.jar"),
             testRelative("liblib-hjar.jar"),
             testRelative("liblib-src.jar"),
             testRelative("liblib.jdeps"),
             // bar_proto
-            testRelative("libbar_proto-speed.jar"),
             testRelative("libbar_proto-speed-hjar.jar"),
             testRelative("bar_proto-speed-src.jar"),
             // foo_proto
-            testRelative("libfoo_proto-speed.jar"),
             testRelative("libfoo_proto-speed-hjar.jar"),
             testRelative("foo_proto-speed-src.jar"));
     assertThat(getOutputGroupFiles(testFixture, "intellij-resolve-java-outputs"))
         .containsExactly(
-            testRelative("liblib.jar"),
             testRelative("liblib-hjar.jar"),
             testRelative("liblib-src.jar"),
             testRelative("liblib.jdeps"));
     assertThat(getOutputGroupFiles(testFixture, "intellij-resolve-java-direct-deps"))
         .containsAllOf(
             // lib
-            testRelative("liblib.jar"),
             testRelative("liblib-hjar.jar"),
             testRelative("liblib-src.jar"),
             testRelative("liblib.jdeps"),
             // bar_proto
-            testRelative("libbar_proto-speed.jar"),
             testRelative("libbar_proto-speed-hjar.jar"),
             testRelative("bar_proto-speed-src.jar"),
             // foo_proto (only hjar)

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/scala/scalabinary/ScalaBinaryTest.java
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/scala/scalabinary/ScalaBinaryTest.java
@@ -48,7 +48,7 @@ public class ScalaBinaryTest extends BazelIntellijAspectTest {
             testRelative(intellijInfoFileName("foolib")),
             testRelative(intellijInfoFileName("foo")));
     assertThat(getOutputGroupFiles(testFixture, "intellij-resolve-java"))
-        .containsAllOf(testRelative("foolib.jar"), testRelative("foo.jar"));
+        .containsAllOf(testRelative("foolib-ijar.jar"), testRelative("foo.jar"));
     assertThat(getOutputGroupFiles(testFixture, "intellij-compile-java"))
         .containsAllOf(testRelative("foolib.jar"), testRelative("foo.jar"));
     assertThat(getOutputGroupFiles(testFixture, "intellij-info-generic")).isEmpty();

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/scala/scalalibrary/ScalaLibraryTest.java
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/scala/scalalibrary/ScalaLibraryTest.java
@@ -45,7 +45,7 @@ public class ScalaLibraryTest extends BazelIntellijAspectTest {
     // Also contains ijars for scala-library.
     // Also contains jars + srcjars for liblibrary.
     assertThat(getOutputGroupFiles(testFixture, "intellij-resolve-java"))
-        .contains(testRelative("simple.jar"));
+        .contains(testRelative("simple-ijar.jar"));
 
     assertThat(getOutputGroupFiles(testFixture, "intellij-info-java"))
         .contains(testRelative(intellijInfoFileName("simple")));


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: https://github.com/bazelbuild/intellij/issues/1785

# Description of this change

Don't build the class jar if source jars are available, as we can use that in conjunction with the interface jar to index the code instead.