### PR TITLE
Add tests against all supported IDE versions to the project CI

### DIFF
--- a/.bazelci/android-studio.yml
+++ b/.bazelci/android-studio.yml
@@ -24,8 +24,8 @@ tasks:
       - --test_output=errors
     test_targets:
       - //:aswb_tests
-  Android-Studio-internal-canary:
-    name: Android Studio Internal Canary
+  Android-Studio-internal-under-dev:
+    name: Android Studio Internal Under Development
     platform: ubuntu1804
     build_flags:
       - --define=ij_product=android-studio-canary
@@ -36,6 +36,8 @@ tasks:
       - --test_output=errors
     test_targets:
       - //:aswb_tests
+    soft_fail:
+      - exit_status: 1
   Android-Studio-OSS-stable:
     name: Android Studio OSS Stable
     platform: ubuntu1804

--- a/.bazelci/android-studio.yml
+++ b/.bazelci/android-studio.yml
@@ -1,6 +1,20 @@
 ---
-platforms:
-  ubuntu1804:
+tasks:
+  Android-Studio-internal-stable:
+    name: Android Studio Internal Stable
+    platform: ubuntu1804
+    build_flags:
+      - --define=ij_product=android-studio-latest
+    build_targets:
+      - //aswb/...
+    test_flags:
+      - --define=ij_product=android-studio-latest
+      - --test_output=errors
+    test_targets:
+      - //:aswb_tests
+  Android-Studio-internal-beta:
+    name: Android Studio Internal Beta
+    platform: ubuntu1804
     build_flags:
       - --define=ij_product=android-studio-beta
     build_targets:
@@ -10,3 +24,54 @@ platforms:
       - --test_output=errors
     test_targets:
       - //:aswb_tests
+  Android-Studio-internal-canary:
+    name: Android Studio Internal Canary
+    platform: ubuntu1804
+    build_flags:
+      - --define=ij_product=android-studio-canary
+    build_targets:
+      - //aswb/...
+    test_flags:
+      - --define=ij_product=android-studio-canary
+      - --test_output=errors
+    test_targets:
+      - //:aswb_tests
+  Android-Studio-OSS-stable:
+    name: Android Studio OSS Stable
+    platform: ubuntu1804
+    build_flags:
+      - --define=ij_product=android-studio-oss-stable
+    build_targets:
+      - //aswb/...
+    test_flags:
+      - --define=ij_product=android-studio-oss-stable
+      - --test_output=errors
+    test_targets:
+      - //:aswb_tests
+  Android-Studio-OSS-beta:
+    name: Android Studio OSS Beta
+    platform: ubuntu1804
+    build_flags:
+      - --define=ij_product=android-studio-oss-beta
+    build_targets:
+      - //aswb/...
+    test_flags:
+      - --define=ij_product=android-studio-oss-beta
+      - --test_output=errors
+    test_targets:
+      - //:aswb_tests
+  Android-Studio-OSS-under-dev:
+    name: Android Studio OSS Under Development
+    platform: ubuntu1804
+    build_flags:
+      - --define=ij_product=android-studio-oss-under-dev
+    build_targets:
+      - //aswb/...
+    test_flags:
+      - --define=ij_product=android-studio-oss-under-dev
+      - --test_output=errors
+    test_targets:
+      - //:aswb_tests
+    soft_fail:
+      - exit_status: 1
+

--- a/.bazelci/android-studio.yml
+++ b/.bazelci/android-studio.yml
@@ -24,8 +24,8 @@ tasks:
       - --test_output=errors
     test_targets:
       - //:aswb_tests
-  Android-Studio-internal-under-dev:
-    name: Android Studio Internal Under Development
+  Android-Studio-internal-canary:
+    name: Android Studio Internal Canary
     platform: ubuntu1804
     build_flags:
       - --define=ij_product=android-studio-canary

--- a/.bazelci/clion.yml
+++ b/.bazelci/clion.yml
@@ -1,6 +1,20 @@
 ---
-platforms:
-  ubuntu1804:
+tasks:
+  CLion-internal-stable:
+    name: CLion Internal Stable
+    platform: ubuntu1804
+    build_flags:
+      - --define=ij_product=clion-latest
+    build_targets:
+      - //clwb/...
+    test_flags:
+      - --define=ij_product=clion-latest
+      - --test_output=errors
+    test_targets:
+      - //:clwb_tests
+  CLion-internal-beta:
+    name: CLion Internal Beta
+    platform: ubuntu1804
     build_flags:
       - --define=ij_product=clion-beta
     build_targets:
