### PR TITLE
Fix main repo target parsing

### DIFF
--- a/base/src/com/google/idea/blaze/base/model/primitives/TargetExpression.java
+++ b/base/src/com/google/idea/blaze/base/model/primitives/TargetExpression.java
@@ -120,7 +120,7 @@ public class TargetExpression
 
     if (targetPattern.charAt(0) == '@') {
       int slashesIndex = targetPattern.indexOf("//");
-      if (slashesIndex <= 1) {
+      if (slashesIndex == -1) {
         return String.format(
             "Invalid target expression '%s': Couldn't find package path", targetPattern);
       }

--- a/base/tests/unittests/com/google/idea/blaze/base/model/primitives/TargetExpressionTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/model/primitives/TargetExpressionTest.java
@@ -75,6 +75,7 @@ public class TargetExpressionTest extends BlazeTestCase {
     assertThat(TargetExpression.validate("//foo/...:all")).isNull();
 
     assertThat(TargetExpression.validate("//...")).isNull();
+    assertThat(TargetExpression.validate("@//package_path:rule")).isNull();
     assertThat(TargetExpression.validate("@repo//foo:bar")).isNull();
     assertThat(TargetExpression.validate("@repo//foo:all")).isNull();
     assertThat(TargetExpression.validate("-@repo//:bar")).isNull();
@@ -82,7 +83,7 @@ public class TargetExpressionTest extends BlazeTestCase {
 
   @Test
   public void testFailingValidations() {
-    assertThat(TargetExpression.validate("@//package_path:rule")).isNotNull();
+    assertThat(TargetExpression.validate("@/package_path:rule")).isNotNull();
     assertThat(TargetExpression.validate("@repo&//package_path:rule")).isNotNull();
     assertThat(TargetExpression.validate("../path")).isNotNull();
     assertThat(TargetExpression.validate("path/../other")).isNotNull();


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #4008

# Description of this change

This commit ensures that main repository target expressions such as `@//foo:test` can be parsed correctly. Since
https://github.com/bazelbuild/bazel/commit/b1113f801da87ed2e089ff4122aa13400c177804, these are emitted by Bazel by default.
