### PR TITLE
Move APIs removed in IntelliJ Platform 2022.3 to sdkcompat modules

### DIFF
--- a/base/src/com/google/idea/blaze/base/project/AutoImportProjectOpenProcessor.java
+++ b/base/src/com/google/idea/blaze/base/project/AutoImportProjectOpenProcessor.java
@@ -22,6 +22,7 @@ import com.google.idea.blaze.base.wizard2.BlazeProjectCommitException;
 import com.google.idea.blaze.base.wizard2.BlazeProjectImportBuilder;
 import com.google.idea.blaze.base.wizard2.CreateFromScratchProjectViewOption;
 import com.google.idea.blaze.base.wizard2.WorkspaceTypeData;
+import com.google.idea.sdkcompat.general.BaseSdkCompat;
 import com.intellij.ide.SaveAndSyncHandler;
 import com.intellij.ide.impl.OpenProjectTask;
 import com.intellij.ide.impl.ProjectUtil;
@@ -114,10 +115,10 @@ public class AutoImportProjectOpenProcessor extends ProjectOpenProcessor {
     ProjectUtil.updateLastProjectLocation(projectFilePath);
 
     ProjectManagerEx.getInstanceEx()
-        .openProject(
-            projectFilePath,
-            OpenProjectTask.withCreatedProject(newProject)
-        );
+            .openProject(
+                    projectFilePath,
+                    BaseSdkCompat.createOpenProjectTask(newProject)
+            );
     SaveAndSyncHandler.getInstance().scheduleProjectSave(newProject);
     return newProject;
   }

--- a/base/src/com/google/idea/blaze/base/project/BlazeProjectOpenProcessor.java
+++ b/base/src/com/google/idea/blaze/base/project/BlazeProjectOpenProcessor.java
@@ -17,12 +17,12 @@ package com.google.idea.blaze.base.project;
 
 import com.google.idea.blaze.base.settings.Blaze;
 import com.google.idea.blaze.base.sync.data.BlazeDataStorage;
-import com.intellij.ide.impl.ProjectUtil;
+import com.google.idea.sdkcompat.general.BaseSdkCompat;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.projectImport.ProjectOpenProcessor;
 import icons.BlazeIcons;
-import java.io.IOException;
+
 import javax.annotation.Nullable;
 import javax.swing.Icon;
 
@@ -85,6 +85,6 @@ public class BlazeProjectOpenProcessor extends ProjectOpenProcessor {
       return null;
     }
     VirtualFile projectSubdirectory = ideaSubdirectory.getParent();
-    return ProjectUtil.openProject(projectSubdirectory.getPath(), projectToClose, forceOpenInNewFrame);
+    return BaseSdkCompat.openProject(projectSubdirectory,projectToClose, forceOpenInNewFrame);
   }
 }

--- a/clwb/src/com/google/idea/blaze/plugin/CMakeNotificationFilter.java
+++ b/clwb/src/com/google/idea/blaze/plugin/CMakeNotificationFilter.java
@@ -27,7 +27,7 @@ import com.intellij.ui.EditorNotifications;
 import com.jetbrains.cidr.cpp.cmake.workspace.CMakeNotificationProvider;
 
 import javax.annotation.Nullable;
-import javax.swing.*;
+import javax.swing.JComponent;
 
 /** Need to filter out CMake messages if we are a Blaze project. */
 public class CMakeNotificationFilter extends EditorNotifications.Provider<JComponent>

--- a/clwb/src/com/google/idea/blaze/plugin/CMakeNotificationFilter.java
+++ b/clwb/src/com/google/idea/blaze/plugin/CMakeNotificationFilter.java
@@ -16,6 +16,7 @@
 package com.google.idea.blaze.plugin;
 
 import com.google.idea.blaze.base.settings.Blaze;
+import com.google.idea.sdkcompat.general.EditorNotificationCompat;
 import com.intellij.openapi.extensions.ExtensionPoint;
 import com.intellij.openapi.fileEditor.FileEditor;
 import com.intellij.openapi.project.DumbAware;
