### PR TITLE
Fix execution of GCC (MinGW) on Windows

### DIFF
--- a/cpp/src/com/google/idea/blaze/cpp/CompilerVersionCheckerImpl.java
+++ b/cpp/src/com/google/idea/blaze/cpp/CompilerVersionCheckerImpl.java
@@ -19,6 +19,7 @@ import com.google.idea.blaze.base.async.process.ExternalTask;
 import com.google.idea.blaze.cpp.CompilerVersionChecker.VersionCheckException.IssueKind;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import static org.apache.commons.lang.SystemUtils.IS_OS_WINDOWS;
 
 /** Runs a compiler to check its version. */
 public class CompilerVersionCheckerImpl implements CompilerVersionChecker {
@@ -29,7 +30,11 @@ public class CompilerVersionCheckerImpl implements CompilerVersionChecker {
     if (!executionRoot.exists()) {
       throw new VersionCheckException(IssueKind.MISSING_EXEC_ROOT, "");
     }
-    if (!cppExecutable.exists()) {
+    if (!cppExecutable.exists()
+        // The default MinGW and MSYS2 toolchain configurations in Bazel lack the ".exe" suffix
+        // in the tool paths. This works fine for building, but it means we have to append ".exe"
+        // manually to know if the compiler actually exists.
+        && !(IS_OS_WINDOWS && new File(cppExecutable.getPath() + ".exe").exists())) {
       throw new VersionCheckException(IssueKind.MISSING_COMPILER, "");
     }
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more details.

# Discussion thread for this change

Issue number: https://github.com/bazelbuild/intellij/issues/3810

# Description of this change

1. Fixes `.exists()` test on the compiler from Bazel's automatic MinGW toolchain on Windows to also test with an extra `.exe` suffix.
2. Add an intermediate compiler wrapper `.bat` on Windows that executes the original compiler wrapper using `%BAZEL_SH%` so that it works on Windows.

With these two changes applied, the plugin is usable on Windows.
