### PR TITLE
Future-proof intellij_info creation by stripping leading '@'s from ma…

### DIFF
--- a/aspect/intellij_info_impl.bzl
+++ b/aspect/intellij_info_impl.bzl
@@ -233,11 +233,22 @@ def _is_language_specific_proto_library(ctx, target):
         return True
     return False
 
+def _stringify_label(label):
+    s = str(label)
+
+    # If the label is in the main repo, make sure any leading '@'s are stripped so that tests are
+    # okay with the fixture setups.
+    if s.startswith("@@//"):
+        return s[2:]
+    if s.startswith("@//"):
+        return s[1:]
+    return s
+
 def make_target_key(label, aspect_ids):
     """Returns a TargetKey proto struct from a target."""
     return struct_omit_none(
         aspect_ids = tuple(aspect_ids) if aspect_ids else None,
-        label = str(label),
+        label = _stringify_label(label),
     )
 
 def make_dep(dep, dependency_type):
@@ -255,7 +266,7 @@ def make_dep_from_label(label, dependency_type):
     """Returns a Dependency proto struct from a label."""
     return struct(
         dependency_type = dependency_type,
-        target = struct(label = str(label)),
+        target = struct(label = _stringify_label(label)),
     )
 
 def update_sync_output_groups(groups_dict, key, new_set):


### PR DESCRIPTION
…in-repo labels

Both "@//foo:bar" and "//foo:bar" mean the same thing in the main repo, but the latter can be ambiguous in a non-main repo, so Bazel 6.0 is going to flip https://github.com/bazelbuild/bazel/issues/16196 (i.e. produce "@//foo:bar" instead of "//foo:bar" when `str(label)` is called). This means that for certain intellij tests (such as those deriving from IntellijAspectTest) to keep working, we need to strip the leading '@'s from any such labels.

PiperOrigin-RevId: 473258584

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

