### PR TITLE
Allow existing target.source-map(s) to coexist

### DIFF
--- a/aswb/src/com/google/idea/blaze/android/run/runner/BlazeAndroidDebuggerService.java
+++ b/aswb/src/com/google/idea/blaze/android/run/runner/BlazeAndroidDebuggerService.java
@@ -74,7 +74,7 @@ public interface BlazeAndroidDebuggerService {
         // to automatically resolve this but it's no longer supported in newer versions of
         // LLDB.
         String sourceMapToWorkspaceRootCommand =
-            "settings set target.source-map /proc/self/cwd/ " + workingDirPath;
+            "settings append target.source-map /proc/self/cwd/ " + workingDirPath;
         ImmutableList<String> startupCommands =
             ImmutableList.<String>builder()
                 .addAll(nativeState.getUserStartupCommands())

--- a/aswb/tests/integrationtests/com/google/idea/blaze/android/run/runner/DefaultDebuggerServiceImplTest.java
+++ b/aswb/tests/integrationtests/com/google/idea/blaze/android/run/runner/DefaultDebuggerServiceImplTest.java
@@ -40,6 +40,6 @@ public class DefaultDebuggerServiceImplTest extends BlazeIntegrationTestCase {
 
     assertThat(state.getWorkingDir()).isEqualTo(workspaceRoot);
     assertThat(state.getUserStartupCommands())
-        .contains("settings set target.source-map /proc/self/cwd/ " + workspaceRoot);
+        .contains("settings append target.source-map /proc/self/cwd/ " + workspaceRoot);
   }
 }


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Description of this change

Currently the target.source-map that are defined in `~/.lldbinit` are being overwritten by the plugin. This change allows for all to coexist.