### PR TITLE
Add --notrim_test_configuration to Bazel CI configuration

### DIFF
--- a/.bazelci/aspect.yml
+++ b/.bazelci/aspect.yml
@@ -8,5 +8,6 @@ platforms:
     test_flags:
       - --define=ij_product=intellij-beta
       - --test_output=errors
+      - --notrim_test_configuration
     test_targets:
       - //aspect/testing/...


### PR DESCRIPTION
The flag flip broke IntelliJ downstream tests.
Fixes https://github.com/bazelbuild/bazel/issues/13328

# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: https://github.com/bazelbuild/bazel/issues/13328

# Description of this change

