### PR TITLE
Automatically import projects from directory

### DIFF
--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -288,7 +288,8 @@
     <additionalTextAttributes scheme="Default" file="resources/colorSchemes/BuildDefault.xml"/>
     <typedHandler implementation="com.google.idea.blaze.base.lang.buildfile.completion.BuildCompletionAutoPopupHandler"/>
     <projectOpenProcessor implementation="com.google.idea.blaze.base.project.BlazeProjectOpenProcessor"/>
-    <projectOpenProcessor implementation="com.google.idea.blaze.base.project.NewBazelProjectOpenProcessor" order="last"/>
+    <!-- not yet imported project handling must be done last -->
+    <projectOpenProcessor implementation="com.google.idea.blaze.base.project.AutoImportProjectOpenProcessor" order="last"/>
     <projectViewNodeDecorator implementation="com.google.idea.blaze.base.syncstatus.SyncStatusNodeDecorator"/>
     <editorTabColorProvider implementation="com.google.idea.blaze.base.syncstatus.SyncStatusEditorTabColorProvider"/>
     <editorTabTitleProvider implementation="com.google.idea.blaze.base.syncstatus.SyncStatusEditorTabTitleProvider"/>

--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -287,8 +287,8 @@
 
     <additionalTextAttributes scheme="Default" file="resources/colorSchemes/BuildDefault.xml"/>
     <typedHandler implementation="com.google.idea.blaze.base.lang.buildfile.completion.BuildCompletionAutoPopupHandler"/>
-    <projectOpenProcessor implementation="com.google.idea.blaze.base.project.NewBazelProjectOpenProcessor"/>
     <projectOpenProcessor implementation="com.google.idea.blaze.base.project.BlazeProjectOpenProcessor"/>
+    <projectOpenProcessor implementation="com.google.idea.blaze.base.project.NewBazelProjectOpenProcessor" order="last"/>
     <projectViewNodeDecorator implementation="com.google.idea.blaze.base.syncstatus.SyncStatusNodeDecorator"/>
     <editorTabColorProvider implementation="com.google.idea.blaze.base.syncstatus.SyncStatusEditorTabColorProvider"/>
     <editorTabTitleProvider implementation="com.google.idea.blaze.base.syncstatus.SyncStatusEditorTabTitleProvider"/>

--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -287,6 +287,7 @@
 
     <additionalTextAttributes scheme="Default" file="resources/colorSchemes/BuildDefault.xml"/>
     <typedHandler implementation="com.google.idea.blaze.base.lang.buildfile.completion.BuildCompletionAutoPopupHandler"/>
+    <projectOpenProcessor implementation="com.google.idea.blaze.base.project.NewBazelProjectOpenProcessor"/>
     <projectOpenProcessor implementation="com.google.idea.blaze.base.project.BlazeProjectOpenProcessor"/>
     <projectViewNodeDecorator implementation="com.google.idea.blaze.base.syncstatus.SyncStatusNodeDecorator"/>
     <editorTabColorProvider implementation="com.google.idea.blaze.base.syncstatus.SyncStatusEditorTabColorProvider"/>

--- a/base/src/com/google/idea/blaze/base/project/AutoImportProjectOpenProcessor.java
+++ b/base/src/com/google/idea/blaze/base/project/AutoImportProjectOpenProcessor.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
+import javax.swing.Icon;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -50,7 +51,7 @@ import org.jetbrains.annotations.Nullable;
  *  <li>workspace - tools/intellij/.managed.bazelproject</li>
  *  <li>if above do not exist, creates minimal project view file</li>
  * </ul>
