### PR TITLE
2127: Patch DelegatingCodeStyleManager for IDEA-244645

### DIFF
--- a/base/src/com/google/idea/blaze/base/formatter/DelegatingCodeStyleManager.java
+++ b/base/src/com/google/idea/blaze/base/formatter/DelegatingCodeStyleManager.java
@@ -204,4 +204,9 @@ abstract class DelegatingCodeStyleManager extends CodeStyleManager
   public <T> T performActionWithFormatterDisabled(Computable<T> r) {
     return delegate.performActionWithFormatterDisabled(r);
   }
+
+  @Override
+  public void scheduleReformatWhenSettingsComputed(PsiFile file) {
+    delegate.scheduleReformatWhenSettingsComputed(file);
+  }
 }


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: https://github.com/bazelbuild/intellij/issues/2127

# Description of this change

Delegates the new `scheduleReformatWhenSettingsComputed` method to avoid `OperationNotSupported` exception in `2020.2+`. Currently running this patch on our fork of this repository without issue.