### PR TITLE
Use third_party jarjar.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -235,8 +235,8 @@ jvm_maven_import_external(
 
 jvm_maven_import_external(
     name = "jarjar",
-    artifact = "com.googlecode.jarjar:jarjar:1.1",
-    artifact_sha256 = "4838f4f29a027522363cef1bcda1b48808880b0de4953fab6db4121ee27b649b",
+    artifact = "com.googlecode.jarjar:jarjar:1.3",
+    artifact_sha256 = "4225c8ee1bf3079c4b07c76fe03c3e28809a22204db6249c9417efa4f804b3a7",
     licenses = ["notice"],  # Apache 2.0
     server_urls = ["https://repo1.maven.org/maven2"],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -235,8 +235,8 @@ jvm_maven_import_external(
 
 jvm_maven_import_external(
     name = "jarjar",
-    artifact = "com.googlecode.jarjar:jarjar:1.3",
-    artifact_sha256 = "4225c8ee1bf3079c4b07c76fe03c3e28809a22204db6249c9417efa4f804b3a7",
+    artifact = "com.googlecode.jarjar:jarjar:1.1",
+    artifact_sha256 = "4838f4f29a027522363cef1bcda1b48808880b0de4953fab6db4121ee27b649b",
     licenses = ["notice"],  # Apache 2.0
     server_urls = ["https://repo1.maven.org/maven2"],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -235,11 +235,29 @@ jvm_maven_import_external(
 
 jvm_maven_import_external(
     name = "jarjar",
-    artifact = "com.googlecode.jarjar:jarjar:1.3",
-    artifact_sha256 = "4225c8ee1bf3079c4b07c76fe03c3e28809a22204db6249c9417efa4f804b3a7",
+    artifact = "org.pantsbuild:jarjar:1.7.2",
+    artifact_sha256 = "0706a455e17b67718abe212e3a77688bbe8260852fc74e3e836d9f2e76d91c27",
+    licenses = ["notice"],  # Apache 2.0
+    server_urls = ["https://repo1.maven.org/maven2"],
+    deps = ["@asm", "@asm-commons"]
+)
+
+jvm_maven_import_external(
+    name = "asm",
+    artifact = "org.ow2.asm:asm:7.0",
+    artifact_sha256 = "b88ef66468b3c978ad0c97fd6e90979e56155b4ac69089ba7a44e9aa7ffe9acf",
     licenses = ["notice"],  # Apache 2.0
     server_urls = ["https://repo1.maven.org/maven2"],
 )
+
+jvm_maven_import_external(
+    name = "asm-commons",
+    artifact = "org.ow2.asm:asm-commons:7.0",
+    artifact_sha256 = "fed348ef05958e3e846a3ac074a12af5f7936ef3d21ce44a62c4fa08a771927d",
+    licenses = ["notice"],  # Apache 2.0
+    server_urls = ["https://repo1.maven.org/maven2"],
+)
+
 
 jvm_maven_import_external(
     name = "auto_value",

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -78,7 +78,7 @@ java_proto_library(
 
 java_binary(
     name = "jarjar_runner",
-    main_class = "com.tonicsystems.jarjar.Main",
+    main_class = "org.pantsbuild.jarjar.Main",
     runtime_deps = ["@jarjar//jar"],
 )
 

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -76,6 +76,13 @@ java_proto_library(
     deps = [":intellij_plugin_target_deploy_info_proto"],
 )
 
+java_binary(
+    name = "jarjar_runner",
+    main_class = "org.pantsbuild.jarjar.Main",
+    visibility = ["//visibility:public"],
+    runtime_deps = ["@jarjar//jar"],
+)
+
 genrule(
     name = "repackaged_proto_deps",
     srcs = [
@@ -84,13 +91,13 @@ genrule(
     ],
     outs = [":repackaged_proto_deps.jar"],
     cmd = """
-    $(location @bazel_tools//third_party/jarjar:jarjar_bin) \
+    $(location :jarjar_runner) \
         process \
         $(location :jarjar_protobuf_rule.txt) \
         $(location :proto_deps_binary_deploy.jar) \
         $@
     """,
-    tools = ["@bazel_tools//third_party/jarjar:jarjar_bin"],
+    tools = [":jarjar_runner"],
 )
 
 java_binary(

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -78,8 +78,7 @@ java_proto_library(
 
 java_binary(
     name = "jarjar_runner",
-    main_class = "org.pantsbuild.jarjar.Main",
-    visibility = ["//visibility:public"],
+    main_class = "com.tonicsystems.jarjar.Main",
     runtime_deps = ["@jarjar//jar"],
 )
 


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: https://github.com/bazelbuild/intellij/issues/2219

# Description of this change

Uses its own dependency on jarjar, because jarjar is not shipped with Bazel anymore.