- *
+ * <p>
  * Must be loaded after {@link BlazeProjectOpenProcessor} to only import new projects.
  */
 public class AutoImportProjectOpenProcessor extends ProjectOpenProcessor {

--- a/base/src/com/google/idea/blaze/base/project/AutoImportProjectOpenProcessor.java
+++ b/base/src/com/google/idea/blaze/base/project/AutoImportProjectOpenProcessor.java
@@ -24,18 +24,12 @@ import com.google.idea.blaze.base.wizard2.WorkspaceTypeData;
 import com.intellij.ide.SaveAndSyncHandler;
 import com.intellij.ide.impl.OpenProjectTask;
 import com.intellij.ide.impl.ProjectUtil;
-import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.project.ex.ProjectManagerEx;
-import com.intellij.openapi.startup.StartupManager;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.openapi.wm.ToolWindow;
-import com.intellij.openapi.wm.ToolWindowId;
-import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.projectImport.ProjectOpenProcessor;
 import icons.BlazeIcons;
 import java.io.File;
@@ -44,14 +38,13 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
 import javax.swing.Icon;
-import javax.swing.SwingUtilities;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class NewBazelProjectOpenProcessor extends ProjectOpenProcessor {
+public class AutoImportProjectOpenProcessor extends ProjectOpenProcessor {
 
-  private static final Logger LOG = Logger.getInstance(NewBazelProjectOpenProcessor.class);
+  private static final Logger LOG = Logger.getInstance(AutoImportProjectOpenProcessor.class);
 
   @Override
   public @NotNull

--- a/base/src/com/google/idea/blaze/base/project/AutoImportProjectOpenProcessor.java
+++ b/base/src/com/google/idea/blaze/base/project/AutoImportProjectOpenProcessor.java
@@ -37,11 +37,22 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
-import javax.swing.Icon;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Adds {@link ProjectOpenProcessor} to import project by opening it directly from a directory
+ * <p>
+ * Project view can be created from (in order of existence):
+ * <ul>
+ *  <li>ENV var: INTELLIJ_BAZEL_PROJECT_VIEW_TEMPLATE=/home/user/some.bazelproject</li>
+ *  <li>workspace - tools/intellij/.managed.bazelproject</li>
+ *  <li>if above do not exist, creates minimal project view file</li>
+ * </ul>
+ *
+ * Must be loaded after {@link BlazeProjectOpenProcessor} to only import new projects.
+ */
 public class AutoImportProjectOpenProcessor extends ProjectOpenProcessor {
 
   private static final Logger LOG = Logger.getInstance(AutoImportProjectOpenProcessor.class);

--- a/base/src/com/google/idea/blaze/base/project/NewBazelProjectOpenProcessor.java
+++ b/base/src/com/google/idea/blaze/base/project/NewBazelProjectOpenProcessor.java
@@ -104,33 +104,6 @@ public class NewBazelProjectOpenProcessor extends ProjectOpenProcessor {
     Project newProject = createProject(virtualFile);
     Objects.requireNonNull(newProject);
 
-    StartupManager.getInstance(newProject)
-        .registerPostStartupActivity(
-            () -> {
-              // ensure the dialog is shown after all startup activities are done
-              //noinspection SSBasedInspection
-              SwingUtilities.invokeLater(
-                  () -> {
-                    if (newProject.isDisposed()) {
-                      return;
-                    }
-                    ApplicationManager.getApplication()
-                        .invokeLater(
-                            () -> {
-                              if (newProject.isDisposed()) {
-                                return;
-                              }
-                              final ToolWindow toolWindow =
-                                  ToolWindowManager.getInstance(newProject)
-                                      .getToolWindow(ToolWindowId.PROJECT_VIEW);
-                              if (toolWindow != null) {
-                                toolWindow.activate(null);
-                              }
-                            },
-                            ModalityState.NON_MODAL);
-                  });
-            });
-
     Path projectFilePath = Paths.get(Objects.requireNonNull(newProject.getProjectFilePath()));
     ProjectUtil.updateLastProjectLocation(projectFilePath);
 

--- a/base/src/com/google/idea/blaze/base/project/NewBazelProjectOpenProcessor.java
+++ b/base/src/com/google/idea/blaze/base/project/NewBazelProjectOpenProcessor.java
@@ -53,8 +53,6 @@ public class NewBazelProjectOpenProcessor extends ProjectOpenProcessor {
 
   private static final Logger LOG = Logger.getInstance(NewBazelProjectOpenProcessor.class);
 
-  private final BlazeProjectOpenProcessor existingProjectProcessor = new BlazeProjectOpenProcessor();
-
   @Override
   public @NotNull
   @Nls
@@ -80,7 +78,7 @@ public class NewBazelProjectOpenProcessor extends ProjectOpenProcessor {
 
   @Override
   public boolean canOpenProject(@NotNull VirtualFile virtualFile) {
-    return !existingProjectProcessor.canOpenProject(virtualFile) && isBazelWorkspace(virtualFile);
+    return isBazelWorkspace(virtualFile);
   }
 
   private boolean isBazelWorkspace(VirtualFile virtualFile) {

--- a/base/src/com/google/idea/blaze/base/project/NewBazelProjectOpenProcessor.java
+++ b/base/src/com/google/idea/blaze/base/project/NewBazelProjectOpenProcessor.java
@@ -1,0 +1,264 @@
+package com.google.idea.blaze.base.project;
+
+import com.google.idea.blaze.base.model.primitives.WorkspacePath;
+import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
+import com.google.idea.blaze.base.projectview.ProjectView;
+import com.google.idea.blaze.base.projectview.ProjectView.Builder;
+import com.google.idea.blaze.base.projectview.ProjectViewSet;
+import com.google.idea.blaze.base.projectview.parser.ProjectViewParser;
+import com.google.idea.blaze.base.projectview.section.ListSection;
+import com.google.idea.blaze.base.projectview.section.ScalarSection;
+import com.google.idea.blaze.base.projectview.section.sections.AutomaticallyDeriveTargetsSection;
+import com.google.idea.blaze.base.projectview.section.sections.DirectoryEntry;
+import com.google.idea.blaze.base.projectview.section.sections.DirectorySection;
+import com.google.idea.blaze.base.projectview.section.sections.TextBlock;
+import com.google.idea.blaze.base.projectview.section.sections.TextBlockSection;
+import com.google.idea.blaze.base.settings.Blaze;
+import com.google.idea.blaze.base.settings.BuildSystemName;
+import com.google.idea.blaze.base.sync.workspace.WorkspacePathResolver;
+import com.google.idea.blaze.base.sync.workspace.WorkspacePathResolverImpl;
+import com.google.idea.blaze.base.wizard2.BlazeProjectCommitException;
+import com.google.idea.blaze.base.wizard2.BlazeProjectImportBuilder;
+import com.google.idea.blaze.base.wizard2.CreateFromScratchProjectViewOption;
+import com.google.idea.blaze.base.wizard2.WorkspaceTypeData;
+import com.intellij.ide.SaveAndSyncHandler;
+import com.intellij.ide.impl.OpenProjectTask;
+import com.intellij.ide.impl.ProjectUtil;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
+import com.intellij.openapi.project.ex.ProjectManagerEx;
+import com.intellij.openapi.startup.StartupManager;
+import com.intellij.openapi.util.io.FileUtil;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.openapi.wm.ToolWindowId;
+import com.intellij.openapi.wm.ToolWindowManager;
+import com.intellij.projectImport.ProjectOpenProcessor;
+import icons.BlazeIcons;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Objects;
+import javax.swing.Icon;
+import javax.swing.SwingUtilities;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class NewBazelProjectOpenProcessor extends ProjectOpenProcessor {
+
+  private static final Logger LOG = Logger.getInstance(NewBazelProjectOpenProcessor.class);
+
+  private final BlazeProjectOpenProcessor existingProjectProcessor = new BlazeProjectOpenProcessor();
+
+  @Override
+  public @NotNull
+  @Nls
+  String getName() {
+    return Blaze.defaultBuildSystemName() + " Project";
+  }
+
+  @javax.annotation.Nullable
+  @Override
+  public Icon getIcon() {
+    return BlazeIcons.Logo;
+  }
+
+  @Override
+  public boolean isStrongProjectInfoHolder() {
+    return true;
+  }
+
+  @Override
+  public boolean lookForProjectsInDirectory() {
+    return false;
+  }
+
+  @Override
+  public boolean canOpenProject(@NotNull VirtualFile virtualFile) {
+    return !existingProjectProcessor.canOpenProject(virtualFile) && isBazelWorkspace(virtualFile);
+  }
+
+  private boolean isBazelWorkspace(VirtualFile virtualFile) {
+    return virtualFile.findChild("WORKSPACE") != null
+        || virtualFile.findChild("WORKSPACE.bazel") != null;
+  }
+
+  @Override
+  public @Nullable
+  Project doOpenProject(
+      @NotNull VirtualFile virtualFile,
+      @Nullable Project projectToClose,
+      boolean forceOpenInNewFrame
+  ) {
+
+    ProjectManager pm = ProjectManager.getInstance();
+    if (projectToClose != null) {
+      pm.closeAndDispose(projectToClose);
+    }
+
+    Project newProject = createProject(virtualFile);
+    Objects.requireNonNull(newProject);
+
+    StartupManager.getInstance(newProject)
+        .registerPostStartupActivity(
+            () -> {
+              // ensure the dialog is shown after all startup activities are done
+              //noinspection SSBasedInspection
+              SwingUtilities.invokeLater(
+                  () -> {
+                    if (newProject.isDisposed()) {
+                      return;
+                    }
+                    ApplicationManager.getApplication()
+                        .invokeLater(
+                            () -> {
+                              if (newProject.isDisposed()) {
+                                return;
+                              }
+                              final ToolWindow toolWindow =
+                                  ToolWindowManager.getInstance(newProject)
+                                      .getToolWindow(ToolWindowId.PROJECT_VIEW);
+                              if (toolWindow != null) {
+                                toolWindow.activate(null);
+                              }
+                            },
+                            ModalityState.NON_MODAL);
+                  });
+            });
+
+    Path projectFilePath = Paths.get(Objects.requireNonNull(newProject.getProjectFilePath()));
+    ProjectUtil.updateLastProjectLocation(projectFilePath);
+
+    ProjectManagerEx.getInstanceEx()
+        .openProject(
+            projectFilePath,
+            OpenProjectTask.withCreatedProject(newProject)
+        );
+    SaveAndSyncHandler.getInstance().scheduleProjectSave(newProject);
+    return newProject;
+  }
+
+  @Nullable
+  private Project createProject(@NotNull VirtualFile virtualFile) {
+
+    String projectFilePath = virtualFile.getPath() + "/.ijwb";
+    createDirs(projectFilePath);
+
+    String name = virtualFile.getName();
+
+    File projectViewFile = new File(projectFilePath + "/.bazelproject");
+
+    BlazeProjectImportBuilder builder = new BlazeProjectImportBuilder();
+    File workspaceRootFile = new File(virtualFile.getPath());
+    WorkspaceRoot root = new WorkspaceRoot(workspaceRootFile);
+
+    WorkspacePathResolver pathResolver = new WorkspacePathResolverImpl(root);
+    builder.builder().setWorkspaceData(
+        WorkspaceTypeData.builder()
+            .setWorkspaceName(workspaceRootFile.getName())
+            .setWorkspaceRoot(root)
+            .setCanonicalProjectDataLocation(workspaceRootFile)
+            .setFileBrowserRoot(workspaceRootFile)
+            .setWorkspacePathResolver(pathResolver)
+            .setBuildSystem(BuildSystemName.Bazel)
+            .build()
+    );
+    ProjectView projectView = createProjectView(virtualFile, pathResolver);
+
+    builder.builder().setProjectView(projectView);
+    builder.builder().setProjectViewFile(projectViewFile);
+    builder.builder().setProjectViewSet(ProjectViewSet.builder().add(projectView).build());
+    builder.builder().setProjectViewOption(new CreateFromScratchProjectViewOption());
+    builder.builder().setProjectName(name);
+    builder.builder().setProjectDataDirectory(projectFilePath);
+
+    try {
+      builder.builder().commit(); // set pending project settings
+    } catch (BlazeProjectCommitException e) {
+      LOG.error("Failed to commit project import builder", e);
+    }
+
+    Project newProject = builder.createProject(name, projectFilePath);
+    if (newProject == null) {
+      LOG.error("Failed to Bazel create project");
+      return null;
+    }
+
+    newProject.save();
+
+    if (!builder.validate(null, newProject)) {
+      LOG.error("New Bazel project validation failed");
+      return null;
+    }
+
+    builder.builder().commitToProject(newProject); // required to trigger sync
+    return newProject;
+  }
+
+  private void createDirs(String projectFilePath) {
+    try {
+      FileUtil.ensureExists(new File(projectFilePath, Project.DIRECTORY_STORE_FOLDER));
+    } catch (IOException e) {
+      LOG.error("Failed creating project dirs", e);
+    }
+  }
+
+  private ProjectView defaultEmptyProjectView() {
+    Builder projectViewBuilder = ProjectView.builder();
+
+    projectViewBuilder.add(
+        ListSection
+            .builder(DirectorySection.KEY)
+            .add(DirectoryEntry.include(new WorkspacePath(".")))
+            .build()
+    );
+
+    projectViewBuilder.add(TextBlockSection.of(TextBlock.newLine()));
+
+    projectViewBuilder.add(
+        ScalarSection
+            .builder(AutomaticallyDeriveTargetsSection.KEY)
+            .set(false)
+            .build()
+    );
+
+    return projectViewBuilder.build();
+  }
+
+  private ProjectView createProjectView(VirtualFile workspaceRoot,
+      WorkspacePathResolver pathResolver) {
+
+    // first check env for project view template
+    String projectViewFileFromEnv = System.getenv(
+        "INTELLIJ_BAZEL_PROJECT_VIEW_TEMPLATE");
+
+    if (projectViewFileFromEnv != null) {
+      return fromFileProjectView(Paths.get(projectViewFileFromEnv), pathResolver);
+    }
+
+    // second check managed project view template
+    Path managedProjectViewFilePath = workspaceRoot.toNioPath()
+        .resolve("tools/intellij/.managed.bazelproject");
+    if (managedProjectViewFilePath.toFile().exists()) {
+      return fromFileProjectView(managedProjectViewFilePath, pathResolver);
+    }
+
+    // create minimal project view file manually
+    return defaultEmptyProjectView();
+  }
+
+  private ProjectView fromFileProjectView(
+      Path projectViewFilePath,
+      WorkspacePathResolver pathResolver
+  ) {
+    ProjectViewParser projectViewParser = new ProjectViewParser(null, pathResolver);
+    projectViewParser.parseProjectView(projectViewFilePath.toFile());
+    ProjectViewSet result = projectViewParser.getResult();
+    return Objects.requireNonNull(result.getTopLevelProjectViewFile()).projectView;
+  }
+}

--- a/base/src/com/google/idea/blaze/base/wizard2/BlazeNewProjectBuilder.java
+++ b/base/src/com/google/idea/blaze/base/wizard2/BlazeNewProjectBuilder.java
@@ -209,7 +209,7 @@ public final class BlazeNewProjectBuilder {
    * Commits the project data. This method mustn't fail, because the project has already been
    * created.
    */
-  void commitToProject(Project project) {
+  public void commitToProject(Project project) {
     BlazeWizardUserSettingsStorage.getInstance().commit(userSettings);
     EventLoggingService.getInstance()
         .logEvent(getClass(), "blaze-project-created", ImmutableMap.copyOf(userSettings.values));

--- a/base/src/com/google/idea/blaze/base/wizard2/BlazeProjectImportBuilder.java
+++ b/base/src/com/google/idea/blaze/base/wizard2/BlazeProjectImportBuilder.java
@@ -25,7 +25,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 
 /** Wrapper around a {@link BlazeNewProjectBuilder} to fit into IntelliJ's import framework. */
-class BlazeProjectImportBuilder extends ProjectBuilder {
+public class BlazeProjectImportBuilder extends ProjectBuilder {
   private BlazeNewProjectBuilder builder = new BlazeNewProjectBuilder();
 
   @Nullable


### PR DESCRIPTION
Opening this PR for discussion, as current implementation may be a bit too feature rich. 

### Motivation:
This PR adds support for opening unimported Bazel projects directly from a directory without a need to go over import wizard steps. **We need this feature to be able to open Bazel projects using remote Intellij.**

### Implementation:
Adds ProjectOpenProcessor to import project by opening it directly from directory

Project view can be created from (in order of existence):
- ENV var: `INTELLIJ_BAZEL_PROJECT_VIEW_TEMPLATE=/home/user/some.bazelproject`
- from workspace: `tools/intellij/.managed.bazelproject`
- if above don't exist, creates minimal project view file manually


