### PR TITLE
Fast test compilation failure reported in new bazel console window

### DIFF
--- a/base/src/com/google/idea/blaze/base/scope/output/StatusOutput.java
+++ b/base/src/com/google/idea/blaze/base/scope/output/StatusOutput.java
@@ -16,6 +16,7 @@
 package com.google.idea.blaze.base.scope.output;
 
 import com.google.idea.blaze.base.scope.Output;
+import com.intellij.execution.filters.HyperlinkInfo;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -28,12 +29,23 @@ import org.jetbrains.annotations.NotNull;
 public class StatusOutput implements Output {
   @NotNull String status;
 
+   HyperlinkInfo hyperlinkInfo;
+
   public StatusOutput(@NotNull String status) {
+    this(status, null);
+  }
+
+  public StatusOutput(@NotNull String status, HyperlinkInfo hyperlinkInfo) {
     this.status = status;
+    this.hyperlinkInfo = hyperlinkInfo;
   }
 
   @NotNull
   public String getStatus() {
     return status;
+  }
+
+  public HyperlinkInfo getHyperlinkInfo() {
+    return hyperlinkInfo;
   }
 }

--- a/base/src/com/google/idea/blaze/base/toolwindow/ConsoleView.java
+++ b/base/src/com/google/idea/blaze/base/toolwindow/ConsoleView.java
@@ -228,7 +228,11 @@ final class ConsoleView implements Disposable {
   }
 
   void println(StatusOutput output) {
-    println(output.getStatus(), OutputType.NORMAL);
+    if (output.getHyperlinkInfo() != null) {
+      printHyperlink(output.getStatus(), output.getHyperlinkInfo());
+    } else {
+      println(output.getStatus(), OutputType.NORMAL);
+    }
   }
 
   void println(PrintOutput output) {


### PR DESCRIPTION
# Checklist

- [V] I have filed an issue about this change and discussed potential changes with the maintainers.
- [V] I have received the approval from the maintainers to make this change.
- [V] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: https://github.com/bazelbuild/intellij/issues/3919

# Description of this change
This PR adds `HyperlinkInfo` to `StatusOutput` and changes `ConsoleView` to print the status output as a hyperlink if it exists.
Finally it changes `FastBuildConfigurationRunner` to emit a `StatusOutput` alongside the old way of reporting to `BlazeConsoleService`
