### PR TITLE
Let debugged Go tests find their runfiles

### DIFF
--- a/golang/src/com/google/idea/blaze/golang/run/BlazeGoRunConfigurationRunner.java
+++ b/golang/src/com/google/idea/blaze/golang/run/BlazeGoRunConfigurationRunner.java
@@ -401,6 +401,8 @@ public class BlazeGoRunConfigurationRunner implements BlazeCommandRunConfigurati
 
   // Matches TEST_SRCDIR=<dir>
   private static final Pattern TEST_SRCDIR = Pattern.compile("TEST_SRCDIR=([^ ]+)");
+  // Matches RUNFILES_<NAME>=<value>
+  private static final Pattern RUNFILES_VAR = Pattern.compile("RUNFILES_([A-Z_]+)=([^ ]+)");
   // Matches a space-delimited arg list. Supports wrapping arg in single quotes.
   private static final Pattern ARGS = Pattern.compile("([^\']\\S*|\'.+?\')\\s*");
 
@@ -431,6 +433,10 @@ public class BlazeGoRunConfigurationRunner implements BlazeCommandRunConfigurati
         throw new ExecutionException("Failed to parse args in script_path: " + scriptPath);
       }
       envVars.put("TEST_SRCDIR", testScrDir.group(1));
+      Matcher runfilesVars = RUNFILES_VAR.matcher(text);
+      while (runfilesVars.find()) {
+        envVars.put(String.format("RUNFILES_%s", runfilesVars.group(1)), runfilesVars.group(2));
+      }
       workingDir = workspaceRoot.directory();
       String workspaceName = execRoot.getName();
       binary =


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #2313

# Description of this change

Go runfiles discovery requires at least one of the runfiles variables
RUNFILES_DIR or RUNFILES_MANIFEST to be set. With the script path
experiment, which is enabled by default, only TEST_SRCDIR is currently
extracted from the script and passed to the test binary. As a result,
runfiles discovery fails on Windows (where a manifest is required) as
well as when following the official runfiles discovery process, which
does not include TEST_SRCDIR.

This is fixed by including all RUNFILES_* variables in the environment
used to start the test binary.
