### PR TITLE
Remove empty glob

### DIFF
--- a/intellij_platform_sdk/BUILD.android_studio213
+++ b/intellij_platform_sdk/BUILD.android_studio213
@@ -69,19 +69,13 @@ java_import(
     name = "android",
     jars = glob([
         "android-studio/plugins/android/lib/*.jar",
-        "android-studio/plugins/android-layoutlib/lib/*.jar",
-        "android-studio/plugins/android-wizardTemplate-plugin/lib/*.jar",
-        "android-studio/plugins/android-wizardTemplate-impl/lib/*.jar",
         "android-studio/plugins/android-ndk/lib/*.jar",
-        "android-studio/plugins/sdk-updates/lib/*.jar",
     ]),
 )
 
 filegroup(
     name = "layoutlib_data",
-    srcs = glob([
-        "android-studio/plugins/android/lib/layoutlib/**/*",
-    ]),
+    srcs = [],
 )
 
 java_import(


### PR DESCRIPTION
This glob is not globbing anything.
This prevents flipping the flag incompatible_disallow_empty_glob https://buildkite.com/bazel/bazelisk-plus-incompatible-flags/builds/1307#0183f814-adfb-484a-91e9-7608fe55a095

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: https://github.com/bazelbuild/intellij/issues/4040

# Description of this change