@@ -23,10 +24,10 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.ui.EditorNotifications;
-import com.intellij.ui.EditorNotificationsImpl;
 import com.jetbrains.cidr.cpp.cmake.workspace.CMakeNotificationProvider;
+
 import javax.annotation.Nullable;
-import javax.swing.JComponent;
+import javax.swing.*;
 
 /** Need to filter out CMake messages if we are a Blaze project. */
 public class CMakeNotificationFilter extends EditorNotifications.Provider<JComponent>
@@ -54,9 +55,8 @@ public class CMakeNotificationFilter extends EditorNotifications.Provider<JCompo
   }
 
   public static void overrideProjectExtension(Project project) {
-    unregisterDelegateExtension(EditorNotificationsImpl.EP_PROJECT.getPoint(project));
-    EditorNotificationsImpl.EP_PROJECT
-        .getPoint(project)
+    unregisterDelegateExtension(EditorNotificationCompat.getEp(project));
+    EditorNotificationCompat.getEp(project)
         .registerExtension(new CMakeNotificationFilter(project));
   }
 

--- a/java/src/com/google/idea/blaze/java/libraries/AddLibraryTargetDirectoryToProjectViewAttachSourcesProvider.java
+++ b/java/src/com/google/idea/blaze/java/libraries/AddLibraryTargetDirectoryToProjectViewAttachSourcesProvider.java
@@ -20,24 +20,25 @@ import com.google.common.collect.Lists;
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.primitives.WorkspacePath;
 import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
-import com.intellij.codeInsight.AttachSourcesProvider;
+import com.google.idea.sdkcompat.java.AttachSourcesProviderAdapter;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.LibraryOrderEntry;
 import com.intellij.openapi.roots.libraries.Library;
 import com.intellij.openapi.util.ActionCallback;
 import com.intellij.psi.PsiFile;
+import org.jetbrains.annotations.NotNull;
+
 import java.util.Collection;
 import java.util.List;
-import org.jetbrains.annotations.NotNull;
 
 /** */
 public class AddLibraryTargetDirectoryToProjectViewAttachSourcesProvider
