### PR TITLE
[Bazel] [intellij] Always clear app data before running instrumentation tests through adb

### DIFF
--- a/aswb/sdkcompat/as203/com/google/idea/blaze/android/run/test/StockAndroidTestLaunchTask.java
+++ b/aswb/sdkcompat/as203/com/google/idea/blaze/android/run/test/StockAndroidTestLaunchTask.java
@@ -23,9 +23,10 @@ class StockAndroidTestLaunchTask extends StockAndroidTestLaunchTaskBase {
   StockAndroidTestLaunchTask(
       BlazeAndroidTestRunConfigurationState configState,
       String runner,
+      String appPackage,
       String testPackage,
       boolean waitForDebugger) {
-    super(configState, runner, testPackage, waitForDebugger);
+    super(configState, runner, appPackage, testPackage, waitForDebugger);
   }
 
   @Override

--- a/aswb/sdkcompat/as42/com/google/idea/blaze/android/run/test/StockAndroidTestLaunchTask.java
+++ b/aswb/sdkcompat/as42/com/google/idea/blaze/android/run/test/StockAndroidTestLaunchTask.java
@@ -23,9 +23,10 @@ class StockAndroidTestLaunchTask extends StockAndroidTestLaunchTaskBase {
   StockAndroidTestLaunchTask(
       BlazeAndroidTestRunConfigurationState configState,
       String runner,
+      String appPackage,
       String testPackage,
       boolean waitForDebugger) {
-    super(configState, runner, testPackage, waitForDebugger);
+    super(configState, runner, appPackage, testPackage, waitForDebugger);
   }
 
   @Override


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change
Issue number: https://github.com/bazelbuild/intellij/issues/2540

# Description of this change
Some of our devs reporting that clearing app data before running instrumentation tests could reduce flakiness. This pr adds the `adb pm clear` step before running the instrumentation tests
