### PR TITLE
Prevent auto import of project if registry key is set

### DIFF
--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -312,6 +312,7 @@
         implementationClass="com.google.idea.blaze.base.run.producers.BuildFileRunLineMarkerContributor"/>
     <actionConfigurationCustomizer implementation="com.google.idea.blaze.base.plugin.BlazeHideMakeActions"/>
     <notificationGroup displayType="BALLOON" id="BuildifierBinaryMissing"/>
+    <registryKey defaultValue="false" description="Disable auto import of bazel projects" key="bazel.auto.import.disabled"/>
   </extensions>
 
   <extensions defaultExtensionNs="com.intellij">

--- a/base/src/com/google/idea/blaze/base/project/AutoImportProjectOpenProcessor.java
+++ b/base/src/com/google/idea/blaze/base/project/AutoImportProjectOpenProcessor.java
@@ -84,7 +84,7 @@ public class AutoImportProjectOpenProcessor extends ProjectOpenProcessor {
 
   @Override
   public boolean canOpenProject(@NotNull VirtualFile virtualFile) {
-    return !Registry.is("external.system.auto.import.disabled", false)
+    return !Registry.is("bazel.auto.import.disabled")
             && isBazelWorkspace(virtualFile);
   }
 

--- a/base/src/com/google/idea/blaze/base/project/AutoImportProjectOpenProcessor.java
+++ b/base/src/com/google/idea/blaze/base/project/AutoImportProjectOpenProcessor.java
@@ -29,6 +29,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.project.ex.ProjectManagerEx;
 import com.intellij.openapi.util.io.FileUtil;
+import com.intellij.openapi.util.registry.Registry;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.projectImport.ProjectOpenProcessor;
 import icons.BlazeIcons;
@@ -83,7 +84,8 @@ public class AutoImportProjectOpenProcessor extends ProjectOpenProcessor {
 
   @Override
   public boolean canOpenProject(@NotNull VirtualFile virtualFile) {
-    return isBazelWorkspace(virtualFile);
+    return !Registry.is("external.system.auto.import.disabled", false)
+            && isBazelWorkspace(virtualFile);
   }
 
   private boolean isBazelWorkspace(VirtualFile virtualFile) {


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

We are slowly migrating a project to bazel and the auto import code is causing issues and making it hard for developers to work the project in the mean time. 

Ultimatly a easy fix for this is to use the `external.system.auto.import.disabled` key (defined [here](https://github.com/JetBrains/intellij-community/blob/master/platform/util/resources/misc/registry.properties#L1476)) to allow us to disable the auto import functionality. 

Its worth noting, this is used in IntelliJ community already to disable maven importing, we can use a different registry key, but I figure this is specific enough as is to qualify for this use case.

Issue number: `<please reference the issue number or url here>`

The change is pretty minimal. Returning false to canOpenProject if the registry value is set to true (defaults to false) to allow bypassing the auto import functionality. 