-    implements AttachSourcesProvider {
+    extends AttachSourcesProviderAdapter {
 
   @NotNull
   @Override
-  public Collection<AttachSourcesAction> getActions(
-      List<LibraryOrderEntry> orderEntries, final PsiFile psiFile) {
+  public Collection<AttachSourcesAction> getAdapterActions(
+      List<? extends LibraryOrderEntry> orderEntries, final PsiFile psiFile) {
     Project project = psiFile.getProject();
     BlazeProjectData blazeProjectData =
         BlazeProjectDataManager.getInstance(project).getBlazeProjectData();
@@ -62,7 +63,7 @@ public class AddLibraryTargetDirectoryToProjectViewAttachSourcesProvider
     }
 
     return ImmutableList.of(
-        new AttachSourcesAction() {
+        new AttachSourcesActionAdapter() {
           @Override
           public String getName() {
             return "Add Source Directories To Project View";
@@ -74,7 +75,7 @@ public class AddLibraryTargetDirectoryToProjectViewAttachSourcesProvider
           }
 
           @Override
-          public ActionCallback perform(List<LibraryOrderEntry> orderEntriesContainingFile) {
+          public ActionCallback adapterPerform(List<? extends LibraryOrderEntry> orderEntriesContainingFile) {
             AddLibraryTargetDirectoryToProjectViewAction.addDirectoriesToProjectView(
                 project, librariesToAttachSourceTo);
             return ActionCallback.DONE;

--- a/java/src/com/google/idea/blaze/java/libraries/BlazeAttachSourceProvider.java
+++ b/java/src/com/google/idea/blaze/java/libraries/BlazeAttachSourceProvider.java
@@ -26,8 +26,8 @@ import com.google.idea.blaze.base.sync.libraries.LibraryEditor;
 import com.google.idea.blaze.java.sync.model.BlazeJarLibrary;
 import com.google.idea.common.experiments.BoolExperiment;
 import com.google.idea.common.util.Transactions;
+import com.google.idea.sdkcompat.java.AttachSourcesProviderAdapter;
 import com.google.idea.sdkcompat.general.BaseSdkCompat;
-import com.intellij.codeInsight.AttachSourcesProvider;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.TransactionGuard;
 import com.intellij.openapi.externalSystem.service.project.IdeModifiableModelsProvider;
@@ -47,14 +47,14 @@ import javax.annotation.Nullable;
  *
  * <p>Optionally also attaches sources automatically, on demand.
  */
-public class BlazeAttachSourceProvider implements AttachSourcesProvider {
+public class BlazeAttachSourceProvider extends AttachSourcesProviderAdapter {
 
   private static final BoolExperiment attachAutomatically =
       new BoolExperiment("blaze.attach.source.jars.automatically.3", true);
 
   @Override
-  public Collection<AttachSourcesAction> getActions(
-      List<LibraryOrderEntry> orderEntries, final PsiFile psiFile) {
+  public Collection<AttachSourcesAction> getAdapterActions(
+      List<? extends LibraryOrderEntry> orderEntries, final PsiFile psiFile) {
     Project project = psiFile.getProject();
     BlazeProjectData blazeProjectData =
         BlazeProjectDataManager.getInstance(project).getBlazeProjectData();
@@ -105,7 +105,7 @@ public class BlazeAttachSourceProvider implements AttachSourcesProvider {
     }
 
     return ImmutableList.of(
-        new AttachSourcesAction() {
+        new AttachSourcesActionAdapter() {
           @Override
           public String getName() {
             return "Attach Blaze Source Jars";
@@ -117,7 +117,7 @@ public class BlazeAttachSourceProvider implements AttachSourcesProvider {
           }
 
           @Override
-          public ActionCallback perform(List<LibraryOrderEntry> orderEntriesContainingFile) {
+          public ActionCallback adapterPerform(List<? extends LibraryOrderEntry> orderEntriesContainingFile) {
             ActionCallback callback =
                 new ActionCallback().doWhenDone(() -> navigateToSource(psiFile));
             Transactions.submitTransaction(

--- a/java/src/com/google/idea/blaze/java/libraries/DisableLibraryBytecodeNotification.java
+++ b/java/src/com/google/idea/blaze/java/libraries/DisableLibraryBytecodeNotification.java
@@ -17,10 +17,11 @@ package com.google.idea.blaze.java.libraries;
 
 import com.google.idea.blaze.base.settings.Blaze;
 import com.google.idea.common.experiments.BoolExperiment;
+import com.google.idea.sdkcompat.general.EditorNotificationCompat;
 import com.intellij.codeInsight.daemon.impl.LibrarySourceNotificationProvider;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.startup.StartupActivity;
-import com.intellij.ui.EditorNotificationsImpl;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Attempt to disable 'library source doesn't match bytecode' butter bar warnings, which are
@@ -33,12 +34,11 @@ final class DisableLibraryBytecodeNotification implements StartupActivity {
       new BoolExperiment("disable.bytecode.notification", true);
 
   @Override
-  public void runActivity(Project project) {
+  public void runActivity(@NotNull Project project) {
     if (!enabled.getValue() || !Blaze.isBlazeProject(project)) {
       return;
     }
-    EditorNotificationsImpl.EP_PROJECT
-        .getPoint(project)
+    EditorNotificationCompat.getEp(project)
         .unregisterExtension(LibrarySourceNotificationProvider.class);
   }
 }

--- a/sdkcompat/v213/BUILD
+++ b/sdkcompat/v213/BUILD
@@ -15,6 +15,7 @@ java_library(
         android_studio = glob([
             "com/google/idea/sdkcompat/cpp/**",
             "aswb/com/google/idea/sdkcompat/kotlin/*.java",
+            "com/google/idea/sdkcompat/java/**",
         ]),
         clion = glob([
             "com/google/idea/sdkcompat/cpp/**",
@@ -22,10 +23,12 @@ java_library(
         intellij = glob([
             "com/google/idea/sdkcompat/scala/**",
             "com/google/idea/sdkcompat/kotlin/**",
+            "com/google/idea/sdkcompat/java/**",
         ]),
         intellij_ue = glob([
             "com/google/idea/sdkcompat/scala/**",
             "com/google/idea/sdkcompat/kotlin/**",
+            "com/google/idea/sdkcompat/java/**",
         ]),
     ),
     visibility = ["//sdkcompat:__pkg__"],

--- a/sdkcompat/v213/com/google/idea/sdkcompat/general/BaseSdkCompat.java
+++ b/sdkcompat/v213/com/google/idea/sdkcompat/general/BaseSdkCompat.java
@@ -7,6 +7,7 @@ import com.intellij.openapi.externalSystem.service.project.IdeModifiableModelsPr
 import com.intellij.openapi.externalSystem.service.project.IdeModifiableModelsProviderImpl;
 import com.intellij.openapi.fileChooser.ex.FileLookup;
 import com.intellij.openapi.fileChooser.ex.LocalFsFinder;
+import com.intellij.ide.impl.ProjectUtil;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.TextComponentAccessor;
 import com.intellij.openapi.ui.TextComponentAccessors;
@@ -87,4 +88,10 @@ public final class BaseSdkCompat {
   public static OpenProjectTask createOpenProjectTask(Project project) {
     return OpenProjectTask.withCreatedProject(project);
   }
+
+  /** #api213 inline when this api support is dropped */
+  public static Project openProject(VirtualFile projectSubdirectory, Project projectToClose, boolean forceOpenInNewFrame) {
+    return ProjectUtil.openProject(projectSubdirectory.getPath(), projectToClose, forceOpenInNewFrame);
+  }
+
 }

--- a/sdkcompat/v213/com/google/idea/sdkcompat/general/EditorNotificationCompat.java
+++ b/sdkcompat/v213/com/google/idea/sdkcompat/general/EditorNotificationCompat.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.sdkcompat.general;
+
+import com.intellij.openapi.extensions.ExtensionPoint;
+import com.intellij.openapi.project.Project;
+import com.intellij.ui.EditorNotificationsImpl;
+import com.intellij.ui.EditorNotifications;
+
+public class EditorNotificationCompat {
+    /** #api213, inline once api213 support is dropped */
+    public static ExtensionPoint<EditorNotifications.Provider<?>> getEp(Project project) {
+        return EditorNotificationsImpl.EP_PROJECT.getPoint(project);
+    }
+}

--- a/sdkcompat/v213/com/google/idea/sdkcompat/java/AttachSourcesProviderAdapter.java
+++ b/sdkcompat/v213/com/google/idea/sdkcompat/java/AttachSourcesProviderAdapter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.sdkcompat.java;
+
+import com.intellij.codeInsight.AttachSourcesProvider;
+import com.intellij.openapi.roots.LibraryOrderEntry;
+import com.intellij.openapi.util.ActionCallback;
+import com.intellij.psi.PsiFile;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * #api222 interface is different in 223, inline when 222 support is dropped
+ */
+public abstract class AttachSourcesProviderAdapter
+        implements AttachSourcesProvider {
+
+    public abstract Collection<AttachSourcesAction> getAdapterActions(
+            List<? extends LibraryOrderEntry> orderEntries, final PsiFile psiFile);
+
+    @NotNull
+    @Override
+    public Collection<AttachSourcesAction> getActions(
+            List<LibraryOrderEntry> orderEntries, final PsiFile psiFile) {
+        return getAdapterActions(orderEntries, psiFile);
+    }
+
+    public static abstract class AttachSourcesActionAdapter implements AttachSourcesAction {
+        public abstract ActionCallback adapterPerform(List<? extends LibraryOrderEntry> orderEntriesContainingFile);
+
+        public ActionCallback perform(List<LibraryOrderEntry> orderEntriesContainingFile) {
+            return adapterPerform(orderEntriesContainingFile);
+        }
+    }
+}

--- a/sdkcompat/v221/com/google/idea/sdkcompat/general/BaseSdkCompat.java
+++ b/sdkcompat/v221/com/google/idea/sdkcompat/general/BaseSdkCompat.java
@@ -1,6 +1,7 @@
 package com.google.idea.sdkcompat.general;
 
 import com.intellij.ide.impl.OpenProjectTask;
+import com.intellij.ide.impl.ProjectUtil;
 import com.intellij.ide.util.projectWizard.WizardContext;
 import com.intellij.ide.wizard.AbstractWizard;
 import com.intellij.openapi.externalSystem.service.project.IdeModifiableModelsProvider;
@@ -20,6 +21,7 @@ import com.intellij.util.indexing.diagnostic.dto.JsonFileProviderIndexStatistics
 import com.intellij.vcs.log.VcsLogProperties;
 import com.intellij.vcs.log.VcsLogProperties.VcsLogProperty;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import javax.annotation.Nullable;
 
@@ -94,5 +96,11 @@ public final class BaseSdkCompat {
   /** #api213: Inline into BlazeProjectCreator. */
   public static OpenProjectTask createOpenProjectTask(Project project) {
     return OpenProjectTask.build().withProject(project);
+  }
+
+  /** #api213 inline when this api support is dropped */
+  public static Project openProject(VirtualFile projectSubdirectory, Project projectToClose, boolean forceOpenInNewFrame) {
+    OpenProjectTask options = OpenProjectTask.build().withForceOpenInNewFrame(forceOpenInNewFrame).withProjectToClose(projectToClose);
+    return ProjectUtil.openProject(Paths.get(projectSubdirectory.getPath()), options);
   }
 }

--- a/sdkcompat/v221/com/google/idea/sdkcompat/general/EditorNotificationCompat.java
+++ b/sdkcompat/v221/com/google/idea/sdkcompat/general/EditorNotificationCompat.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.sdkcompat.general;
+
+import com.intellij.openapi.extensions.ExtensionPoint;
+import com.intellij.openapi.project.Project;
+import com.intellij.ui.EditorNotificationProvider;
+
+public class EditorNotificationCompat {
+    /** #api213, inline once api213 support is dropped */
+    public static ExtensionPoint<EditorNotificationProvider> getEp(Project project) {
+        return EditorNotificationProvider.EP_NAME.getPoint(project);
+    }
+}

--- a/sdkcompat/v221/com/google/idea/sdkcompat/java/AttachSourcesProviderAdapter.java
+++ b/sdkcompat/v221/com/google/idea/sdkcompat/java/AttachSourcesProviderAdapter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.sdkcompat.java;
+
+import com.intellij.codeInsight.AttachSourcesProvider;
+import com.intellij.openapi.roots.LibraryOrderEntry;
+import com.intellij.openapi.util.ActionCallback;
+import com.intellij.psi.PsiFile;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * #api222 interface is different in 223, inline when 222 support is dropped
+ */
+public abstract class AttachSourcesProviderAdapter
+        implements AttachSourcesProvider {
+
+    public abstract Collection<AttachSourcesAction> getAdapterActions(
+            List<? extends LibraryOrderEntry> orderEntries, final PsiFile psiFile);
+
+    @NotNull
+    @Override
+    public Collection<AttachSourcesAction> getActions(
+            List<LibraryOrderEntry> orderEntries, final PsiFile psiFile) {
+        return getAdapterActions(orderEntries, psiFile);
+    }
+
+    public static abstract class AttachSourcesActionAdapter implements AttachSourcesAction {
+        public abstract ActionCallback adapterPerform(List<? extends LibraryOrderEntry> orderEntriesContainingFile);
+
+        public ActionCallback perform(List<LibraryOrderEntry> orderEntriesContainingFile) {
+            return adapterPerform(orderEntriesContainingFile);
+        }
+    }
+}

--- a/sdkcompat/v222/com/google/idea/sdkcompat/general/BaseSdkCompat.java
+++ b/sdkcompat/v222/com/google/idea/sdkcompat/general/BaseSdkCompat.java
@@ -1,6 +1,7 @@
 package com.google.idea.sdkcompat.general;
 
 import com.intellij.ide.impl.OpenProjectTask;
+import com.intellij.ide.impl.ProjectUtil;
 import com.intellij.ide.util.projectWizard.WizardContext;
 import com.intellij.ide.wizard.AbstractWizard;
 import com.intellij.openapi.actionSystem.AnActionEvent;
@@ -33,6 +34,7 @@ import com.intellij.util.ui.VcsExecutablePathSelector;
 import com.intellij.vcs.log.VcsLogProperties;
 import com.intellij.vcs.log.VcsLogProperties.VcsLogProperty;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -168,5 +170,11 @@ public final class BaseSdkCompat {
   /** #api213: Inline into BlazeProjectCreator. */
   public static OpenProjectTask createOpenProjectTask(Project project) {
     return OpenProjectTask.build().withProject(project);
+  }
+
+  /** #api213 inline when this api support is dropped */
+  public static Project openProject(VirtualFile projectSubdirectory, Project projectToClose, boolean forceOpenInNewFrame) {
+    OpenProjectTask options = OpenProjectTask.build().withForceOpenInNewFrame(forceOpenInNewFrame).withProjectToClose(projectToClose);
+    return ProjectUtil.openProject(Paths.get(projectSubdirectory.getPath()),options);
   }
 }

--- a/sdkcompat/v222/com/google/idea/sdkcompat/general/EditorNotificationCompat.java
+++ b/sdkcompat/v222/com/google/idea/sdkcompat/general/EditorNotificationCompat.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.sdkcompat.general;
+
+import com.intellij.openapi.extensions.ExtensionPoint;
+import com.intellij.openapi.project.Project;
+import com.intellij.ui.EditorNotificationProvider;
+
+public class EditorNotificationCompat {
+    /** #api213, inline once api213 support is dropped */
+    public static ExtensionPoint<EditorNotificationProvider> getEp(Project project) {
+        return EditorNotificationProvider.EP_NAME.getPoint(project);
+    }
+}

--- a/sdkcompat/v222/com/google/idea/sdkcompat/java/AttachSourcesProviderAdapter.java
+++ b/sdkcompat/v222/com/google/idea/sdkcompat/java/AttachSourcesProviderAdapter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.sdkcompat.java;
+
+import com.intellij.codeInsight.AttachSourcesProvider;
+import com.intellij.openapi.roots.LibraryOrderEntry;
+import com.intellij.openapi.util.ActionCallback;
+import com.intellij.psi.PsiFile;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * #api222 interface is different in 223, inline when 222 support is dropped
+ */
+public abstract class AttachSourcesProviderAdapter
+        implements AttachSourcesProvider {
+
+    public abstract Collection<AttachSourcesAction> getAdapterActions(
+            List<? extends LibraryOrderEntry> orderEntries, final PsiFile psiFile);
+
+    @NotNull
+    @Override
+    public Collection<AttachSourcesAction> getActions(
+            List<LibraryOrderEntry> orderEntries, final PsiFile psiFile) {
+        return getAdapterActions(orderEntries, psiFile);
+    }
+
+    public static abstract class AttachSourcesActionAdapter implements AttachSourcesAction {
+        public abstract ActionCallback adapterPerform(List<? extends LibraryOrderEntry> orderEntriesContainingFile);
+
+        public ActionCallback perform(List<LibraryOrderEntry> orderEntriesContainingFile) {
+            return adapterPerform(orderEntriesContainingFile);
+        }
+    }
+}


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #4037 

# Description of this change
Preparation before introduction of 2022.3 support. The original PR introducing 2022.3 is here #4019, but I decided to split it into smaller parts in order to simplify review
