### PR TITLE
Correct test target of IntelliJ CE configuration

### DIFF
--- a/.bazelci/intellij.yml
+++ b/.bazelci/intellij.yml
@@ -9,4 +9,4 @@ platforms:
       - --define=ij_product=intellij-beta
       - --test_output=errors
     test_targets:
-      - //:ijwb_tests
+      - //:ijwb_ce_tests


### PR DESCRIPTION
The IntelliJ tests were split up into CE and UE tests in the past.
The general ijwb_tests target was only kept for compatibility with our
test configuration. Hence, cleanup the test configuration so that we
can remove this unnecessary target.