### PR TITLE
Make ArtifactLocation.getExecutionRootRelativePath() return Path inst…

### DIFF
--- a/aswb/tests/integrationtests/com/google/idea/blaze/android/projectsystem/RenderJarClassFileFinderTest.java
+++ b/aswb/tests/integrationtests/com/google/idea/blaze/android/projectsystem/RenderJarClassFileFinderTest.java
@@ -54,6 +54,7 @@ import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.module.StdModuleTypes;
 import java.io.File;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Objects;
 import org.junit.Before;
@@ -85,8 +86,7 @@ public class RenderJarClassFileFinderTest extends BlazeAndroidIntegrationTestCas
         new MockArtifactLocationDecoder() {
           @Override
           public File decode(ArtifactLocation artifactLocation) {
-            File f =
-                new File(fileSystem.getRootDir(), artifactLocation.getExecutionRootRelativePath());
+            File f = Paths.get(fileSystem.getRootDir()).resolve(artifactLocation.getExecutionRootRelativePath()).toFile();
 
             // Create the artifact if it does not exist
             // This allows us to set fileModifiedTime for the file which is used by RenderJarCache

--- a/aswb/tests/integrationtests/com/google/idea/blaze/android/sync/importer/BlazeAndroidWorkspaceImporterTest.java
+++ b/aswb/tests/integrationtests/com/google/idea/blaze/android/sync/importer/BlazeAndroidWorkspaceImporterTest.java
@@ -1454,17 +1454,17 @@ public class BlazeAndroidWorkspaceImporterTest extends BlazeTestCase {
   }
 
   private static String aarJarName(AarLibrary library) {
-    return new File(library.libraryArtifact.jarForIntellijLibrary().getExecutionRootRelativePath())
-        .getName();
+    return library.libraryArtifact.jarForIntellijLibrary().getExecutionRootRelativePath()
+        .toFile().getName();
   }
 
   private static String aarName(AarLibrary library) {
-    return new File(library.aarArtifact.getExecutionRootRelativePath()).getName();
+    return library.aarArtifact.getExecutionRootRelativePath().toFile().getName();
   }
 
   private static String libraryJarName(BlazeJarLibrary library) {
-    return new File(library.libraryArtifact.jarForIntellijLibrary().getExecutionRootRelativePath())
-        .getName();
+    return library.libraryArtifact.jarForIntellijLibrary().getExecutionRootRelativePath()
+        .toFile().getName();
   }
 
   private ArtifactLocation source(String relativePath) {

--- a/aswb/tests/integrationtests/com/google/idea/blaze/android/sync/model/idea/BlazeImportFixture.java
+++ b/aswb/tests/integrationtests/com/google/idea/blaze/android/sync/model/idea/BlazeImportFixture.java
@@ -65,6 +65,7 @@ import com.google.idea.blaze.java.sync.model.BlazeJavaImportResult;
 import com.google.idea.blaze.java.sync.model.BlazeJavaSyncData;
 import com.intellij.openapi.project.Project;
 import java.io.File;
+import java.nio.file.Paths;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -181,7 +182,7 @@ public final class BlazeImportFixture {
   }
 
   public static File decodePath(ArtifactLocation location) {
-    return new File("/src", location.getExecutionRootRelativePath());
+    return Paths.get("/src").resolve(location.getExecutionRootRelativePath()).toFile();
   }
 
   public ProjectView getProjectView() {
@@ -335,7 +336,7 @@ public final class BlazeImportFixture {
     for (String relativeJarPath : relativeJarPaths) {
       ArtifactLocation jar = source(relativeJarPath);
       builder.addJar(LibraryArtifact.builder().setClassJar(jar));
-      fileSystem.createFile(jar.getExecutionRootRelativePath());
+      fileSystem.createFile(jar.getExecutionRootRelativePath().toString());
     }
     return builder;
   }

--- a/aswb/tests/unittests/com/google/idea/blaze/android/rendering/BlazeRenderErrorContributorTest.java
+++ b/aswb/tests/unittests/com/google/idea/blaze/android/rendering/BlazeRenderErrorContributorTest.java
@@ -75,6 +75,7 @@ import com.intellij.psi.impl.JvmPsiConversionHelperImpl;
 import com.intellij.psi.search.ProjectScopeBuilder;
 import com.intellij.psi.search.ProjectScopeBuilderImpl;
 import java.io.File;
+import java.nio.file.Paths;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.junit.Ignore;
@@ -714,7 +715,7 @@ public class BlazeRenderErrorContributorTest extends BlazeTestCase {
           new MockArtifactLocationDecoder() {
             @Override
             public File decode(ArtifactLocation location) {
-              return new File("/src", location.getExecutionRootRelativePath());
+              return Paths.get("/src").resolve(location.getExecutionRootRelativePath()).toFile();
             }
           };
       this.blazeProjectData =

--- a/base/src/com/google/idea/blaze/base/ideinfo/ArtifactLocation.java
+++ b/base/src/com/google/idea/blaze/base/ideinfo/ArtifactLocation.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ComparisonChain;
 import com.google.devtools.intellij.aspect.Common;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.intellij.openapi.util.text.StringUtil;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
@@ -112,8 +113,15 @@ public final class ArtifactLocation
   }
 
   /** For main-workspace source artifacts, this is simply the workspace-relative path. */
-  public String getExecutionRootRelativePath() {
-    return Paths.get(getRootExecutionPathFragment(), getRelativePath()).toString();
+  public Path getExecutionRootRelativePath() {
+    Path path = Paths.get(getRootExecutionPathFragment(), getRelativePath());
+    if (path.isAbsolute()) {
+      // Result must always be relative. If it is absolute (due to rootExecutionPathFragment
+      // or relativePath being mistakenly set to an absolute path) - we forcefully make it absolute
+      // by removing the root part.
+      path = path.getRoot().relativize(path);
+    }
+    return path;
   }
 
   public static Builder builder() {
@@ -187,7 +195,7 @@ public final class ArtifactLocation
 
   @Override
   public String toString() {
-    return getExecutionRootRelativePath();
+    return getExecutionRootRelativePath().toString();
   }
 
   @Override

--- a/base/src/com/google/idea/blaze/base/model/LibraryKey.java
+++ b/base/src/com/google/idea/blaze/base/model/LibraryKey.java
@@ -31,7 +31,7 @@ public final class LibraryKey implements ProtoWrapper<String> {
   }
 
   public static String libraryNameFromArtifactLocation(ArtifactLocation artifactLocation) {
-    File file = new File(artifactLocation.getExecutionRootRelativePath());
+    File file = artifactLocation.getExecutionRootRelativePath().toFile();
     String parent = file.getParent();
     int parentHash = parent != null ? parent.hashCode() : file.hashCode();
     return FileUtil.getNameWithoutExtension(file) + "_" + Integer.toHexString(parentHash);

--- a/base/src/com/google/idea/blaze/base/model/RemoteOutputArtifacts.java
+++ b/base/src/com/google/idea/blaze/base/model/RemoteOutputArtifacts.java
@@ -30,6 +30,9 @@ import com.google.idea.blaze.base.ideinfo.ProtoWrapper;
 import com.google.idea.blaze.base.ideinfo.TargetIdeInfo;
 import com.google.idea.blaze.base.ideinfo.TargetMap;
 import com.google.idea.blaze.base.sync.projectview.WorkspaceLanguageSettings;
+import com.intellij.openapi.util.io.FileUtil;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -154,11 +157,12 @@ public final class RemoteOutputArtifacts
     if (location.isSource()) {
       return null;
     }
-    String execRootPath = location.getExecutionRootRelativePath();
-    if (!execRootPath.startsWith("blaze-out/")) {
+    Path execRootPath = location.getExecutionRootRelativePath();
+    Path blazeOutPrefix = Paths.get("blaze-out");
+    if (!execRootPath.startsWith(blazeOutPrefix)) {
       return null;
     }
-    return findRemoteOutput(execRootPath.substring("blaze-out/".length()));
+    return findRemoteOutput(FileUtil.toCanonicalPath(blazeOutPrefix.relativize(execRootPath).toString()));
   }
 
   @Nullable

--- a/base/tests/unittests/com/google/idea/blaze/base/sync/workspace/ArtifactLocationDecoderTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/sync/workspace/ArtifactLocationDecoderTest.java
@@ -68,7 +68,7 @@ public class ArtifactLocationDecoderTest extends BlazeTestCase {
                 .build());
 
     assertThat(artifactLocation.getRelativePath()).isEqualTo("com/google/Bla.java");
-    assertThat(artifactLocation.getExecutionRootRelativePath())
+    assertThat(artifactLocation.getExecutionRootRelativePath().toString())
         .isEqualTo("external/repo_name/com/google/Bla.java");
 
     ArtifactLocationDecoder decoder =
@@ -98,7 +98,7 @@ public class ArtifactLocationDecoderTest extends BlazeTestCase {
                 .build());
 
     assertThat(artifactLocation.getRelativePath()).isEqualTo("com/google/Bla.java");
-    assertThat(artifactLocation.getExecutionRootRelativePath())
+    assertThat(artifactLocation.getExecutionRootRelativePath().toString())
         .isEqualTo("blaze-out/crosstool/bin/external/repo_name/com/google/Bla.java");
 
     ArtifactLocationDecoder decoder =
@@ -130,7 +130,7 @@ public class ArtifactLocationDecoderTest extends BlazeTestCase {
                 .build());
 
     assertThat(artifactLocation.getRelativePath()).isEqualTo("com/google/Bla.java");
-    assertThat(artifactLocation.getExecutionRootRelativePath())
+    assertThat(artifactLocation.getExecutionRootRelativePath().toString())
         .isEqualTo("../repo_name/com/google/Bla.java");
 
     ArtifactLocationDecoder decoder =
@@ -160,7 +160,7 @@ public class ArtifactLocationDecoderTest extends BlazeTestCase {
                 .build());
 
     assertThat(artifactLocation.getRelativePath()).isEqualTo("com/google/Bla.java");
-    assertThat(artifactLocation.getExecutionRootRelativePath())
+    assertThat(artifactLocation.getExecutionRootRelativePath().toString())
         .isEqualTo("../repo_name/blaze-out/crosstool/bin/com/google/Bla.java");
 
     ArtifactLocationDecoder decoder =

--- a/base/tests/utils/unit/com/google/idea/blaze/base/sync/workspace/MockArtifactLocationDecoder.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/sync/workspace/MockArtifactLocationDecoder.java
@@ -58,6 +58,6 @@ public class MockArtifactLocationDecoder implements ArtifactLocationDecoder {
       return new FakeRemoteOutputArtifact(file);
     }
     return new LocalFileOutputArtifact(
-        decode(artifact), artifact.getRelativePath(), artifact.getExecutionRootRelativePath());
+        decode(artifact), artifact.getRelativePath(), artifact.getExecutionRootRelativePath().toString());
   }
 }

--- a/java/tests/unittests/com/google/idea/blaze/java/sync/importer/BlazeJavaWorkspaceImporterTest.java
+++ b/java/tests/unittests/com/google/idea/blaze/java/sync/importer/BlazeJavaWorkspaceImporterTest.java
@@ -1639,15 +1639,15 @@ public class BlazeJavaWorkspaceImporterTest extends BlazeTestCase {
             result.pluginProcessorJars.stream()
                 .map(
                     artifactLocation ->
-                        new File(artifactLocation.getExecutionRootRelativePath()).getName()))
+                        artifactLocation.getExecutionRootRelativePath().toFile().getName()))
         .containsExactly("lint.jar");
   }
 
   /* Utility methods */
 
   private static String libraryFileName(BlazeJarLibrary library) {
-    return new File(library.libraryArtifact.jarForIntellijLibrary().getExecutionRootRelativePath())
-        .getName();
+    return library.libraryArtifact.jarForIntellijLibrary().getExecutionRootRelativePath()
+        .toFile().getName();
   }
 
   @Nullable


### PR DESCRIPTION
Make ArtifactLocation.getExecutionRootRelativePath() return Path instead of String.

Update call-sites accordingly:
* Fix ArtifactLocationDecoderImpl.outputArtifactFromExecRoot being broken on Windows
* In the RemoteOutputArtifact always convert a path to canonical (with '/' on any OS) as remoteOutputArtifacts are keyed by OutputArtifact.getKey(), which always uses '/'.
* Trivial changes in all other places.

# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue numbers:
https://github.com/bazelbuild/intellij/issues/113 - this fixes one of the biggest problems on Windows - most of External 
Libraries disappearing when doing "Sync Project with BUILD files", specifically when Working Set is empty/insufficient.

It was also discussed in https://github.com/bazelbuild/intellij/issues/490#issuecomment-454383837 - there it was assumed that the problem is in the missing/broken jdeps files, which isn't correct as of now - jdeps files **are** correct, but we fail to read them because of paths issue in `ArtifactLocationDecoderImpl`.
There people have come with various workarounds (e.g. creating new branch helps, as it causes Working Set to be null (not empty!), which results in all targets being built and all target dependencies being added to External Libraries).
There are also at least 3 workaround-ish PR https://github.com/jesseschalken/intellij/commit/3b805f7f397856e08d723a46eca74cfa27418441 and https://github.com/gergelyfabian/intellij/commit/8e1bfdacb2f99da77582d736a0f5127d473be71f which "solve" the issue by doing full build every time (which is non-scalable).
https://github.com/bazelbuild/intellij/pull/1204 - tries to solve the actual problem in `ArtifactLocationDecoderImpl`, but in a bit of a hacky way.

There are also probably some duplicate issues (e.g. https://github.com/bazelbuild/intellij/issues/2277). I'll try to link them in the comments.

# Description of this change

