### PR TITLE
Remove reference to support matrix from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,6 @@ plugins in the JetBrains' plugin repository. See the
 [releases](https://github.com/bazelbuild/intellij/releases) tab for more
 information.
 
-## Support
-
-See the [support matrix](https://ij.bazel.build/docs/bazel-support.html)
-on the various plugin support levels across JetBrains products, languages,
-and operating systems.
-
 ## Installation
 
 You can find our plugin in the Jetbrains plugin repository by going to


### PR DESCRIPTION
We removed the support matrix from the documentation and hence cannot reference it in the README anymore.

