### PR TITLE
Improve performance of Java package parser by making it a Bazel worker

### DIFF
--- a/aspect/intellij_info_impl.bzl
+++ b/aspect/intellij_info_impl.bzl
@@ -694,7 +694,15 @@ def build_java_package_manifest(ctx, target, source_files, suffix):
         join_with = ":",
         map_each = _package_manifest_file_argument,
     )
-    args.use_param_file("@%s")
+
+    # Bazel has an option to put your command line args in a file, and then pass the name of that file as the only
+    # argument to your executable. The PackageParser supports taking args in this way, we can pass in an args file
+    # as "@filename".
+    # Bazel Persistent Workers take their input as a file that contains the argument that will be parsed and turned
+    # into a WorkRequest proto and read on stdin. It also wants an argument of the form "@filename". We can use the
+    # params file as an arg file.
+    # Thus if we always use a params file, we can support both persistent worker mode and local mode (regular) mode.
+    args.use_param_file("@%s", use_always = True)
     args.set_param_file_format("multiline")
 
     ctx.actions.run(
@@ -704,6 +712,10 @@ def build_java_package_manifest(ctx, target, source_files, suffix):
         arguments = [args],
         mnemonic = "JavaPackageManifest",
         progress_message = "Parsing java package strings for " + str(target.label),
+        execution_requirements = {
+            "supports-workers": "1",
+            "requires-worker-protocol": "proto",
+        },
     )
     return output
 

--- a/aspect/tools/BUILD
+++ b/aspect/tools/BUILD
@@ -22,6 +22,7 @@ java_library(
         ":guava",
         "//intellij_platform_sdk:jsr305",
         "//proto:proto_deps",
+        "//third_party/bazel/src/main/protobuf:worker_protocol_java_proto",
     ],
 )
 


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change 
- [ ] and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #3685

# Description of this change
Makes the package parser tool (a Java CLI application) able to be run as a Bazel worker. Also modify the Starlark to enable worker mode.
