### PR TITLE
Add a test configuration for IntelliJ UE

### DIFF
--- a/.bazelci/intellij-ue.yml
+++ b/.bazelci/intellij-ue.yml
@@ -1,0 +1,12 @@
+---
+platforms:
+  ubuntu1804:
+    build_flags:
+      - --define=ij_product=intellij-ue-beta
+    build_targets:
+      - //ijwb/...
+    test_flags:
+      - --define=ij_product=intellij-ue-beta
+      - --test_output=errors
+    test_targets:
+      - //:ijwb_ue_tests


### PR DESCRIPTION
Until now, we've only automatically run the tests for IntelliJ CE.
This means that we catch issues with the UE version only much later
(e.g. when we build and test it for the upload to the public plugin
repository). Let's change this.