### PR TITLE
Add .bazelrc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bazel-*
 /.ijwb/
 /.aswb/
 /.clwb/
+.bazelrc


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

# Discussion thread for this change

Issue number: https://github.com/bazelbuild/intellij/issues/3726

# Description of this change

Allows devs to specify settings for all build targets without using a global `$HOME/.bazelrc` and without having to add things like `--define=<stuff>` to `bazel build //<path/to/target>`.

```
$ cat .bazelrc
build --define=ij_product=intellij-ue-oss-stable
```

Note that something like this is also useful for getting sync'ing to work; i.e.:

<img width="438" alt="image" src="https://user-images.githubusercontent.com/1097794/175792127-df18d430-0428-4295-8554-2b42ef5815f8.png">

Results in this attribute error:

```
ERROR: /Users/ahillman/Development/intellij/aswb/BUILD:106:13: configurable attribute "srcs" in //aswb:aswb_lib doesn't match this configuration: define an intellij product version, e.g. --define=ij_product=intellij-latest
```

... which a `.bazelrc` with the above contents would rectify.