### PR TITLE
Quote same_pkg_direct_rdeps argument

### DIFF
--- a/base/src/com/google/idea/blaze/base/dependencies/BlazeQuerySourceToTargetProvider.java
+++ b/base/src/com/google/idea/blaze/base/dependencies/BlazeQuerySourceToTargetProvider.java
@@ -104,7 +104,7 @@ public class BlazeQuerySourceToTargetProvider implements SourceToTargetProvider 
       return ImmutableList.of();
     }
     String expr = Joiner.on('+').join(sources);
-    String query = String.format("same_pkg_direct_rdeps(%s)", expr);
+    String query = String.format("same_pkg_direct_rdeps('%s')", expr);
 
     // never use a custom output base for queries during sync
     String outputBaseFlag =


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: https://github.com/bazelbuild/intellij/issues/2570

# Description of this change

Sometimes an error `Error while parsing 'same_pkg_direct_rdeps(<...>)'`  appears when syncing bazel repo:
```
Syncing project: Sync (incremental)...
Updating VCS...
Running Bazel info...
Command: /usr/local/bin/bazel info --tool_tag=ijwb:IDEA:community --curses=no --color=yes --progress_in_terminal_title=no --
Command: git diff --name-status --no-renames 39decda9b1b4f711ce850a48de940518eafb6df2
INFO: Invocation ID: b776fb7b-1749-4a98-abc1-d22fcccaa87c
Computing VCS working set...
  ...
  some path/with spaces (modified)
  ...
  (and 10 more)
Querying targets building source files...
Command: /usr/local/bin/bazel query --tool_tag=ijwb:IDEA:community --output=label_kind --keep_going "same_pkg_direct_rdeps(some
path/with
spaces
Loading: 0 packages loaded
ERROR: Error while parsing 'same_pkg_direct_rdeps(some
path/with
spaces...[truncated]': syntax error at 'path/with'
Loading: 0 packages loaded
Loading: 0 packages loaded
Sync finished
Sync failed
```

This can be fixed easily if `same_pkg_direct_rdeps` argument is quoted.
