### PR TITLE
Stop running the tests on Java 8 (via ubuntu 1604)

### DIFF
--- a/.bazelci/aspect.yml
+++ b/.bazelci/aspect.yml
@@ -1,15 +1,5 @@
 ---
 platforms:
-  ubuntu1604:
-    build_flags:
-      - --define=ij_product=intellij-beta
-    build_targets:
-      - //aspect:aspect_files
-    test_flags:
-      - --define=ij_product=intellij-beta
-      - --test_output=errors
-    test_targets:
-      - //aspect/testing/...
   ubuntu1804:
     build_flags:
       - --define=ij_product=intellij-beta

--- a/.bazelci/clion.yml
+++ b/.bazelci/clion.yml
@@ -1,15 +1,5 @@
 ---
 platforms:
-  ubuntu1604:
-    build_flags:
-      - --define=ij_product=clion-beta
-    build_targets:
-      - //clwb/...
-    test_flags:
-      - --define=ij_product=clion-beta
-      - --test_output=errors
-    test_targets:
-      - //:clwb_tests
   ubuntu1804:
     build_flags:
       - --define=ij_product=clion-beta

--- a/.bazelci/intellij.yml
+++ b/.bazelci/intellij.yml
@@ -1,15 +1,5 @@
 ---
 platforms:
-  ubuntu1604:
-    build_flags:
-      - --define=ij_product=intellij-beta
-    build_targets:
-      - //ijwb/...
-    test_flags:
-      - --define=ij_product=intellij-beta
-      - --test_output=errors
-    test_targets:
-      - //:ijwb_tests
   ubuntu1804:
     build_flags:
       - --define=ij_product=intellij-beta
@@ -20,4 +10,3 @@ platforms:
       - --test_output=errors
     test_targets:
       - //:ijwb_tests
-


### PR DESCRIPTION
Current versions of IntelliJ/CLion run with JDK 11 and hence we don't
need compatibility with Java 8 anymore. This doesn't mean that we can
start using Java language features of Java 9+ immediately. That's still
a bit out in the future.