### PR TITLE
Support Preview Java Language Levels

### DIFF
--- a/base/tests/utils/integration/com/google/idea/blaze/base/sync/BlazeSyncIntegrationTestCase.java
+++ b/base/tests/utils/integration/com/google/idea/blaze/base/sync/BlazeSyncIntegrationTestCase.java
@@ -95,8 +95,8 @@ public abstract class BlazeSyncIntegrationTestCase extends BlazeIntegrationTestC
   private static final JavaVersion JAVA_VERSION = LanguageLevel.JDK_1_9.toJavaVersion();
   // Mimic JavaLanguageLevelSection.KEY as we don't want to add a dependency on the whole :java
   // package for this language-independent class.
-  private static final SectionKey<LanguageLevel, ScalarSection<LanguageLevel>> JAVA_LANGUAGE_LEVEL_SECTION_KEY =
-      new SectionKey<>("java_language_level");
+  private static final SectionKey<LanguageLevel, ScalarSection<LanguageLevel>> JAVA_LANGUAGE_LEVEL_SECTION_KEY = new SectionKey<>(
+      "java_language_level");
 
   private Disposable thisClassDisposable; // disposed prior to calling parent class's @After methods
   private MockProjectViewManager projectViewManager;
@@ -218,7 +218,8 @@ public abstract class BlazeSyncIntegrationTestCase extends BlazeIntegrationTestC
         && projectViewSet.getScalarValue(JAVA_LANGUAGE_LEVEL_SECTION_KEY).isEmpty()) {
       ProjectView additionalProjectView =
           ProjectView.builder()
-              .add(ScalarSection.builder(JAVA_LANGUAGE_LEVEL_SECTION_KEY).set(LanguageLevel.parse(Integer.toString(JAVA_VERSION.feature))))
+              .add(ScalarSection.builder(JAVA_LANGUAGE_LEVEL_SECTION_KEY)
+                  .set(LanguageLevel.parse(Integer.toString(JAVA_VERSION.feature))))
               .build();
       return ProjectViewSet.builder()
           .add(additionalProjectView)

--- a/base/tests/utils/integration/com/google/idea/blaze/base/sync/BlazeSyncIntegrationTestCase.java
+++ b/base/tests/utils/integration/com/google/idea/blaze/base/sync/BlazeSyncIntegrationTestCase.java
@@ -95,7 +95,7 @@ public abstract class BlazeSyncIntegrationTestCase extends BlazeIntegrationTestC
   private static final JavaVersion JAVA_VERSION = LanguageLevel.JDK_1_9.toJavaVersion();
   // Mimic JavaLanguageLevelSection.KEY as we don't want to add a dependency on the whole :java
   // package for this language-independent class.
-  private static final SectionKey<Integer, ScalarSection<Integer>> JAVA_LANGUAGE_LEVEL_SECTION_KEY =
+  private static final SectionKey<LanguageLevel, ScalarSection<LanguageLevel>> JAVA_LANGUAGE_LEVEL_SECTION_KEY =
       new SectionKey<>("java_language_level");
 
   private Disposable thisClassDisposable; // disposed prior to calling parent class's @After methods
@@ -218,7 +218,7 @@ public abstract class BlazeSyncIntegrationTestCase extends BlazeIntegrationTestC
         && projectViewSet.getScalarValue(JAVA_LANGUAGE_LEVEL_SECTION_KEY).isEmpty()) {
       ProjectView additionalProjectView =
           ProjectView.builder()
-              .add(ScalarSection.builder(JAVA_LANGUAGE_LEVEL_SECTION_KEY).set(JAVA_VERSION.feature))
+              .add(ScalarSection.builder(JAVA_LANGUAGE_LEVEL_SECTION_KEY).set(LanguageLevel.parse(Integer.toString(JAVA_VERSION.feature))))
               .build();
       return ProjectViewSet.builder()
           .add(additionalProjectView)

--- a/examples/java/greetings_project/.bazelrc
+++ b/examples/java/greetings_project/.bazelrc
@@ -1,4 +1,0 @@
-build --java_runtime_version=remotejdk_17
-build --java_language_version=17
-build --tool_java_language_version=17
-build --tool_java_runtime_version=remotejdk_17

--- a/examples/java/greetings_project/.bazelrc
+++ b/examples/java/greetings_project/.bazelrc
@@ -1,0 +1,4 @@
+build --java_runtime_version=remotejdk_17
+build --java_language_version=17
+build --tool_java_language_version=17
+build --tool_java_runtime_version=remotejdk_17

--- a/java/src/com/google/idea/blaze/java/projectview/JavaLanguageLevelSection.java
+++ b/java/src/com/google/idea/blaze/java/projectview/JavaLanguageLevelSection.java
@@ -58,7 +58,7 @@ public class JavaLanguageLevelSection {
       if (numericVersion <= 0) {
         return defaultValue;
       }
-    } catch (NumberFormatException nje) {
+    } catch (NumberFormatException e) {
       return defaultValue;
     }
 

--- a/java/src/com/google/idea/blaze/java/projectview/JavaLanguageLevelSection.java
+++ b/java/src/com/google/idea/blaze/java/projectview/JavaLanguageLevelSection.java
@@ -44,17 +44,17 @@ public class JavaLanguageLevelSection {
   @Nullable
   @VisibleForTesting
   static LanguageLevel getLanguageLevel(String level, @Nullable LanguageLevel defaultValue) {
-      try {
-        return LanguageLevel.valueOf(level.toUpperCase(Locale.ROOT));
-      } catch(IllegalArgumentException e) {
-        // fall through
-      }
+    try {
+      return LanguageLevel.valueOf(level.toUpperCase(Locale.ROOT));
+    } catch (IllegalArgumentException e) {
+      // fall through
+    }
 
-      LanguageLevel languageLevel = LanguageLevel.parse(level);
-      if (languageLevel != null) {
-        return languageLevel;
-      }
-      return defaultValue;
+    LanguageLevel languageLevel = LanguageLevel.parse(level);
+    if (languageLevel != null) {
+      return languageLevel;
+    }
+    return defaultValue;
   }
 
   private static class JavaLanguageLevelParser extends ScalarSectionParser<LanguageLevel> {
@@ -64,7 +64,8 @@ public class JavaLanguageLevelSection {
 
     @Nullable
     @Override
-    protected LanguageLevel parseItem(ProjectViewParser parser, ParseContext parseContext, String rest) {
+    protected LanguageLevel parseItem(ProjectViewParser parser, ParseContext parseContext,
+        String rest) {
       LanguageLevel languageLevel = getLanguageLevel(rest, null);
       if (languageLevel == null) {
         // Fall through to error handler

--- a/java/src/com/google/idea/blaze/java/projectview/JavaLanguageLevelSection.java
+++ b/java/src/com/google/idea/blaze/java/projectview/JavaLanguageLevelSection.java
@@ -25,10 +25,12 @@ import com.google.idea.blaze.base.projectview.section.SectionKey;
 import com.google.idea.blaze.base.projectview.section.SectionParser;
 import com.intellij.pom.java.LanguageLevel;
 import javax.annotation.Nullable;
+import java.util.Locale;
 
 /** Section to force the java language level used */
 public class JavaLanguageLevelSection {
-  public static final SectionKey<Integer, ScalarSection<Integer>> KEY =
+
+  public static final SectionKey<LanguageLevel, ScalarSection<LanguageLevel>> KEY =
       SectionKey.of("java_language_level");
   public static final SectionParser PARSER = new JavaLanguageLevelParser();
 
@@ -36,40 +38,45 @@ public class JavaLanguageLevelSection {
       ProjectViewSet projectViewSet, LanguageLevel defaultValue) {
     return projectViewSet
         .getScalarValue(KEY)
-        .map(i -> getLanguageLevel(i, defaultValue))
         .orElse(defaultValue);
   }
 
   @Nullable
   @VisibleForTesting
-  static LanguageLevel getLanguageLevel(Integer level, @Nullable LanguageLevel defaultValue) {
-    LanguageLevel parsed = LanguageLevel.parse(level.toString());
-    return parsed != null ? parsed : defaultValue;
+  static LanguageLevel getLanguageLevel(String level, @Nullable LanguageLevel defaultValue) {
+      try {
+        return LanguageLevel.valueOf(level.toUpperCase(Locale.ROOT));
+      } catch(IllegalArgumentException e) {
+        // fall through
+      }
+
+      LanguageLevel languageLevel = LanguageLevel.parse(level);
+      if (languageLevel != null) {
+        return languageLevel;
+      }
+      return defaultValue;
   }
 
-  private static class JavaLanguageLevelParser extends ScalarSectionParser<Integer> {
+  private static class JavaLanguageLevelParser extends ScalarSectionParser<LanguageLevel> {
     JavaLanguageLevelParser() {
       super(KEY, ':');
     }
 
     @Nullable
     @Override
-    protected Integer parseItem(ProjectViewParser parser, ParseContext parseContext, String rest) {
-      try {
-        Integer value = Integer.parseInt(rest);
-        if (getLanguageLevel(value, null) != null) {
-          return value;
-        }
+    protected LanguageLevel parseItem(ProjectViewParser parser, ParseContext parseContext, String rest) {
+      LanguageLevel languageLevel = getLanguageLevel(rest, null);
+      if (languageLevel == null) {
         // Fall through to error handler
-      } catch (NumberFormatException e) {
-        // Fall through to error handler
+        parseContext.addError("Illegal java language level: " + rest);
+        return null;
+      } else {
+        return languageLevel;
       }
-      parseContext.addError("Illegal java language level: " + rest);
-      return null;
     }
 
     @Override
-    protected void printItem(StringBuilder sb, Integer value) {
+    protected void printItem(StringBuilder sb, LanguageLevel value) {
       sb.append(value.toString());
     }
 

--- a/java/src/com/google/idea/blaze/java/projectview/JavaLanguageLevelSection.java
+++ b/java/src/com/google/idea/blaze/java/projectview/JavaLanguageLevelSection.java
@@ -50,7 +50,19 @@ public class JavaLanguageLevelSection {
       // fall through
     }
 
-    LanguageLevel languageLevel = LanguageLevel.parse(level);
+    final int numericVersion;
+    try {
+      // LanguageLevel.parse will return levels for strings containing numeric components
+      // like FOO_11_FOO that should not be accepted by the plugin
+      numericVersion = Integer.parseInt(level);
+      if (numericVersion <= 0) {
+        return defaultValue;
+      }
+    } catch (NumberFormatException nje) {
+      return defaultValue;
+    }
+
+    LanguageLevel languageLevel = LanguageLevel.parse(Integer.toString(numericVersion));
     if (languageLevel != null) {
       return languageLevel;
     }

--- a/java/src/com/google/idea/blaze/java/sync/projectstructure/Jdks.java
+++ b/java/src/com/google/idea/blaze/java/sync/projectstructure/Jdks.java
@@ -129,6 +129,10 @@ public class Jdks {
 
   private static boolean isLanguageLevelSupportedBySdk(LanguageLevel requestedLanguageLevel,
       Sdk sdk) {
+    if (!(sdk.getSdkType() instanceof JavaSdk)) {
+      return false;
+    }
+
     JavaSdkVersion version = JavaSdk.getInstance().getVersion(sdk);
     return isLanguageLevelSupportedBySdkVersion(requestedLanguageLevel, version);
   }

--- a/java/src/com/google/idea/blaze/java/sync/projectstructure/Jdks.java
+++ b/java/src/com/google/idea/blaze/java/sync/projectstructure/Jdks.java
@@ -74,7 +74,8 @@ public class Jdks {
         return currentSdk;
       } else if (jdkHomePaths.isEmpty()) {
         LanguageLevel currentLangLevel = getJavaLanguageLevel(currentSdk);
-        if (isLanguageLevelSupportedBySdkLevel(langLevel, currentLangLevel) && isValid(currentSdk)) {
+        if (isLanguageLevelSupportedBySdkLevel(langLevel, currentLangLevel) && isValid(
+            currentSdk)) {
           return currentSdk;
         }
       }

--- a/java/tests/integrationtests/com/google/idea/blaze/java/sync/projectstructure/JdksTest.java
+++ b/java/tests/integrationtests/com/google/idea/blaze/java/sync/projectstructure/JdksTest.java
@@ -223,7 +223,7 @@ public class JdksTest extends BlazeIntegrationTestCase {
   }
 
   @Test
-  public void testChooseSameVersionAsPreviewLanguageLevel() {
+  public void testChooseJdkProvidingRequestedPreviewLanguageLevel() {
     Sdk jdk11 = getUniqueMockJdk(LanguageLevel.JDK_11);
     Sdk jdk17 = getUniqueMockJdk(LanguageLevel.JDK_17);
 
@@ -240,22 +240,21 @@ public class JdksTest extends BlazeIntegrationTestCase {
   }
 
   @Test
-  public void testChooseNoJdkIfNoMatchingPreviewVersionInAvailable() {
-    Sdk jdk8 = getUniqueMockJdk(LanguageLevel.JDK_1_8);
+  public void testChoosesJdkProvidingLevelWhenMultipleLevelsProvided() {
     Sdk jdk11 = getUniqueMockJdk(LanguageLevel.JDK_11);
+    Sdk jdk17 = getUniqueMockJdk(LanguageLevel.JDK_17);
 
     registerJdkProvider(
         ImmutableMap.of(
-            LanguageLevel.JDK_1_8, jdk8,
-            LanguageLevel.JDK_11, jdk11
+            LanguageLevel.JDK_11, jdk11,
+            LanguageLevel.JDK_17, jdk17,
+            LanguageLevel.JDK_17_PREVIEW, jdk17
         ));
 
-    setJdkTable(jdk8, jdk11);
+    setJdkTable(jdk11, jdk17);
 
     Sdk chosenSdk = Jdks.chooseOrCreateJavaSdk(jdk11, LanguageLevel.JDK_17_PREVIEW);
-    // chosenSdk may be non-null when finding a local, system-installed sdk that provides the preview version
-    assertThat(chosenSdk).isNotEqualTo(jdk8);
-    assertThat(chosenSdk).isNotEqualTo(jdk11);
+    assertThat(chosenSdk).isEqualTo(jdk17);
   }
 
   private void setJdkTable(Sdk... jdks) {

--- a/java/tests/integrationtests/com/google/idea/blaze/java/sync/projectstructure/JdksTest.java
+++ b/java/tests/integrationtests/com/google/idea/blaze/java/sync/projectstructure/JdksTest.java
@@ -222,6 +222,42 @@ public class JdksTest extends BlazeIntegrationTestCase {
     assertThat(chosenSdk).isNotEqualTo(currentJdk7);
   }
 
+  @Test
+  public void testChooseSameVersionAsPreviewLanguageLevel() {
+    Sdk jdk11 = getUniqueMockJdk(LanguageLevel.JDK_11);
+    Sdk jdk17 = getUniqueMockJdk(LanguageLevel.JDK_17);
+
+    registerJdkProvider(
+        ImmutableMap.of(
+            LanguageLevel.JDK_11, jdk11,
+            LanguageLevel.JDK_17, jdk17));
+
+    setJdkTable(jdk11, jdk17);
+
+    Sdk chosenSdk = Jdks.chooseOrCreateJavaSdk(jdk11, LanguageLevel.JDK_17_PREVIEW);
+    assertThat(chosenSdk).isNotEqualTo(jdk11);
+    assertThat(chosenSdk).isEqualTo(jdk17);
+  }
+
+  @Test
+  public void testChooseNoJdkIfNoMatchingPreviewVersionInAvailable() {
+    Sdk jdk8 = getUniqueMockJdk(LanguageLevel.JDK_1_8);
+    Sdk jdk11 = getUniqueMockJdk(LanguageLevel.JDK_11);
+
+    registerJdkProvider(
+        ImmutableMap.of(
+            LanguageLevel.JDK_1_8, jdk8,
+            LanguageLevel.JDK_11, jdk11
+        ));
+
+    setJdkTable(jdk8, jdk11);
+
+    Sdk chosenSdk = Jdks.chooseOrCreateJavaSdk(jdk11, LanguageLevel.JDK_17_PREVIEW);
+    // chosenSdk may be non-null when finding a local, system-installed sdk that provides the preview version
+    assertThat(chosenSdk).isNotEqualTo(jdk8);
+    assertThat(chosenSdk).isNotEqualTo(jdk11);
+  }
+
   private void setJdkTable(Sdk... jdks) {
     WriteAction.run(
         () -> {

--- a/java/tests/unittests/com/google/idea/blaze/java/projectview/JavaLanguageLevelSectionTest.java
+++ b/java/tests/unittests/com/google/idea/blaze/java/projectview/JavaLanguageLevelSectionTest.java
@@ -45,4 +45,12 @@ public class JavaLanguageLevelSectionTest {
       assertThat(level.toJavaVersion().feature).isEqualTo(languageLevel.toJavaVersion().feature);
     }
   }
+
+  @Test
+  public void testInvalidLanguageLevelsAreRejected() {
+    for (String invalidLevel : new String[]{"INVALID_11_INVALID", "-11", "117", "0"}) {
+      LanguageLevel level = JavaLanguageLevelSection.getLanguageLevel(invalidLevel, null);
+      assertThat(level).isNull();
+    }
+  }
 }

--- a/java/tests/unittests/com/google/idea/blaze/java/projectview/JavaLanguageLevelSectionTest.java
+++ b/java/tests/unittests/com/google/idea/blaze/java/projectview/JavaLanguageLevelSectionTest.java
@@ -31,9 +31,18 @@ public class JavaLanguageLevelSectionTest {
     int minLevelToTest = 5;
     int maxLevelToTest = LanguageLevel.HIGHEST.toJavaVersion().feature;
     for (int i = minLevelToTest; i <= maxLevelToTest; i++) {
-      LanguageLevel level = JavaLanguageLevelSection.getLanguageLevel(i, null);
+      LanguageLevel level = JavaLanguageLevelSection.getLanguageLevel(Integer.toString(i), null);
       assertThat(level).isNotNull();
       assertThat(level.toJavaVersion().feature).isEqualTo(i);
+    }
+  }
+
+  @Test
+  public void testParseLanguageLevelsByNameIncludingPreview() {
+    for (LanguageLevel languageLevel : LanguageLevel.values()) {
+      LanguageLevel level = JavaLanguageLevelSection.getLanguageLevel(languageLevel.name(), null);
+      assertThat(level).isNotNull();
+      assertThat(level.toJavaVersion().feature).isEqualTo(languageLevel.toJavaVersion().feature);
     }
   }
 }


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: https://github.com/bazelbuild/intellij/issues/3080

# Description of this change

Intellij project language levels may include variants of major Java
versions such as "17 (preview)". Today, the Bazel plugin
`java_language_level` option specified in in the Project View File
accepts an integer value which defines the major Java version to use.
As an integer, it is not possible to specify preview versions.

This changes adds support for specifying any Java language level by
specifying a string for `java_language_level` that is attempted to be
matched against the LanguageLevel enum value names (found in
`com.intellij.pom.java.LanguageLevel`). If no match is found, the
previous parsing logic is used to parse the given language version.

To enable Java 17 preview features, you can set:

```yaml
java_language_level: jdk_17_preview
```

in your project view file.

To use a preview language level, the version of the SDK providing that level must be
available to Intellij.
