### PR TITLE
Update product versions aliases

### DIFF
--- a/.bazelci/android-studio.yml
+++ b/.bazelci/android-studio.yml
@@ -38,27 +38,27 @@ tasks:
       - //:aswb_tests
     soft_fail:
       - exit_status: 1
-  Android-Studio-OSS-stable:
-    name: Android Studio OSS Stable
+  Android-Studio-OSS-oldest-stable:
+    name: Android Studio OSS Oldest Stable
     platform: ubuntu1804
     build_flags:
-      - --define=ij_product=android-studio-oss-stable
+      - --define=ij_product=android-studio-oss-oldest-stable
     build_targets:
       - //aswb/...
     test_flags:
-      - --define=ij_product=android-studio-oss-stable
+      - --define=ij_product=android-studio-oss-oldest-stable
       - --test_output=errors
     test_targets:
       - //:aswb_tests
-  Android-Studio-OSS-beta:
-    name: Android Studio OSS Beta
+  Android-Studio-OSS-latest-stable:
+    name: Android Studio OSS Latest Stable
     platform: ubuntu1804
     build_flags:
-      - --define=ij_product=android-studio-oss-beta
+      - --define=ij_product=android-studio-oss-latest-stable
     build_targets:
       - //aswb/...
     test_flags:
-      - --define=ij_product=android-studio-oss-beta
+      - --define=ij_product=android-studio-oss-latest-stable
       - --test_output=errors
     test_targets:
       - //:aswb_tests
@@ -76,4 +76,3 @@ tasks:
       - //:aswb_tests
     soft_fail:
       - exit_status: 1
-

--- a/.bazelci/aspect.yml
+++ b/.bazelci/aspect.yml
@@ -41,28 +41,28 @@ tasks:
       - //aspect/testing/...
     soft_fail:
       - exit_status: 1
-  Aspect-oss-stable:
-    name: Aspect Tests for IJ OSS Stable
+  Aspect-oss-oldest-stable:
+    name: Aspect Tests for IJ OSS Oldest Stable
     platform: ubuntu1804
     build_flags:
-      - --define=ij_product=intellij-oss-stable
+      - --define=ij_product=intellij-oss-oldest-stable
     build_targets:
       - //aspect:aspect_files
     test_flags:
-      - --define=ij_product=intellij-oss-stable
+      - --define=ij_product=intellij-oss-oldest-stable
       - --test_output=errors
       - --notrim_test_configuration
     test_targets:
       - //aspect/testing/...
-  Aspect-oss-beta:
-    name: Aspect Tests for IJ OSS Beta
+  Aspect-oss-latest-stable:
+    name: Aspect Tests for IJ OSS Latest Stable
     platform: ubuntu1804
     build_flags:
-      - --define=ij_product=intellij-oss-beta
+      - --define=ij_product=intellij-oss-latest-stable
     build_targets:
       - //aspect:aspect_files
     test_flags:
-      - --define=ij_product=intellij-oss-beta
+      - --define=ij_product=intellij-oss-latest-stable
       - --test_output=errors
       - --notrim_test_configuration
     test_targets:

--- a/.bazelci/clion.yml
+++ b/.bazelci/clion.yml
@@ -38,27 +38,27 @@ tasks:
       - //:clwb_tests
     soft_fail:
       - exit_status: 1
-  CLion-OSS-stable:
-    name: CLion OSS Stable
+  CLion-OSS-oldest-stable:
+    name: CLion OSS Oldest Stable
     platform: ubuntu1804
     build_flags:
-      - --define=ij_product=clion-oss-stable
+      - --define=ij_product=clion-oss-oldest-stable
     build_targets:
       - //clwb/...
     test_flags:
-      - --define=ij_product=clion-oss-stable
+      - --define=ij_product=clion-oss-oldest-stable
       - --test_output=errors
     test_targets:
       - //:clwb_tests
-  CLion-OSS-beta:
-    name: CLion OSS Beta
+  CLion-OSS-latest-stable:
+    name: CLion OSS Latest Stable
     platform: ubuntu1804
     build_flags:
-      - --define=ij_product=clion-oss-beta
+      - --define=ij_product=clion-oss-latest-stable
     build_targets:
       - //clwb/...
     test_flags:
