### PR TITLE
Conditionally prepend parentPath in WorkspacePath

### DIFF
--- a/base/src/com/google/idea/blaze/base/model/primitives/WorkspacePath.java
+++ b/base/src/com/google/idea/blaze/base/model/primitives/WorkspacePath.java
@@ -57,7 +57,7 @@ public class WorkspacePath implements ProtoWrapper<String>, Serializable {
   }
 
   public WorkspacePath(WorkspacePath parentPath, String childPath) {
-    this((parentPath.isWorkspaceRoot() ? "" : (parentPath.relativePath() + BLAZE_COMPONENT_SEPARATOR)) + childPath);
+    this(parentPath.isWorkspaceRoot() ? childPath : parentPath.relativePath() + BLAZE_COMPONENT_SEPARATOR + childPath);
   }
 
   public static boolean isValid(String relativePath) {

--- a/base/src/com/google/idea/blaze/base/model/primitives/WorkspacePath.java
+++ b/base/src/com/google/idea/blaze/base/model/primitives/WorkspacePath.java
@@ -57,7 +57,7 @@ public class WorkspacePath implements ProtoWrapper<String>, Serializable {
   }
 
   public WorkspacePath(WorkspacePath parentPath, String childPath) {
-    this(parentPath.relativePath() + BLAZE_COMPONENT_SEPARATOR + childPath);
+    this((parentPath.isWorkspaceRoot() ? "" : (parentPath.relativePath() + BLAZE_COMPONENT_SEPARATOR)) + childPath);
   }
 
   public static boolean isValid(String relativePath) {

--- a/base/tests/unittests/com/google/idea/blaze/base/model/primitives/WorkspacePathTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/model/primitives/WorkspacePathTest.java
@@ -56,4 +56,17 @@ public class WorkspacePathTest extends BlazeTestCase {
     assertThat(WorkspacePath.validate("foo:bar"))
         .isEqualTo("Workspace path may not contain ':': foo:bar");
   }
+
+  @Test
+  public void testStringConcatenationConstructor() {
+    WorkspacePath empty = new WorkspacePath("");
+    WorkspacePath dot = new WorkspacePath(".");
+    WorkspacePath foo = new WorkspacePath("foo");
+    WorkspacePath dotBar = new WorkspacePath("./bar");
+
+    assertThat((new WorkspacePath(empty, "baz")).relativePath()).isEqualTo("baz");
+    assertThat((new WorkspacePath(dot, "baz")).relativePath()).isEqualTo("baz");
+    assertThat((new WorkspacePath(foo, "baz")).relativePath()).isEqualTo("foo/baz");
+    assertThat((new WorkspacePath(dotBar, "baz")).relativePath()).isEqualTo("./bar/baz");
+  }
 }


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #2338

# Description of this change
Prepending `parentPath` when the `parentPath` is the workspace root could end up with a path that starts with `/` (`BLAZE_COMPONENT_SEPERATOR`), which is incorrect and results in an invalid WorkspacePath. This change will only prepend the `parentPath` if the `parentPath` is not the workspace root.

Fixes: https://github.com/bazelbuild/intellij/issues/2338

Takes over from PR: https://github.com/bazelbuild/intellij/pull/2829