### PR TITLE
Correct where stdout and stderr are read from

### DIFF
--- a/base/src/com/google/idea/blaze/base/run/smrunner/BlazeXmlSchema.java
+++ b/base/src/com/google/idea/blaze/base/run/smrunner/BlazeXmlSchema.java
@@ -145,10 +145,10 @@ public class BlazeXmlSchema {
     @XmlAttribute public String result;
     @XmlAttribute public String time;
 
-    @XmlAttribute(name = "system-out")
+    @XmlElement(name = "system-out")
     String sysOut;
 
-    @XmlAttribute(name = "system-err")
+    @XmlElement(name = "system-err")
     String sysErr;
 
     @XmlElement(name = "error", type = ErrorOrFailureOrSkipped.class)


### PR DESCRIPTION
# Checklist

- [X] I have filed an issue about this change and discussed potential changes with the maintainers.
- [X] I have received the approval from the maintainers to make this change.
- [X] This is not a stylistic, refactoring, or cleanup change.

# Discussion thread for this change

The junit.xml format outputs stdout and stderr in elements, not attributes. Fixing the encoding, fixes that issue.

Issue number: #2167 

Closes #2167 
