### PR TITLE
IntelliJ 2022.2 compatibility fixes

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -100,8 +100,8 @@ http_archive(
 http_archive(
     name = "clion_2022_2",
     build_file = "@//intellij_platform_sdk:BUILD.clion222",
-    sha256 = "12edae92d2fdb2a6234963f329fb65241a0aba12ec96a8302571affa0e3edd26",
-    url = "https://download.jetbrains.com/cpp/CLion-222.2964.48.tar.gz",
+    sha256 = "94ffbdf82606f2f90618c1fdb89432d627e7f24ae158b36a591da2c303047436",
+    url = "https://download.jetbrains.com/cpp/CLion-2022.2.tar.gz",
 )
 
 _PYTHON_CE_BUILD_FILE = """

--- a/golang/BUILD
+++ b/golang/BUILD
@@ -102,6 +102,7 @@ intellij_integration_test_suite(
         "//base:unit_test_utils",
         "//common/experiments",
         "//common/experiments:unit_test_utils",
+        "//intellij_platform_sdk:intellilang_for_tests",
         "//intellij_platform_sdk:jsr305",
         "//intellij_platform_sdk:plugin_api_for_tests",
         "//intellij_platform_sdk:test_libs",

--- a/intellij_platform_sdk/BUILD
+++ b/intellij_platform_sdk/BUILD
@@ -617,6 +617,17 @@ java_library(
     ),
 )
 
+# IntelliJ IntelliLang plugin
+java_library(
+    name = "intellilang_for_tests",
+    testonly = 1,
+    exports = select_from_plugin_api_directory(
+        android_studio = [],
+        clion = [],
+        intellij = [":intellilang"],
+    ),
+)
+
 # IntelliJ Kotlin plugin
 java_library(
     name = "kotlin",

--- a/intellij_platform_sdk/BUILD.idea212
+++ b/intellij_platform_sdk/BUILD.idea212
@@ -58,6 +58,11 @@ java_import(
 )
 
 java_import(
+    name = "intellilang",
+    jars = [],
+)
+
+java_import(
     name = "kotlin",
     jars = glob(["plugins/Kotlin/lib/*.jar"]),
 )

--- a/intellij_platform_sdk/BUILD.idea213
+++ b/intellij_platform_sdk/BUILD.idea213
@@ -58,6 +58,11 @@ java_import(
 )
 
 java_import(
+    name = "intellilang",
+    jars = [],
+)
+
+java_import(
     name = "kotlin",
     jars = glob(["plugins/Kotlin/lib/*.jar"]),
 )

--- a/intellij_platform_sdk/BUILD.idea221
+++ b/intellij_platform_sdk/BUILD.idea221
@@ -58,6 +58,11 @@ java_import(
 )
 
 java_import(
+    name = "intellilang",
+    jars = [],
+)
+
+java_import(
     name = "kotlin",
     jars = glob(["plugins/Kotlin/lib/*.jar"]),
 )

--- a/intellij_platform_sdk/BUILD.idea222
+++ b/intellij_platform_sdk/BUILD.idea222
@@ -58,6 +58,11 @@ java_import(
 )
 
 java_import(
+    name = "intellilang",
+    jars = [],
+)
+
+java_import(
     name = "kotlin",
     jars = glob(["plugins/Kotlin/lib/*.jar"]),
 )

--- a/intellij_platform_sdk/BUILD.ue212
+++ b/intellij_platform_sdk/BUILD.ue212
@@ -81,6 +81,11 @@ java_import(
 )
 
 java_import(
+    name = "intellilang",
+    jars = [],
+)
+
+java_import(
     name = "kotlin",
     jars = glob(["plugins/Kotlin/lib/*.jar"]),
 )

--- a/intellij_platform_sdk/BUILD.ue213
+++ b/intellij_platform_sdk/BUILD.ue213
@@ -81,6 +81,11 @@ java_import(
 )
 
 java_import(
+    name = "intellilang",
+    jars = [],
+)
+
+java_import(
     name = "kotlin",
     jars = glob(["plugins/Kotlin/lib/*.jar"]),
 )

--- a/intellij_platform_sdk/BUILD.ue221
+++ b/intellij_platform_sdk/BUILD.ue221
@@ -81,6 +81,11 @@ java_import(
 )
 
 java_import(
+    name = "intellilang",
+    jars = [],
+)
+
+java_import(
     name = "kotlin",
     jars = glob(["plugins/Kotlin/lib/*.jar"]),
 )

--- a/intellij_platform_sdk/BUILD.ue222
+++ b/intellij_platform_sdk/BUILD.ue222
@@ -81,6 +81,11 @@ java_import(
 )
 
 java_import(
+    name = "intellilang",
+    jars = glob(["plugins/IntelliLang/lib/*.jar"]),
+)
+
+java_import(
     name = "kotlin",
     jars = glob(["plugins/Kotlin/lib/*.jar"]),
 )

--- a/testing/testcompat/v222/com/google/idea/sdkcompat/indexing/ProjectIndexingHistoryWrapper.java
+++ b/testing/testcompat/v222/com/google/idea/sdkcompat/indexing/ProjectIndexingHistoryWrapper.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import com.intellij.openapi.project.Project;
 import com.intellij.util.indexing.diagnostic.IndexingTimes;
 import com.intellij.util.indexing.diagnostic.ProjectIndexingHistory;
+import com.intellij.util.indexing.diagnostic.ScanningType;
 import com.intellij.util.indexing.diagnostic.StatsPerFileType;
 import com.intellij.util.indexing.diagnostic.StatsPerIndexer;
 import com.intellij.util.indexing.diagnostic.dto.JsonDuration;
@@ -250,8 +251,8 @@ public class ProjectIndexingHistoryWrapper {
     }
 
     @Override
-    public boolean getWasFullRescanning() {
-      return false;
+    public ScanningType getScanningType() {
+      return ScanningType.PARTIAL;
     }
 
     @Override


### PR DESCRIPTION
- Replace `boolean getWasFullRescanning()` with `ScanningType getScanningType()` and return `ScanningType.PARTIAL`.
-  Use bundled IntelliLang plugin in golang integration tests
