### PR TITLE
Fix a bug with setting test folders in ContentEntryEditor

### DIFF
--- a/base/src/com/google/idea/blaze/base/sync/projectstructure/ContentEntryEditor.java
+++ b/base/src/com/google/idea/blaze/base/sync/projectstructure/ContentEntryEditor.java
@@ -104,7 +104,7 @@ public class ContentEntryEditor {
     if (currentOrParent != null && isTest != currentOrParent.isTestSource()) {
       currentOrParent =
           provider.setSourceFolderForLocation(contentEntry, currentOrParent, file, isTest);
-      if (current != null) {
+      if (current != null && !current.equals(currentOrParent)) {
         contentEntry.removeSourceFolder(current);
       }
     }


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: [3670](https://github.com/bazelbuild/intellij/issues/3670)

# Description of this change
If a test folder is not conforming to any regex in the project view file but is marked as a test source by the SourceFolderProvider, then the `setSourceFolderForLocation` method is called on the relevant SourceFolderProvider. However, if the provider then adds the folder as a test source anyway, the ContentEntryEditor removes it in the subsequent step, because the ContentEntry map has the (folder, isTestSource) pair as the unique key. This prevents the SourceFolderProviders from setting the test source folders
