### PR TITLE
Fix CI for 2021.3

### DIFF
--- a/golang/BUILD
+++ b/golang/BUILD
@@ -102,4 +102,9 @@ intellij_integration_test_suite(
         "//third_party/go:go_for_tests",
         "@junit//jar",
     ],
+    env = {
+        # Disable runtime checks because GoGenericsLibraryRootsProvider causes them to trigger
+        # genericsStub folder containing builtin.go should be added to source roots, but it's not
+        "NO_FS_ROOTS_ACCESS_CHECK": "true"
+    },
 )

--- a/golang/BUILD
+++ b/golang/BUILD
@@ -105,7 +105,7 @@ intellij_integration_test_suite(
     env = {
         # Disable runtime checks because GoGenericsLibraryRootsProvider causes them to trigger
         # genericsStub folder containing builtin.go should be added to source roots, but it's not.
-        # This affects only 2021.3 version of the platform. Should be fixed in 2022.1 and potentially
+        # #api212: This affects only 2021.3 version of the platform. Should be fixed in 2022.1 and potentially
         # in a Go plugin release after 213.6461.48 version.
         "NO_FS_ROOTS_ACCESS_CHECK": "true"
     },

--- a/golang/BUILD
+++ b/golang/BUILD
@@ -104,7 +104,9 @@ intellij_integration_test_suite(
     ],
     env = {
         # Disable runtime checks because GoGenericsLibraryRootsProvider causes them to trigger
-        # genericsStub folder containing builtin.go should be added to source roots, but it's not
+        # genericsStub folder containing builtin.go should be added to source roots, but it's not.
+        # This affects only 2021.3 version of the platform. Should be fixed in 2022.1 and potentially
+        # in a Go plugin release after 213.6461.48 version.
         "NO_FS_ROOTS_ACCESS_CHECK": "true"
     },
 )

--- a/java/tests/integrationtests/com/google/idea/blaze/java/run/producers/MultipleJavaClassesTestContextProviderTest.java
+++ b/java/tests/integrationtests/com/google/idea/blaze/java/run/producers/MultipleJavaClassesTestContextProviderTest.java
@@ -74,6 +74,7 @@ public class MultipleJavaClassesTestContextProviderTest
         WorkspaceFileFinder.Provider.class, () -> file -> file.getPath().contains("test"));
 
     // required for IntelliJ to recognize annotations, JUnit version, etc.
+    // Adding into java source root so resolve scopes of all files in tests is the same.
     workspace.createPsiFile(
         new WorkspacePath("java/org/junit/runner/RunWith.java"),
         "package org.junit.runner;"

--- a/java/tests/integrationtests/com/google/idea/blaze/java/run/producers/MultipleJavaClassesTestContextProviderTest.java
+++ b/java/tests/integrationtests/com/google/idea/blaze/java/run/producers/MultipleJavaClassesTestContextProviderTest.java
@@ -53,19 +53,17 @@ import org.junit.runners.JUnit4;
 public class MultipleJavaClassesTestContextProviderTest
     extends BlazeRunConfigurationProducerTestCase {
 
-  private SourceFolder javaSourceRoot;
-
   @Before
   public final void addSourceFolder() {
-    // create a source root so that the package prefixes are correct.
-    VirtualFile pkgRoot = workspace.createDirectory(new WorkspacePath("java"));
     ApplicationManager.getApplication()
         .runWriteAction(
             () -> {
               final ModifiableRootModel model =
                   ModuleRootManager.getInstance(testFixture.getModule()).getModifiableModel();
               ContentEntry contentEntry = model.getContentEntries()[0];
-              javaSourceRoot = contentEntry.addSourceFolder(pkgRoot, true, "");
+              // create a source root so that the package prefixes are correct.
+              VirtualFile pkgRoot = workspace.createDirectory(new WorkspacePath("java"));
+              contentEntry.addSourceFolder(pkgRoot, true, "");
               model.commit();
             });
 
@@ -77,17 +75,17 @@ public class MultipleJavaClassesTestContextProviderTest
 
     // required for IntelliJ to recognize annotations, JUnit version, etc.
     workspace.createPsiFile(
-        new WorkspacePath("org/junit/runner/RunWith.java"),
+        new WorkspacePath("java/org/junit/runner/RunWith.java"),
         "package org.junit.runner;"
             + "public @interface RunWith {"
             + "    Class<? extends Runner> value();"
             + "}");
     workspace.createPsiFile(
-        new WorkspacePath("org/junit/Test.java"),
+        new WorkspacePath("java/org/junit/Test.java"),
         "package org.junit;",
         "public @interface Test {}");
     workspace.createPsiFile(
-        new WorkspacePath("org/junit/runners/JUnit4.java"),
+        new WorkspacePath("java/org/junit/runners/JUnit4.java"),
         "package org.junit.runners;",
         "public class JUnit4 {}");
   }
@@ -100,7 +98,7 @@ public class MultipleJavaClassesTestContextProviderTest
               final ModifiableRootModel model =
                   ModuleRootManager.getInstance(testFixture.getModule()).getModifiableModel();
               ContentEntry contentEntry = model.getContentEntries()[0];
-              contentEntry.removeSourceFolder(javaSourceRoot);
+              contentEntry.clearSourceFolders();
               model.commit();
             });
   }

--- a/scala/src/com/google/idea/blaze/scala/run/producers/DeployableJarRunConfigurationProducer.java
+++ b/scala/src/com/google/idea/blaze/scala/run/producers/DeployableJarRunConfigurationProducer.java
@@ -67,6 +67,9 @@ class DeployableJarRunConfigurationProducer
       return false;
     }
 
+    // Update to a more specific element so the resulting run configuration will have higher priority
+    sourceElement.set(mainObject);
+
     configuration.putUserData(TARGET_LABEL, target.label);
     configuration.setModule(context.getModule());
     configuration.setMainClassName(mainObject.qualifiedName());


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #3001

# Description of this change

Attempt to fix CI for 2021.3. There were two issue with Scala part:

1. Bazel run configuration was specifying the whole Scala file as a source where the standard `ScalaApplicationConfigurationProducer` was specifying a more specific element which resulted in more priority.
2. Flaky tests when a source root was already removed on a test cleanup. Used a clearer way for cleanup which fixed the issue.

