### PR TITLE
Make "Import Bazel Project" action visible in Remote Development mode

### DIFF
--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -18,7 +18,7 @@
       <action id="Blaze.ImportProject2"
           class="com.google.idea.blaze.base.wizard2.BlazeImportProjectAction"
           icon="BlazeIcons.Logo">
-        <add-to-group group-id="FileOpenGroup" anchor="first"/>
+        <add-to-group group-id="FileMenu" anchor="first"/>
         <add-to-group group-id="WelcomeScreen.QuickStart" anchor="before"
             relative-to-action="Vcs.VcsClone"/>
       </action>


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #3775 

# Description of this change
Move the "Import Bazel Project" Button to a group visible in Remote Development Mode