### PR TITLE
Update rollout percentage of experimental features

### DIFF
--- a/common/experiments/src/com/google/idea/common/experiments/experiment.properties
+++ b/common/experiments/src/com/google/idea/common/experiments/experiment.properties
@@ -8,10 +8,13 @@
 aswb.use.studio.deployer.2=0
 
 # [Rollout %] Enable Kotlin coroutines debugging
-kotlin.coroutinesDebugging.enabled=70
+kotlin.coroutinesDebugging.enabled=100
 
-# [Rollout %] new Sync Window
-blazeconsole.v2.rollout=70
+# [Rollout %] New Sync Window
+blazeconsole.v2.rollout=100
 
 # [Rollout %] Display Go external packages as a tree based on the importpath.
-go.import.treestructure=20
+go.import.treestructure=100
+
+# [Rollout %] Move minimum supported version of Bazel to 1.2.0
+new.oldest.bazel.version.enabled=20


### PR DESCRIPTION
- Roll out Kotlin coroutines debugging to 100% of users
- Roll out the new sync window to 100% of users
- Roll out Go external packages tree display to 100% of users
- Roll out the new minimum supported version of Bazel (1.2.0) to 20% of users