@@ -10,3 +24,41 @@ platforms:
       - --test_output=errors
     test_targets:
       - //:clwb_tests
+  CLion-OSS-stable:
+    name: CLion OSS Stable
+    platform: ubuntu1804
+    build_flags:
+      - --define=ij_product=clion-oss-stable
+    build_targets:
+      - //clwb/...
+    test_flags:
+      - --define=ij_product=clion-oss-stable
+      - --test_output=errors
+    test_targets:
+      - //:clwb_tests
+  CLion-OSS-beta:
+    name: CLion OSS Beta
+    platform: ubuntu1804
+    build_flags:
+      - --define=ij_product=clion-oss-beta
+    build_targets:
+      - //clwb/...
+    test_flags:
+      - --define=ij_product=clion-oss-beta
+      - --test_output=errors
+    test_targets:
+      - //:clwb_tests
+  CLion-OSS-under-dev:
+    name: CLion OSS Under Development
+    platform: ubuntu1804
+    build_flags:
+      - --define=ij_product=clion-oss-under-dev
+    build_targets:
+      - //clwb/...
+    test_flags:
+      - --define=ij_product=clion-oss-under-dev
+      - --test_output=errors
+    test_targets:
+      - //:clwb_tests
+    soft_fail:
+      - exit_status: 1

--- a/.bazelci/intellij-ue.yml
+++ b/.bazelci/intellij-ue.yml
@@ -36,6 +36,8 @@ tasks:
       - --test_output=errors
     test_targets:
       - //:ijwb_ue_tests
+    soft_fail:
+      - exit_status: 1
   IntelliJ-UE-OSS-stable:
     name: IntelliJ UE OSS Stable
     platform: ubuntu1804

--- a/.bazelci/intellij-ue.yml
+++ b/.bazelci/intellij-ue.yml
@@ -24,8 +24,8 @@ tasks:
       - --test_output=errors
     test_targets:
       - //:ijwb_ue_tests
-  IntelliJ-UE-internal-canary:
-    name: IntelliJ UE Internal Canary
+  IntelliJ-UE-internal-under-dev:
+    name: IntelliJ UE Internal Under Development
     platform: ubuntu1804
     build_flags:
       - --define=ij_product=intellij-ue-canary

--- a/.bazelci/intellij-ue.yml
+++ b/.bazelci/intellij-ue.yml
@@ -1,6 +1,20 @@
 ---
-platforms:
-  ubuntu1804:
+tasks:
+  IntelliJ-UE-internal-stable:
+    name: IntelliJ UE Internal Stable
+    platform: ubuntu1804
+    build_flags:
+      - --define=ij_product=intellij-ue-latest
+    build_targets:
+      - //ijwb/...
+    test_flags:
+      - --define=ij_product=intellij-ue-latest
+      - --test_output=errors
+    test_targets:
+      - //:ijwb_ue_tests
+  IntelliJ-UE-internal-beta:
+    name: IntelliJ UE Internal Beta
+    platform: ubuntu1804
     build_flags:
       - --define=ij_product=intellij-ue-beta
     build_targets:
@@ -10,3 +24,54 @@ platforms:
       - --test_output=errors
     test_targets:
       - //:ijwb_ue_tests
+  IntelliJ-UE-internal-canary:
+    name: IntelliJ UE Internal Canary
+    platform: ubuntu1804
+    build_flags:
+      - --define=ij_product=intellij-ue-canary
+    build_targets:
+      - //ijwb/...
+    test_flags:
+      - --define=ij_product=intellij-ue-canary
+      - --test_output=errors
+    test_targets:
+      - //:ijwb_ue_tests
+  IntelliJ-UE-OSS-stable:
+    name: IntelliJ UE OSS Stable
+    platform: ubuntu1804
+    build_flags:
+      - --define=ij_product=intellij-ue-oss-stable
+    build_targets:
+      - //ijwb/...
+    test_flags:
+      - --define=ij_product=intellij-ue-oss-stable
+      - --test_output=errors
+    test_targets:
+      - //:ijwb_ue_tests
+  IntelliJ-UE-OSS-beta:
+    name: IntelliJ UE OSS Beta
+    platform: ubuntu1804
+    build_flags:
+      - --define=ij_product=intellij-ue-oss-beta
+    build_targets:
+      - //ijwb/...
+    test_flags:
+      - --define=ij_product=intellij-ue-oss-beta
+      - --test_output=errors
+    test_targets:
+      - //:ijwb_ue_tests
+  IntelliJ-UE-OSS-under-dev:
+    name: IntelliJ UE OSS Under Development
+    platform: ubuntu1804
+    build_flags:
+      - --define=ij_product=intellij-ue-oss-under-dev
+    build_targets:
+      - //ijwb/...
+    test_flags:
+      - --define=ij_product=intellij-ue-oss-under-dev
+      - --test_output=errors
+    test_targets:
+      - //:ijwb_ue_tests
+    soft_fail:
+      - exit_status: 1
+

