### PR TITLE
[WIP] Added compatibility for IntelliJ IDEA CE & Ultimate 2020.3

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -24,6 +24,15 @@ http_archive(
     url = "https://www.jetbrains.com/intellij-repository/releases/com/jetbrains/intellij/idea/ideaIC/2020.2.2/ideaIC-2020.2.2.zip",
 )
 
+# The plugin api for IntelliJ 2020.1. This is required to build IJwB,
+# and run integration tests.
+http_archive(
+    name = "intellij_ce_2020_3",
+    build_file = "@//intellij_platform_sdk:BUILD.idea203",
+    sha256 = "2c621e40a8a965c7ea5e1005652d1d1dd80b8fe4241be13ef3d4df2c0b2d72c5",
+    url = "https://www.jetbrains.com/intellij-repository/releases/com/jetbrains/intellij/idea/ideaIC/2020.3.1/ideaIC-2020.3.1.zip",
+)
+
 # The plugin api for IntelliJ UE 2020.1. This is required to run UE-specific
 # integration tests.
 http_archive(
@@ -40,6 +49,15 @@ http_archive(
     build_file = "@//intellij_platform_sdk:BUILD.ue202",
     sha256 = "434adfaa3e98e7eac8ab3d292086958c9f453b6ab2390e8d5c0a53e945e3f857",
     url = "https://www.jetbrains.com/intellij-repository/releases/com/jetbrains/intellij/idea/ideaIU/2020.2.2/ideaIU-2020.2.2.zip",
+)
+
+# The plugin api for IntelliJ UE 2020.1. This is required to run UE-specific
+# integration tests.
+http_archive(
+    name = "intellij_ue_2020_3",
+    build_file = "@//intellij_platform_sdk:BUILD.ue203",
+    sha256 = "ffd4e98b7a3e7cd40a66e518b01e1fb160fe03071aa6085a543decd7b825b4c3",
+    url = "https://www.jetbrains.com/intellij-repository/releases/com/jetbrains/intellij/idea/ideaIU/2020.3.1/ideaIU-2020.3.1.zip",
 )
 
 # The plugin api for CLion 2019.3. This is required to build CLwB,
@@ -111,6 +129,20 @@ http_archive(
     url = "https://plugins.jetbrains.com/files/7322/97141/python-ce-202.7319.64.zip",
 )
 
+# Python plugin for IntelliJ CE. Required at compile-time for python-specific features.
+http_archive(
+    name = "python_2020_3",
+    build_file_content = "\n".join([
+        "java_import(",
+        "    name = 'python',",
+        "    jars = ['python-ce/lib/python-ce.jar'],",
+        "    visibility = ['//visibility:public'],",
+        ")",
+    ]),
+    sha256 = "510303a863ea138554777d18968accdd1320aa41e63e62170012b9b6566b4a7e",
+    url = "https://plugins.jetbrains.com/files/7322/106700/python-ce-203.6682.179.zip",
+)
+
 # Go plugin for IntelliJ UE. Required at compile-time for Bazel integration.
 http_archive(
     name = "go_2020_1",
@@ -139,6 +171,20 @@ http_archive(
     url = "https://plugins.jetbrains.com/files/9568/97011/go-202.7319.50.zip",
 )
 
+# Go plugin for IntelliJ UE. Required at compile-time for Bazel integration.
+http_archive(
+    name = "go_2020_3",
+    build_file_content = "\n".join([
+        "java_import(",
+        "    name = 'go',",
+        "    jars = glob(['go/lib/*.jar']),",
+        "    visibility = ['//visibility:public'],",
+        ")",
+    ]),
+    sha256 = "4570ea6145590d92fa984e7ae5e7e75a0dc948dc2866e227f22986abed5527a3",
+    url = "https://plugins.jetbrains.com/files/9568/106609/go-203.6682.168.zip",
+)
+
 # Scala plugin for IntelliJ CE. Required at compile-time for scala-specific features.
 http_archive(
     name = "scala_2020_1",
@@ -165,6 +211,20 @@ http_archive(
     ]),
     sha256 = "52004387981df909afaeabb91b032aee51d1860acf7b434d111f261a9e1ed07d",
     url = "https://plugins.jetbrains.com/files/1347/97067/scala-intellij-bin-2020.2.27.zip",
+)
+
+# Scala plugin for IntelliJ CE. Required at compile-time for scala-specific features.
+http_archive(
+    name = "scala_2020_3",
+    build_file_content = "\n".join([
+        "java_import(",
+        "    name = 'scala',",
+        "    jars = glob(['Scala/lib/*.jar']),",
+        "    visibility = ['//visibility:public'],",
+        ")",
+    ]),
+    sha256 = "4924ccda4a5d6ee830813efb86966bed8f7caf5a19e9cc1b27fa4e288e57a250",
+    url = "https://plugins.jetbrains.com/files/1347/105697/scala-intellij-bin-2020.3.18.zip",
 )
 
 # The plugin api for Android Studio 4.1. This is required to build ASwB,

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -87,6 +87,15 @@ http_archive(
     url = "https://download.jetbrains.com/cpp/CLion-2020.2.5.tar.gz",
 )
 
+# The plugin api for CLion 2020.2. This is required to build CLwB,
+# and run integration tests.
+http_archive(
+    name = "clion_2020_3",
+    build_file = "@//intellij_platform_sdk:BUILD.clion203",
+    sha256 = "9a5f61360ed1fea699c3b692800e7df42e41589d6b994e2b6613e87472e4dbc9",
+    url = "https://download.jetbrains.com/cpp/CLion-2020.3.1.tar.gz",
+)
+
 # Python plugin for IntelliJ CE. Required at compile-time for python-specific features.
 http_archive(
     name = "python_2019_3",

--- a/base/BUILD
+++ b/base/BUILD
@@ -46,6 +46,8 @@ intellij_plugin_library(
         "intellij-ue-2020.1": ["sdkcompat/v201/META-INF/blaze-base-v201.xml"],
         "intellij-2020.2": ["sdkcompat/v201/META-INF/blaze-base-v201.xml"],
         "intellij-ue-2020.2": ["sdkcompat/v201/META-INF/blaze-base-v201.xml"],
+        "intellij-2020.3": ["sdkcompat/v203/META-INF/blaze-base-v203.xml"],
+        "intellij-ue-2020.3": ["sdkcompat/v203/META-INF/blaze-base-v203.xml"],
         "clion-2019.3": [],
         "clion-2020.1": ["sdkcompat/v201/META-INF/blaze-base-v201.xml"],
         "clion-2020.2": ["sdkcompat/v201/META-INF/blaze-base-v201.xml"],

--- a/base/BUILD
+++ b/base/BUILD
@@ -51,6 +51,7 @@ intellij_plugin_library(
         "clion-2019.3": [],
         "clion-2020.1": ["sdkcompat/v201/META-INF/blaze-base-v201.xml"],
         "clion-2020.2": ["sdkcompat/v201/META-INF/blaze-base-v201.xml"],
+        "clion-2020.3": ["sdkcompat/v203/META-INF/blaze-base-v203.xml"]
     }),
     visibility = ["//visibility:public"],
     deps = [":base"],

--- a/base/sdkcompat/v203/META-INF/blaze-base-v203.xml
+++ b/base/sdkcompat/v203/META-INF/blaze-base-v203.xml
@@ -1,0 +1,23 @@
+<!--
+  ~ Copyright 2020 The Bazel Authors. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<idea-plugin>
+  <projectListeners>
+    <listener
+        class="com.google.idea.blaze.base.actions.ProjectFrameUpdater"
+        activeInHeadlessMode="false" activeInTestMode="false"
+        topic="com.intellij.openapi.project.ProjectManagerListener"/>
+  </projectListeners>
+</idea-plugin>

--- a/golang/src/com/google/idea/blaze/golang/resolve/BlazeGoImportResolver.java
+++ b/golang/src/com/google/idea/blaze/golang/resolve/BlazeGoImportResolver.java
@@ -50,6 +50,9 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
+import org.jetbrains.annotations.NotNull;
+
+
 /** Converts each go target in the {@link TargetMap} into a corresponding {@link BlazeGoPackage}. */
 class BlazeGoImportResolver implements GoImportResolver {
   private static final String GO_PACKAGE_MAP_KEY = "BlazeGoPackageMap";
@@ -215,7 +218,7 @@ class BlazeGoImportResolver implements GoImportResolver {
     }
 
     @Override
-    public boolean processChildren(PsiElementProcessor<PsiFileSystemItem> psiElementProcessor) {
+    public boolean processChildren(@NotNull PsiElementProcessor<? super PsiFileSystemItem> psiElementProcessor) {
       return false;
     }
   }

--- a/intellij_platform_sdk/BUILD
+++ b/intellij_platform_sdk/BUILD
@@ -105,6 +105,13 @@ config_setting(
 )
 
 config_setting(
+    name = "intellij-2020.3",
+    values = {
+        "define": "ij_product=intellij-2020.3",
+    },
+)
+
+config_setting(
     name = "intellij-ue-2020.1",
     values = {
         "define": "ij_product=intellij-ue-2020.1",
@@ -131,6 +138,13 @@ config_setting(
     values = {
         "cpu": "darwin_x86_64",
         "define": "ij_product=intellij-ue-2020.2",
+    },
+)
+
+config_setting(
+    name = "intellij-ue-2020.3",
+    values = {
+        "define": "ij_product=intellij-ue-2020.3",
     },
 )
 
@@ -369,6 +383,7 @@ java_library(
         "clion-2020.2": ["@jsr305_annotations//jar"],
         "intellij-ue-2020.1": ["@jsr305_annotations//jar"],
         "intellij-ue-2020.2": ["@jsr305_annotations//jar"],
+        "intellij-ue-2020.3": ["@jsr305_annotations//jar"],
         "android-studio-4.2": ["@jsr305_annotations//jar"],
         "android-studio-2020.3": ["@jsr305_annotations//jar"],
         "default": [":plugin_api"],

--- a/intellij_platform_sdk/BUILD
+++ b/intellij_platform_sdk/BUILD
@@ -273,6 +273,13 @@ config_setting(
     },
 )
 
+config_setting(
+    name = "clion-2020.3",
+    values = {
+        "define": "ij_product=clion-2020.3",
+    },
+)
+
 # The purpose of this rule is to hide the versioning
 # complexity from users of this api.
 # There will be additional versions added in the future
@@ -381,6 +388,7 @@ java_library(
         "clion-2019.3": ["@jsr305_annotations//jar"],
         "clion-2020.1": ["@jsr305_annotations//jar"],
         "clion-2020.2": ["@jsr305_annotations//jar"],
+        "clion-2020.3": ["@jsr305_annotations//jar"],
         "intellij-ue-2020.1": ["@jsr305_annotations//jar"],
         "intellij-ue-2020.2": ["@jsr305_annotations//jar"],
         "intellij-ue-2020.3": ["@jsr305_annotations//jar"],

--- a/intellij_platform_sdk/BUILD.clion203
+++ b/intellij_platform_sdk/BUILD.clion203
@@ -1,0 +1,88 @@
+# Description:
+#
+# Plugin source jars for CLion, accessed remotely.
+
+package(default_visibility = ["//visibility:public"])
+
+java_import(
+    name = "sdk",
+    jars = glob(
+        [
+            "clion-*/lib/*.jar",
+            "clion-*/plugins/clion-test-google/lib/*.jar",
+            "clion-*/plugins/clion-test-catch/lib/*.jar",
+            "clion-*/plugins/clion-test-boost/lib/*.jar",
+        ],
+    ),
+    tags = ["intellij-provided-by-sdk"],
+    deps = ["@error_prone_annotations//jar"],
+)
+
+java_import(
+    name = "guava",
+    jars = glob([
+        "clion-*/lib/failureaccess-*.jar",
+        "clion-*/lib/guava-*.jar",
+    ]),
+)
+
+java_import(
+    name = "hg4idea",
+    jars = glob(["clion-*/plugins/hg4idea/lib/hg4idea.jar"]),
+)
+
+java_import(
+    name = "javascript",
+    jars = glob(["clion-*/plugins/JavaScriptLanguage/lib/*.jar"]),
+)
+
+java_import(
+    name = "css",
+    jars = glob(["clion-*/plugins/CSS/lib/*.jar"]),
+)
+
+java_import(
+    name = "tslint",
+    jars = glob(["clion-*/plugins/tslint/lib/*.jar"]),
+)
+
+java_import(
+    name = "tasks",
+    jars = glob([
+        "clion-*/plugins/tasks/lib/tasks-api.jar",
+        "clion-*/plugins/tasks/lib/tasks-core.jar",
+    ]),
+)
+
+java_import(
+    name = "terminal",
+    jars = glob(["clion-*/plugins/terminal/lib/terminal.jar"]),
+)
+
+java_import(
+    name = "python",
+    jars = glob(["clion-*/plugins/python-ce/lib/*.jar"]),
+)
+
+java_import(
+    name = "forms_rt",
+    jars = glob(["clion-*/lib/forms_rt.jar"]),
+)
+
+java_import(
+    name = "objenesis",
+    jars = glob(["clion-*/lib/objenesis-*.jar"]),
+)
+
+# The plugins required by CLwB. Presumably there will be some, when we write
+# some integration tests.
+java_import(
+    name = "bundled_plugins",
+    jars = [],
+    tags = ["intellij-provided-by-sdk"],
+)
+
+filegroup(
+    name = "application_info_jar",
+    srcs = glob(["clion-*/lib/clion.jar"]),
+)

--- a/intellij_platform_sdk/BUILD.idea203
+++ b/intellij_platform_sdk/BUILD.idea203
@@ -1,0 +1,96 @@
+# Description:
+#
+# Plugin source jars for IntelliJ CE, accessed remotely.
+
+package(default_visibility = ["//visibility:public"])
+
+java_import(
+    name = "sdk",
+    jars = glob(
+        # temporarily include the newly extracted java and platform-images plugins in the core SDK
+        # see https://blog.jetbrains.com/platform/2019/06/java-functionality-extracted-as-a-plugin/
+        # api#191: expose the java plugin as a separate target
+        # api#193: platform-images has been extracted to a separate plugin in 2020.1
+        [
+            "lib/*.jar",
+            "plugins/java/lib/*.jar",
+            "plugins/platform-images/lib/*.jar",
+        ],
+    ),
+    tags = ["intellij-provided-by-sdk"],
+    deps = ["@error_prone_annotations//jar"],
+)
+
+java_import(
+    name = "devkit",
+    jars = glob(["plugins/devkit/lib/devkit.jar"]),
+)
+
+java_import(
+    name = "guava",
+    jars = glob([
+        "lib/failureaccess-*.jar",
+        "lib/guava-*.jar",
+    ]),
+)
+
+java_import(
+    name = "coverage",
+    jars = glob(["plugins/coverage/lib/*.jar"]),
+)
+
+java_import(
+    name = "hg4idea",
+    jars = glob(["plugins/hg4idea/lib/hg4idea.jar"]),
+)
+
+java_import(
+    name = "kotlin",
+    jars = glob(["plugins/Kotlin/lib/*.jar"]),
+)
+
+java_import(
+    name = "junit",
+    jars = glob(["plugins/junit/lib/*.jar"]),
+)
+
+java_import(
+    name = "tasks",
+    jars = glob([
+        "plugins/tasks/lib/tasks-api.jar",
+        "plugins/tasks/lib/tasks-core.jar",
+    ]),
+)
+
+java_import(
+    name = "terminal",
+    jars = glob(["plugins/terminal/lib/terminal.jar"]),
+)
+
+java_import(
+    name = "forms_rt",
+    jars = ["lib/forms_rt.jar"],
+)
+
+java_import(
+    name = "objenesis",
+    jars = glob(["lib/objenesis-*.jar"]),
+)
+
+# The plugins required by IJwB. We need to include them
+# when running integration tests.
+java_import(
+    name = "bundled_plugins",
+    jars = glob([
+        "plugins/devkit/lib/*.jar",
+        "plugins/java-i18n/lib/*.jar",
+        "plugins/junit/lib/*.jar",
+        "plugins/properties/lib/*.jar",
+    ]),
+    tags = ["intellij-provided-by-sdk"],
+)
+
+filegroup(
+    name = "application_info_jar",
+    srcs = glob(["lib/resources.jar"]),
+)

--- a/intellij_platform_sdk/BUILD.ue203
+++ b/intellij_platform_sdk/BUILD.ue203
@@ -1,0 +1,117 @@
+# Description:
+#
+# Plugin source jars for IntelliJ UE, accessed remotely.
+
+package(default_visibility = ["//visibility:public"])
+
+java_import(
+    name = "sdk",
+    jars = glob(
+        # temporarily include the newly extracted java plugin in the core SDK
+        # see https://blog.jetbrains.com/platform/2019/06/java-functionality-extracted-as-a-plugin/
+        # api#191: expose the java plugin as a separate target
+        [
+            "lib/*.jar",
+            "plugins/java/lib/*.jar",
+        ],
+    ),
+    tags = ["intellij-provided-by-sdk"],
+    deps = ["@error_prone_annotations//jar"],
+)
+
+java_import(
+    name = "guava",
+    jars = glob([
+        "lib/failureaccess-*.jar",
+        "lib/guava-*.jar",
+    ]),
+)
+
+java_import(
+    name = "coverage",
+    jars = glob(["plugins/coverage/lib/*.jar"]),
+)
+
+java_import(
+    name = "devkit",
+    jars = glob(["plugins/devkit/lib/devkit.jar"]),
+)
+
+java_import(
+    name = "hg4idea",
+    jars = glob(["plugins/hg4idea/lib/hg4idea.jar"]),
+)
+
+java_import(
+    name = "javascript",
+    jars = glob(["plugins/JavaScriptLanguage/lib/*.jar"]),
+)
+
+java_import(
+    name = "css",
+    jars = glob([
+        "plugins/CSS/lib/*.jar",
+        "plugins/platform-images/lib/*.jar",
+    ]),
+)
+
+java_import(
+    name = "tslint",
+    jars = glob(["plugins/tslint/lib/*.jar"]),
+)
+
+java_import(
+    name = "angular",
+    jars = glob(["plugins/AngularJS/lib/*.jar"]),
+)
+
+java_import(
+    name = "kotlin",
+    jars = glob(["plugins/Kotlin/lib/*.jar"]),
+)
+
+java_import(
+    name = "junit",
+    jars = glob(["plugins/junit/lib/*.jar"]),
+)
+
+java_import(
+    name = "tasks",
+    jars = glob([
+        "plugins/tasks/lib/tasks-api.jar",
+        "plugins/tasks/lib/tasks-core.jar",
+    ]),
+)
+
+java_import(
+    name = "terminal",
+    jars = glob(["plugins/terminal/lib/terminal.jar"]),
+)
+
+java_import(
+    name = "forms_rt",
+    jars = ["lib/forms_rt.jar"],
+)
+
+java_import(
+    name = "objenesis",
+    jars = glob(["lib/objenesis-*.jar"]),
+)
+
+# The plugins required by IJwB. We need to include them
+# when running integration tests.
+java_import(
+    name = "bundled_plugins",
+    jars = glob([
+        "plugins/devkit/lib/*.jar",
+        "plugins/java-i18n/lib/*.jar",
+        "plugins/junit/lib/*.jar",
+        "plugins/properties/lib/*.jar",
+    ]),
+    tags = ["intellij-provided-by-sdk"],
+)
+
+filegroup(
+    name = "application_info_jar",
+    srcs = glob(["lib/resources.jar"]),
+)

--- a/intellij_platform_sdk/build_defs.bzl
+++ b/intellij_platform_sdk/build_defs.bzl
@@ -100,6 +100,10 @@ DIRECT_IJ_PRODUCTS = {
         ide = "clion",
         directory = "clion_2020_2",
     ),
+    "clion-2020.3": struct(
+        ide = "clion",
+        directory = "clion_2020_3",
+    ),
 }
 
 def select_for_plugin_api(params):

--- a/intellij_platform_sdk/build_defs.bzl
+++ b/intellij_platform_sdk/build_defs.bzl
@@ -5,11 +5,11 @@ INDIRECT_IJ_PRODUCTS = {
     "intellij-latest": "intellij-2020.1",
     "intellij-latest-mac": "intellij-2020.1-mac",
     "intellij-beta": "intellij-2020.2",
-    "intellij-canary": "intellij-2020.2",
+    "intellij-canary": "intellij-2020.3",
     "intellij-ue-latest": "intellij-ue-2020.1",
     "intellij-ue-latest-mac": "intellij-ue-2020.1-mac",
     "intellij-ue-beta": "intellij-ue-2020.2",
-    "intellij-ue-canary": "intellij-ue-2020.2",
+    "intellij-ue-canary": "intellij-ue-2020.3",
     "android-studio-latest": "android-studio-4.1",
     "android-studio-beta": "android-studio-4.1",
     "android-studio-beta-mac": "android-studio-4.1-mac",
@@ -36,6 +36,10 @@ DIRECT_IJ_PRODUCTS = {
         ide = "intellij",
         directory = "intellij_ce_2020_2",
     ),
+    "intellij-2020.3": struct(
+        ide = "intellij",
+        directory = "intellij_ce_2020_3",
+    ),
     "intellij-ue-2020.1": struct(
         ide = "intellij-ue",
         directory = "intellij_ue_2020_1",
@@ -51,6 +55,10 @@ DIRECT_IJ_PRODUCTS = {
     "intellij-ue-2020.2-mac": struct(
         ide = "intellij-ue",
         directory = "intellij_ue_2020_2",
+    ),
+    "intellij-ue-2020.3": struct(
+        ide = "intellij-ue",
+        directory = "intellij_ue_2020_3",
     ),
     "android-studio-4.1": struct(
         ide = "android-studio",

--- a/python/src/com/google/idea/blaze/python/PySdkUtils.java
+++ b/python/src/com/google/idea/blaze/python/PySdkUtils.java
@@ -34,7 +34,7 @@ public class PySdkUtils {
       return projectSdk;
     }
     // look for a SDK associated with a python facet instead.
-    return PythonSdkType.findPythonSdk(
+    return PythonSdkType.findPython2Sdk(
         ModuleManager.getInstance(project)
             .findModuleByName(BlazeDataStorage.WORKSPACE_MODULE_NAME));
   }

--- a/python/src/com/google/idea/blaze/python/issueparser/PyIssueParserProvider.java
+++ b/python/src/com/google/idea/blaze/python/issueparser/PyIssueParserProvider.java
@@ -130,7 +130,8 @@ public class PyIssueParserProvider implements BlazeIssueParserProvider {
       if (projectScope.contains(vf)) {
         return 0;
       }
-      return PythonSdkType.isStdLib(vf, sdk) ? 2 : 1;
+      return 2;
+      // return PythonSdkType.isStdLib(vf, sdk) ? 2 : 1;
     }
 
     /** defaults to -1 if no line number can be parsed. */

--- a/python/src/com/google/idea/blaze/python/sync/BlazePythonSyncPlugin.java
+++ b/python/src/com/google/idea/blaze/python/sync/BlazePythonSyncPlugin.java
@@ -234,7 +234,7 @@ public class BlazePythonSyncPlugin implements BlazeSyncPlugin {
     }
     // facets aren't properly updated when SDKs change (e.g. when they're deleted), so we need to
     // manually check against the full list.
-    if (!PythonSdkType.getAllSdks().contains(sdk)) {
+    if (!Arrays.asList(PythonSdkType.getAllTypes()).contains(sdk)) {
       return false;
     }
 

--- a/python/src/com/google/idea/blaze/python/sync/PySdkSuggester.java
+++ b/python/src/com/google/idea/blaze/python/sync/PySdkSuggester.java
@@ -21,7 +21,10 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.openapi.projectRoots.impl.SdkConfigurationUtil;
 import com.jetbrains.python.sdk.PythonSdkType;
+import com.jetbrains.python.sdk.PyDetectedSdk;
 import javax.annotation.Nullable;
+
+import java.util.Arrays;
 
 /** Extension to allow suggestion of Python SDK to use for a particular project */
 public abstract class PySdkSuggester {
@@ -87,9 +90,6 @@ public abstract class PySdkSuggester {
   /** Utility method for PySdkSuggester to resolve a homepath to a registered SDK. */
   @Nullable
   private static Sdk findPythonSdk(String homePath) {
-    return PythonSdkType.getAllSdks().stream()
-        .filter(sdk -> homePath.equals(sdk.getHomePath()))
-        .findAny()
-        .orElse(null);
+    return new PyDetectedSdk(homePath);
   }
 }

--- a/sdkcompat/BUILD
+++ b/sdkcompat/BUILD
@@ -28,6 +28,8 @@ java_library(
         "intellij-ue-2020.1": ["//sdkcompat/v201"],
         "intellij-2020.2": ["//sdkcompat/v202"],
         "intellij-ue-2020.2": ["//sdkcompat/v202"],
+        "intellij-2020.3": ["//sdkcompat/v203"],
+        "intellij-ue-2020.3": ["//sdkcompat/v203"],
         "clion-2019.3": ["//sdkcompat/v193"],
         "clion-2020.1": ["//sdkcompat/v201"],
         "clion-2020.2": ["//sdkcompat/v202"],

--- a/sdkcompat/BUILD
+++ b/sdkcompat/BUILD
@@ -33,5 +33,6 @@ java_library(
         "clion-2019.3": ["//sdkcompat/v193"],
         "clion-2020.1": ["//sdkcompat/v201"],
         "clion-2020.2": ["//sdkcompat/v202"],
+        "clion-2020.3": ["//sdkcompat/v203"],
     }),
 )

--- a/sdkcompat/v203/BUILD
+++ b/sdkcompat/v203/BUILD
@@ -1,0 +1,40 @@
+# Description: Indirections for SDK changes to the underlying platform library.
+
+load("//intellij_platform_sdk:build_defs.bzl", "select_for_ide")
+
+licenses(["notice"])
+
+java_library(
+    name = "v203",
+    srcs = glob([
+        "com/google/idea/sdkcompat/general/**",
+        "com/google/idea/sdkcompat/formatter/**",
+        "com/google/idea/sdkcompat/platform/**",
+        "com/google/idea/sdkcompat/python/**",
+        "com/google/idea/sdkcompat/vcs/**",
+    ]) + select_for_ide(
+        android_studio = glob([
+            "com/google/idea/sdkcompat/cpp/**",
+            "com/google/idea/sdkcompat/java/**",
+        ]),
+        clion = glob([
+            "com/google/idea/sdkcompat/clion/**",
+            "com/google/idea/sdkcompat/cpp/**",
+        ]),
+        intellij = glob([
+            "com/google/idea/sdkcompat/java/**",
+            "com/google/idea/sdkcompat/scala/**",
+        ]),
+        intellij_ue = glob([
+            "com/google/idea/sdkcompat/java/**",
+            "com/google/idea/sdkcompat/scala/**",
+        ]),
+    ),
+    visibility = ["//sdkcompat:__pkg__"],
+    deps = [
+        "//intellij_platform_sdk:jsr305",
+        "//intellij_platform_sdk:plugin_api",
+        "//third_party/python",
+        "//third_party/scala",
+    ],
+)

--- a/sdkcompat/v203/com/google/idea/sdkcompat/clion/CidrConsoleBuilderAdapter.java
+++ b/sdkcompat/v203/com/google/idea/sdkcompat/clion/CidrConsoleBuilderAdapter.java
@@ -1,0 +1,12 @@
+package com.google.idea.sdkcompat.clion;
+
+import com.intellij.openapi.project.Project;
+import com.jetbrains.cidr.execution.CidrConsoleBuilder;
+
+/** Api compat with 2020.2 #api201 */
+public class CidrConsoleBuilderAdapter extends CidrConsoleBuilder {
+
+  public CidrConsoleBuilderAdapter(Project project) {
+    super(project, null, null);
+  }
+}

--- a/sdkcompat/v203/com/google/idea/sdkcompat/clion/CidrLauncherAdapter.java
+++ b/sdkcompat/v203/com/google/idea/sdkcompat/clion/CidrLauncherAdapter.java
@@ -1,0 +1,6 @@
+package com.google.idea.sdkcompat.clion;
+
+import com.jetbrains.cidr.execution.CidrLauncher;
+
+/** Api compat with 2020.2 #api201 */
+public abstract class CidrLauncherAdapter extends CidrLauncher {}

--- a/sdkcompat/v203/com/google/idea/sdkcompat/clion/ToolchainCompat.java
+++ b/sdkcompat/v203/com/google/idea/sdkcompat/clion/ToolchainCompat.java
@@ -1,0 +1,10 @@
+package com.google.idea.sdkcompat.clion;
+
+import com.jetbrains.cidr.cpp.toolchains.CPPToolchains.Toolchain;
+
+/** Api compat with 2020.1 #api193 */
+public class ToolchainCompat {
+  public static String getDefaultName() {
+    return Toolchain.getDefault();
+  }
+}

--- a/sdkcompat/v203/com/google/idea/sdkcompat/cpp/IncludedHeadersRootCompat.java
+++ b/sdkcompat/v203/com/google/idea/sdkcompat/cpp/IncludedHeadersRootCompat.java
@@ -1,0 +1,27 @@
+package com.google.idea.sdkcompat.cpp;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.jetbrains.cidr.lang.workspace.headerRoots.HeadersSearchPath;
+import com.jetbrains.cidr.lang.workspace.headerRoots.HeadersSearchRoot;
+import com.jetbrains.cidr.lang.workspace.headerRoots.IncludedHeadersRoot;
+
+/**
+ * Compat for {@link IncludedHeadersRoot}.
+ *
+ * <p>#api201
+ */
+public class IncludedHeadersRootCompat {
+  public static boolean isUserHeaders(IncludedHeadersRoot root) {
+    return root.getKind() == HeadersSearchPath.Kind.USER;
+  }
+
+  public static HeadersSearchRoot create(
+      Project project, VirtualFile vf, boolean recursive, boolean isUserHeader) {
+    HeadersSearchPath.Kind kind =
+        isUserHeader ? HeadersSearchPath.Kind.USER : HeadersSearchPath.Kind.SYSTEM;
+    return IncludedHeadersRoot.create(project, vf, recursive, kind);
+  }
+
+  private IncludedHeadersRootCompat() {}
+}

--- a/sdkcompat/v203/com/google/idea/sdkcompat/cpp/MessageBusSupplier.java
+++ b/sdkcompat/v203/com/google/idea/sdkcompat/cpp/MessageBusSupplier.java
@@ -1,0 +1,32 @@
+package com.google.idea.sdkcompat.cpp;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.util.messages.ListenerDescriptor;
+import com.intellij.util.messages.MessageBus;
+import com.intellij.util.messages.MessageBusOwner;
+import com.intellij.util.messages.impl.MessageBusFactoryImpl;
+
+/** Compat for 2020.1 api changes #api193 */
+public class MessageBusSupplier {
+  public static MessageBus createMessageBus(Project project) {
+    return MessageBusFactoryImpl.createRootBus(new MessageBusOwnerForProject(project));
+  }
+
+  private static class MessageBusOwnerForProject implements MessageBusOwner {
+    private final Project realOwner;
+
+    MessageBusOwnerForProject(Project project) {
+      realOwner = project;
+    }
+
+    @Override
+    public Object createListener(ListenerDescriptor listenerDescriptor) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isDisposed() {
+      return realOwner.isDisposed();
+    }
+  }
+}

--- a/sdkcompat/v203/com/google/idea/sdkcompat/cpp/OCImportGraphCompat.java
+++ b/sdkcompat/v203/com/google/idea/sdkcompat/cpp/OCImportGraphCompat.java
@@ -1,0 +1,14 @@
+package com.google.idea.sdkcompat.cpp;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.jetbrains.cidr.lang.preprocessor.OCImportGraph;
+import java.util.Collection;
+
+/** Compat utilities for {@link OCImportGraph}. */
+public class OCImportGraphCompat {
+  // #api193
+  public static Collection<VirtualFile> getAllHeaderRoots(Project project, VirtualFile headerFile) {
+    return OCImportGraph.getInstance(project).getAllHeaderRoots(headerFile);
+  }
+}

--- a/sdkcompat/v203/com/google/idea/sdkcompat/cpp/OCWorkspaceEventCompat.java
+++ b/sdkcompat/v203/com/google/idea/sdkcompat/cpp/OCWorkspaceEventCompat.java
@@ -1,0 +1,24 @@
+package com.google.idea.sdkcompat.cpp;
+
+import com.jetbrains.cidr.lang.workspace.OCWorkspaceEventImpl;
+
+/**
+ * Compat methods for {@link OCWorkspaceEventImpl}.
+ *
+ * <p>#api201
+ */
+public class OCWorkspaceEventCompat {
+  private OCWorkspaceEventCompat() {}
+
+  public static OCWorkspaceEventImpl newEvent(
+      boolean resolveConfigurationsChanged,
+      boolean sourceFilesChanged,
+      boolean compilerSettingsChanged,
+      boolean clientVersionChanged) {
+    return new OCWorkspaceEventImpl(
+        resolveConfigurationsChanged,
+        sourceFilesChanged,
+        compilerSettingsChanged,
+        clientVersionChanged);
+  }
+}

--- a/sdkcompat/v203/com/google/idea/sdkcompat/formatter/DelegatingCodeStyleManagerCompat.java
+++ b/sdkcompat/v203/com/google/idea/sdkcompat/formatter/DelegatingCodeStyleManagerCompat.java
@@ -1,0 +1,19 @@
+package com.google.idea.sdkcompat.formatter;
+
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.codeStyle.CodeStyleManager;
+
+/**
+ * Compat for {@code DelegatingCodeStyleManager}. {@link CodeStyleManager} got a new method in
+ * 2020.2. #api201
+ */
+public class DelegatingCodeStyleManagerCompat {
+
+  private DelegatingCodeStyleManagerCompat() {}
+
+  // #api201: Method introduced in 2020.2. If not overridden, an exception is thrown upon class
+  // creation.
+  public static void scheduleReformatWhenSettingsComputed(CodeStyleManager delegate, PsiFile file) {
+    delegate.scheduleReformatWhenSettingsComputed(file);
+  }
+}

--- a/sdkcompat/v203/com/google/idea/sdkcompat/general/BaseSdkCompat.java
+++ b/sdkcompat/v203/com/google/idea/sdkcompat/general/BaseSdkCompat.java
@@ -1,0 +1,190 @@
+package com.google.idea.sdkcompat.general;
+
+import com.intellij.codeInsight.daemon.LineMarkerInfo;
+import com.intellij.codeInsight.daemon.LineMarkerProvider;
+import com.intellij.codeInsight.template.impl.TemplateManagerImpl;
+import com.intellij.diff.DiffContentFactoryImpl;
+import com.intellij.dvcs.branch.BranchType;
+import com.intellij.dvcs.branch.DvcsBranchManager;
+import com.intellij.dvcs.branch.DvcsBranchSettings;
+import com.intellij.find.findUsages.CustomUsageSearcher;
+import com.intellij.find.findUsages.FindUsagesOptions;
+import com.intellij.icons.AllIcons;
+import com.intellij.ide.impl.OpenProjectTask;
+import com.intellij.ide.plugins.PluginManagerCore;
+import com.intellij.ide.projectView.TreeStructureProvider;
+import com.intellij.ide.projectView.ViewSettings;
+import com.intellij.ide.scratch.ScratchesNamedScope;
+import com.intellij.ide.util.treeView.AbstractTreeNode;
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.extensions.PluginId;
+import com.intellij.openapi.extensions.ProjectExtensionPointName;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.openapi.projectRoots.SdkAdditionalData;
+import com.intellij.openapi.projectRoots.SdkType;
+import com.intellij.openapi.projectRoots.impl.ProjectJdkImpl;
+import com.intellij.openapi.projectRoots.impl.SdkConfigurationUtil;
+import com.intellij.openapi.vcs.FilePath;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.wm.ToolWindowManager;
+import com.intellij.platform.PlatformProjectOpenProcessor;
+import com.intellij.psi.PsiElement;
+import com.intellij.ui.EditorNotifications;
+import com.intellij.ui.EditorNotificationsImpl;
+import com.intellij.ui.EditorTextField;
+import com.intellij.ui.content.ContentManager;
+import com.intellij.usages.Usage;
+import com.intellij.util.ContentUtilEx;
+import com.intellij.util.Processor;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import javax.annotation.Nullable;
+import javax.swing.Icon;
+import javax.swing.JComponent;
+
+/** Provides SDK compatibility shims for base plugin API classes, available to all IDEs. */
+public final class BaseSdkCompat {
+  private BaseSdkCompat() {}
+
+  /** #api193: made public in 2020.1. */
+  public static ProjectExtensionPointName<EditorNotifications.Provider<?>>
+      getEditorNotificationsEp() {
+    return EditorNotificationsImpl.EP_PROJECT;
+  }
+
+  /** #api193: constructor changed in 2020.1. */
+  public static class DvcsBranchManagerAdapter extends DvcsBranchManager {
+    protected DvcsBranchManagerAdapter(
+        Project project, DvcsBranchSettings settings, BranchType[] branchTypes) {
+      super(project, settings, branchTypes);
+    }
+  }
+
+  /** #api193: wildcard generics added in 2020.1. */
+  public abstract static class CustomUsageSearcherAdapter extends CustomUsageSearcher {
+    /** #api193: wildcard generics added in 2020.1. */
+    @Override
+    public void processElementUsages(
+        PsiElement element, Processor<? super Usage> processor, FindUsagesOptions options) {
+      doProcessElementUsages(element, processor, options);
+    }
+
+    protected abstract void doProcessElementUsages(
+        PsiElement element, Processor<? super Usage> processor, FindUsagesOptions options);
+  }
+
+  /** #api193: wildcard generics added in 2020.1. */
+  public interface TreeStructureProviderAdapter extends TreeStructureProvider {
+    @Nullable
+    default Object doGetData(Collection<AbstractTreeNode<?>> selected, String dataId) {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    default Object getData(Collection<AbstractTreeNode<?>> selected, String dataId) {
+      return doGetData(selected, dataId);
+    }
+
+    @Override
+    default Collection<AbstractTreeNode<?>> modify(
+        AbstractTreeNode<?> parent,
+        Collection<AbstractTreeNode<?>> children,
+        ViewSettings settings) {
+      return doModify(parent, children, settings);
+    }
+
+    Collection<AbstractTreeNode<?>> doModify(
+        AbstractTreeNode<?> parent,
+        Collection<AbstractTreeNode<?>> children,
+        ViewSettings settings);
+  }
+
+  /** #api201: wildcard generics added in 2020.2. */
+  public interface LineMarkerProviderAdapter extends LineMarkerProvider {
+    @Override
+    default void collectSlowLineMarkers(
+        List<? extends PsiElement> elements, Collection<? super LineMarkerInfo<?>> result) {
+      doCollectSlowLineMarkers(elements, result);
+    }
+
+    void doCollectSlowLineMarkers(
+        List<? extends PsiElement> elements, Collection<? super LineMarkerInfo<?>> result);
+  }
+
+  /** #api193: changed in 2020.1 */
+  public static final String SCRATCHES_SCOPE_NAME = ScratchesNamedScope.scratchesAndConsoles();
+
+  /** #api193: 'project' param removed in 2020.1 */
+  public static void setTemplateTesting(Project project, Disposable parentDisposable) {
+    TemplateManagerImpl.setTemplateTesting(parentDisposable);
+  }
+
+  /** #api193: changed in 2020.1. */
+  @Nullable
+  public static String getActiveToolWindowId(Project project) {
+    return ToolWindowManager.getInstance(project).getActiveToolWindowId();
+  }
+
+  /** Compat class for {@link AllIcons}. */
+  public static final class AllIconsCompat {
+    private AllIconsCompat() {}
+
+    /** #api193: changed in 2020.1. */
+    public static final Icon collapseAll = AllIcons.Actions.Collapseall;
+
+    /** #api193: this is unavailable (and not used) in 2020.1 */
+    public static final Icon disabledRun = AllIcons.Process.Stop;
+
+    /** #api193: this is unavailable (and not used) in 2020.1 */
+    public static final Icon disabledDebug = AllIcons.Process.Stop;
+  }
+
+  /** #api193: SdkConfigurationUtil changed in 2020.1. */
+  public static ProjectJdkImpl createSdk(
+      Collection<? extends Sdk> allSdks,
+      VirtualFile homeDir,
+      SdkType sdkType,
+      @Nullable SdkAdditionalData additionalData,
+      @Nullable String customSdkSuggestedName) {
+    return SdkConfigurationUtil.createSdk(
+        allSdks, homeDir, sdkType, additionalData, customSdkSuggestedName);
+  }
+
+  /** #api201: project opening API changed in 2020.2. */
+  public static void openProject(Project project, Path projectFile) {
+    PlatformProjectOpenProcessor.openExistingProject(
+        /* file= */ projectFile,
+        /* projectDir= */ projectFile,
+        OpenProjectTask.withCreatedProject(project));
+  }
+
+  /** #api193: auto-disposed with UI component in 2020.1+ */
+  public static void disposeEditorTextField(EditorTextField field) {}
+
+  /** #api201: changed in 2020.2 */
+  public static boolean isDisabledPlugin(PluginId id) {
+    return PluginManagerCore.isDisabled(id);
+  }
+
+  /** #api201: changed in 2020.2 */
+  public static Charset guessCharsetFromVcsRevisionData(
+      Project project, byte[] revisionContent, FilePath filePath) {
+    return DiffContentFactoryImpl.guessCharset(project, revisionContent, filePath);
+  }
+
+  /** #api201: ContentUtilEx changed in 2020.2 */
+  public static void addTabbedContent(
+      ContentManager manager,
+      JComponent contentComponent,
+      String groupPrefix,
+      String tabName,
+      boolean select,
+      @Nullable Disposable childDisposable) {
+    ContentUtilEx.addTabbedContent(
+        manager, contentComponent, groupPrefix, tabName, select, childDisposable);
+  }
+}

--- a/sdkcompat/v203/com/google/idea/sdkcompat/platform/ServiceHelperCompat.java
+++ b/sdkcompat/v203/com/google/idea/sdkcompat/platform/ServiceHelperCompat.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.sdkcompat.platform;
+
+import com.google.common.base.Verify;
+import com.intellij.ide.plugins.IdeaPluginDescriptor;
+import com.intellij.ide.plugins.PluginManager;
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.components.ComponentManager;
+import com.intellij.serviceContainer.ComponentManagerImpl;
+import java.util.List;
+import java.util.Optional;
+
+/** #api193: wildcard generics added in 2020.1 */
+public class ServiceHelperCompat {
+  public static <T> void registerService(
+      ComponentManager componentManager,
+      Class<T> key,
+      T implementation,
+      Disposable parentDisposable) {
+    @SuppressWarnings({"rawtypes", "unchecked"}) // #api193: wildcard generics added in 2020.1
+    List<? extends IdeaPluginDescriptor> loadedPlugins = (List) PluginManager.getLoadedPlugins();
+    Optional<? extends IdeaPluginDescriptor> platformPlugin =
+        loadedPlugins.stream()
+            .filter(descriptor -> descriptor.getName().startsWith("IDEA CORE"))
+            .findAny();
+
+    Verify.verify(platformPlugin.isPresent());
+
+    ((ComponentManagerImpl) componentManager)
+        .registerServiceInstance(key, implementation, platformPlugin.get());
+  }
+
+  private ServiceHelperCompat() {}
+}

--- a/sdkcompat/v203/com/google/idea/sdkcompat/python/PyParserAdapter.java
+++ b/sdkcompat/v203/com/google/idea/sdkcompat/python/PyParserAdapter.java
@@ -1,0 +1,18 @@
+package com.google.idea.sdkcompat.python;
+
+import com.intellij.lang.SyntaxTreeBuilder;
+import com.jetbrains.python.parsing.ParsingContext;
+import com.jetbrains.python.parsing.PyParser;
+import com.jetbrains.python.psi.LanguageLevel;
+
+/** Compatibility adapter for {@link PyParser}. #api201 */
+public abstract class PyParserAdapter extends PyParser {
+
+  /** #api201: Super method uses new interface SyntaxTreeBuilder in 2020.2 */
+  @Override
+  protected ParsingContext createParsingContext(
+          SyntaxTreeBuilder builder, LanguageLevel languageLevel) {
+    return super.createParsingContext(builder, languageLevel);
+  }
+
+}

--- a/sdkcompat/v203/com/google/idea/sdkcompat/python/SyntaxTreeBuilderWrapper.java
+++ b/sdkcompat/v203/com/google/idea/sdkcompat/python/SyntaxTreeBuilderWrapper.java
@@ -1,0 +1,25 @@
+package com.google.idea.sdkcompat.python;
+
+import com.intellij.lang.SyntaxTreeBuilder;
+import java.util.function.Supplier;
+
+/**
+ * Compatibility wrapper to support that constructor of ParsingContext uses new interface
+ * SyntaxTreeBuilder in 2020.2. #api201
+ */
+public interface SyntaxTreeBuilderWrapper extends Supplier<SyntaxTreeBuilder> {
+
+  static SyntaxTreeBuilderWrapper wrap(SyntaxTreeBuilder builder) {
+    return () -> builder;
+  }
+
+  /**
+   * #api201: Compatibility wrapper for marker which is represented by a new interface in 2020.2.
+   */
+  interface MarkerWrapper extends Supplier<SyntaxTreeBuilder.Marker> {
+
+    static MarkerWrapper wrap(SyntaxTreeBuilder.Marker marker) {
+      return () -> marker;
+    }
+  }
+}

--- a/sdkcompat/v203/com/google/idea/sdkcompat/scala/ScalaTestRunLineMarkerProviderCompat.java
+++ b/sdkcompat/v203/com/google/idea/sdkcompat/scala/ScalaTestRunLineMarkerProviderCompat.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.sdkcompat.scala;
+
+import org.jetbrains.plugins.scala.testingSupport.test.ui.ScalaTestRunLineMarkerProvider;
+
+/**
+ * Compat class for {@link ScalaTestRunLineMarkerProvider} which was moved to a different package in
+ * 2020.2. #api201
+ */
+public class ScalaTestRunLineMarkerProviderCompat extends ScalaTestRunLineMarkerProvider {}

--- a/sdkcompat/v203/com/google/idea/sdkcompat/vcs/VcsRepositoryCreatorAdapter.java
+++ b/sdkcompat/v203/com/google/idea/sdkcompat/vcs/VcsRepositoryCreatorAdapter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.sdkcompat.vcs;
+
+import com.intellij.dvcs.repo.Repository;
+import com.intellij.dvcs.repo.VcsRepositoryCreator;
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import javax.annotation.Nullable;
+
+/**
+ * Compatibility adapter for {@link VcsRepositoryCreator}. Changed to an interface in 2020.2.
+ * #api201
+ */
+public abstract class VcsRepositoryCreatorAdapter implements VcsRepositoryCreator {
+
+  // #api201: Project parameter necessary to support implementation of createRepositoryIfValid() for
+  // versions <2020.2.
+  protected VcsRepositoryCreatorAdapter(Project myProject) {}
+
+  // #api201: No-arg constructor necessary to avoid an exception from 2020.2 on.
+  protected VcsRepositoryCreatorAdapter() {}
+
+  @Nullable
+  public abstract Repository createRepository(
+      Project project, VirtualFile root, Disposable parentDisposable);
+
+  @Nullable
+  @Override
+  // #api201: Project parameter added in 2020.2
+  public Repository createRepositoryIfValid(
+      Project project, VirtualFile root, Disposable parentDisposable) {
+    return createRepository(project, root, parentDisposable);
+  }
+}

--- a/testing/BUILD
+++ b/testing/BUILD
@@ -35,10 +35,13 @@ java_library(
         "clion-2019.3": glob(["testcompat/v201/com/google/idea/sdkcompat/**/*.java"]),
         "clion-2020.1": glob(["testcompat/v201/com/google/idea/sdkcompat/**/*.java"]),
         "clion-2020.2": glob(["testcompat/v202/com/google/idea/sdkcompat/**/*.java"]),
+        "clion-2020.3": glob(["testcompat/v202/com/google/idea/sdkcompat/**/*.java"]),
         "intellij-2020.1": glob(["testcompat/v201/com/google/idea/sdkcompat/**/*.java"]),
         "intellij-ue-2020.1": glob(["testcompat/v201/com/google/idea/sdkcompat/**/*.java"]),
         "intellij-2020.2": glob(["testcompat/v202/com/google/idea/sdkcompat/**/*.java"]),
         "intellij-ue-2020.2": glob(["testcompat/v202/com/google/idea/sdkcompat/**/*.java"]),
+        "intellij-2020.3": glob(["testcompat/v202/com/google/idea/sdkcompat/**/*.java"]),
+        "intellij-ue-2020.3": glob(["testcompat/v202/com/google/idea/sdkcompat/**/*.java"]),
         "default": [],
     }),
     deps = [

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -12,6 +12,8 @@ java_library(
         "intellij-ue-2020.1": ["@go_2020_1//:go"],
         "intellij-2020.2": ["@go_2020_2//:go"],
         "intellij-ue-2020.2": ["@go_2020_2//:go"],
+        "intellij-2020.3": ["@go_2020_3//:go"],
+        "intellij-ue-2020.3": ["@go_2020_3//:go"],
         "default": [],
     }),
 )

--- a/third_party/javascript/BUILD
+++ b/third_party/javascript/BUILD
@@ -11,6 +11,7 @@ java_library(
     exports = select_for_plugin_api({
         "intellij-ue-2020.1": ["@intellij_ue_2020_1//:javascript"],
         "intellij-ue-2020.2": ["@intellij_ue_2020_2//:javascript"],
+        "intellij-ue-2020.3": ["@intellij_ue_2020_3//:javascript"],
         "clion-2019.3": ["@clion_2019_3//:javascript"],
         "clion-2020.1": ["@clion_2020_1//:javascript"],
         "clion-2020.2": ["@clion_2020_2//:javascript"],
@@ -25,6 +26,7 @@ java_library(
     exports = select_for_plugin_api({
         "intellij-ue-2020.1": ["@intellij_ue_2020_1//:css"],
         "intellij-ue-2020.2": ["@intellij_ue_2020_2//:css"],
+        "intellij-ue-2020.3": ["@intellij_ue_2020_3//:css"],
         "clion-2019.3": ["@clion_2019_3//:css"],
         "clion-2020.1": ["@clion_2020_1//:css"],
         "clion-2020.2": ["@clion_2020_2//:css"],
@@ -39,6 +41,7 @@ java_library(
     exports = select_for_plugin_api({
         "intellij-ue-2020.1": ["@intellij_ue_2020_1//:tslint"],
         "intellij-ue-2020.2": ["@intellij_ue_2020_2//:tslint"],
+        "intellij-ue-2020.3": ["@intellij_ue_2020_3//:tslint"],
         "clion-2019.3": ["@clion_2019_3//:tslint"],
         "clion-2020.1": ["@clion_2020_1//:tslint"],
         "clion-2020.2": ["@clion_2020_2//:tslint"],
@@ -53,6 +56,7 @@ java_library(
     exports = select_for_plugin_api({
         "intellij-ue-2020.1": ["@intellij_ue_2020_1//:angular"],
         "intellij-ue-2020.2": ["@intellij_ue_2020_2//:angular"],
+        "intellij-ue-2020.3": ["@intellij_ue_2020_3//:angular"],
         "clion-2019.3": ["@intellij_ue_2019_3//:angular"],
         "clion-2020.1": ["@intellij_ue_2020_1//:angular"],
         "clion-2020.2": ["@intellij_ue_2020_2//:angular"],

--- a/third_party/javascript/BUILD
+++ b/third_party/javascript/BUILD
@@ -15,6 +15,7 @@ java_library(
         "clion-2019.3": ["@clion_2019_3//:javascript"],
         "clion-2020.1": ["@clion_2020_1//:javascript"],
         "clion-2020.2": ["@clion_2020_2//:javascript"],
+        "clion-2020.3": ["@clion_2020_3//:javascript"],
         "default": [],
     }),
 )
@@ -30,6 +31,7 @@ java_library(
         "clion-2019.3": ["@clion_2019_3//:css"],
         "clion-2020.1": ["@clion_2020_1//:css"],
         "clion-2020.2": ["@clion_2020_2//:css"],
+        "clion-2020.3": ["@clion_2020_3//:css"],
         "default": [],
     }),
 )
@@ -45,6 +47,7 @@ java_library(
         "clion-2019.3": ["@clion_2019_3//:tslint"],
         "clion-2020.1": ["@clion_2020_1//:tslint"],
         "clion-2020.2": ["@clion_2020_2//:tslint"],
+        "clion-2020.3": ["@clion_2020_3//:tslint"],
         "default": [],
     }),
 )
@@ -60,6 +63,7 @@ java_library(
         "clion-2019.3": ["@intellij_ue_2019_3//:angular"],
         "clion-2020.1": ["@intellij_ue_2020_1//:angular"],
         "clion-2020.2": ["@intellij_ue_2020_2//:angular"],
+        "clion-2020.3": ["@intellij_ue_2020_3//:angular"],
         "default": [],
     }),
 )

--- a/third_party/python/BUILD
+++ b/third_party/python/BUILD
@@ -12,6 +12,8 @@ java_library(
         "intellij-ue-2020.1": ["@python_2020_1//:python"],
         "intellij-2020.2": ["@python_2020_2//:python"],
         "intellij-ue-2020.2": ["@python_2020_2//:python"],
+        "intellij-2020.3": ["@python_2020_3//:python"],
+        "intellij-ue-2020.3": ["@python_2020_3//:python"],
         "clion-2019.3": ["@clion_2019_3//:python"],
         "clion-2020.1": ["@clion_2020_1//:python"],
         "clion-2020.2": ["@clion_2020_2//:python"],

--- a/third_party/python/BUILD
+++ b/third_party/python/BUILD
@@ -17,6 +17,7 @@ java_library(
         "clion-2019.3": ["@clion_2019_3//:python"],
         "clion-2020.1": ["@clion_2020_1//:python"],
         "clion-2020.2": ["@clion_2020_2//:python"],
+        "clion-2020.3": ["@clion_2020_3//:python"],
         "android-studio-4.1": ["@python_2020_1//:python"],
         "android-studio-4.2": ["@python_2020_2//:python"],
         "android-studio-2020.3": ["@python_2020_2//:python"],

--- a/third_party/scala/BUILD
+++ b/third_party/scala/BUILD
@@ -12,6 +12,8 @@ java_library(
         "intellij-ue-2020.1": ["@scala_2020_1//:scala"],
         "intellij-2020.2": ["@scala_2020_2//:scala"],
         "intellij-ue-2020.2": ["@scala_2020_2//:scala"],
+        "intellij-2020.3": ["@scala_2020_3//:scala"],
+        "intellij-ue-2020.3": ["@scala_2020_3//:scala"],
         "default": [],
     }),
 )


### PR DESCRIPTION
ij_product definitions are intellij-canary and intellij-ue-canary

Signed-off-by: Chaitanya Munukutla <chaitanya.m61292@gmail.com>

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #2102

# Description of this change

This PR adds support for IntelliJ 2020.3. CLion 2020.3 is NOT supported yet.