### PR TITLE
Remove nolaunch_app to fix mobile-install

### DIFF
--- a/aswb/src/com/google/idea/blaze/android/run/binary/mobileinstall/MobileInstallBuildStep.java
+++ b/aswb/src/com/google/idea/blaze/android/run/binary/mobileinstall/MobileInstallBuildStep.java
@@ -150,6 +150,7 @@ public class MobileInstallBuildStep implements ApkBuildStep {
       return;
     }
 
+    BuildSystemName buildSystemName = Blaze.getBuildSystemName(project);
     BuildInvoker invoker =
         Blaze.getBuildSystemProvider(project).getBuildSystem().getBuildInvoker(project, context);
     BlazeCommand.Builder command = BlazeCommand.builder(invoker, BlazeCommandName.MOBILE_INSTALL);
@@ -167,7 +168,7 @@ public class MobileInstallBuildStep implements ApkBuildStep {
     }
 
     WorkspaceRoot workspaceRoot = WorkspaceRoot.fromProject(project);
-    final String deployInfoSuffix = getDeployInfoSuffix(Blaze.getBuildSystemName(project));
+    final String deployInfoSuffix = getDeployInfoSuffix(buildSystemName);
 
     try (BuildResultHelper buildResultHelper = invoker.createBuildResultHelper();
         AdbTunnelConfigurator tunnelConfig = getTunnelConfigurator(context)) {
@@ -196,6 +197,11 @@ public class MobileInstallBuildStep implements ApkBuildStep {
           .addBlazeFlags(blazeFlags)
           .addBlazeFlags(buildResultHelper.getBuildFlags())
           .addExeFlags(exeFlags);
+
+      if (buildSystemName == BuildSystemName.Blaze) {
+          // MI launches apps by default. Defer app launch to BlazeAndroidLaunchTasksProvider.
+          command.addExeFlags("--nolaunch_app");
+      }
 
       if (StudioDeployerExperiment.isEnabled()) {
         command.addExeFlags("--nodeploy");

--- a/aswb/src/com/google/idea/blaze/android/run/binary/mobileinstall/MobileInstallBuildStep.java
+++ b/aswb/src/com/google/idea/blaze/android/run/binary/mobileinstall/MobileInstallBuildStep.java
@@ -195,9 +195,7 @@ public class MobileInstallBuildStep implements ApkBuildStep {
           .addTargets(label)
           .addBlazeFlags(blazeFlags)
           .addBlazeFlags(buildResultHelper.getBuildFlags())
-          .addExeFlags(exeFlags)
-          // MI launches apps by default. Defer app launch to BlazeAndroidLaunchTasksProvider.
-          .addExeFlags("--nolaunch_app");
+          .addExeFlags(exeFlags);
 
       if (StudioDeployerExperiment.isEnabled()) {
         command.addExeFlags("--nodeploy");

--- a/aswb/tests/integrationtests/com/google/idea/blaze/android/functional/MobileInstallBuildStepIntegrationTest.java
+++ b/aswb/tests/integrationtests/com/google/idea/blaze/android/functional/MobileInstallBuildStepIntegrationTest.java
@@ -157,7 +157,6 @@ public class MobileInstallBuildStepIntegrationTest extends BlazeAndroidIntegrati
     assertThat(externalTaskInterceptor.context).isEqualTo(context);
     assertThat(externalTaskInterceptor.command).containsAllIn(blazeFlags);
     assertThat(externalTaskInterceptor.command).containsAllIn(execFlags);
-    assertThat(externalTaskInterceptor.command).contains("--nolaunch_app");
     assertThat(externalTaskInterceptor.command)
         .containsAnyOf("serial-number", "serial-number:tcp:0");
     assertThat(externalTaskInterceptor.command).contains(buildTarget.toString());
@@ -196,7 +195,6 @@ public class MobileInstallBuildStepIntegrationTest extends BlazeAndroidIntegrati
     assertThat(externalTaskInterceptor.context).isEqualTo(context);
     assertThat(externalTaskInterceptor.command).containsAllIn(blazeFlags);
     assertThat(externalTaskInterceptor.command).containsAllIn(execFlags);
-    assertThat(externalTaskInterceptor.command).contains("--nolaunch_app");
     assertThat(externalTaskInterceptor.command).contains("--device");
     // workaround for inconsistent stateful AndroidDebugBridge class.
     assertThat(externalTaskInterceptor.command)
@@ -237,7 +235,6 @@ public class MobileInstallBuildStepIntegrationTest extends BlazeAndroidIntegrati
     assertThat(externalTaskInterceptor.context).isEqualTo(context);
     assertThat(externalTaskInterceptor.command).containsAllIn(blazeFlags);
     assertThat(externalTaskInterceptor.command).containsAllIn(execFlags);
-    assertThat(externalTaskInterceptor.command).contains("--nolaunch_app");
     assertThat(externalTaskInterceptor.command).contains("--device");
     assertThat(externalTaskInterceptor.command).contains("serial-number:tcp:12345");
     assertThat(externalTaskInterceptor.command).contains(buildTarget.toString());
@@ -276,7 +273,6 @@ public class MobileInstallBuildStepIntegrationTest extends BlazeAndroidIntegrati
     assertThat(externalTaskInterceptor.context).isEqualTo(context);
     assertThat(externalTaskInterceptor.command).containsAllIn(blazeFlags);
     assertThat(externalTaskInterceptor.command).containsAllIn(execFlags);
-    assertThat(externalTaskInterceptor.command).contains("--nolaunch_app");
     assertThat(externalTaskInterceptor.command).contains("--device");
     // workaround for inconsistent stateful AndroidDebugBridge class.
     assertThat(externalTaskInterceptor.command)


### PR DESCRIPTION
## Checklist

- [X] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [X] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See  the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more details.

## Discussion thread for this change
https://github.com/bazelbuild/intellij/issues/2328 and https://github.com/bazelbuild/intellij/issues/2084

## Description of this change

When running `mobile-install` through Android Studio, it appends the `--nolaunch_app` flag to the command. This flag cannot be found and prevents the app from being installed. This PR removes it. Perhaps `nolaunch_app` was removed or it only exists in Blaze?

```
Invoking mobile-install...
Command: bazel mobile-install --tool_tag=ijwb:AndroidStudio --adb sdk/platform-tools/adb --device ABC123:tcp:7890 --curses=no --color=yes --progress_in_terminal_title=no --build_event_binary_file=/tmp/intellij-bep-3 --nobuild_event_binary_file_path_conversion -- //src/main:template_app --nolaunch_app

Loading: 
Loading: 0 packages loaded
ERROR: Skipping '-nolaunch_app': no such target '//:-nolaunch_app': target '-nolaunch_app' not declared in package '' defined by android-bazel-java-app-template/BUILD
WARNING: Target pattern parsing failed.
ERROR: no such target '//:-nolaunch_app': target '-nolaunch_app' not declared in package '' defined by android-bazel-java-app-template/BUILD
```

This PR https://github.com/bazelbuild/intellij/pull/3202 attempted to fix the issue but I was still able to reproduce using that branch.

## Root Cause Analysis
This was added in https://github.com/bazelbuild/intellij/pull/1895

## Reproduction Steps

1. Have an android bazel project. I used https://github.com/jaredsburrows/android-bazel-java-app-template
2. On the run configuration check `mobile-install`
3. Press the run button

![Screenshot from 2022-07-25 16-00-46](https://user-images.githubusercontent.com/6628497/180864254-e0b943cf-dcc6-451e-8d68-d3b4b889b126.png)


Android Studio: `Chipmunk 2021.2.1 Patch 1`
Bazel Plugin: `2022.06.14.0.1-api-version-212`
bazel: `5.2.0`