### PR TITLE
feat: Add gazelle to plugin

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -55,6 +55,7 @@ test_suite(
     name = "ijwb_ue_tests",
     tests = [
         ":ijwb_common_tests",
+        "//gazelle:integration_tests",
         "//golang:integration_tests",
         "//golang:unit_tests",
         "//javascript:integration_tests",

--- a/examples/go/with_proto/BUILD.bazel
+++ b/examples/go/with_proto/BUILD.bazel
@@ -3,7 +3,6 @@ load("@bazel_gazelle//:def.bzl", "gazelle")
 # gazelle:prefix github.com/bazelbuild/intellij/examples/go/with_proto
 gazelle(name = "gazelle")
 
-# gazelle:prefix github.com/bazelbuild/intellij/examples/go/with_proto
 gazelle(
     name = "gazelle_other",
 )

--- a/examples/go/with_proto/with_proto.bazelproject
+++ b/examples/go/with_proto/with_proto.bazelproject
@@ -1,3 +1,4 @@
+
 directories:
   .
 
@@ -5,3 +6,5 @@ derive_targets_from_directories: true
 
 additional_languages:
   go
+
+gazelle_target: //:gazelle

--- a/gazelle/BUILD
+++ b/gazelle/BUILD
@@ -1,0 +1,100 @@
+load(
+    "//testing:test_defs.bzl",
+    "intellij_integration_test_suite",
+    "intellij_unit_test_suite",
+)
+load(
+    "//build_defs:build_defs.bzl",
+    "intellij_plugin",
+    "intellij_plugin_library",
+    "optional_plugin_xml",
+    "stamped_plugin_xml",
+)
+load(
+    "//:build-visibility.bzl",
+    "PLUGIN_PACKAGES_VISIBILITY",
+)
+
+licenses(["notice"])  # Apache 2.0
+
+java_library(
+    name = "gazelle",
+    srcs = glob(["src/**/*.java"]),
+    visibility = PLUGIN_PACKAGES_VISIBILITY,
+    deps = [
+        "//base",
+        "//common/experiments",
+        "//common/settings",
+        "//common/util:transactions",
+        "//intellij_platform_sdk:jsr305",
+        "//intellij_platform_sdk:plugin_api",
+    ],
+)
+
+intellij_plugin_library(
+    name = "plugin_library",
+    optional_plugin_xmls = [],
+    plugin_xmls = ["src/META-INF/blaze-gazelle.xml"],
+    visibility = PLUGIN_PACKAGES_VISIBILITY,
+    deps = [":gazelle"],
+)
+
+stamped_plugin_xml(
+    name = "gazelle_plugin_xml",
+    plugin_id = "com.google.idea.blaze.gazelle",
+    plugin_name = "com.google.idea.blaze.gazelle",
+)
+
+intellij_plugin(
+    name = "gazelle_integration_test_plugin",
+    testonly = 1,
+    plugin_xml = ":gazelle_plugin_xml",
+    deps = [
+        ":plugin_library",
+        "//base:plugin_library",
+    ],
+)
+
+intellij_integration_test_suite(
+    name = "integration_tests",
+    srcs = glob(["tests/integrationtests/**/*.java"]),
+    jvm_flags = [
+        # These flags are necessary for jdk17, since it removes `--illegal-access`.
+        "--add-opens=java.desktop/java.awt.event=ALL-UNNAMED",
+        "--add-opens=java.desktop/sun.awt=ALL-UNNAMED",
+        "--add-opens=java.base/java.io=ALL-UNNAMED",
+        "--add-opens=java.desktop/java.awt=ALL-UNNAMED",
+        "--add-opens=java.desktop/sun.font=ALL-UNNAMED",
+        "--add-opens=java.desktop/java.awt=ALL-UNNAMED",
+        "--add-opens=java.base/java.lang=ALL-UNNAMED",
+        "--add-opens=java.base/java.util=ALL-UNNAMED",
+        "--add-opens=java.desktop/javax.swing=ALL-UNNAMED",
+        "--add-opens=java.desktop/sun.swing=ALL-UNNAMED",
+        "--add-opens=java.desktop/javax.swing.plaf.basic=ALL-UNNAMED",
+        "--add-opens=java.desktop/java.awt.peer=ALL-UNNAMED",
+        "--add-opens=java.desktop/javax.swing.text.html=ALL-UNNAMED",
+        "--add-opens=java.desktop/sun.lwawt.macosx=ALL-UNNAMED",
+        "--add-exports=java.desktop/sun.font=ALL-UNNAMED",
+        "--add-exports=java.desktop/com.apple.eawt=ALL-UNNAMED",
+        "--add-exports=java.desktop/com.apple.laf=ALL-UNNAMED",
+        "--add-exports=java.desktop/com.apple.eawt.event=ALL-UNNAMED",
+    ],
+    required_plugins = "com.google.idea.blaze.gazelle",
+    test_package_root = "com.google.idea.blaze.gazelle",
+    runtime_deps = [
+        ":gazelle_integration_test_plugin",
+    ],
+    deps = [
+        ":gazelle",
+        "//base",
+        "//base:integration_test_utils",
+        "//base:unit_test_utils",
+        "//common/experiments",
+        "//common/experiments:unit_test_utils",
+        "//intellij_platform_sdk:intellilang_for_tests",
+        "//intellij_platform_sdk:jsr305",
+        "//intellij_platform_sdk:plugin_api_for_tests",
+        "//intellij_platform_sdk:test_libs",
+        "@junit//jar",
+    ],
+)

--- a/gazelle/BUILD
+++ b/gazelle/BUILD
@@ -1,7 +1,6 @@
 load(
     "//testing:test_defs.bzl",
     "intellij_integration_test_suite",
-    "intellij_unit_test_suite",
 )
 load(
     "//build_defs:build_defs.bzl",
@@ -80,6 +79,7 @@ intellij_integration_test_suite(
         "--add-exports=java.desktop/com.apple.eawt.event=ALL-UNNAMED",
     ],
     required_plugins = "com.google.idea.blaze.gazelle",
+    tags = ["large"],
     test_package_root = "com.google.idea.blaze.gazelle",
     runtime_deps = [
         ":gazelle_integration_test_plugin",

--- a/gazelle/src/META-INF/blaze-gazelle.xml
+++ b/gazelle/src/META-INF/blaze-gazelle.xml
@@ -1,0 +1,27 @@
+<!--
+  ~ Copyright 2017 The Bazel Authors. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<idea-plugin>
+  <extensions defaultExtensionNs="com.google.idea.blaze">
+    <SyncListener implementation="com.google.idea.blaze.gazelle.GazelleSyncListener" />
+    <SyncPlugin implementation="com.google.idea.blaze.gazelle.GazelleSyncPlugin" />
+    <SettingsUiContributor implementation="com.google.idea.blaze.gazelle.GazelleUserSettingsConfigurable$UiContributor" />
+  </extensions>
+  <extensions defaultExtensionNs="com.intellij">
+    <applicationService serviceInterface="com.google.idea.blaze.gazelle.BlazeGazelleRunner"
+                        serviceImplementation="com.google.idea.blaze.gazelle.BlazeGazelleRunnerImpl"/>
+    <applicationService id="GazelleUserSettings" serviceImplementation="com.google.idea.blaze.gazelle.GazelleUserSettings"/>
+  </extensions>
+</idea-plugin>

--- a/gazelle/src/com/google/idea/blaze/gazelle/BlazeGazelleRunner.java
+++ b/gazelle/src/com/google/idea/blaze/gazelle/BlazeGazelleRunner.java
@@ -21,7 +21,8 @@ public abstract class BlazeGazelleRunner {
   /**
    * Run the provided Gazelle target via Blaze.
    *
-   * @return
+   * @return GazelleRunResult,
+   *         an enum determining whether the command succeeded, failed, and/or had errors.
    */
   public abstract GazelleRunResult runBlazeGazelle(
       BlazeContext context,

--- a/gazelle/src/com/google/idea/blaze/gazelle/BlazeGazelleRunner.java
+++ b/gazelle/src/com/google/idea/blaze/gazelle/BlazeGazelleRunner.java
@@ -1,0 +1,33 @@
+package com.google.idea.blaze.gazelle;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.idea.blaze.base.bazel.BuildSystem;
+import com.google.idea.blaze.base.model.primitives.Label;
+import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
+import com.google.idea.blaze.base.projectview.section.sections.DirectoryEntry;
+import com.google.idea.blaze.base.scope.BlazeContext;
+import com.intellij.openapi.components.ServiceManager;
+
+import java.util.List;
+
+/** Runs the blaze run command, on gazelle. The results may be cached in the workspace. */
+public abstract class BlazeGazelleRunner {
+    public static BlazeGazelleRunner getInstance() {
+        return ServiceManager.getService(BlazeGazelleRunner.class);
+    }
+
+    /**
+     * This will call Blaze run with the argument of the gazelle target provided.
+     *
+     * @param blazeFlags The blaze flags that will be passed to Blaze.
+     * @return stdout of the gazelle process.
+     */
+    public abstract ListenableFuture<String> runBlazeGazelle(
+            BlazeContext context,
+            BuildSystem.BuildInvoker invoker,
+            WorkspaceRoot workspaceRoot,
+            List<String> blazeFlags,
+            Label gazelleTarget,
+            List<DirectoryEntry> directories
+    );
+}

--- a/gazelle/src/com/google/idea/blaze/gazelle/BlazeGazelleRunner.java
+++ b/gazelle/src/com/google/idea/blaze/gazelle/BlazeGazelleRunner.java
@@ -1,33 +1,34 @@
 package com.google.idea.blaze.gazelle;
 
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.idea.blaze.base.bazel.BuildSystem;
+import com.google.common.collect.ImmutableList;
+import com.google.idea.blaze.base.bazel.BuildSystem.BuildInvoker;
+import com.google.idea.blaze.base.issueparser.BlazeIssueParser.Parser;
 import com.google.idea.blaze.base.model.primitives.Label;
+import com.google.idea.blaze.base.model.primitives.WorkspacePath;
 import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
-import com.google.idea.blaze.base.projectview.section.sections.DirectoryEntry;
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.intellij.openapi.components.ServiceManager;
-
+import java.util.Collection;
 import java.util.List;
 
 /** Runs the blaze run command, on gazelle. The results may be cached in the workspace. */
 public abstract class BlazeGazelleRunner {
-    public static BlazeGazelleRunner getInstance() {
-        return ServiceManager.getService(BlazeGazelleRunner.class);
-    }
 
-    /**
-     * This will call Blaze run with the argument of the gazelle target provided.
-     *
-     * @param blazeFlags The blaze flags that will be passed to Blaze.
-     * @return stdout of the gazelle process.
-     */
-    public abstract ListenableFuture<String> runBlazeGazelle(
-            BlazeContext context,
-            BuildSystem.BuildInvoker invoker,
-            WorkspaceRoot workspaceRoot,
-            List<String> blazeFlags,
-            Label gazelleTarget,
-            List<DirectoryEntry> directories
-    );
+  public static BlazeGazelleRunner getInstance() {
+    return ServiceManager.getService(BlazeGazelleRunner.class);
+  }
+
+  /**
+   * Run the provided Gazelle target via Blaze.
+   *
+   * @return
+   */
+  public abstract GazelleRunResult runBlazeGazelle(
+      BlazeContext context,
+      BuildInvoker invoker,
+      WorkspaceRoot workspaceRoot,
+      List<String> blazeFlags,
+      Label gazelleTarget,
+      Collection<WorkspacePath> directories,
+      ImmutableList<Parser> issueParsers);
 }

--- a/gazelle/src/com/google/idea/blaze/gazelle/BlazeGazelleRunnerImpl.java
+++ b/gazelle/src/com/google/idea/blaze/gazelle/BlazeGazelleRunnerImpl.java
@@ -1,67 +1,57 @@
 package com.google.idea.blaze.gazelle;
 
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.idea.blaze.base.async.executor.BlazeExecutor;
+import com.google.common.collect.ImmutableList;
 import com.google.idea.blaze.base.async.process.ExternalTask;
 import com.google.idea.blaze.base.async.process.LineProcessingOutputStream;
-import com.google.idea.blaze.base.async.process.PrintOutputLineProcessor;
-import com.google.idea.blaze.base.bazel.BuildSystem;
+import com.google.idea.blaze.base.bazel.BuildSystem.BuildInvoker;
 import com.google.idea.blaze.base.command.BlazeCommand;
 import com.google.idea.blaze.base.command.BlazeCommandName;
-import com.google.idea.blaze.base.command.info.BlazeInfoException;
+import com.google.idea.blaze.base.issueparser.BlazeIssueParser.Parser;
+import com.google.idea.blaze.base.issueparser.IssueOutputLineProcessor;
 import com.google.idea.blaze.base.model.primitives.Label;
+import com.google.idea.blaze.base.model.primitives.WorkspacePath;
 import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
-import com.google.idea.blaze.base.projectview.section.sections.DirectoryEntry;
 import com.google.idea.blaze.base.scope.BlazeContext;
-
 import java.io.ByteArrayOutputStream;
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
 public class BlazeGazelleRunnerImpl extends BlazeGazelleRunner {
-    public ListenableFuture<String> runBlazeGazelle(
-            BlazeContext context,
-            BuildSystem.BuildInvoker buildInvoker,
-            WorkspaceRoot workspaceRoot,
-            List<String> blazeFlags,
-            Label gazelleTarget,
-            List<DirectoryEntry> directories
-    ) {
-        return BlazeExecutor.getInstance()
-                .submit(
-                        () -> {
-                            String blazeGazelleString = runBlazeGazelle(buildInvoker, workspaceRoot, blazeFlags, context, gazelleTarget, directories)
-                                    .toString()
-                                    .trim();
-                            return blazeGazelleString;
-                        });
-    }
 
-    private static ByteArrayOutputStream runBlazeGazelle(
-            BuildSystem.BuildInvoker buildInvoker,
-            WorkspaceRoot workspaceRoot,
-            List<String> blazeFlags,
-            BlazeContext context,
-            Label gazelleTarget,
-            List<DirectoryEntry> directories
-    ) throws BlazeInfoException {
-        BlazeCommand.Builder builder = BlazeCommand.builder(buildInvoker, BlazeCommandName.RUN);
-        builder.addBlazeFlags(blazeFlags);
-        builder.addTargets(gazelleTarget);
-        List<String> directoriesToRegenerate = directories.stream().map(DirectoryEntry::toString).collect(Collectors.toList());
-        builder.addExeFlags(directoriesToRegenerate);
-        BlazeCommand command = builder.build();
-        ByteArrayOutputStream stdout = new ByteArrayOutputStream();
-        ByteArrayOutputStream stderr = new ByteArrayOutputStream();
-        int exitCode = ExternalTask.builder(workspaceRoot).addBlazeCommand(command).context(context)
-                .stdout(stdout)
-                .stderr(stderr)
-                .build()
-                .run();
-        if (exitCode != 0) {
-            throw new BlazeInfoException(exitCode, stderr.toString());
-        }
-        return stdout;
+  @Override
+  public GazelleRunResult runBlazeGazelle(
+      BlazeContext context,
+      BuildInvoker invoker,
+      WorkspaceRoot workspaceRoot,
+      List<String> blazeFlags,
+      Label gazelleTarget,
+      Collection<WorkspacePath> directories,
+      ImmutableList<Parser> issueParsers) {
+    BlazeCommand.Builder builder = BlazeCommand.builder(invoker, BlazeCommandName.RUN);
+    builder.addBlazeFlags(blazeFlags);
+    builder.addTargets(gazelleTarget);
+    List<String> directoriesToRegenerate =
+        directories.stream().map(WorkspacePath::toString).collect(Collectors.toList());
+    builder.addExeFlags(directoriesToRegenerate);
+    BlazeCommand command = builder.build();
+    ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+    int exitCode =
+        ExternalTask.builder(workspaceRoot)
+            .addBlazeCommand(command)
+            .context(context)
+            .stderr(
+                LineProcessingOutputStream.of(new IssueOutputLineProcessor(context, issueParsers)))
+            .stdout(stdout)
+            .build()
+            .run();
+    if (exitCode != 0) {
+      // Note that gazelle won't return a non-0 exit code on a failure unless we specify the -strict
+      // flag.
+      // This exception will only catch the instances of bazel failing to build the gazelle target.
+      return GazelleRunResult.FAILED_TO_RUN;
     }
-
+    // If the issue parsers have caught at least one error, they will have modified the context.
+    return context.hasErrors() ? GazelleRunResult.RAN_WITH_ERRORS : GazelleRunResult.SUCCESS;
+  }
 }

--- a/gazelle/src/com/google/idea/blaze/gazelle/BlazeGazelleRunnerImpl.java
+++ b/gazelle/src/com/google/idea/blaze/gazelle/BlazeGazelleRunnerImpl.java
@@ -1,0 +1,67 @@
+package com.google.idea.blaze.gazelle;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.idea.blaze.base.async.executor.BlazeExecutor;
+import com.google.idea.blaze.base.async.process.ExternalTask;
+import com.google.idea.blaze.base.async.process.LineProcessingOutputStream;
+import com.google.idea.blaze.base.async.process.PrintOutputLineProcessor;
+import com.google.idea.blaze.base.bazel.BuildSystem;
+import com.google.idea.blaze.base.command.BlazeCommand;
+import com.google.idea.blaze.base.command.BlazeCommandName;
+import com.google.idea.blaze.base.command.info.BlazeInfoException;
+import com.google.idea.blaze.base.model.primitives.Label;
+import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
+import com.google.idea.blaze.base.projectview.section.sections.DirectoryEntry;
+import com.google.idea.blaze.base.scope.BlazeContext;
+
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class BlazeGazelleRunnerImpl extends BlazeGazelleRunner {
+    public ListenableFuture<String> runBlazeGazelle(
+            BlazeContext context,
+            BuildSystem.BuildInvoker buildInvoker,
+            WorkspaceRoot workspaceRoot,
+            List<String> blazeFlags,
+            Label gazelleTarget,
+            List<DirectoryEntry> directories
+    ) {
+        return BlazeExecutor.getInstance()
+                .submit(
+                        () -> {
+                            String blazeGazelleString = runBlazeGazelle(buildInvoker, workspaceRoot, blazeFlags, context, gazelleTarget, directories)
+                                    .toString()
+                                    .trim();
+                            return blazeGazelleString;
+                        });
+    }
+
+    private static ByteArrayOutputStream runBlazeGazelle(
+            BuildSystem.BuildInvoker buildInvoker,
+            WorkspaceRoot workspaceRoot,
+            List<String> blazeFlags,
+            BlazeContext context,
+            Label gazelleTarget,
+            List<DirectoryEntry> directories
+    ) throws BlazeInfoException {
+        BlazeCommand.Builder builder = BlazeCommand.builder(buildInvoker, BlazeCommandName.RUN);
+        builder.addBlazeFlags(blazeFlags);
+        builder.addTargets(gazelleTarget);
+        List<String> directoriesToRegenerate = directories.stream().map(DirectoryEntry::toString).collect(Collectors.toList());
+        builder.addExeFlags(directoriesToRegenerate);
+        BlazeCommand command = builder.build();
+        ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+        ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+        int exitCode = ExternalTask.builder(workspaceRoot).addBlazeCommand(command).context(context)
+                .stdout(stdout)
+                .stderr(stderr)
+                .build()
+                .run();
+        if (exitCode != 0) {
+            throw new BlazeInfoException(exitCode, stderr.toString());
+        }
+        return stdout;
+    }
+
+}

--- a/gazelle/src/com/google/idea/blaze/gazelle/GazelleIssueParsers.java
+++ b/gazelle/src/com/google/idea/blaze/gazelle/GazelleIssueParsers.java
@@ -1,0 +1,50 @@
+package com.google.idea.blaze.gazelle;
+
+import static com.google.idea.blaze.base.issueparser.BlazeIssueParser.*;
+
+import com.google.common.collect.ImmutableList;
+import com.google.idea.blaze.base.issueparser.BlazeIssueParser;
+import com.google.idea.blaze.base.run.filter.FileResolver;
+import com.google.idea.blaze.base.scope.output.IssueOutput;
+import com.google.idea.blaze.base.scope.output.IssueOutput.Category;
+import com.intellij.openapi.project.Project;
+import java.io.File;
+import java.util.regex.Matcher;
+import org.jetbrains.annotations.Nullable;
+
+public class GazelleIssueParsers {
+
+  public static ImmutableList<BlazeIssueParser.Parser> allGazelleIssueParsers(Project project) {
+    // We eventually may want to introduce per-language gazelle error parsing,
+    // so we expose this function to conveniently gather all of them.
+    return ImmutableList.of(new GazelleIssueParsers.GenericGazelleIssueParser(project));
+  }
+
+  private static final String GAZELLE_ISSUE_REGEX =
+      "^gazelle: "
+          + // Prefix for gazelle errors.
+          "(.*?): "
+          + // File
+          "(.*)$"; // Message
+
+  private static class GenericGazelleIssueParser extends BlazeIssueParser.SingleLineParser {
+
+    Project project;
+
+    GenericGazelleIssueParser(Project project) {
+      super(GAZELLE_ISSUE_REGEX);
+      this.project = project;
+    }
+
+    @Nullable
+    @Override
+    protected IssueOutput createIssue(Matcher matcher) {
+      final File file = FileResolver.resolveToFile(project, matcher.group(1));
+      return IssueOutput.issue(Category.ERROR, matcher.group(2))
+          .inFile(file)
+          .consoleHyperlinkRange(
+              union(fileHighlightRange(matcher, 1), matchedTextRange(matcher, 1, 1)))
+          .build();
+    }
+  }
+}

--- a/gazelle/src/com/google/idea/blaze/gazelle/GazelleIssueParsers.java
+++ b/gazelle/src/com/google/idea/blaze/gazelle/GazelleIssueParsers.java
@@ -21,11 +21,12 @@ public class GazelleIssueParsers {
   }
 
   private static final String GAZELLE_ISSUE_REGEX =
-      "^gazelle: "
-          + // Prefix for gazelle errors.
-          "(.*?): "
-          + // File
-          "(.*)$"; // Message
+      // Prefix for gazelle errors. We match the beginning to get rid of the control characters.
+      "^.*gazelle: " +
+          // File
+          "(.*?): " +
+          // Message
+          "(.*)$";
 
   private static class GenericGazelleIssueParser extends BlazeIssueParser.SingleLineParser {
 

--- a/gazelle/src/com/google/idea/blaze/gazelle/GazelleRunResult.java
+++ b/gazelle/src/com/google/idea/blaze/gazelle/GazelleRunResult.java
@@ -1,8 +1,11 @@
 package com.google.idea.blaze.gazelle;
 
+/**
+ * Enum to differentiate whether a gazelle run succeeded, failed, and/or had errors.
+ */
 public enum GazelleRunResult {
   // Note that this will only happen when Bazel itself fails or when we pass
-  // `-strict` to gazelle.
+  // `-strict` to gazelle, or when the gazelle target can't be built.
   FAILED_TO_RUN,
 
   RAN_WITH_ERRORS,

--- a/gazelle/src/com/google/idea/blaze/gazelle/GazelleRunResult.java
+++ b/gazelle/src/com/google/idea/blaze/gazelle/GazelleRunResult.java
@@ -1,0 +1,10 @@
+package com.google.idea.blaze.gazelle;
+
+public enum GazelleRunResult {
+  // Note that this will only happen when Bazel itself fails or when we pass
+  // `-strict` to gazelle.
+  FAILED_TO_RUN,
+
+  RAN_WITH_ERRORS,
+  SUCCESS,
+}

--- a/gazelle/src/com/google/idea/blaze/gazelle/GazelleSection.java
+++ b/gazelle/src/com/google/idea/blaze/gazelle/GazelleSection.java
@@ -1,0 +1,52 @@
+package com.google.idea.blaze.gazelle;
+
+import com.google.idea.blaze.base.model.primitives.Label;
+import com.google.idea.blaze.base.projectview.parser.ParseContext;
+import com.google.idea.blaze.base.projectview.parser.ProjectViewParser;
+import com.google.idea.blaze.base.projectview.section.ScalarSection;
+import com.google.idea.blaze.base.projectview.section.ScalarSectionParser;
+import com.google.idea.blaze.base.projectview.section.SectionKey;
+import com.google.idea.blaze.base.projectview.section.SectionParser;
+import org.jetbrains.annotations.Nullable;
+
+
+/** Section for project-specific gazelle configuration. */
+public class GazelleSection {
+    public static final SectionKey<Label, ScalarSection<Label>> KEY = SectionKey.of("gazelle_target");
+    public static final SectionParser PARSER = new GazelleSectionParser();
+
+    private static class GazelleSectionParser extends ScalarSectionParser<Label> {
+        public GazelleSectionParser() {
+            super(KEY, ' ');
+        }
+
+        @Nullable
+        @Override
+        protected Label parseItem(ProjectViewParser parser, ParseContext parseContext, String text) {
+            if (text == null) {
+                return null;
+            }
+            String error = Label.validate(text);
+            if (error != null) {
+                parseContext.addError(error);
+                return null;
+            }
+            return Label.create(text);
+        }
+
+        @Override
+        protected void printItem(StringBuilder sb, Label value) {
+            sb.append(value.toString());
+        }
+
+        @Override
+        public ItemType getItemType() {
+            return ItemType.Label;
+        }
+
+        @Override
+        public String quickDocs() {
+            return "Gazelle target used to refresh the project. If not specified, gazelle will not run on sync.";
+        }
+    }
+}

--- a/gazelle/src/com/google/idea/blaze/gazelle/GazelleSection.java
+++ b/gazelle/src/com/google/idea/blaze/gazelle/GazelleSection.java
@@ -9,44 +9,46 @@ import com.google.idea.blaze.base.projectview.section.SectionKey;
 import com.google.idea.blaze.base.projectview.section.SectionParser;
 import org.jetbrains.annotations.Nullable;
 
-
 /** Section for project-specific gazelle configuration. */
 public class GazelleSection {
-    public static final SectionKey<Label, ScalarSection<Label>> KEY = SectionKey.of("gazelle_target");
-    public static final SectionParser PARSER = new GazelleSectionParser();
 
-    private static class GazelleSectionParser extends ScalarSectionParser<Label> {
-        public GazelleSectionParser() {
-            super(KEY, ' ');
-        }
+  public static final SectionKey<Label, ScalarSection<Label>> KEY = SectionKey.of("gazelle_target");
+  public static final SectionParser PARSER = new GazelleSectionParser();
 
-        @Nullable
-        @Override
-        protected Label parseItem(ProjectViewParser parser, ParseContext parseContext, String text) {
-            if (text == null) {
-                return null;
-            }
-            String error = Label.validate(text);
-            if (error != null) {
-                parseContext.addError(error);
-                return null;
-            }
-            return Label.create(text);
-        }
+  private static class GazelleSectionParser extends ScalarSectionParser<Label> {
 
-        @Override
-        protected void printItem(StringBuilder sb, Label value) {
-            sb.append(value.toString());
-        }
-
-        @Override
-        public ItemType getItemType() {
-            return ItemType.Label;
-        }
-
-        @Override
-        public String quickDocs() {
-            return "Gazelle target used to refresh the project. If not specified, gazelle will not run on sync.";
-        }
+    public GazelleSectionParser() {
+      super(KEY, ':');
     }
+
+    @Nullable
+    @Override
+    protected Label parseItem(ProjectViewParser parser, ParseContext parseContext, String text) {
+      if (text == null) {
+        return null;
+      }
+      String error = Label.validate(text);
+      if (error != null) {
+        parseContext.addError(error);
+        return null;
+      }
+      return Label.create(text);
+    }
+
+    @Override
+    protected void printItem(StringBuilder sb, Label value) {
+      sb.append(value.toString());
+    }
+
+    @Override
+    public ItemType getItemType() {
+      return ItemType.Label;
+    }
+
+    @Override
+    public String quickDocs() {
+      return "Gazelle target used to refresh the project. If not specified, gazelle will not run on"
+          + " sync.";
+    }
+  }
 }

--- a/gazelle/src/com/google/idea/blaze/gazelle/GazelleSyncListener.java
+++ b/gazelle/src/com/google/idea/blaze/gazelle/GazelleSyncListener.java
@@ -51,6 +51,10 @@ public class GazelleSyncListener implements SyncListener {
     return settings.getGazelleTargetLabel();
   }
 
+  private boolean runGazelleHeadless() {
+    return GazelleUserSettings.getInstance().shouldRunHeadless();
+  }
+
   private GazelleRunResult doRunGazelle(
       Project project,
       BlazeContext context,
@@ -83,7 +87,7 @@ public class GazelleSyncListener implements SyncListener {
         .build();
   }
 
-  private void setUpContext(
+  private void setUpUI(
       BlazeContext context,
       BlazeContext parentContext,
       Project project,
@@ -134,8 +138,9 @@ public class GazelleSyncListener implements SyncListener {
 
                       ImmutableList<BlazeIssueParser.Parser> issueParsers =
                           gazelleIssueParsers(project, workspaceRoot);
-
-                      setUpContext(context, parentContext, project, indicator, issueParsers);
+                      if (! this.runGazelleHeadless()) {
+                        setUpUI(context, parentContext, project, indicator, issueParsers);
+                      }
 
                       Collection<WorkspacePath> importantDirectories =
                           importantDirectories(project);

--- a/gazelle/src/com/google/idea/blaze/gazelle/GazelleSyncListener.java
+++ b/gazelle/src/com/google/idea/blaze/gazelle/GazelleSyncListener.java
@@ -1,0 +1,69 @@
+package com.google.idea.blaze.gazelle;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.idea.blaze.base.async.FutureUtil;
+import com.google.idea.blaze.base.bazel.BuildSystem;
+import com.google.idea.blaze.base.model.primitives.Label;
+import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
+import com.google.idea.blaze.base.projectview.ProjectViewManager;
+import com.google.idea.blaze.base.projectview.ProjectViewSet;
+import com.google.idea.blaze.base.projectview.section.sections.BazelBinarySection;
+import com.google.idea.blaze.base.projectview.section.sections.DirectoryEntry;
+import com.google.idea.blaze.base.projectview.section.sections.DirectorySection;
+import com.google.idea.blaze.base.scope.BlazeContext;
+import com.google.idea.blaze.base.scope.scopes.TimingScope;
+import com.google.idea.blaze.base.settings.Blaze;
+import com.google.idea.blaze.base.settings.BlazeImportSettings;
+import com.google.idea.blaze.base.settings.BlazeImportSettingsManager;
+import com.google.idea.blaze.base.settings.BlazeUserSettings;
+import com.google.idea.blaze.base.sync.SyncListener;
+import com.google.idea.blaze.base.sync.SyncMode;
+import com.google.idea.blaze.base.sync.SyncScope;
+import com.intellij.openapi.project.Project;
+
+import java.io.File;
+import java.util.List;
+import java.util.Optional;
+
+public class GazelleSyncListener implements SyncListener {
+
+    private Optional<Label> getGazelleBinary(ProjectViewSet projectViewSet) {
+        Optional<Label> gazelleBinaryFromProjectSettings = projectViewSet.getScalarValue(GazelleSection.KEY);
+        if (gazelleBinaryFromProjectSettings.isPresent()) {
+            return gazelleBinaryFromProjectSettings;
+        }
+        GazelleUserSettings settings = GazelleUserSettings.getInstance();
+        if (settings.getGazelleTarget().equals("")) {
+            return Optional.empty();
+        }
+        return Optional.of(Label.create(settings.getGazelleTarget()));
+    }
+    public void onSyncStart(Project project, BlazeContext context, SyncMode syncMode)
+            throws SyncScope.SyncFailedException, SyncScope.SyncCanceledException {
+        if (syncMode == SyncMode.NO_BUILD) {
+            return;
+        }
+        ProjectViewSet projectViewSet = ProjectViewManager.getInstance(project).getProjectViewSet();
+        Optional<Label> gazelleBinary = this.getGazelleBinary(projectViewSet);
+        BuildSystem.BuildInvoker invoker = Blaze.getBuildSystemProvider(project).getBuildSystem().getBuildInvoker(project, context);
+        List<DirectoryEntry> importantDirectories = projectViewSet.listItems(DirectorySection.KEY);
+        if (gazelleBinary.isPresent()) {
+            BlazeImportSettings importSettings = BlazeImportSettingsManager.getInstance(project).getImportSettings();
+            WorkspaceRoot workspaceRoot = WorkspaceRoot.fromImportSettings(importSettings);
+
+            ListenableFuture<String> blazeGazelleFuture = BlazeGazelleRunner.getInstance().runBlazeGazelle(
+                    context,
+                    invoker,
+                    workspaceRoot,
+                    ImmutableList.of(),
+                    gazelleBinary.get(),
+                    importantDirectories);
+            FutureUtil.waitForFuture(context, blazeGazelleFuture)
+                    .withProgressMessage("Running Gazelle...")
+                    .timed("GazelleRun", TimingScope.EventType.BlazeInvocation)
+                    .onError("Gazelle failed")
+                    .run();
+        }
+    }
+}

--- a/gazelle/src/com/google/idea/blaze/gazelle/GazelleSyncListener.java
+++ b/gazelle/src/com/google/idea/blaze/gazelle/GazelleSyncListener.java
@@ -3,67 +3,221 @@ package com.google.idea.blaze.gazelle;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.idea.blaze.base.async.FutureUtil;
+import com.google.idea.blaze.base.async.executor.ProgressiveTaskWithProgressIndicator;
 import com.google.idea.blaze.base.bazel.BuildSystem;
+import com.google.idea.blaze.base.command.BlazeCommandName;
+import com.google.idea.blaze.base.command.BlazeFlags;
+import com.google.idea.blaze.base.command.BlazeInvocationContext;
+import com.google.idea.blaze.base.issueparser.BlazeIssueParser;
+import com.google.idea.blaze.base.issueparser.BlazeIssueParser.Parser;
+import com.google.idea.blaze.base.issueparser.IssueOutputFilter;
+import com.google.idea.blaze.base.model.primitives.InvalidTargetException;
 import com.google.idea.blaze.base.model.primitives.Label;
+import com.google.idea.blaze.base.model.primitives.WorkspacePath;
 import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
 import com.google.idea.blaze.base.projectview.ProjectViewManager;
 import com.google.idea.blaze.base.projectview.ProjectViewSet;
-import com.google.idea.blaze.base.projectview.section.sections.BazelBinarySection;
-import com.google.idea.blaze.base.projectview.section.sections.DirectoryEntry;
-import com.google.idea.blaze.base.projectview.section.sections.DirectorySection;
 import com.google.idea.blaze.base.scope.BlazeContext;
+import com.google.idea.blaze.base.scope.Scope;
+import com.google.idea.blaze.base.scope.output.SummaryOutput;
+import com.google.idea.blaze.base.scope.scopes.BlazeConsoleScope;
+import com.google.idea.blaze.base.scope.scopes.NotificationScope;
 import com.google.idea.blaze.base.scope.scopes.TimingScope;
+import com.google.idea.blaze.base.scope.scopes.ToolWindowScope;
 import com.google.idea.blaze.base.settings.Blaze;
-import com.google.idea.blaze.base.settings.BlazeImportSettings;
-import com.google.idea.blaze.base.settings.BlazeImportSettingsManager;
-import com.google.idea.blaze.base.settings.BlazeUserSettings;
 import com.google.idea.blaze.base.sync.SyncListener;
 import com.google.idea.blaze.base.sync.SyncMode;
 import com.google.idea.blaze.base.sync.SyncScope;
+import com.google.idea.blaze.base.sync.projectview.ImportRoots;
+import com.google.idea.blaze.base.toolwindow.Task;
+import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.project.Project;
-
-import java.io.File;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class GazelleSyncListener implements SyncListener {
 
-    private Optional<Label> getGazelleBinary(ProjectViewSet projectViewSet) {
-        Optional<Label> gazelleBinaryFromProjectSettings = projectViewSet.getScalarValue(GazelleSection.KEY);
-        if (gazelleBinaryFromProjectSettings.isPresent()) {
-            return gazelleBinaryFromProjectSettings;
-        }
-        GazelleUserSettings settings = GazelleUserSettings.getInstance();
-        if (settings.getGazelleTarget().equals("")) {
-            return Optional.empty();
-        }
-        return Optional.of(Label.create(settings.getGazelleTarget()));
+  private Optional<Label> getGazelleBinary(ProjectViewSet projectViewSet)
+      throws InvalidTargetException {
+    Optional<Label> gazelleBinaryFromProjectSettings =
+        projectViewSet.getScalarValue(GazelleSection.KEY);
+    if (gazelleBinaryFromProjectSettings.isPresent()) {
+      return gazelleBinaryFromProjectSettings;
     }
-    public void onSyncStart(Project project, BlazeContext context, SyncMode syncMode)
-            throws SyncScope.SyncFailedException, SyncScope.SyncCanceledException {
-        if (syncMode == SyncMode.NO_BUILD) {
-            return;
-        }
-        ProjectViewSet projectViewSet = ProjectViewManager.getInstance(project).getProjectViewSet();
-        Optional<Label> gazelleBinary = this.getGazelleBinary(projectViewSet);
-        BuildSystem.BuildInvoker invoker = Blaze.getBuildSystemProvider(project).getBuildSystem().getBuildInvoker(project, context);
-        List<DirectoryEntry> importantDirectories = projectViewSet.listItems(DirectorySection.KEY);
-        if (gazelleBinary.isPresent()) {
-            BlazeImportSettings importSettings = BlazeImportSettingsManager.getInstance(project).getImportSettings();
-            WorkspaceRoot workspaceRoot = WorkspaceRoot.fromImportSettings(importSettings);
+    GazelleUserSettings settings = GazelleUserSettings.getInstance();
+    return settings.getGazelleTargetLabel();
+  }
 
-            ListenableFuture<String> blazeGazelleFuture = BlazeGazelleRunner.getInstance().runBlazeGazelle(
-                    context,
-                    invoker,
-                    workspaceRoot,
-                    ImmutableList.of(),
-                    gazelleBinary.get(),
-                    importantDirectories);
-            FutureUtil.waitForFuture(context, blazeGazelleFuture)
-                    .withProgressMessage("Running Gazelle...")
-                    .timed("GazelleRun", TimingScope.EventType.BlazeInvocation)
-                    .onError("Gazelle failed")
-                    .run();
-        }
+  private GazelleRunResult doRunGazelle(
+      Project project,
+      BlazeContext context,
+      Label gazelleBinary,
+      WorkspaceRoot workspaceRoot,
+      ImmutableList<Parser> issueParsers,
+      Collection<WorkspacePath> importantDirectories,
+      List<String> blazeFlags) {
+    BuildSystem.BuildInvoker invoker =
+        Blaze.getBuildSystemProvider(project).getBuildSystem().getBuildInvoker(project, context);
+
+    return BlazeGazelleRunner.getInstance()
+        .runBlazeGazelle(
+            context,
+            invoker,
+            workspaceRoot,
+            blazeFlags,
+            gazelleBinary,
+            importantDirectories,
+            issueParsers);
+  }
+
+  private ImmutableList<BlazeIssueParser.Parser> gazelleIssueParsers(
+      Project project, WorkspaceRoot workspaceRoot) {
+    return ImmutableList.<BlazeIssueParser.Parser>builder()
+        .addAll(
+            BlazeIssueParser.defaultIssueParsers(
+                project, workspaceRoot, BlazeInvocationContext.ContextType.Sync))
+        .addAll(GazelleIssueParsers.allGazelleIssueParsers(project))
+        .build();
+  }
+
+  private void setUpContext(
+      BlazeContext context,
+      BlazeContext parentContext,
+      Project project,
+      ProgressIndicator indicator,
+      ImmutableList<Parser> issueParsers) {
+    // Do not make the entire sync fail if Gazelle fails.
+    // It's possible that gazelle runs on directories that are included but irrelevant to the
+    // current build.
+    // Let the downstream sync machinery catch any build errors.
+    context.setPropagatesErrors(false);
+    ToolWindowScope parentToolWindowScope = parentContext.getScope(ToolWindowScope.class);
+    Task parentToolWindowTask =
+        parentToolWindowScope != null ? parentToolWindowScope.getTask() : null;
+    Task gazelleTask = new Task(project, "Run Gazelle", Task.Type.SYNC, parentToolWindowTask);
+
+    context
+        .push(
+            new ToolWindowScope.Builder(project, gazelleTask)
+                .setProgressIndicator(indicator)
+                .setIssueParsers(issueParsers)
+                .showSummaryOutput()
+                .build())
+        .push(
+            new BlazeConsoleScope.Builder(project, indicator)
+                .addConsoleFilters(
+                    new IssueOutputFilter(
+                        project,
+                        WorkspaceRoot.fromProject(project),
+                        BlazeInvocationContext.ContextType.Sync,
+                        true))
+                .build())
+        .push(
+            new NotificationScope(
+                project,
+                "Gazelle",
+                "Gazelle Run",
+                "Gazelle completed successfully.",
+                "Gazelle run completed with errors."));
+  }
+
+  private ListenableFuture<Void> createGazelleFuture(
+      Project project,
+      BlazeContext parentContext,
+      ProjectViewSet projectViewSet,
+      Label gazelleLabel) {
+    return ProgressiveTaskWithProgressIndicator.builder(project, "Running Gazelle")
+        .submitTask(
+            indicator ->
+                Scope.push(
+                    parentContext,
+                    context -> {
+                      WorkspaceRoot workspaceRoot = WorkspaceRoot.fromProject(project);
+
+                      ImmutableList<BlazeIssueParser.Parser> issueParsers =
+                          gazelleIssueParsers(project, workspaceRoot);
+
+                      setUpContext(context, parentContext, project, indicator, issueParsers);
+
+                      Collection<WorkspacePath> importantDirectories =
+                          importantDirectories(project);
+                      List<String> blazeFlags = blazeFlags(project, context, projectViewSet);
+                      GazelleRunResult result =
+                          doRunGazelle(
+                              project,
+                              context,
+                              gazelleLabel,
+                              workspaceRoot,
+                              issueParsers,
+                              importantDirectories,
+                              blazeFlags);
+                      if (result == GazelleRunResult.FAILED_TO_RUN) {
+                        String error =
+                            "Failed to invoke Gazelle. Please review that the Gazelle target can be"
+                                + " built and run without errors.";
+                        parentContext.output(
+                            SummaryOutput.error(SummaryOutput.Prefix.TIMESTAMP, error));
+                      } else if (result == GazelleRunResult.RAN_WITH_ERRORS) {
+                        parentContext.output(
+                            SummaryOutput.error(
+                                SummaryOutput.Prefix.TIMESTAMP,
+                                "Gazelle invocation finished with errors."));
+                      } else {
+                        parentContext.output(
+                            SummaryOutput.output(
+                                SummaryOutput.Prefix.TIMESTAMP, "Gazelle finished."));
+                      }
+                    }));
+  }
+
+  public void onSyncStart(Project project, BlazeContext parentContext, SyncMode syncMode)
+      throws SyncScope.SyncFailedException, SyncScope.SyncCanceledException {
+    if (syncMode == SyncMode.NO_BUILD) {
+      return;
     }
+    ProjectViewSet projectViewSet = ProjectViewManager.getInstance(project).getProjectViewSet();
+    Optional<Label> gazelleBinary;
+    try {
+      gazelleBinary = this.getGazelleBinary(projectViewSet);
+    } catch (InvalidTargetException e) {
+      String msg = "Label for Gazelle target is invalid. Please re-check the plugin's settings.";
+      parentContext.output(SummaryOutput.error(SummaryOutput.Prefix.TIMESTAMP, msg));
+      // If there is an invalid target, the user wanted to have a gazelle.
+      // Therefore, failing the sync is proper, as it will otherwise likely fail for out-of-date
+      // changes.
+      throw new SyncScope.SyncFailedException(msg, e);
+    }
+
+    gazelleBinary.ifPresent(
+        label -> {
+          ListenableFuture<Void> gazelleFuture =
+              createGazelleFuture(project, parentContext, projectViewSet, label);
+          FutureUtil.waitForFuture(parentContext, gazelleFuture)
+              .withProgressMessage("Running Gazelle...")
+              .timed("GazelleRun", TimingScope.EventType.BlazeInvocation)
+              .onError("Gazelle failed")
+              .run();
+        });
+  }
+
+  private List<String> blazeFlags(
+      Project project, BlazeContext context, ProjectViewSet projectViewSet) {
+    return BlazeFlags.blazeFlags(
+        project,
+        projectViewSet,
+        BlazeCommandName.BUILD,
+        context,
+        BlazeInvocationContext.SYNC_CONTEXT);
+  }
+
+  private Collection<WorkspacePath> importantDirectories(Project project) {
+    ImportRoots roots = ImportRoots.forProjectSafe(project);
+    Collection<WorkspacePath> paths =
+        roots.rootDirectories().stream()
+            .filter(dir -> !roots.excludeDirectories().contains(dir))
+            .collect(Collectors.toSet());
+    return paths;
+  }
 }

--- a/gazelle/src/com/google/idea/blaze/gazelle/GazelleSyncListener.java
+++ b/gazelle/src/com/google/idea/blaze/gazelle/GazelleSyncListener.java
@@ -19,10 +19,13 @@ import com.google.idea.blaze.base.projectview.ProjectViewSet;
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.scope.Scope;
 import com.google.idea.blaze.base.scope.output.SummaryOutput;
+import com.google.idea.blaze.base.scope.scopes.IdeaLogScope;
 import com.google.idea.blaze.base.scope.scopes.NotificationScope;
+import com.google.idea.blaze.base.scope.scopes.ProblemsViewScope;
 import com.google.idea.blaze.base.scope.scopes.TimingScope;
 import com.google.idea.blaze.base.scope.scopes.ToolWindowScope;
 import com.google.idea.blaze.base.settings.Blaze;
+import com.google.idea.blaze.base.settings.BlazeUserSettings;
 import com.google.idea.blaze.base.sync.SyncListener;
 import com.google.idea.blaze.base.sync.SyncMode;
 import com.google.idea.blaze.base.sync.SyncScope;
@@ -101,15 +104,19 @@ public class GazelleSyncListener implements SyncListener {
             new ToolWindowScope.Builder(project, gazelleTask)
                 .setProgressIndicator(indicator)
                 .setIssueParsers(issueParsers)
+                .setPopupBehavior(BlazeUserSettings.getInstance().getShowBlazeConsoleOnSync())
                 .showSummaryOutput()
                 .build())
+        .push(new ProblemsViewScope(
+            project, BlazeUserSettings.getInstance().getShowProblemsViewOnSync()))
         .push(
             new NotificationScope(
                 project,
                 "Gazelle",
                 "Gazelle Run",
                 "Gazelle completed successfully.",
-                "Gazelle run completed with errors."));
+                "Gazelle run completed with errors."))
+        .push(new IdeaLogScope());
   }
 
   private ListenableFuture<Void> createGazelleFuture(

--- a/gazelle/src/com/google/idea/blaze/gazelle/GazelleSyncPlugin.java
+++ b/gazelle/src/com/google/idea/blaze/gazelle/GazelleSyncPlugin.java
@@ -1,0 +1,13 @@
+package com.google.idea.blaze.gazelle;
+
+import com.google.common.collect.ImmutableList;
+import com.google.idea.blaze.base.projectview.section.SectionParser;
+import com.google.idea.blaze.base.sync.BlazeSyncPlugin;
+
+import java.util.Collection;
+
+public class GazelleSyncPlugin implements BlazeSyncPlugin {
+    public Collection<SectionParser> getSections() {
+        return ImmutableList.of(GazelleSection.PARSER);
+    }
+}

--- a/gazelle/src/com/google/idea/blaze/gazelle/GazelleSyncPlugin.java
+++ b/gazelle/src/com/google/idea/blaze/gazelle/GazelleSyncPlugin.java
@@ -3,11 +3,10 @@ package com.google.idea.blaze.gazelle;
 import com.google.common.collect.ImmutableList;
 import com.google.idea.blaze.base.projectview.section.SectionParser;
 import com.google.idea.blaze.base.sync.BlazeSyncPlugin;
-
 import java.util.Collection;
 
 public class GazelleSyncPlugin implements BlazeSyncPlugin {
-    public Collection<SectionParser> getSections() {
-        return ImmutableList.of(GazelleSection.PARSER);
-    }
+  public Collection<SectionParser> getSections() {
+    return ImmutableList.of(GazelleSection.PARSER);
+  }
 }

--- a/gazelle/src/com/google/idea/blaze/gazelle/GazelleUserSettings.java
+++ b/gazelle/src/com/google/idea/blaze/gazelle/GazelleUserSettings.java
@@ -42,7 +42,11 @@ public class GazelleUserSettings implements PersistentStateComponent<GazelleUser
     if (rawTarget.equals(EMPTY_GAZELLE_TARGET)) {
       return Optional.empty();
     }
-    Label targetLabel = (Label) TargetExpression.fromString(rawTarget);
+    String validationError = Label.validate(rawTarget);
+    if ( validationError != null) {
+      throw new InvalidTargetException(validationError);
+    }
+    Label targetLabel = Label.create(rawTarget);
     return Optional.of(targetLabel);
   }
 

--- a/gazelle/src/com/google/idea/blaze/gazelle/GazelleUserSettings.java
+++ b/gazelle/src/com/google/idea/blaze/gazelle/GazelleUserSettings.java
@@ -1,0 +1,38 @@
+package com.google.idea.blaze.gazelle;
+
+import com.intellij.openapi.components.PersistentStateComponent;
+import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.components.State;
+import com.intellij.openapi.components.Storage;
+import com.intellij.openapi.util.text.StringUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@State(name = "GazelleUserSettings", storages = {
+        @Storage("gazelle.user.settings.xml")
+})
+public class GazelleUserSettings implements PersistentStateComponent<GazelleUserSettings> {
+
+    private static final String DEFAULT_GAZELLE_TARGET = "";
+    private String gazelleTarget = DEFAULT_GAZELLE_TARGET;
+
+    public static GazelleUserSettings getInstance() { return ServiceManager.getService(GazelleUserSettings.class); }
+
+    public void setGazelleTarget(String target) {
+        this.gazelleTarget = target;
+    }
+
+    public void clearGazelleTarget() { this.gazelleTarget = DEFAULT_GAZELLE_TARGET; }
+
+    public String getGazelleTarget() { return StringUtil.defaultIfEmpty(this.gazelleTarget, DEFAULT_GAZELLE_TARGET).trim();}
+
+    @Override
+    public @Nullable GazelleUserSettings getState() {
+        return this;
+    }
+
+    @Override
+    public void loadState(@NotNull GazelleUserSettings state) {
+        this.gazelleTarget = state.gazelleTarget;
+    }
+}

--- a/gazelle/src/com/google/idea/blaze/gazelle/GazelleUserSettings.java
+++ b/gazelle/src/com/google/idea/blaze/gazelle/GazelleUserSettings.java
@@ -2,7 +2,6 @@ package com.google.idea.blaze.gazelle;
 
 import com.google.idea.blaze.base.model.primitives.InvalidTargetException;
 import com.google.idea.blaze.base.model.primitives.Label;
-import com.google.idea.blaze.base.model.primitives.TargetExpression;
 import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.components.State;
@@ -19,10 +18,26 @@ import org.jetbrains.annotations.Nullable;
 public class GazelleUserSettings implements PersistentStateComponent<GazelleUserSettings> {
 
   private static final String EMPTY_GAZELLE_TARGET = "";
+
+  private static final boolean GAZELLE_HEADLESS_MODE = false;
+
   private String gazelleTarget = EMPTY_GAZELLE_TARGET;
+
+  // Headless mode will not try to set up the UI at all.
+  // Used mainly for testing,
+  // not registered in the global configuration UI on purpose,
+  private boolean gazelleHeadless = GAZELLE_HEADLESS_MODE;
 
   public static GazelleUserSettings getInstance() {
     return ServiceManager.getService(GazelleUserSettings.class);
+  }
+
+  public boolean shouldRunHeadless() {
+    return gazelleHeadless;
+  }
+
+  public void setGazelleHeadless(boolean headless) {
+    gazelleHeadless = headless;
   }
 
   public void clearGazelleTarget() {

--- a/gazelle/src/com/google/idea/blaze/gazelle/GazelleUserSettings.java
+++ b/gazelle/src/com/google/idea/blaze/gazelle/GazelleUserSettings.java
@@ -1,38 +1,58 @@
 package com.google.idea.blaze.gazelle;
 
+import com.google.idea.blaze.base.model.primitives.InvalidTargetException;
+import com.google.idea.blaze.base.model.primitives.Label;
+import com.google.idea.blaze.base.model.primitives.TargetExpression;
 import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
 import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.util.xmlb.XmlSerializerUtil;
+import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-@State(name = "GazelleUserSettings", storages = {
-        @Storage("gazelle.user.settings.xml")
-})
+@State(
+    name = "GazelleUserSettings",
+    storages = {@Storage("gazelle.user.settings.xml")})
 public class GazelleUserSettings implements PersistentStateComponent<GazelleUserSettings> {
 
-    private static final String DEFAULT_GAZELLE_TARGET = "";
-    private String gazelleTarget = DEFAULT_GAZELLE_TARGET;
+  private static final String EMPTY_GAZELLE_TARGET = "";
+  private String gazelleTarget = EMPTY_GAZELLE_TARGET;
 
-    public static GazelleUserSettings getInstance() { return ServiceManager.getService(GazelleUserSettings.class); }
+  public static GazelleUserSettings getInstance() {
+    return ServiceManager.getService(GazelleUserSettings.class);
+  }
 
-    public void setGazelleTarget(String target) {
-        this.gazelleTarget = target;
+  public void clearGazelleTarget() {
+    this.gazelleTarget = EMPTY_GAZELLE_TARGET;
+  }
+
+  public String getGazelleTarget() {
+    return StringUtil.defaultIfEmpty(this.gazelleTarget, EMPTY_GAZELLE_TARGET).trim();
+  }
+
+  public void setGazelleTarget(String target) {
+    this.gazelleTarget = target;
+  }
+
+  public Optional<Label> getGazelleTargetLabel() throws InvalidTargetException {
+    String rawTarget = getGazelleTarget();
+    if (rawTarget.equals(EMPTY_GAZELLE_TARGET)) {
+      return Optional.empty();
     }
+    Label targetLabel = (Label) TargetExpression.fromString(rawTarget);
+    return Optional.of(targetLabel);
+  }
 
-    public void clearGazelleTarget() { this.gazelleTarget = DEFAULT_GAZELLE_TARGET; }
+  @Override
+  public @Nullable GazelleUserSettings getState() {
+    return this;
+  }
 
-    public String getGazelleTarget() { return StringUtil.defaultIfEmpty(this.gazelleTarget, DEFAULT_GAZELLE_TARGET).trim();}
-
-    @Override
-    public @Nullable GazelleUserSettings getState() {
-        return this;
-    }
-
-    @Override
-    public void loadState(@NotNull GazelleUserSettings state) {
-        this.gazelleTarget = state.gazelleTarget;
-    }
+  @Override
+  public void loadState(@NotNull GazelleUserSettings state) {
+    XmlSerializerUtil.copyBean(state, this);
+  }
 }

--- a/gazelle/src/com/google/idea/blaze/gazelle/GazelleUserSettingsConfigurable.java
+++ b/gazelle/src/com/google/idea/blaze/gazelle/GazelleUserSettingsConfigurable.java
@@ -10,36 +10,43 @@ import com.google.idea.common.settings.SearchableText;
 import com.google.idea.common.settings.SettingComponent;
 import com.intellij.openapi.options.UnnamedConfigurable;
 import com.intellij.ui.TextFieldWithStoredHistory;
+import com.intellij.util.PlatformUtils;
 
 class GazelleUserSettingsConfigurable extends AutoConfigurable {
-    static class UiContributor implements BlazeUserSettingsCompositeConfigurable.UiContributor {
+  static class UiContributor implements BlazeUserSettingsCompositeConfigurable.UiContributor {
 
-        @Override
-        public UnnamedConfigurable getConfigurable() {
-            return new GazelleUserSettingsConfigurable();
-        }
-
-        @Override
-        public ImmutableCollection<SearchableText> getSearchableText() {
-            return SearchableText.collect(SETTINGS);
-        }
+    @Override
+    public UnnamedConfigurable getConfigurable() {
+      return new GazelleUserSettingsConfigurable();
     }
 
-    private static final ConfigurableSetting<?, ?> GAZELLE_TARGET = ConfigurableSetting.builder(GazelleUserSettings::getInstance)
-            .label("Gazelle target to run on Sync.")
-            .getter(GazelleUserSettings::getGazelleTarget)
-            .setter(GazelleUserSettings::setGazelleTarget)
-            .componentFactory(
-                    SettingComponent.LabeledComponent.factory(
-                            () -> new TextFieldWithStoredHistory("TEST"),
-                            s -> Strings.nullToEmpty(s.getText()).trim(),
-                            TextFieldWithStoredHistory::setTextAndAddToHistory
-                    )
-            );
-
-    private static final ImmutableList<ConfigurableSetting<?, ?>> SETTINGS = ImmutableList.of(GAZELLE_TARGET);
-
-    private GazelleUserSettingsConfigurable() {
-        super(SETTINGS);
+    @Override
+    public ImmutableCollection<SearchableText> getSearchableText() {
+      return SearchableText.collect(SETTINGS);
     }
+  }
+
+  private static boolean shouldShow() {
+    return PlatformUtils.isIdeaUltimate() || PlatformUtils.isGoIde();
+  }
+
+  private static final String GAZELLE_TARGET_KEY = "gazelle.target";
+  private static final ConfigurableSetting<?, ?> GAZELLE_TARGET =
+      ConfigurableSetting.builder(GazelleUserSettings::getInstance)
+          .label("Gazelle target to run on Sync.")
+          .getter(GazelleUserSettings::getGazelleTarget)
+          .setter(GazelleUserSettings::setGazelleTarget)
+          .hideIf(() -> !shouldShow())
+          .componentFactory(
+              SettingComponent.LabeledComponent.factory(
+                  () -> new TextFieldWithStoredHistory(GAZELLE_TARGET_KEY),
+                  s -> Strings.nullToEmpty(s.getText()).trim(),
+                  TextFieldWithStoredHistory::setTextAndAddToHistory));
+
+  private static final ImmutableList<ConfigurableSetting<?, ?>> SETTINGS =
+      ImmutableList.of(GAZELLE_TARGET);
+
+  private GazelleUserSettingsConfigurable() {
+    super(SETTINGS);
+  }
 }

--- a/gazelle/src/com/google/idea/blaze/gazelle/GazelleUserSettingsConfigurable.java
+++ b/gazelle/src/com/google/idea/blaze/gazelle/GazelleUserSettingsConfigurable.java
@@ -1,0 +1,45 @@
+package com.google.idea.blaze.gazelle;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableList;
+import com.google.idea.blaze.base.settings.ui.BlazeUserSettingsCompositeConfigurable;
+import com.google.idea.common.settings.AutoConfigurable;
+import com.google.idea.common.settings.ConfigurableSetting;
+import com.google.idea.common.settings.SearchableText;
+import com.google.idea.common.settings.SettingComponent;
+import com.intellij.openapi.options.UnnamedConfigurable;
+import com.intellij.ui.TextFieldWithStoredHistory;
+
+class GazelleUserSettingsConfigurable extends AutoConfigurable {
+    static class UiContributor implements BlazeUserSettingsCompositeConfigurable.UiContributor {
+
+        @Override
+        public UnnamedConfigurable getConfigurable() {
+            return new GazelleUserSettingsConfigurable();
+        }
+
+        @Override
+        public ImmutableCollection<SearchableText> getSearchableText() {
+            return SearchableText.collect(SETTINGS);
+        }
+    }
+
+    private static final ConfigurableSetting<?, ?> GAZELLE_TARGET = ConfigurableSetting.builder(GazelleUserSettings::getInstance)
+            .label("Gazelle target to run on Sync.")
+            .getter(GazelleUserSettings::getGazelleTarget)
+            .setter(GazelleUserSettings::setGazelleTarget)
+            .componentFactory(
+                    SettingComponent.LabeledComponent.factory(
+                            () -> new TextFieldWithStoredHistory("TEST"),
+                            s -> Strings.nullToEmpty(s.getText()).trim(),
+                            TextFieldWithStoredHistory::setTextAndAddToHistory
+                    )
+            );
+
+    private static final ImmutableList<ConfigurableSetting<?, ?>> SETTINGS = ImmutableList.of(GAZELLE_TARGET);
+
+    private GazelleUserSettingsConfigurable() {
+        super(SETTINGS);
+    }
+}

--- a/gazelle/tests/integrationtests/com/google/idea/blaze/gazelle/sync/RunGazelleOnSyncTest.java
+++ b/gazelle/tests/integrationtests/com/google/idea/blaze/gazelle/sync/RunGazelleOnSyncTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2018 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.gazelle.sync;
+
+
+import com.google.common.base.Joiner;
+import com.google.idea.blaze.base.BlazeIntegrationTestCase;
+import com.google.idea.blaze.base.MockProjectViewManager;
+import com.google.idea.blaze.base.async.executor.BlazeExecutor;
+import com.google.idea.blaze.base.model.primitives.WorkspacePath;
+import com.google.idea.blaze.base.projectview.ProjectViewSet;
+import com.google.idea.blaze.base.projectview.parser.ProjectViewParser;
+import com.google.idea.blaze.base.scope.BlazeContext;
+import com.google.idea.blaze.base.scope.ErrorCollector;
+import com.google.idea.blaze.base.scope.output.IssueOutput;
+import com.google.idea.blaze.base.sync.BlazeSyncIntegrationTestCase;
+import com.google.idea.blaze.base.sync.BlazeSyncManager;
+import com.google.idea.blaze.base.sync.BlazeSyncParams;
+import com.google.idea.blaze.base.sync.SyncMode;
+import com.google.idea.blaze.base.sync.workspace.WorkspacePathResolverImpl;
+import com.google.idea.blaze.gazelle.GazelleUserSettings;
+import javaslang.collection.List;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOExceptionList;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Spy;
+
+import java.io.File;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@RunWith(JUnit4.class)
+public class RunGazelleOnSyncTest extends BlazeSyncIntegrationTestCase {
+
+    @Override
+    protected boolean isLightTestCase() {
+        return false;
+    }
+
+    public void setUpRepoWithGazelle() {
+        workspace.createFile(new WorkspacePath("BUILD.bazel"),
+                "load(\"@bazel_gazelle//:def.bzl\", \"gazelle\")",
+                "# gazelle:prefix github.com/bazelbuild/intellij",
+                "gazelle(name = \"gazelle\")"
+        );
+        workspace.createFile(new WorkspacePath("WORKSPACE"),
+                "load(\"@bazel_tools//tools/build_defs/repo:http.bzl\", \"http_archive\")",
+                "",
+                "http_archive(",
+                "    name = \"io_bazel_rules_go\",",
+                "    sha256 = \"2b1641428dff9018f9e85c0384f03ec6c10660d935b750e3fa1492a281a53b0f\",",
+                "    urls = [",
+                "        \"https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.29.0/rules_go-v0.29.0.zip\",",
+                "        \"https://github.com/bazelbuild/rules_go/releases/download/v0.29.0/rules_go-v0.29.0.zip\",",
+                "    ],",
+                ")",
+                "",
+                "http_archive(",
+                "    name = \"bazel_gazelle\",",
+                "    sha256 = \"de69a09dc70417580aabf20a28619bb3ef60d038470c7cf8442fafcf627c21cb\",",
+                "    urls = [",
+                "        \"https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.24.0/bazel-gazelle-v0.24.0.tar.gz\",",
+                "        \"https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.24.0/bazel-gazelle-v0.24.0.tar.gz\",",
+                "    ],",
+                ")",
+                "",
+                "load(\"@io_bazel_rules_go//go:deps.bzl\", \"go_register_toolchains\", \"go_rules_dependencies\")",
+                "load(\"@bazel_gazelle//:deps.bzl\", \"gazelle_dependencies\", \"go_repository\")",
+                "go_rules_dependencies()",
+                "",
+                "go_register_toolchains(version = \"1.17.2\")",
+                "",
+                "gazelle_dependencies()"
+        );
+        workspace.createDirectory(new WorkspacePath("src"));
+        workspace.createFile(new WorkspacePath("src/main.go"),
+                "package main",
+                "import \"fmt\"",
+                "func main() {",
+                "  fmt.Println(\"Hello World\")",
+                "}"
+        );
+    }
+
+    private void runBazelSync() {
+        BlazeSyncParams syncParams =
+                BlazeSyncParams.builder()
+                        .setTitle("Full Sync")
+                        .setSyncMode(SyncMode.FULL)
+                        .setSyncOrigin("test")
+                        .setAddProjectViewTargets(true)
+                        .build();
+        runBlazeSync(syncParams);
+    }
+
+    @Test
+    public void testGazelleDoesntRunWhenNotConfigured() throws Exception {
+        setUpRepoWithGazelle();
+        setProjectView(
+                "directories:",
+                "  ."
+        );
+
+        runBazelSync();
+
+        errorCollector.assertNoIssues();
+
+        File resultBuildFile = workspaceRoot.fileForPath(new WorkspacePath("src/BUILD.bazel"));
+        assertThat(workspaceRoot.isInWorkspace(resultBuildFile)).isFalse();
+    }
+
+    String WANTED_BUILD_CONTENTS =
+            "load(\"@io_bazel_rules_go//go:def.bzl\", \"go_binary\", \"go_library\")\n" +
+                    "\n" +
+                    "go_library(\n" +
+                    "    name = \"src_lib\",\n" +
+                    "    srcs = [\"main.go\"],\n" +
+                    "    importpath = \"github.com/bazelbuild/intellij/src\",\n" +
+                    "    visibility = [\"//visibility:private\"],\n" +
+                    ")\n" +
+                    "\n" +
+                    "go_binary(\n" +
+                    "    name = \"src\",\n" +
+                    "    embed = [\":src_lib\"],\n" +
+                    "    visibility = [\"//visibility:public\"],\n" +
+                    ")\n";
+
+    @Test
+    public void testRunGazelleWhenConfiguredInProject() throws Exception {
+        setUpRepoWithGazelle();
+        setProjectView(
+                "directories:",
+                "  .",
+                "gazelle_target //:gazelle"
+        );
+
+        runBazelSync();
+
+        errorCollector.assertNoIssues();
+
+        File resultBuildFile = workspaceRoot.fileForPath(new WorkspacePath("src/BUILD.bazel"));
+        assertThat(workspaceRoot.isInWorkspace(resultBuildFile)).isTrue();
+        assertThat(FileUtils.readFileToString(resultBuildFile, "UTF-8")).contains(WANTED_BUILD_CONTENTS);
+    }
+
+    @Test
+    public void testRunGazelleWhenConfiguredGlobally() throws Exception {
+        setUpRepoWithGazelle();
+
+        GazelleUserSettings gazelleSettings = GazelleUserSettings.getInstance();
+        gazelleSettings.setGazelleTarget("//:gazelle");
+
+        setProjectView(
+                "directories:",
+                "  ."
+        );
+
+        runBazelSync();
+
+        errorCollector.assertNoIssues();
+
+        File resultBuildFile = workspaceRoot.fileForPath(new WorkspacePath("src/BUILD.bazel"));
+        assertThat(workspaceRoot.isInWorkspace(resultBuildFile)).isTrue();
+        assertThat(FileUtils.readFileToString(resultBuildFile, "UTF-8")).contains(WANTED_BUILD_CONTENTS);
+    }
+}

--- a/gazelle/tests/integrationtests/com/google/idea/blaze/gazelle/sync/RunGazelleOnSyncTest.java
+++ b/gazelle/tests/integrationtests/com/google/idea/blaze/gazelle/sync/RunGazelleOnSyncTest.java
@@ -22,7 +22,9 @@ import com.google.idea.blaze.base.model.primitives.WorkspacePath;
 import com.google.idea.blaze.base.sync.BlazeSyncIntegrationTestCase;
 import com.google.idea.blaze.base.sync.BlazeSyncParams;
 import com.google.idea.blaze.base.sync.SyncMode;
+import com.google.idea.blaze.base.ui.problems.BlazeProblemsView;
 import com.google.idea.blaze.gazelle.GazelleUserSettings;
+import com.intellij.openapi.wm.ToolWindowManager;
 import java.io.File;
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
@@ -90,6 +92,10 @@ public class RunGazelleOnSyncTest extends BlazeSyncIntegrationTestCase {
   }
 
   private void runBazelSync() {
+    // This forces the plugin to register the appropriate views with the IntelliJ UI,
+    // so that gazelle can create the appropriate tool windows even within a test project.
+    BlazeProblemsView.getInstance(getProject()).addMessage(null, null);
+
     BlazeSyncParams syncParams =
         BlazeSyncParams.builder()
             .setTitle("Full Sync")

--- a/gazelle/tests/integrationtests/com/google/idea/blaze/gazelle/sync/RunGazelleOnSyncTest.java
+++ b/gazelle/tests/integrationtests/com/google/idea/blaze/gazelle/sync/RunGazelleOnSyncTest.java
@@ -15,170 +15,190 @@
  */
 package com.google.idea.blaze.gazelle.sync;
 
+import static com.google.common.truth.Truth.assertThat;
 
-import com.google.common.base.Joiner;
-import com.google.idea.blaze.base.BlazeIntegrationTestCase;
-import com.google.idea.blaze.base.MockProjectViewManager;
-import com.google.idea.blaze.base.async.executor.BlazeExecutor;
+import com.google.common.collect.ImmutableList;
 import com.google.idea.blaze.base.model.primitives.WorkspacePath;
-import com.google.idea.blaze.base.projectview.ProjectViewSet;
-import com.google.idea.blaze.base.projectview.parser.ProjectViewParser;
-import com.google.idea.blaze.base.scope.BlazeContext;
-import com.google.idea.blaze.base.scope.ErrorCollector;
-import com.google.idea.blaze.base.scope.output.IssueOutput;
 import com.google.idea.blaze.base.sync.BlazeSyncIntegrationTestCase;
-import com.google.idea.blaze.base.sync.BlazeSyncManager;
 import com.google.idea.blaze.base.sync.BlazeSyncParams;
 import com.google.idea.blaze.base.sync.SyncMode;
-import com.google.idea.blaze.base.sync.workspace.WorkspacePathResolverImpl;
 import com.google.idea.blaze.gazelle.GazelleUserSettings;
-import javaslang.collection.List;
+import java.io.File;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOExceptionList;
+import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.Spy;
-
-import java.io.File;
-
-import static com.google.common.truth.Truth.assertThat;
 
 @RunWith(JUnit4.class)
 public class RunGazelleOnSyncTest extends BlazeSyncIntegrationTestCase {
 
-    @Override
-    protected boolean isLightTestCase() {
-        return false;
+  @Override
+  protected boolean isLightTestCase() {
+    return false;
+  }
+
+  @Before
+  public void setUpRepoWithGazelle() {
+    workspace.createFile(
+        new WorkspacePath("BUILD.bazel"),
+        "load(\"@bazel_gazelle//:def.bzl\", \"gazelle\")",
+        "# gazelle:prefix github.com/bazelbuild/intellij",
+        "gazelle(name = \"gazelle\")");
+    workspace.createFile(
+        new WorkspacePath("WORKSPACE"),
+        "load(\"@bazel_tools//tools/build_defs/repo:http.bzl\", \"http_archive\")",
+        "",
+        "http_archive(",
+        "    name = \"io_bazel_rules_go\",",
+        "    sha256 = \"2b1641428dff9018f9e85c0384f03ec6c10660d935b750e3fa1492a281a53b0f\",",
+        "    urls = [",
+        "       "
+            + " \"https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.29.0/rules_go-v0.29.0.zip\",",
+        "       "
+            + " \"https://github.com/bazelbuild/rules_go/releases/download/v0.29.0/rules_go-v0.29.0.zip\",",
+        "    ],",
+        ")",
+        "",
+        "http_archive(",
+        "    name = \"bazel_gazelle\",",
+        "    sha256 = \"de69a09dc70417580aabf20a28619bb3ef60d038470c7cf8442fafcf627c21cb\",",
+        "    urls = [",
+        "       "
+            + " \"https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.24.0/bazel-gazelle-v0.24.0.tar.gz\",",
+        "       "
+            + " \"https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.24.0/bazel-gazelle-v0.24.0.tar.gz\",",
+        "    ],",
+        ")",
+        "",
+        "load(\"@io_bazel_rules_go//go:deps.bzl\", \"go_register_toolchains\","
+            + " \"go_rules_dependencies\")",
+        "load(\"@bazel_gazelle//:deps.bzl\", \"gazelle_dependencies\", \"go_repository\")",
+        "go_rules_dependencies()",
+        "go_register_toolchains(version = \"1.17.2\")",
+        "gazelle_dependencies()");
+    workspace.createDirectory(new WorkspacePath("src"));
+    workspace.createFile(
+        new WorkspacePath("src/main.go"),
+        "package main",
+        "import \"fmt\"",
+        "func main() {",
+        "  fmt.Println(\"Hello World\")",
+        "}");
+  }
+
+  private void runBazelSync() {
+    BlazeSyncParams syncParams =
+        BlazeSyncParams.builder()
+            .setTitle("Full Sync")
+            .setSyncMode(SyncMode.INCREMENTAL)
+            .setSyncOrigin("test")
+            .setAddProjectViewTargets(true)
+            .build();
+    runBlazeSync(syncParams);
+  }
+
+  // Common directories so that the tests can cache the download of Gazelle.
+  private static final String REPOSITORY_CACHE_LOCATION =
+      FileUtils.getTempDirectoryPath() + "/temp_repository_cache";
+  private static final String DISK_CACHE_LOCATION =
+      FileUtils.getTempDirectoryPath() + "/temp_disk_cache";
+
+  @BeforeClass
+  public static void createCacheDirs() {
+    ImmutableList<String> cachedirs =
+        ImmutableList.of(REPOSITORY_CACHE_LOCATION, DISK_CACHE_LOCATION);
+    for (String cachedir : cachedirs) {
+      File directory = new File(cachedir);
+      if (!directory.exists()) {
+        directory.mkdirs();
+      }
     }
+  }
 
-    public void setUpRepoWithGazelle() {
-        workspace.createFile(new WorkspacePath("BUILD.bazel"),
-                "load(\"@bazel_gazelle//:def.bzl\", \"gazelle\")",
-                "# gazelle:prefix github.com/bazelbuild/intellij",
-                "gazelle(name = \"gazelle\")"
-        );
-        workspace.createFile(new WorkspacePath("WORKSPACE"),
-                "load(\"@bazel_tools//tools/build_defs/repo:http.bzl\", \"http_archive\")",
-                "",
-                "http_archive(",
-                "    name = \"io_bazel_rules_go\",",
-                "    sha256 = \"2b1641428dff9018f9e85c0384f03ec6c10660d935b750e3fa1492a281a53b0f\",",
-                "    urls = [",
-                "        \"https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.29.0/rules_go-v0.29.0.zip\",",
-                "        \"https://github.com/bazelbuild/rules_go/releases/download/v0.29.0/rules_go-v0.29.0.zip\",",
-                "    ],",
-                ")",
-                "",
-                "http_archive(",
-                "    name = \"bazel_gazelle\",",
-                "    sha256 = \"de69a09dc70417580aabf20a28619bb3ef60d038470c7cf8442fafcf627c21cb\",",
-                "    urls = [",
-                "        \"https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.24.0/bazel-gazelle-v0.24.0.tar.gz\",",
-                "        \"https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.24.0/bazel-gazelle-v0.24.0.tar.gz\",",
-                "    ],",
-                ")",
-                "",
-                "load(\"@io_bazel_rules_go//go:deps.bzl\", \"go_register_toolchains\", \"go_rules_dependencies\")",
-                "load(\"@bazel_gazelle//:deps.bzl\", \"gazelle_dependencies\", \"go_repository\")",
-                "go_rules_dependencies()",
-                "",
-                "go_register_toolchains(version = \"1.17.2\")",
-                "",
-                "gazelle_dependencies()"
-        );
-        workspace.createDirectory(new WorkspacePath("src"));
-        workspace.createFile(new WorkspacePath("src/main.go"),
-                "package main",
-                "import \"fmt\"",
-                "func main() {",
-                "  fmt.Println(\"Hello World\")",
-                "}"
-        );
-    }
+  @After
+  public void clearState() {
+    // Some test modify this global state, which doesn't get reset by regular cleanup.
+    GazelleUserSettings.getInstance().clearGazelleTarget();
+  }
 
-    private void runBazelSync() {
-        BlazeSyncParams syncParams =
-                BlazeSyncParams.builder()
-                        .setTitle("Full Sync")
-                        .setSyncMode(SyncMode.FULL)
-                        .setSyncOrigin("test")
-                        .setAddProjectViewTargets(true)
-                        .build();
-        runBlazeSync(syncParams);
-    }
+  private static final String GENERATED_BUILD_FILE_PATH = "src/BUILD.bazel";
+  private static final String WANTED_BUILD_CONTENTS =
+      "load(\"@io_bazel_rules_go//go:def.bzl\", \"go_binary\", \"go_library\")\n"
+          + "\n"
+          + "go_library(\n"
+          + "    name = \"src_lib\",\n"
+          + "    srcs = [\"main.go\"],\n"
+          + "    importpath = \"github.com/bazelbuild/intellij/src\",\n"
+          + "    visibility = [\"//visibility:private\"],\n"
+          + ")\n"
+          + "\n"
+          + "go_binary(\n"
+          + "    name = \"src\",\n"
+          + "    embed = [\":src_lib\"],\n"
+          + "    visibility = [\"//visibility:public\"],\n"
+          + ")\n";
 
-    @Test
-    public void testGazelleDoesntRunWhenNotConfigured() throws Exception {
-        setUpRepoWithGazelle();
-        setProjectView(
-                "directories:",
-                "  ."
-        );
+  @Test
+  public void testGazelleDoesntRunWhenNotConfigured() throws Exception {
+    setProjectView(
+        "directories:",
+        "  .",
+        "build_flags:",
+        "  --repository_cache=" + REPOSITORY_CACHE_LOCATION,
+        "  --disk_cache=" + DISK_CACHE_LOCATION);
 
-        runBazelSync();
+    runBazelSync();
 
-        errorCollector.assertNoIssues();
+    errorCollector.assertNoIssues();
 
-        File resultBuildFile = workspaceRoot.fileForPath(new WorkspacePath("src/BUILD.bazel"));
-        assertThat(workspaceRoot.isInWorkspace(resultBuildFile)).isFalse();
-    }
+    File resultBuildFile = workspaceRoot.fileForPath(new WorkspacePath(GENERATED_BUILD_FILE_PATH));
+    assertThat(resultBuildFile.exists()).isFalse();
+  }
 
-    String WANTED_BUILD_CONTENTS =
-            "load(\"@io_bazel_rules_go//go:def.bzl\", \"go_binary\", \"go_library\")\n" +
-                    "\n" +
-                    "go_library(\n" +
-                    "    name = \"src_lib\",\n" +
-                    "    srcs = [\"main.go\"],\n" +
-                    "    importpath = \"github.com/bazelbuild/intellij/src\",\n" +
-                    "    visibility = [\"//visibility:private\"],\n" +
-                    ")\n" +
-                    "\n" +
-                    "go_binary(\n" +
-                    "    name = \"src\",\n" +
-                    "    embed = [\":src_lib\"],\n" +
-                    "    visibility = [\"//visibility:public\"],\n" +
-                    ")\n";
+  @Test
+  public void testRunGazelleWhenConfiguredInProject() throws Exception {
+    setProjectView(
+        "directories:",
+        "  .",
+        "gazelle_target: //:gazelle",
+        "build_flags:",
+        "  --repository_cache=" + REPOSITORY_CACHE_LOCATION,
+        "  --disk_cache=" + DISK_CACHE_LOCATION);
 
-    @Test
-    public void testRunGazelleWhenConfiguredInProject() throws Exception {
-        setUpRepoWithGazelle();
-        setProjectView(
-                "directories:",
-                "  .",
-                "gazelle_target //:gazelle"
-        );
+    runBazelSync();
 
-        runBazelSync();
+    errorCollector.assertNoIssues();
 
-        errorCollector.assertNoIssues();
+    File resultBuildFile = workspaceRoot.fileForPath(new WorkspacePath(GENERATED_BUILD_FILE_PATH));
+    assertThat(resultBuildFile.exists()).isTrue();
+    assertThat(workspaceRoot.isInWorkspace(resultBuildFile)).isTrue();
+    assertThat(FileUtils.readFileToString(resultBuildFile, "UTF-8"))
+        .contains(WANTED_BUILD_CONTENTS);
+  }
 
-        File resultBuildFile = workspaceRoot.fileForPath(new WorkspacePath("src/BUILD.bazel"));
-        assertThat(workspaceRoot.isInWorkspace(resultBuildFile)).isTrue();
-        assertThat(FileUtils.readFileToString(resultBuildFile, "UTF-8")).contains(WANTED_BUILD_CONTENTS);
-    }
+  @Test
+  public void testRunGazelleWhenConfiguredGlobally() throws Exception {
+    GazelleUserSettings gazelleSettings = GazelleUserSettings.getInstance();
+    gazelleSettings.setGazelleTarget("//:gazelle");
 
-    @Test
-    public void testRunGazelleWhenConfiguredGlobally() throws Exception {
-        setUpRepoWithGazelle();
+    setProjectView(
+        "directories:",
+        "  .",
+        "build_flags:",
+        "  --repository_cache=" + REPOSITORY_CACHE_LOCATION,
+        "  --disk_cache=" + DISK_CACHE_LOCATION);
 
-        GazelleUserSettings gazelleSettings = GazelleUserSettings.getInstance();
-        gazelleSettings.setGazelleTarget("//:gazelle");
+    runBazelSync();
 
-        setProjectView(
-                "directories:",
-                "  ."
-        );
+    errorCollector.assertNoIssues();
 
-        runBazelSync();
-
-        errorCollector.assertNoIssues();
-
-        File resultBuildFile = workspaceRoot.fileForPath(new WorkspacePath("src/BUILD.bazel"));
-        assertThat(workspaceRoot.isInWorkspace(resultBuildFile)).isTrue();
-        assertThat(FileUtils.readFileToString(resultBuildFile, "UTF-8")).contains(WANTED_BUILD_CONTENTS);
-    }
+    File resultBuildFile = workspaceRoot.fileForPath(new WorkspacePath("src/BUILD.bazel"));
+    assertThat(resultBuildFile.exists()).isTrue();
+    assertThat(workspaceRoot.isInWorkspace(resultBuildFile)).isTrue();
+    assertThat(FileUtils.readFileToString(resultBuildFile, "UTF-8"))
+        .contains(WANTED_BUILD_CONTENTS);
+  }
 }

--- a/gazelle/tests/integrationtests/com/google/idea/blaze/gazelle/sync/RunGazelleOnSyncTest.java
+++ b/gazelle/tests/integrationtests/com/google/idea/blaze/gazelle/sync/RunGazelleOnSyncTest.java
@@ -55,23 +55,23 @@ public class RunGazelleOnSyncTest extends BlazeSyncIntegrationTestCase {
         "",
         "http_archive(",
         "    name = \"io_bazel_rules_go\",",
-        "    sha256 = \"2b1641428dff9018f9e85c0384f03ec6c10660d935b750e3fa1492a281a53b0f\",",
+        "    sha256 = \"099a9fb96a376ccbbb7d291ed4ecbdfd42f6bc822ab77ae6f1b5cb9e914e94fa\",",
         "    urls = [",
         "       "
-            + " \"https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.29.0/rules_go-v0.29.0.zip\",",
+            + " \"https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.35.0/rules_go-v0.35.0.zip\",",
         "       "
-            + " \"https://github.com/bazelbuild/rules_go/releases/download/v0.29.0/rules_go-v0.29.0.zip\",",
+            + " \"https://github.com/bazelbuild/rules_go/releases/download/v0.35.0/rules_go-v0.35.0.zip\",",
         "    ],",
         ")",
         "",
         "http_archive(",
         "    name = \"bazel_gazelle\",",
-        "    sha256 = \"de69a09dc70417580aabf20a28619bb3ef60d038470c7cf8442fafcf627c21cb\",",
+        "    sha256 = \"efbbba6ac1a4fd342d5122cbdfdb82aeb2cf2862e35022c752eaddffada7c3f3\",",
         "    urls = [",
         "       "
-            + " \"https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.24.0/bazel-gazelle-v0.24.0.tar.gz\",",
+            + " \"https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.27.0/bazel-gazelle-v0.27.0.tar.gz\",",
         "       "
-            + " \"https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.24.0/bazel-gazelle-v0.24.0.tar.gz\",",
+            + " \"https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.27.0/bazel-gazelle-v0.27.0.tar.gz\",",
         "    ],",
         ")",
         "",
@@ -79,7 +79,7 @@ public class RunGazelleOnSyncTest extends BlazeSyncIntegrationTestCase {
             + " \"go_rules_dependencies\")",
         "load(\"@bazel_gazelle//:deps.bzl\", \"gazelle_dependencies\", \"go_repository\")",
         "go_rules_dependencies()",
-        "go_register_toolchains(version = \"1.17.2\")",
+        "go_register_toolchains(version = \"1.18.3\")",
         "gazelle_dependencies()");
     workspace.createDirectory(new WorkspacePath("src"));
     workspace.createFile(
@@ -92,9 +92,7 @@ public class RunGazelleOnSyncTest extends BlazeSyncIntegrationTestCase {
   }
 
   private void runBazelSync() {
-    // This forces the plugin to register the appropriate views with the IntelliJ UI,
-    // so that gazelle can create the appropriate tool windows even within a test project.
-    BlazeProblemsView.getInstance(getProject()).addMessage(null, null);
+    GazelleUserSettings.getInstance().setGazelleHeadless(true);
 
     BlazeSyncParams syncParams =
         BlazeSyncParams.builder()

--- a/ijwb/BUILD
+++ b/ijwb/BUILD
@@ -85,10 +85,10 @@ intellij_plugin(
         "//scala:plugin_library",
         "//skylark:plugin_library",
         "//terminal:plugin_library",
-        "//gazelle:plugin_library",
     ] + select_for_ide(
         intellij = [],
         intellij_ue = [
+            "//gazelle:plugin_library",
             "//golang:plugin_library",
             "//javascript:plugin_library",
         ],

--- a/ijwb/BUILD
+++ b/ijwb/BUILD
@@ -85,6 +85,7 @@ intellij_plugin(
         "//scala:plugin_library",
         "//skylark:plugin_library",
         "//terminal:plugin_library",
+        "//gazelle:plugin_library",
     ] + select_for_ide(
         intellij = [],
         intellij_ue = [


### PR DESCRIPTION
This is a WIP because I can't figure out how to make the tests work.

# Checklist

- [X] I have filed an issue about this change and discussed potential changes with the maintainers.
- [X] I have received the approval from the maintainers to make this change.
- [X] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `3216`

# Description of this change

See linked issue for a description and general design.
This is a port of the existing plugin: https://github.com/blorente/intellij_gazelle. Refer to that README for usage.

Architecturally, this plugin does two things:
- Implements a `GazelleSyncPlugin`, which inserts itself between the `bazel info` and `bazel build` phases of a sync cycle, to run gazelle in between, via a `BlazeGazelleRunnerImpl`.
- Hooks into UserSettings, to add a global field to specify a gazelle target to run on sync.

Refer to `gazelle/src/META-INF/blaze-gazelle.xml` for a reference of the extension points to the plugin.

**NOTE:** The added tests in this PR set up a full repository and run gazelle. This is potentially expensive, in the order of single-digit seconds.