### PR TITLE
Remove .so libraries from layoutlib_data.

### DIFF
--- a/intellij_platform_sdk/BUILD.android_studio203
+++ b/intellij_platform_sdk/BUILD.android_studio203
@@ -44,9 +44,12 @@ java_import(
 
 filegroup(
     name = "layoutlib_data",
-    srcs = glob([
-        "android-studio/plugins/android/lib/layoutlib/**/*",
-    ]),
+    srcs = glob(
+        [
+            "android-studio/plugins/android/lib/layoutlib/**/*",
+        ],
+        exclude = ["**/*.so"],
+    ),
 )
 
 java_import(

--- a/intellij_platform_sdk/BUILD.android_studio42
+++ b/intellij_platform_sdk/BUILD.android_studio42
@@ -44,9 +44,12 @@ java_import(
 
 filegroup(
     name = "layoutlib_data",
-    srcs = glob([
-        "android-studio/plugins/android/lib/layoutlib/**/*",
-    ]),
+    srcs = glob(
+        [
+            "android-studio/plugins/android/lib/layoutlib/**/*",
+        ],
+        exclude = ["**/*.so"],
+    ),
 )
 
 java_import(


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

# Discussion thread for this change

Issue number: https://github.com/bazelbuild/intellij/issues/2368

# Description of this change

The .so libraries are not used as native dependencies (the tests
continue to pass).

Bazel is undergoing modification where those file won't be collected
anymore (not added to --java.library.path parameter when executing JVM).

Additional information on https://github.com/bazelbuild/bazel/issues/13043
