### PR TITLE
Run tests also on Java 11 (via ubuntu1804)

### DIFF
--- a/.bazelci/aspect.yml
+++ b/.bazelci/aspect.yml
@@ -12,11 +12,11 @@ platforms:
       - //aspect/testing/...
   ubuntu1804:
     build_flags:
-    - --define=ij_product=intellij-beta
+      - --define=ij_product=intellij-beta
     build_targets:
-    - //aspect:aspect_files
+      - //aspect:aspect_files
     test_flags:
-    - --define=ij_product=intellij-beta
-    - --test_output=errors
+      - --define=ij_product=intellij-beta
+      - --test_output=errors
     test_targets:
-    - //aspect/testing/...
+      - //aspect/testing/...

--- a/.bazelci/aspect.yml
+++ b/.bazelci/aspect.yml
@@ -10,3 +10,13 @@ platforms:
       - --test_output=errors
     test_targets:
       - //aspect/testing/...
+  ubuntu1804:
+    build_flags:
+    - --define=ij_product=intellij-beta
+    build_targets:
+    - //aspect:aspect_files
+    test_flags:
+    - --define=ij_product=intellij-beta
+    - --test_output=errors
+    test_targets:
+    - //aspect/testing/...

--- a/.bazelci/clion.yml
+++ b/.bazelci/clion.yml
@@ -10,3 +10,13 @@ platforms:
       - --test_output=errors
     test_targets:
       - //:clwb_tests
+  ubuntu1804:
+    build_flags:
+    - --define=ij_product=clion-beta
+    build_targets:
+    - //clwb/...
+    test_flags:
+    - --define=ij_product=clion-beta
+    - --test_output=errors
+    test_targets:
+    - //:clwb_tests

--- a/.bazelci/clion.yml
+++ b/.bazelci/clion.yml
@@ -12,11 +12,11 @@ platforms:
       - //:clwb_tests
   ubuntu1804:
     build_flags:
-    - --define=ij_product=clion-beta
+      - --define=ij_product=clion-beta
     build_targets:
-    - //clwb/...
+      - //clwb/...
     test_flags:
-    - --define=ij_product=clion-beta
-    - --test_output=errors
+      - --define=ij_product=clion-beta
+      - --test_output=errors
     test_targets:
-    - //:clwb_tests
+      - //:clwb_tests

--- a/.bazelci/intellij.yml
+++ b/.bazelci/intellij.yml
@@ -12,12 +12,12 @@ platforms:
       - //:ijwb_tests
   ubuntu1804:
     build_flags:
-    - --define=ij_product=intellij-beta
+      - --define=ij_product=intellij-beta
     build_targets:
-    - //ijwb/...
+      - //ijwb/...
     test_flags:
-    - --define=ij_product=intellij-beta
-    - --test_output=errors
+      - --define=ij_product=intellij-beta
+      - --test_output=errors
     test_targets:
-    - //:ijwb_tests
+      - //:ijwb_tests
 

--- a/.bazelci/intellij.yml
+++ b/.bazelci/intellij.yml
@@ -10,3 +10,14 @@ platforms:
       - --test_output=errors
     test_targets:
       - //:ijwb_tests
+  ubuntu1804:
+    build_flags:
+    - --define=ij_product=intellij-beta
+    build_targets:
+    - //ijwb/...
+    test_flags:
+    - --define=ij_product=intellij-beta
+    - --test_output=errors
+    test_targets:
+    - //:ijwb_tests
+


### PR DESCRIPTION
The IntelliJ platform SDKs already switched to Java 11 and the plugins will be
running in a Java 11 environment. Hence, build and tests the plugins also in
the context of Java 11. To do so, we need to choose a test environment which
features Java 11 as default JDK. ubuntu1804 is one of those (see #722).

For the moment, we'll keep the ubuntu1604 configuration to have a graceful
transition period. We expect to drop that configuration soon as we don't need
Java 8 compatibility anymore.
