### PR TITLE
Add diffutils library to fix test failure messages

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -196,6 +196,14 @@ jvm_maven_import_external(
 )
 
 jvm_maven_import_external(
+    name = "diffutils",
+    artifact = "com.googlecode.java-diff-utils:diffutils:1.2.1",
+    artifact_sha256 = "c98697c3b8dd745353cd0a83b109c1c999fec43b4a5cedb2f579452d8da2c171",
+    licenses = ["notice"],  # Apache 2.0
+    server_urls = ["https://repo1.maven.org/maven2"],
+)
+
+jvm_maven_import_external(
     name = "truth8",
     artifact = "com.google.truth.extensions:truth-java8-extension:0.42",
     artifact_sha256 = "cf9e095a6763bc33633b8844c3ebadffe3b082c81dd97a4d79b64ad88d305bc1",

--- a/intellij_platform_sdk/BUILD
+++ b/intellij_platform_sdk/BUILD
@@ -300,6 +300,7 @@ java_library(
     exports = [
         ":objenesis",
         "//third_party:truth",
+        "//third_party:diffutils",
         "@bytebuddy-agent//jar",
         "@bytebuddy//jar",
         "@mockito//jar",

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -18,3 +18,10 @@ java_library(
         "@truth8//jar",
     ],
 )
+
+java_library(
+    name = "diffutils",
+    exports = [
+        "@diffutils//jar",
+    ],
+)


### PR DESCRIPTION
This is a dependency of Google truth library, but it is not pulled in transitively. When a test fails, instead of the textual diff we'd get a ClassNotFoundException.

Fix #2068 

# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #2068 

# Description of this change