-      - --define=ij_product=clion-oss-beta
+      - --define=ij_product=clion-oss-latest-stable
       - --test_output=errors
     test_targets:
       - //:clwb_tests

--- a/.bazelci/intellij-ue.yml
+++ b/.bazelci/intellij-ue.yml
@@ -38,27 +38,27 @@ tasks:
       - //:ijwb_ue_tests
     soft_fail:
       - exit_status: 1
-  IntelliJ-UE-OSS-stable:
-    name: IntelliJ UE OSS Stable
+  IntelliJ-UE-OSS-oldest-stable:
+    name: IntelliJ UE OSS Oldest Stable
     platform: ubuntu1804
     build_flags:
-      - --define=ij_product=intellij-ue-oss-stable
+      - --define=ij_product=intellij-ue-oss-oldest-stable
     build_targets:
       - //ijwb/...
     test_flags:
-      - --define=ij_product=intellij-ue-oss-stable
+      - --define=ij_product=intellij-ue-oss-oldest-stable
       - --test_output=errors
     test_targets:
       - //:ijwb_ue_tests
-  IntelliJ-UE-OSS-beta:
-    name: IntelliJ UE OSS Beta
+  IntelliJ-UE-OSS-latest-stable:
+    name: IntelliJ UE OSS Latest Stable
     platform: ubuntu1804
     build_flags:
-      - --define=ij_product=intellij-ue-oss-beta
+      - --define=ij_product=intellij-ue-oss-latest-stable
     build_targets:
       - //ijwb/...
     test_flags:
-      - --define=ij_product=intellij-ue-oss-beta
+      - --define=ij_product=intellij-ue-oss-latest-stable
       - --test_output=errors
     test_targets:
       - //:ijwb_ue_tests
@@ -77,3 +77,4 @@ tasks:
     soft_fail:
       - exit_status: 1
 
+Footer

--- a/.bazelci/intellij-ue.yml
+++ b/.bazelci/intellij-ue.yml
@@ -76,5 +76,3 @@ tasks:
       - //:ijwb_ue_tests
     soft_fail:
       - exit_status: 1
-
-Footer

--- a/.bazelci/intellij.yml
+++ b/.bazelci/intellij.yml
@@ -38,27 +38,27 @@ tasks:
       - //:ijwb_ce_tests
     soft_fail:
       - exit_status: 1
-  IntelliJ-CE-OSS-stable:
-    name: IntelliJ CE OSS Stable
+  IntelliJ-CE-OSS-oldest-stable:
+    name: IntelliJ CE OSS Oldest Stable
     platform: ubuntu1804
     build_flags:
-      - --define=ij_product=intellij-oss-stable
+      - --define=ij_product=intellij-oss-oldest-stable
     build_targets:
       - //ijwb/...
     test_flags:
-      - --define=ij_product=intellij-oss-stable
+      - --define=ij_product=intellij-oss-oldest-stable
       - --test_output=errors
     test_targets:
       - //:ijwb_ce_tests
-  IntelliJ-CE-OSS-beta:
-    name: IntelliJ CE OSS Beta
+  IntelliJ-CE-OSS-latest-stable:
+    name: IntelliJ CE OSS Latest Stable
     platform: ubuntu1804
     build_flags:
-      - --define=ij_product=intellij-oss-beta
+      - --define=ij_product=intellij-oss-latest-stable
     build_targets:
       - //ijwb/...
     test_flags:
-      - --define=ij_product=intellij-oss-beta
+      - --define=ij_product=intellij-oss-latest-stable
       - --test_output=errors
     test_targets:
       - //:ijwb_ce_tests
@@ -77,3 +77,4 @@ tasks:
     soft_fail:
       - exit_status: 1
 
+Footer

--- a/.bazelci/intellij.yml
+++ b/.bazelci/intellij.yml
@@ -76,5 +76,3 @@ tasks:
       - //:ijwb_ce_tests
     soft_fail:
       - exit_status: 1
-
-Footer


### PR DESCRIPTION
Update plugin versions name and build/test flags in CI following the update in https://github.com/bazelbuild/intellij/pull/3843.

- {PRODUCT}-oss-oldest-stable: the oldest stable IDE version supported
- {PRODUCT}-oss-latest-stable: the second stable IDE version supported
- {PRODUCT}-oss-under-dev: the EAP version we are working towards supporting