### PR TITLE
Add Scala support to plugin workspace

### DIFF
--- a/plugin_dev/src/META-INF/blaze-plugin-dev.xml
+++ b/plugin_dev/src/META-INF/blaze-plugin-dev.xml
@@ -19,6 +19,7 @@
   <extensions defaultExtensionNs="com.google.idea.blaze">
     <RunConfigurationFactory implementation="com.google.idea.blaze.plugin.run.BlazeIntellijPluginConfigurationType$BlazeIntellijPluginRunConfigurationFactory" order="first"/>
     <SyncPlugin implementation="com.google.idea.blaze.plugin.sync.IntellijPluginSyncPlugin"/>
+    <SyncPlugin implementation="com.google.idea.blaze.plugin.sync.IntellijScalaPluginSyncPlugin"/>
   </extensions>
 
   <extensions defaultExtensionNs="com.intellij">

--- a/plugin_dev/src/com/google/idea/blaze/plugin/sync/IntellijScalaPluginSyncPlugin.java
+++ b/plugin_dev/src/com/google/idea/blaze/plugin/sync/IntellijScalaPluginSyncPlugin.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2016 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.plugin.sync;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.idea.blaze.base.model.BlazeProjectData;
+import com.google.idea.blaze.base.model.BlazeVersionData;
+import com.google.idea.blaze.base.model.primitives.LanguageClass;
+import com.google.idea.blaze.base.model.primitives.WorkspaceType;
+import com.google.idea.blaze.base.projectview.ProjectViewSet;
+import com.google.idea.blaze.base.scope.BlazeContext;
+import com.google.idea.blaze.base.sync.BlazeSyncPlugin;
+import com.google.idea.blaze.base.sync.SourceFolderProvider;
+import com.google.idea.blaze.java.sync.JavaLanguageLevelHelper;
+import com.google.idea.blaze.java.sync.model.BlazeJavaSyncData;
+import com.google.idea.blaze.java.sync.projectstructure.JavaSourceFolderProvider;
+import com.google.idea.common.util.Transactions;
+import com.intellij.openapi.module.ModuleType;
+import com.intellij.openapi.module.StdModuleTypes;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.LanguageLevelProjectExtension;
+import com.intellij.pom.java.LanguageLevel;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+/**
+ * Development environment support for intellij plugin projects with Scala language
+ */
+public class IntellijScalaPluginSyncPlugin implements BlazeSyncPlugin {
+
+  @Override
+  public ImmutableList<WorkspaceType> getSupportedWorkspaceTypes() {
+    return ImmutableList.of(WorkspaceType.INTELLIJ_PLUGIN);
+  }
+
+  @Nullable
+  @Override
+  public ModuleType getWorkspaceModuleType(WorkspaceType workspaceType) {
+    if (workspaceType == WorkspaceType.INTELLIJ_PLUGIN) {
+      return StdModuleTypes.JAVA;
+    }
+    return null;
+  }
+
+  @Override
+  public Set<LanguageClass> getSupportedLanguagesInWorkspace(WorkspaceType workspaceType) {
+    if (workspaceType == WorkspaceType.INTELLIJ_PLUGIN) {
+      return ImmutableSet.of(LanguageClass.SCALA);
+    }
+    return ImmutableSet.of();
+  }
+
+  @Nullable
+  @Override
+  public SourceFolderProvider getSourceFolderProvider(BlazeProjectData projectData) {
+    if (!projectData
+        .getWorkspaceLanguageSettings()
+        .isWorkspaceType(WorkspaceType.INTELLIJ_PLUGIN)) {
+      return null;
+    }
+    return new JavaSourceFolderProvider(projectData.getSyncState().get(BlazeJavaSyncData.class));
+  }
+
+  @Override
+  public void updateProjectSdk(
+      Project project,
+      BlazeContext context,
+      ProjectViewSet projectViewSet,
+      BlazeVersionData blazeVersionData,
+      BlazeProjectData blazeProjectData) {
+    if (!blazeProjectData
+        .getWorkspaceLanguageSettings()
+        .isWorkspaceType(WorkspaceType.INTELLIJ_PLUGIN)) {
+      return;
+    }
+
+    LanguageLevel javaLanguageLevel =
+        JavaLanguageLevelHelper.getJavaLanguageLevel(
+            projectViewSet, blazeProjectData);
+
+    // Leave the SDK, but set the language level
+    Transactions.submitWriteActionTransactionAndWait(
+        () -> {
+          LanguageLevelProjectExtension ext = LanguageLevelProjectExtension.getInstance(project);
+          ext.setLanguageLevel(javaLanguageLevel);
+        });
+  }
+}

