### PR TITLE
Fix NPE which breaks debugging with LLDB on CLion

### DIFF
--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrLauncher.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrLauncher.java
@@ -217,6 +217,8 @@ public final class BlazeCidrLauncher extends CidrLauncher {
 
       GeneralCommandLine commandLine = new GeneralCommandLine(runner.executableToDebug.getPath());
 
+      commandLine.setWorkDirectory(workingDir);
+
       commandLine.addParameters(handlerState.getExeFlagsState().getFlagsForExternalProcesses());
       commandLine.addParameters(handlerState.getTestArgs());
 


### PR DESCRIPTION
Issue number: #1868 

# Description of this change

A [recent change ](https://github.com/bazelbuild/intellij/commit/c7533ce471a0453f8b65609dd0a84f421ecd7446) has caused LLDB debugging on macOS to be broken, where a NPE is thrown and LLDB never starts (see issue). This change adds back in the offending line which I have verified fixes the issue on CLion 2019.3.6 and plugin version 2020.04.13.0.0 on macOS 10.14.6 (Bazel 2.2.0).
