### PR TITLE
Golang: Display Go external libraries based on importpath structure

### DIFF
--- a/base/src/com/google/idea/blaze/base/sync/libraries/BlazeExternalLibraryProvider.java
+++ b/base/src/com/google/idea/blaze/base/sync/libraries/BlazeExternalLibraryProvider.java
@@ -34,7 +34,7 @@ public abstract class BlazeExternalLibraryProvider extends AdditionalLibraryRoot
       Project project, BlazeProjectData projectData);
 
   @Override
-  public final Collection<SyntheticLibrary> getAdditionalProjectLibraries(Project project) {
+  public Collection<SyntheticLibrary> getAdditionalProjectLibraries(Project project) {
     SyntheticLibrary library = ExternalLibraryManager.getInstance(project).getLibrary(getClass());
     return library != null ? ImmutableList.of(library) : ImmutableList.of();
   }

--- a/base/src/com/google/idea/blaze/base/sync/libraries/BlazeExternalSyntheticLibrary.java
+++ b/base/src/com/google/idea/blaze/base/sync/libraries/BlazeExternalSyntheticLibrary.java
@@ -36,7 +36,7 @@ import javax.swing.Icon;
  * A {@link SyntheticLibrary} pointing to a list of external files for a language. Only supports one
  * instance per value of presentableText.
  */
-public final class BlazeExternalSyntheticLibrary extends SyntheticLibrary
+public class BlazeExternalSyntheticLibrary extends SyntheticLibrary
     implements ItemPresentation {
   private final String presentableText;
   private final ImmutableSet<File> files;
@@ -49,7 +49,7 @@ public final class BlazeExternalSyntheticLibrary extends SyntheticLibrary
    *     equals, hashcode -- there must only be one instance per value of this text
    * @param files collection of files that this synthetic library is responsible for.
    */
-  BlazeExternalSyntheticLibrary(String presentableText, Collection<File> files) {
+  public BlazeExternalSyntheticLibrary(String presentableText, Collection<File> files) {
     this.presentableText = presentableText;
     this.files = ImmutableSet.copyOf(files);
     this.validFiles =

--- a/golang/src/META-INF/go-contents.xml
+++ b/golang/src/META-INF/go-contents.xml
@@ -44,5 +44,6 @@
     <documentationProvider implementation="com.google.idea.blaze.golang.resolve.BlazeGoImportResolver$GoPackageDocumentationProvider"/>
     <additionalLibraryRootsProvider implementation="com.google.idea.blaze.golang.sync.BlazeGoAdditionalLibraryRootsProvider"/>
     <postStartupActivity implementation="com.google.idea.blaze.golang.run.producers.NonBlazeProducerSuppressor"/>
+    <treeStructureProvider implementation="com.google.idea.blaze.golang.treeview.BlazeGoTreeStructureProvider" order="last"/>
   </extensions>
 </idea-plugin>

--- a/golang/src/com/google/idea/blaze/golang/resolve/BlazeGoPackageFactory.java
+++ b/golang/src/com/google/idea/blaze/golang/resolve/BlazeGoPackageFactory.java
@@ -36,7 +36,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import javax.annotation.Nullable;
 
-class BlazeGoPackageFactory implements GoPackageFactory {
+public class BlazeGoPackageFactory implements GoPackageFactory {
   @Nullable
   @Override
   public GoPackage createPackage(GoFile goFile) {
@@ -54,7 +54,7 @@ class BlazeGoPackageFactory implements GoPackageFactory {
   }
 
   @Nullable
-  static ConcurrentMap<File, String> getFileToImportPathMap(Project project) {
+  public static ConcurrentMap<File, String> getFileToImportPathMap(Project project) {
     return SyncCache.getInstance(project)
         .get(BlazeGoPackageFactory.class, BlazeGoPackageFactory::buildFileToImportPathMap);
   }

--- a/golang/src/com/google/idea/blaze/golang/sync/BlazeGoExternalSyntheticLibrary.java
+++ b/golang/src/com/google/idea/blaze/golang/sync/BlazeGoExternalSyntheticLibrary.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2021 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.golang.sync;
+
+import com.goide.GoIcons;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.idea.blaze.base.sync.libraries.BlazeExternalSyntheticLibrary;
+import com.intellij.openapi.roots.SyntheticLibrary;
+import java.io.File;
+import java.util.Collection;
+import javax.swing.Icon;
+
+/**
+ * A {@link BlazeExternalSyntheticLibrary} for Go external libraries. Only supports one instance
+ * per importPath. 
+ */
+public final class BlazeGoExternalSyntheticLibrary extends BlazeExternalSyntheticLibrary {
+    private final ImmutableMultimap<String, File> importpathToFilesMap;
+    private final String importPath;
+    private final boolean isRoot;
+
+    /**
+    * Constructs a root Go external library. Holds a flat list of all external source files. Later
+    * processed by {@link BlazeGoTreeStructureProvider} to structure external source files based on
+    * their importpath.
+    */
+    public BlazeGoExternalSyntheticLibrary(String presentableText, ImmutableMultimap<String, File> importpathToFilesMap) {
+        super(presentableText, importpathToFilesMap.values());
+        this.importpathToFilesMap = importpathToFilesMap;
+        this.importPath = presentableText;
+        this.isRoot = true;
+    }
+
+    /**
+    * Constructs a non-root Go external library. Holds the external source files for an external directory.
+    * Intended for use by {@link GoSyntheticLibraryElementNode}.
+    */
+    public BlazeGoExternalSyntheticLibrary(String presentableText, String importPath, Collection<File> files) {
+        super(presentableText, files);
+        this.importpathToFilesMap = null;
+        this.importPath = importPath;
+        this.isRoot = false;
+    }
+
+    public boolean isRoot() {
+        return this.isRoot;
+    }
+
+    public ImmutableMultimap<String, File> getImportpathToFilesMap() {
+        return importpathToFilesMap;
+    }
+
+    @Override
+    public Icon getIcon(boolean unused) {
+        return GoIcons.VENDOR_DIRECTORY;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        // intended to be only a single instance added to the project for each value of importPath
+        return o instanceof BlazeGoExternalSyntheticLibrary
+            && importPath.equals(((BlazeGoExternalSyntheticLibrary) o).importPath);
+    }
+
+    @Override
+    public int hashCode() {
+        // intended to be only a single instance added to the project for each value of importPath
+        return importPath.hashCode();
+    }
+}

--- a/golang/src/com/google/idea/blaze/golang/treeview/BlazeGoTreeStructureProvider.java
+++ b/golang/src/com/google/idea/blaze/golang/treeview/BlazeGoTreeStructureProvider.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.golang.treeview;
+
+import com.google.common.collect.ImmutableMultimap;
+import com.google.idea.blaze.base.settings.Blaze;
+import com.google.idea.blaze.base.sync.libraries.BlazeExternalSyntheticLibrary;
+import com.google.idea.blaze.golang.sync.BlazeGoExternalSyntheticLibrary;
+import com.intellij.ide.projectView.impl.nodes.ExternalLibrariesNode;
+import com.intellij.ide.projectView.impl.nodes.SyntheticLibraryElementNode;
+import com.intellij.ide.projectView.TreeStructureProvider;
+import com.intellij.ide.projectView.ViewSettings;
+import com.intellij.ide.util.treeView.AbstractTreeNode;
+import com.intellij.navigation.ItemPresentation;
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.SyntheticLibrary;
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Iterator;
+import java.util.HashMap;
+
+/**
+ * Modifies the project view by replacing the External Go Libraries root node (contaning a flat list of sources)
+ * with a root node that structures sources based on their importpaths.
+ */
+public class BlazeGoTreeStructureProvider implements TreeStructureProvider, DumbAware {
+  @Override
+  public Collection<AbstractTreeNode<?>> modify(
+      AbstractTreeNode<?> parent, Collection<AbstractTreeNode<?>> children, ViewSettings settings) {
+    Project project = parent.getProject();
+    if (!Blaze.isBlazeProject(project) || !(parent instanceof ExternalLibrariesNode)) {
+      return children;
+    }
+    List<AbstractTreeNode<?>> newChildren = new ArrayList<AbstractTreeNode<?>>();
+    for (AbstractTreeNode<?> child : children) {
+      if ((child.getValue() instanceof BlazeGoExternalSyntheticLibrary)) {
+        BlazeGoExternalSyntheticLibrary libraryRoot = (BlazeGoExternalSyntheticLibrary)child.getValue();
+        child = libraryRoot.isRoot() ? createSyntheticDirectoryStructure(libraryRoot, settings, project) : child;
+      }
+      newChildren.add(child);
+    }
+    return newChildren;
+  }
+
+  /**
+  * Creates the importpath based project structure.
+  * Loops through the Go project's external importpath references and creates a {@link GoSyntheticLibraryElementNode} for each directory.
+  * Each node holds a {@link BlazeExternalSyntheticLibrary} representing the dir's source files.
+  */
+  private static GoSyntheticLibraryElementNode createSyntheticDirectoryStructure(BlazeGoExternalSyntheticLibrary libraryRoot, ViewSettings settings, Project project) {
+    ImmutableMultimap<String, File> importPathToFilesMap = libraryRoot.getImportpathToFilesMap();
+    BlazeExternalSyntheticLibrary newLibraryRoot =  new BlazeExternalSyntheticLibrary(libraryRoot.getPresentableText(), Collections.emptyList());
+    GoSyntheticLibraryElementNode rootNode = new GoSyntheticLibraryElementNode(project, newLibraryRoot, (ItemPresentation)newLibraryRoot, settings, new HashMap<String, GoSyntheticLibraryElementNode>());
+    String[] imports = importPathToFilesMap.keySet().toArray(String[]::new);
+    // sort imports to ensure parent dirs are visited before children
+    Arrays.sort(imports);
+    for (String key : imports) {
+      GoSyntheticLibraryElementNode currRoot = rootNode;
+      String currImport = null;
+      Iterator<Path> it = Paths.get(key).iterator();
+      while (it.hasNext()) {
+        String dir = it.next().toString();
+        currImport = currImport == null ? dir : currImport + "/" + dir;
+        if (!currRoot.hasChild(currImport)) {
+          Collection<File> files = it.hasNext() ? Collections.emptyList() :  importPathToFilesMap.get(key);
+          BlazeExternalSyntheticLibrary currLib =  new BlazeGoExternalSyntheticLibrary(dir, currImport, files);
+          GoSyntheticLibraryElementNode currNode = new GoSyntheticLibraryElementNode(project, currLib, (ItemPresentation)currLib, settings, new HashMap<String, GoSyntheticLibraryElementNode>());
+          currRoot.addChild(currImport, currNode);
+        }
+        currRoot = currRoot.getChild(currImport);
+      }
+    }
+    return rootNode;
+  }
+}

--- a/golang/src/com/google/idea/blaze/golang/treeview/GoSyntheticLibraryElementNode.java
+++ b/golang/src/com/google/idea/blaze/golang/treeview/GoSyntheticLibraryElementNode.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2021 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.idea.blaze.golang.treeview;
+
+import com.intellij.ide.projectView.ViewSettings;
+import com.intellij.ide.projectView.impl.nodes.SyntheticLibraryElementNode;
+import com.intellij.ide.projectView.impl.nodes.ProjectViewDirectoryHelper;
+import com.intellij.ide.util.treeView.AbstractTreeNode;
+import com.intellij.navigation.ItemPresentation;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.SyntheticLibrary;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.VfsUtil;
+import com.intellij.util.ObjectUtils;
+import com.intellij.util.containers.ContainerUtil;
+import com.google.idea.blaze.golang.resolve.BlazeGoPackageFactory;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.jetbrains.annotations.NotNull;
+
+/**
+* Represents a Go directory node within the "External Libraries" project view.
+*/
+public class GoSyntheticLibraryElementNode extends SyntheticLibraryElementNode {
+    protected Map<String, GoSyntheticLibraryElementNode> importToChildNodeMap;
+
+    public GoSyntheticLibraryElementNode(@NotNull Project project, @NotNull SyntheticLibrary library,
+                                         @NotNull ItemPresentation itemPresentation, ViewSettings settings,
+                                         @NotNull Map<String, GoSyntheticLibraryElementNode> children) {
+        super(project, library, itemPresentation, settings);
+        importToChildNodeMap = children;
+    }
+
+    @Override
+    public boolean contains(@NotNull VirtualFile file) {
+        if (getLibrary().contains(file)) {
+            return true;
+        }
+        Project project = Objects.requireNonNull(getProject());
+        // Get the file's importpath so we can determine if it is a descendant of the current node
+        Map<File, String> fileToImportPathMap = BlazeGoPackageFactory.getFileToImportPathMap(project);
+        String importPath = fileToImportPathMap.get(VfsUtil.virtualToIoFile(file));
+        Path parent = importPath != null ? Paths.get(importPath) : null;
+        while (parent != null) {
+            if (hasChild(parent.toString())) {
+                return true;
+            }
+            parent = parent.getParent();
+        }
+        return false;
+    }
+
+    @NotNull
+    @Override
+    public Collection<AbstractTreeNode<?>> getChildren() {
+        List<AbstractTreeNode<?>> children = new ArrayList<AbstractTreeNode<?>>();
+        children.addAll(importToChildNodeMap.values());
+        SyntheticLibrary library = getLibrary();
+        Project project = Objects.requireNonNull(getProject());
+        Set<VirtualFile> excludedRoots = library.getExcludedRoots();
+        List<VirtualFile> childrenFiles = ContainerUtil.filter(library.getAllRoots(), file -> file.isValid() && !excludedRoots.contains(file));
+        children.addAll(ProjectViewDirectoryHelper.getInstance(project).createFileAndDirectoryNodes(childrenFiles, getSettings()));
+        return children;
+    }
+
+    @NotNull
+    private SyntheticLibrary getLibrary() {
+        return Objects.requireNonNull(getValue());
+    }
+
+    public void addChild(String importPath, GoSyntheticLibraryElementNode child) { importToChildNodeMap.put(importPath, child); }
+
+    public boolean hasChild(String importPath) { return importToChildNodeMap.containsKey(importPath); }
+
+    public GoSyntheticLibraryElementNode getChild(String importPath) { return importToChildNodeMap.get(importPath); }
+
+}


### PR DESCRIPTION
# Checklist

- [X] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [X] This is not a stylistic, refactoring, or cleanup change.

# Discussion thread for this change

Issue number: #1744 #2365 

# Description of this change

Modifies the structure of the external "Go Libraries" project view to be based on importpath rather than a flat list of files. See my comment within #2365 for an example of how the new structure looks.

This is essentially achieved by extending Go's `additionalLibraryRootsProvider` to carry external dependency importpath mappings and then using that information from a new Go `treeStructureProvider` to create the importpath based directory structure. 

Due to my unfamiliarity with this project and the lack of pre-existing tests I struggled to write tests for this feature. If anyone more familiar with the codebase could provide some guidance that would be very helpful.