### PR TITLE
Update checksum for python_2020_2 repo

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -97,7 +97,7 @@ http_archive(
         "    visibility = ['//visibility:public'],",
         ")",
     ]),
-    sha256 = "fa9524db2f5b6e42be559ffdab73a963ca06ca057e27a290f5665d38e581764a",
+    sha256 = "61eb876781f3fd75f2d9e76cac192672a02e008725ad9d7ac0fbd4e3dcf25b16",
     url = "https://plugins.jetbrains.com/files/7322/97141/python-ce-202.7319.64.zip",
 )
 


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

# Description of this change

While I haven't checked all of the requisite boxes, I think this change is pretty straightforward and necessary to build the plugin.

When trying to resolve to build the plugin locally (specifically `intellij-canary`), Bazel kept complaining when fetching the specified repo:

```
WARNING: Download from https://plugins.jetbrains.com/files/7322/97141/python-ce-202.7319.64.zip failed: class com.google.devtools.build.lib.bazel.repository.downloader.UnrecoverableHttpException Checksum was 61eb876781f3fd75f2d9e76cac192672a02e008725ad9d7ac0fbd4e3dcf25b16 but wanted fa9524db2f5b6e42be559ffdab73a963ca06ca057e27a290f5665d38e581764a
```

It would be surprising to me if the artifact at https://plugins.jetbrains.com/files/7322/97141/python-ce-202.7319.64.zip somehow changed, but it seemingly did or the sha256 wasn't properly specified in the first place.

This updates it to the correct sha256 and the intellij-canary build now proceeds (until it comes upon a separate issue 😄 )
