### PR TITLE
Updating sha256 of python and scala

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -110,7 +110,7 @@ http_archive(
         "    visibility = ['//visibility:public'],",
         ")",
     ]),
-    sha256 = "a3d7217794619dfa0432d922218dd875f49658939c6e5a54c01f99b333d35e12",
+    sha256 = "648438d26e85072f90a62f9f5b9f9b983a49f3cb752e87d01f915cb6a03644b9",
     url = "https://plugins.jetbrains.com/files/7322/88054/python-ce-201.7846.93.zip",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -194,7 +194,7 @@ http_archive(
         "    visibility = ['//visibility:public'],",
         ")",
     ]),
-    sha256 = "bbc019e7cde3baf21b11f0abde21f42d4606ca5ca9100b3bdace3292f70cceef",
+    sha256 = "626b9c9bc2f90d64498524bd7138558edacf50bbc72a02f882401118a1fc1403",
     url = "https://plugins.jetbrains.com/files/1347/76628/scala-intellij-bin-2020.1.7.zip",
 )
 


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.



Issue number: #2343

# Description of this change
Build is failing on 
`ERROR: /home/builduser/workspace/intellij-plugins-ci/intellij-check-and-notify-plugins-state/intellij/third_party/python/BUILD:7:13: //third_party/python:python_internal depends on @python_2020_1//:python in repository @python_2020_1 which failed to fetch. no such package '@python_2020_1//': java.io.IOException: Error downloading [https://plugins.jetbrains.com/files/7322/88054/python-ce-201.7846.93.zip] to /home/builduser/.cache/bazel/_bazel_builduser/1c03a469a8e977776a02273bfa495afd/external/python_2020_1/python-ce-201.7846.93.zip: Checksum was 648438d26e85072f90a62f9f5b9f9b983a49f3cb752e87d01f915cb6a03644b9 but wanted a3d7217794619dfa0432d922218dd875f49658939c6e5a54c01f99b333d35e12` 

and 

`Error in download_and_extract: java.io.IOException: Error downloading [https://plugins.jetbrains.com/files/1347/76628/scala-intellij-bin-2020.1.7.zip] to /home/builduser/.cache/bazel/_bazel_builduser/1c03a469a8e977776a02273bfa495afd/external/scala_2020_1/scala-intellij-bin-2020.1.7.zip: Checksum was 626b9c9bc2f90d64498524bd7138558edacf50bbc72a02f882401118a1fc1403 but wanted bbc019e7cde3baf21b11f0abde21f42d4606ca5ca9100b3bdace3292f70cceef`

Manually downloading from those URL reveals that the content has indeed changed :-/