### PR TITLE
[2021.2 compat fix] Remove @Override from AppLifecycleListener.appFrameCreated

### DIFF
--- a/java/src/com/google/idea/blaze/java/plugin/JUnitPluginDependencyWarning.java
+++ b/java/src/com/google/idea/blaze/java/plugin/JUnitPluginDependencyWarning.java
@@ -113,7 +113,6 @@ public class JUnitPluginDependencyWarning implements ApplicationComponent {
             Transactions.submitTransactionAndWait(() -> Notifications.Bus.notify(notification));
           }
 
-          @Override
           public void appFrameCreated(
               List<String> commandLineArgs, Ref<? super Boolean> willOpenProject) {}
 


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #2757

# Description of this change
AppLifecycleListener.appFrameCreated is removed in 2021.2 plugin api, we remove @Override from it so that it can support 2021.2 as well as older versions.
