### PR TITLE
Auto import should not override existing projects

### DIFF
--- a/base/src/com/google/idea/blaze/base/project/AutoImportProjectOpenProcessor.java
+++ b/base/src/com/google/idea/blaze/base/project/AutoImportProjectOpenProcessor.java
@@ -72,11 +72,6 @@ public class AutoImportProjectOpenProcessor extends ProjectOpenProcessor {
   }
 
   @Override
-  public boolean isStrongProjectInfoHolder() {
-    return true;
-  }
-
-  @Override
   public boolean lookForProjectsInDirectory() {
     return false;
   }


### PR DESCRIPTION
Auto import should run last and only if there are no other projects already created. In case users still need to create a project, they can use existing wizard.

Fixes #3895 
