### PR TITLE
CLion tests are started with the wrong working directory in debug #2745

### DIFF
--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrLauncher.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrLauncher.java
@@ -215,7 +215,8 @@ public final class BlazeCidrLauncher extends CidrLauncher {
         workingDir = workspaceRootDirectory;
       }
 
-      GeneralCommandLine commandLine = new GeneralCommandLine(runner.executableToDebug.getPath());
+      GeneralCommandLine commandLine = new GeneralCommandLine(runner.executableToDebug.getPath())
+          .withWorkDirectory(workingDir);
 
       commandLine.addParameters(handlerState.getExeFlagsState().getFlagsForExternalProcesses());
       commandLine.addParameters(handlerState.getTestArgs());


### PR DESCRIPTION
# Checklist

- [X] I have filed an issue about this change and discussed potential changes with the maintainers.
- [X] I have received the approval from the maintainers to make this change.
- [X] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

https://bazelbuild.slack.com/archives/CHSV3RSR0/p1623754447018100
https://bazelbuild.slack.com/archives/CHSV3RSR0/p1624020584020300
https://bazelbuild.slack.com/archives/C025SBYFC4E/p1624700226016000

Issue number: `#2745`

# Description of this change

Sets the runfiles directory as working directory for the command line when running bazel binaries in debug mode with CLion.
Note: the `workingDir` variable was already properly defined in code, but never used.