### PR TITLE
Simplify opening of Bazel project using ProjectUtil.

### DIFF
--- a/base/src/com/google/idea/blaze/base/project/BlazeProjectOpenProcessor.java
+++ b/base/src/com/google/idea/blaze/base/project/BlazeProjectOpenProcessor.java
@@ -17,15 +17,14 @@ package com.google.idea.blaze.base.project;
 
 import com.google.idea.blaze.base.settings.Blaze;
 import com.google.idea.blaze.base.sync.data.BlazeDataStorage;
+import com.intellij.ide.impl.ProjectUtil;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.projectImport.ProjectOpenProcessor;
 import icons.BlazeIcons;
 import java.io.IOException;
 import javax.annotation.Nullable;
 import javax.swing.Icon;
-import org.jdom.JDOMException;
 
 /** Allows directly opening a project with project data directory embedded within the project. */
 public class BlazeProjectOpenProcessor extends ProjectOpenProcessor {
@@ -81,19 +80,11 @@ public class BlazeProjectOpenProcessor extends ProjectOpenProcessor {
   @Override
   public Project doOpenProject(
       VirtualFile file, @Nullable Project projectToClose, boolean forceOpenInNewFrame) {
-    ProjectManager pm = ProjectManager.getInstance();
-    if (projectToClose != null) {
-      pm.closeProject(projectToClose);
-    }
-    try {
-      VirtualFile ideaSubdirectory = getIdeaSubdirectory(file);
-      if (ideaSubdirectory == null) {
-        return null;
-      }
-      VirtualFile projectSubdirectory = ideaSubdirectory.getParent();
-      return pm.loadAndOpenProject(projectSubdirectory.getPath());
-    } catch (IOException | JDOMException e) {
+    VirtualFile ideaSubdirectory = getIdeaSubdirectory(file);
+    if (ideaSubdirectory == null) {
       return null;
     }
+    VirtualFile projectSubdirectory = ideaSubdirectory.getParent();
+    return ProjectUtil.openProject(projectSubdirectory.getPath(), projectToClose, forceOpenInNewFrame);
   }
 }


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: https://github.com/bazelbuild/intellij/issues/2147

# Description of this change

Shows a modal dialogue asking where to open the new Bazel project as with regular projects.
