### PR TITLE
Suppress rawtypes warning in KotlinTestContextProvider

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,5 +1,5 @@
 #
-# Description: Blaze plugin for various IntelliJ products.
+# Description: Blaze plugin for various IntelliJ.
 #
 
 licenses(["notice"])

--- a/aspect/testing/tests/src/com/google/idea/blaze/BazelIntellijAspectTest.java
+++ b/aspect/testing/tests/src/com/google/idea/blaze/BazelIntellijAspectTest.java
@@ -17,7 +17,7 @@ package com.google.idea.blaze;
 
 import com.google.idea.blaze.aspect.IntellijAspectTest;
 
-/** Abstract test class for Bazel aspect tests */
+/** Abstract test class for Bazel aspect tests testing import pr */
 public abstract class BazelIntellijAspectTest extends IntellijAspectTest {
 
   protected BazelIntellijAspectTest() {

--- a/base/BUILD
+++ b/base/BUILD
@@ -360,7 +360,10 @@ java_library(
     name = "unit_test_utils",
     testonly = 1,
     srcs = glob(["tests/utils/unit/**/*.java"]),
-    visibility = ["//visibility:public"],
+    visibility = [
+        # intellijplugins_visibility
+        "//visibility:public",
+    ],
     deps = [
         "//base",
         "//intellij_platform_sdk:jsr305",

--- a/base/BUILD
+++ b/base/BUILD
@@ -121,7 +121,10 @@ java_library(
         "src/com/google/idea/blaze/base/vcs/VcsSyncListener.java",
     ],
     neverlink = 1,
-    visibility = ["//visibility:public"],
+    visibility = [
+        # intellijplugins_visibility
+        "//visibility:public",
+    ],
     deps = [
         "//intellij_platform_sdk:plugin_api",
     ],

--- a/base/BUILD
+++ b/base/BUILD
@@ -32,7 +32,7 @@ java_library(
         "//proto:proto_deps",
         "//sdkcompat",
         "//third_party/auto_value",
-        "//third_part/auto_value:auto_value_test",
+        "//third_party/auto_value:auto_value_test",
         "@error_prone_annotations//jar",
     ],
 )

--- a/base/BUILD
+++ b/base/BUILD
@@ -32,6 +32,7 @@ java_library(
         "//proto:proto_deps",
         "//sdkcompat",
         "//third_party/auto_value",
+        "//third_part/auto_value:auto_value_test",
         "@error_prone_annotations//jar",
     ],
 )

--- a/intellij_platform_sdk/BUILD
+++ b/intellij_platform_sdk/BUILD
@@ -475,8 +475,7 @@ java_library(
     visibility = [":test_libs_visibility"],
     exports = [
         "//third_party:truth",
-        "@bytebuddy-agent//jar",
-        "@bytebuddy//jar",
+        "@bytebuddy-agent//jar", "@bytebuddy//jar",
         "@mockito//jar",
     ],
 )

--- a/intellij_platform_sdk/BUILD
+++ b/intellij_platform_sdk/BUILD
@@ -475,7 +475,8 @@ java_library(
     visibility = [":test_libs_visibility"],
     exports = [
         "//third_party:truth",
-        "@bytebuddy-agent//jar", "@bytebuddy//jar",
+        "@bytebuddy//jar",
+        "@bytebuddy-agent//jar",
         "@mockito//jar",
     ],
 )

--- a/intellij_platform_sdk/BUILD
+++ b/intellij_platform_sdk/BUILD
@@ -475,7 +475,8 @@ java_library(
     visibility = [":test_libs_visibility"],
     exports = [
         "//third_party:truth",
-        "@bytebuddy-agent//jar", "@bytebuddy//jar",
+        "@bytebuddy-agent//jar",
+        "@bytebuddy//jar",
         "@mockito//jar",
     ],
 )

--- a/intellij_platform_sdk/BUILD.android_studio203
+++ b/intellij_platform_sdk/BUILD.android_studio203
@@ -3,7 +3,7 @@
 # Plugin source jars for Android Studio (version encoded in directory name)
 load("@//intellij_platform_sdk:build_defs.bzl", "no_mockito_extensions")
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//visibility:public"]) # test import pr
 
 licenses(["restricted"])
 

--- a/intellij_platform_sdk/build_defs.bzl
+++ b/intellij_platform_sdk/build_defs.bzl
@@ -1,5 +1,5 @@
 """Convenience methods for plugin_api."""
-
+# test import pr
 # The current indirect ij_product mapping (eg. "intellij-latest")
 INDIRECT_IJ_PRODUCTS = {
     # Indirect ij_product mapping for internal Blaze Plugin

--- a/kotlin/src/com/google/idea/blaze/kotlin/run/producers/KotlinTestContextProvider.java
+++ b/kotlin/src/com/google/idea/blaze/kotlin/run/producers/KotlinTestContextProvider.java
@@ -52,6 +52,7 @@ class KotlinTestContextProvider implements TestContextProvider {
         .map(target -> createTestContext(testClass, testMethod, target));
   }
 
+  @SuppressWarnings({"rawtypes"})
   private static Optional<PsiElement> getPsiElement(ConfigurationContext context) {
     return Optional.ofNullable(context.getLocation()).map(Location::getPsiElement);
   }

--- a/testing/BUILD
+++ b/testing/BUILD
@@ -8,7 +8,10 @@ load(
     "select_for_plugin_api",
 )
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = [
+    # intellijplugins_visibility
+    "//visibility:public",
+])
 
 licenses(["notice"])  # Apache 2.0
 


### PR DESCRIPTION
This PR adds @SuppressWarnings for rawtypes warning when using raw Location type in place of Location<? extends PsiElement>.


