### PR TITLE
Enable the Autoscroll to console by default

### DIFF
--- a/base/src/com/google/idea/blaze/base/ui/problems/ProblemsViewConfiguration.java
+++ b/base/src/com/google/idea/blaze/base/ui/problems/ProblemsViewConfiguration.java
@@ -30,7 +30,7 @@ import com.intellij.util.xmlb.XmlSerializerUtil;
 )
 class ProblemsViewConfiguration implements PersistentStateComponent<ProblemsViewConfiguration> {
 
-  private boolean autoscrollToConsole = false;
+  private boolean autoscrollToConsole = true;
 
   public static ProblemsViewConfiguration getInstance(Project project) {
     return ServiceManager.getService(project, ProblemsViewConfiguration.class);


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #3106

# Description of this change

Currently the Autoscroll to console feature in the Bazel plugin is disabled by default.

Considering that many Bazel output parsers only emit the first line of the error to the Bazel problems view, it is very common for developers to look for errors details in the Bazel output. The Autoscroll to console feature is a great help here. But it is disabled by default and poorly advertised, which degrades the UX for Bazel-powered projects.

This commit enables the Autoscroll to console feature by default. The feature can still be disabled if necessary.