### PR TITLE
Heuristically fix IntelliJ pointing to dangling symlinks

### DIFF
--- a/java/src/com/google/idea/blaze/java/libraries/JarCache.java
+++ b/java/src/com/google/idea/blaze/java/libraries/JarCache.java
@@ -359,6 +359,14 @@ public class JarCache {
     return Optional.ofNullable(cacheState.get(cacheKey));
   }
 
+  private static File patchExternalFilePath(File maybeExternal) {
+    String externalString = maybeExternal.toString();
+    if(externalString.contains("/external/") && !externalString.contains("/bazel-out/")) {
+      return new File(externalString.replaceAll("/execroot.*external", "/external"));
+    }
+    return maybeExternal;
+  }
+
   /** The file to return if there's no locally cached version. */
   @Nullable
   private static File getFallbackFile(BlazeArtifact output) {
@@ -366,7 +374,7 @@ public class JarCache {
       // TODO(brendandouglas): copy locally on the fly?
       return null;
     }
-    return ((LocalFileArtifact) output).getFile();
+    return patchExternalFilePath(((LocalFileArtifact) output).getFile());
   }
 
   private static String cacheKeyInternal(BlazeArtifact output) {


### PR DESCRIPTION
# Checklist

- [X] I have filed an issue about this change and discussed potential changes with the maintainers.
- [X] I have received the approval from the maintainers to make this change.
- [X] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `https://github.com/bazelbuild/intellij/issues/1256`

# Description of this change

This is to solve the issue where jars that are seen to be external binaries to Bazel are reported to IntelliJ with symlink paths which are removed by bazel when targets not requiring those binaries are built. (More description of issue in issue).

We take the approach here following:
1) The jar is not in the cache
2) The jar was in an external path and the jar is not produced by bazel (no Bazel-out)
3) Remove the exec root part of the path. The external repositories under here symlink up one level under external. 

Expected result:

Much less red when syncing different targets in IntelliJ



