### PR TITLE
Include 2022.3 libraries in Plugin Run Configuration

### DIFF
--- a/plugin_dev/src/com/google/idea/blaze/plugin/run/IntellijWithPluginClasspathHelper.java
+++ b/plugin_dev/src/com/google/idea/blaze/plugin/run/IntellijWithPluginClasspathHelper.java
@@ -46,21 +46,41 @@ public class IntellijWithPluginClasspathHelper {
   private static final ImmutableList<String> IJ_LIBRARIES_AFTER_2022_1 =
       ImmutableList.of("util_rt.jar");
 
+  private static final ImmutableList<String> IJ_LIBRARIES_AFTER_2022_3 =
+      ImmutableList.of(
+          "3rd-party-rt.jar",
+          "app.jar",
+          "xml-dom.jar",
+          "xml-dom-impl.jar",
+          "jps-model.jar",
+          "protobuf.jar",
+          "rd.jar",
+          "stats.jar",
+          "external-system-rt.jar",
+          "forms_rt.jar",
+          "intellij-test-discovery.jar"
+      );
   private static void addIntellijLibraries(JavaParameters params, Sdk ideaJdk) {
     String libPath = ideaJdk.getHomePath() + File.separator + "lib";
     PathsList list = params.getClassPath();
-    for (String lib : IJ_LIBRARIES) {
-      list.addFirst(libPath + File.separator + lib);
-    }
+    addLibrariesToList(IJ_LIBRARIES, libPath, list);
 
     BuildNumber buildNumber = BuildNumber.fromString(IdeaJdkHelper.getBuildNumber(ideaJdk));
     if (buildNumber != null && buildNumber.getBaselineVersion() >= 221) {
-      for (String lib : IJ_LIBRARIES_AFTER_2022_1) {
-        list.addFirst(libPath + File.separator + lib);
-      }
+      addLibrariesToList(IJ_LIBRARIES_AFTER_2022_1, libPath, list);
+    }
+
+    if(buildNumber != null && buildNumber.getBaselineVersion() >= 223) {
+      addLibrariesToList(IJ_LIBRARIES_AFTER_2022_3, libPath, list);
     }
 
     list.addFirst(((JavaSdkType) ideaJdk.getSdkType()).getToolsPath(ideaJdk));
+  }
+
+  private static void addLibrariesToList(ImmutableList<String> ijLibraries, String libPath, PathsList list) {
+    for (String lib : ijLibraries) {
+      list.addFirst(libPath + File.separator + lib);
+    }
   }
 
   public static void addRequiredVmParams(


### PR DESCRIPTION
Without it, will be impossible to use 'Debug' button after Bazel Plugin upgrade to 2022.3

# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #4037 

# Description of this change

