### PR TITLE
Support go_transition_test kind

### DIFF
--- a/aspect/intellij_info_impl.bzl
+++ b/aspect/intellij_info_impl.bzl
@@ -366,6 +366,7 @@ def collect_go_info(target, ctx, semantics, ide_info, ide_info_file, output_grou
         "go_binary",
         "go_library",
         "go_test",
+        "go_transition_test",
         "go_appengine_binary",
         "go_appengine_library",
         "go_appengine_test",
@@ -394,7 +395,7 @@ def collect_go_info(target, ctx, semantics, ide_info, ide_info_file, output_grou
         import_path = go_semantics.get_import_path(ctx)
 
     library_labels = []
-    if ctx.rule.kind == "go_test" or ctx.rule.kind == "go_appengine_test":
+    if ctx.rule.kind == "go_test" or ctx.rule.kind == "go_transition_test" or ctx.rule.kind == "go_appengine_test":
         if getattr(ctx.rule.attr, "library", None) != None:
             library_labels = [str(ctx.rule.attr.library.label)]
         elif getattr(ctx.rule.attr, "embed", None) != None:

--- a/golang/src/com/google/idea/blaze/golang/GoBlazeRules.java
+++ b/golang/src/com/google/idea/blaze/golang/GoBlazeRules.java
@@ -30,6 +30,7 @@ public final class GoBlazeRules implements Kind.Provider {
   /** Go-specific blaze rules. */
   public enum RuleTypes {
     GO_TEST("go_test", LanguageClass.GO, RuleType.TEST),
+    GO_TRANSITION_TEST("go_transition_test", LanguageClass.GO, RuleType.TEST),
     GO_APPENGINE_TEST("go_appengine_test", LanguageClass.GO, RuleType.TEST),
     GO_BINARY("go_binary", LanguageClass.GO, RuleType.BINARY),
     GO_APPENGINE_BINARY("go_appengine_binary", LanguageClass.GO, RuleType.BINARY),


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: https://github.com/bazelbuild/rules_go/pull/3160

# Description of this change

If a `go_test` has, for example, `race` turned on than `rules_go` will [transition the original target](https://github.com/bazelbuild/rules_go/blob/db9458406295b6f569fc1fa5142483636fb86b45/go/private/rules/transition.bzl#L83-L97) into a new one with a new kind. This change adds support for it.