--- a/plugin_dev/tests/integrationtests/com/google/idea/blaze/plugin/sync/PluginScalaDevSyncTest.java
+++ b/plugin_dev/tests/integrationtests/com/google/idea/blaze/plugin/sync/PluginScalaDevSyncTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2016 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.plugin.sync;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.idea.blaze.base.ideinfo.TargetIdeInfo;
+import com.google.idea.blaze.base.ideinfo.TargetMap;
+import com.google.idea.blaze.base.ideinfo.TargetMapBuilder;
+import com.google.idea.blaze.base.model.BlazeProjectData;
+import com.google.idea.blaze.base.model.primitives.WorkspacePath;
+import com.google.idea.blaze.base.model.primitives.WorkspaceType;
+import com.google.idea.blaze.base.sync.BlazeSyncIntegrationTestCase;
+import com.google.idea.blaze.base.sync.BlazeSyncParams;
+import com.google.idea.blaze.base.sync.SyncMode;
+import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
+import com.google.idea.blaze.plugin.run.BlazeIntellijPluginConfiguration;
+import com.intellij.execution.RunManager;
+import com.intellij.execution.configurations.RunConfiguration;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Plugin-dev specific sync integration test.
+ *
+ * Tests additional_languages: scala support in plugin workspace
+ */
+@RunWith(JUnit4.class)
+public class PluginScalaDevSyncTest extends BlazeSyncIntegrationTestCase {
+
+  @Test
+  public void testRunConfigurationCreatedDuringSync() throws Exception {
+    setProjectView(
+        "directories:",
+        "  java/com/google",
+        "targets:",
+        "  //java/com/google:lib",
+        "  //java/com/google:plugin",
+        "workspace_type: intellij_plugin",
+        "additional_languages:",
+        "  scala");
+
+    workspace.createFile(
+        new WorkspacePath("java/com/google/ClassWithUniqueName1.java"),
+        "package com.google;",
+        "public class ClassWithUniqueName1 {}");
+
+    workspace.createFile(
+        new WorkspacePath("java/com/google/ClassWithUniqueName2.java"),
+        "package com.google;",
+        "public class ClassWithUniqueName2 {}");
+
+    TargetMap targetMap =
+        TargetMapBuilder.builder()
+            .addTarget(
+                TargetIdeInfo.builder()
+                    .setBuildFile(sourceRoot("java/com/google/BUILD"))
+                    .setLabel("//java/com/google:lib")
+                    .setKind("java_library")
+                    .addSource(sourceRoot("java/com/google/ClassWithUniqueName1.java"))
+                    .addSource(sourceRoot("java/com/google/ClassWithUniqueName2.java")))
+            .addTarget(
+                TargetIdeInfo.builder()
+                    .setBuildFile(sourceRoot("java/com/google/BUILD"))
+                    .setLabel("//java/com/google:plugin")
+                    .setKind("intellij_plugin_debug_target"))
+            .build();
+
+    setTargetMap(targetMap);
+
+    runBlazeSync(
+        BlazeSyncParams.builder()
+            .setTitle("Sync")
+            .setSyncOrigin("test")
+            .setSyncMode(SyncMode.INCREMENTAL)
+            .setAddProjectViewTargets(true)
+            .build());
+
+    errorCollector.assertNoIssues();
+
+    BlazeProjectData blazeProjectData =
+        BlazeProjectDataManager.getInstance(getProject()).getBlazeProjectData();
+    assertThat(blazeProjectData).isNotNull();
+    assertThat(blazeProjectData.getTargetMap()).isEqualTo(targetMap);
+    assertThat(blazeProjectData.getWorkspaceLanguageSettings().getWorkspaceType())
+        .isEqualTo(WorkspaceType.INTELLIJ_PLUGIN);
+
+    List<RunConfiguration> runConfigs =
+        RunManager.getInstance(getProject()).getAllConfigurationsList();
+    assertThat(runConfigs).hasSize(1);
+    assertThat(runConfigs.get(0)).isInstanceOf(BlazeIntellijPluginConfiguration.class);
+  }
+}


### PR DESCRIPTION
At Wix we use Scala code to write internal plugins, but Scala language is not supported if `workspace_type` is `intellij_plugin`. This PR adds support to allow Scala language to be used in plugin workspaces.

Implementation is mostly copy of `IntellijPluginSyncPlugin` with added modifications to allow Scala to be used in the workspace. The test only adds `scala` to `additional_languages` project view section, but still uses Java code, because compiling code with Rules Scala would require complex workspace setup as the ruleset is not bundled with Bazel. I think this is enough to verify Scala language is supported.

I am open to make any changes, if needed.