### PR TITLE
Move go.import.treestructure to 100%

### DIFF
--- a/common/experiments/src/com/google/idea/common/experiments/experiment.properties
+++ b/common/experiments/src/com/google/idea/common/experiments/experiment.properties
@@ -14,4 +14,4 @@ kotlin.coroutinesDebugging.enabled=50
 blazeconsole.v2.rollout=50
 
 # [Rollout %] Display Go external packages as a tree based on the importpath.
-go.import.treestructure=20
+go.import.treestructure=100


### PR DESCRIPTION
See https://github.com/bazelbuild/intellij/issues/2365  and https://github.com/bazelbuild/intellij/pull/2973 for context.

Co-authored-by: Brandon Lico <brandonlico@gmail.com>

