### PR TITLE
Remove empty glob

### DIFF
--- a/sdkcompat/v213/BUILD
+++ b/sdkcompat/v213/BUILD
@@ -10,25 +10,20 @@ java_library(
         "com/google/idea/sdkcompat/general/**",
         "com/google/idea/sdkcompat/indexing/**",
         "com/google/idea/sdkcompat/logging/**",
-        "com/google/idea/sdkcompat/platform/**",
-        "com/google/idea/sdkcompat/python/**",
         "com/google/idea/sdkcompat/vcs/**",
     ]) + select_for_ide(
         android_studio = glob([
             "com/google/idea/sdkcompat/cpp/**",
-            "com/google/idea/sdkcompat/java/**",
             "aswb/com/google/idea/sdkcompat/kotlin/*.java",
         ]),
         clion = glob([
             "com/google/idea/sdkcompat/cpp/**",
         ]),
         intellij = glob([
-            "com/google/idea/sdkcompat/java/**",
             "com/google/idea/sdkcompat/scala/**",
             "com/google/idea/sdkcompat/kotlin/**",
         ]),
         intellij_ue = glob([
-            "com/google/idea/sdkcompat/java/**",
             "com/google/idea/sdkcompat/scala/**",
             "com/google/idea/sdkcompat/kotlin/**",
         ]),


### PR DESCRIPTION
This glob is not globbing anything.
This prevents flipping the flag incompatible_disallow_empty_glob https://buildkite.com/bazel/bazelisk-plus-incompatible-flags/builds/1301#0183e377-8857-4e31-8aca-c14ba82f4a15

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