--- a/.bazelci/intellij.yml
+++ b/.bazelci/intellij.yml
@@ -1,6 +1,20 @@
 ---
-platforms:
-  ubuntu1804:
+tasks:
+  IntelliJ-CE-internal-stable:
+    name: IntelliJ CE Internal Stable
+    platform: ubuntu1804
+    build_flags:
+      - --define=ij_product=intellij-latest
+    build_targets:
+      - //ijwb/...
+    test_flags:
+      - --define=ij_product=intellij-latest
+      - --test_output=errors
+    test_targets:
+      - //:ijwb_ce_tests
+  IntelliJ-CE-internal-beta:
+    name: IntelliJ CE Internal Beta
+    platform: ubuntu1804
     build_flags:
       - --define=ij_product=intellij-beta
     build_targets:
@@ -10,3 +24,54 @@ platforms:
       - --test_output=errors
     test_targets:
       - //:ijwb_ce_tests
+  IntelliJ-CE-internal-canary:
+    name: IntelliJ CE Internal Canary
+    platform: ubuntu1804
+    build_flags:
+      - --define=ij_product=intellij-canary
+    build_targets:
+      - //ijwb/...
+    test_flags:
+      - --define=ij_product=intellij-canary
+      - --test_output=errors
+    test_targets:
+      - //:ijwb_ce_tests
+  IntelliJ-CE-OSS-stable:
+    name: IntelliJ CE OSS Stable
+    platform: ubuntu1804
+    build_flags:
+      - --define=ij_product=intellij-oss-stable
+    build_targets:
+      - //ijwb/...
+    test_flags:
+      - --define=ij_product=intellij-oss-stable
+      - --test_output=errors
+    test_targets:
+      - //:ijwb_ce_tests
+  IntelliJ-CE-OSS-beta:
+    name: IntelliJ CE OSS Beta
+    platform: ubuntu1804
+    build_flags:
+      - --define=ij_product=intellij-oss-beta
+    build_targets:
+      - //ijwb/...
+    test_flags:
+      - --define=ij_product=intellij-oss-beta
+      - --test_output=errors
+    test_targets:
+      - //:ijwb_ce_tests
+  IntelliJ-CE-OSS-under-dev:
+    name: IntelliJ CE OSS Under Development
+    platform: ubuntu1804
+    build_flags:
+      - --define=ij_product=intellij-oss-under-dev
+    build_targets:
+      - //ijwb/...
+    test_flags:
+      - --define=ij_product=intellij-oss-under-dev
+      - --test_output=errors
+    test_targets:
+      - //:ijwb_ce_tests
+    soft_fail:
+      - exit_status: 1
+

--- a/.bazelci/intellij.yml
+++ b/.bazelci/intellij.yml
@@ -24,8 +24,8 @@ tasks:
       - --test_output=errors
     test_targets:
       - //:ijwb_ce_tests
-  IntelliJ-CE-internal-canary:
-    name: IntelliJ CE Internal Canary
+  IntelliJ-CE-internal-under-dev:
+    name: IntelliJ CE Internal Under Development
     platform: ubuntu1804
     build_flags:
       - --define=ij_product=intellij-canary

--- a/.bazelci/intellij.yml
+++ b/.bazelci/intellij.yml
@@ -36,6 +36,8 @@ tasks:
       - --test_output=errors
     test_targets:
       - //:ijwb_ce_tests
+    soft_fail:
+      - exit_status: 1
   IntelliJ-CE-OSS-stable:
     name: IntelliJ CE OSS Stable
     platform: ubuntu1804


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

# Discussion thread for this change

Issue number: #2595

# Description of this change

This pull request adds tasks for testing against all the IDE versions supported internally and externally. I update the CI config files to include a task for testing against every supported version.

I also added a soft fail option for the IDE version that we currently work towards supporting (labeled as under development) so that its failure won't affect the overall check status. Testing against this version is expected to fail for most PRs until we fully support it but we want the whole presubmit test pipeline to succeed if the tests against older versions passes. This will allow us to merge the pull request, of course, after checking that the failed test log does not contain anything that should have passed and was broken by the PR.
