### PR TITLE
Include implicit dependencies from proto compilers

### DIFF
--- a/aspect/intellij_info_impl.bzl
+++ b/aspect/intellij_info_impl.bzl
@@ -41,6 +41,7 @@ DEPS = [
     "test_app",  # android_instrumentation_test
     "instruments",  # android_instrumentation_test
     "tests",  # From test_suite
+    "compilers",  # From go_proto_library
 ]
 
 # Run-time dependency attributes, grouped by type.


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Description of this change

`go_proto_library` has compilers which bring some types implicitly. Let's not forget to include them.
