### PR TITLE
Allow for more flexibility when reporting test failures

### DIFF
--- a/base/src/com/google/idea/blaze/base/run/smrunner/BlazeXmlToTestEventsConverter.java
+++ b/base/src/com/google/idea/blaze/base/run/smrunner/BlazeXmlToTestEventsConverter.java
@@ -351,7 +351,7 @@ public class BlazeXmlToTestEventsConverter extends OutputToGeneralTestEventsConv
       processor.onTestOutput(new TestOutputEvent(displayName, test.sysOut, true));
     }
     if (test.sysErr != null) {
-      processor.onTestOutput(new TestOutputEvent(displayName, test.sysErr, true));
+      processor.onTestOutput(new TestOutputEvent(displayName, test.sysErr, false));
     }
 
     if (isIgnored(test)) {

--- a/base/src/com/google/idea/blaze/base/run/smrunner/BlazeXmlToTestEventsConverter.java
+++ b/base/src/com/google/idea/blaze/base/run/smrunner/BlazeXmlToTestEventsConverter.java
@@ -186,7 +186,7 @@ public class BlazeXmlToTestEventsConverter extends OutputToGeneralTestEventsConv
   private void reportTestRuntimeError(String errorName, String errorMessage) {
     GeneralTestEventsProcessor processor = getProcessor();
     processor.onTestFailure(
-        getTestFailedEvent(errorName, errorMessage, null, BlazeComparisonFailureData.NONE, 0));
+        getTestFailedEvent(errorName, errorMessage, null, BlazeComparisonFailureData.NONE, 0, true));
   }
 
   /** Return false if there's output XML which should be parsed. */
@@ -221,7 +221,7 @@ public class BlazeXmlToTestEventsConverter extends OutputToGeneralTestEventsConv
                 + " See console output for details",
             /* content= */ null,
             BlazeComparisonFailureData.NONE,
-            /* duration= */ 0));
+            /* duration= */ 0, true));
     processor.onTestFinished(new TestFinishedEvent(targetName, /*duration=*/ 0L));
     processor.onSuiteFinished(new TestSuiteFinishedEvent(label.toString()));
   }
@@ -364,8 +364,9 @@ public class BlazeXmlToTestEventsConverter extends OutputToGeneralTestEventsConv
           !test.failures.isEmpty()
               ? test.failures
               : !test.errors.isEmpty() ? test.errors : ImmutableList.of(NO_ERROR);
+      boolean isError = test.failures.isEmpty();
       for (ErrorOrFailureOrSkipped err : errors) {
-        processor.onTestFailure(getTestFailedEvent(displayName, err, parseTimeMillis(test.time)));
+        processor.onTestFailure(getTestFailedEvent(displayName, err, parseTimeMillis(test.time), isError));
       }
     }
     processor.onTestFinished(new TestFinishedEvent(displayName, parseTimeMillis(test.time)));
@@ -384,11 +385,11 @@ public class BlazeXmlToTestEventsConverter extends OutputToGeneralTestEventsConv
   }
 
   private static TestFailedEvent getTestFailedEvent(
-      String name, ErrorOrFailureOrSkipped error, long duration) {
+      String name, ErrorOrFailureOrSkipped error, long duration, boolean isError) {
     String message =
         error.message != null ? error.message : "Test failed (no error message present)";
     String content = pruneErrorMessage(error.message, BlazeXmlSchema.getErrorContent(error));
-    return getTestFailedEvent(name, message, content, parseComparisonData(error), duration);
+    return getTestFailedEvent(name, message, content, parseComparisonData(error), duration, isError);
   }
 
   private static TestFailedEvent getTestFailedEvent(
@@ -396,13 +397,14 @@ public class BlazeXmlToTestEventsConverter extends OutputToGeneralTestEventsConv
       String message,
       @Nullable String content,
       BlazeComparisonFailureData comparisonData,
-      long duration) {
+      long duration,
+      boolean isError) {
     return new TestFailedEvent(
         name,
         null,
         message,
         content,
-        true,
+        isError,
         comparisonData.actual,
         comparisonData.expected,
         null,


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: https://github.com/bazelbuild/intellij/issues/2149

# Description of this change

When using certain assertion libraries, such as https://github.com/google/truth, the expected and actual value are not always present and the patterns defined in com.intellij.junit4.ExpectedPatterns are not covering all possible messages (actually I don't see them covering any of Google Truth messages).

But even without them, IMO the test should be considered a "failure" rather than an "error" when an assertion fails. This can be controlled by the means of the "error" XML element in the generated JUnit report making it much more flexible for the plugin users.

Additionally, a "system-err" element of the "testsuite" element is currently converted to a "system-out" output in the SM runner test console which seems to be a bug.
