### PR TITLE
Fix: Build jvm class file format v52

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,2 @@
-build --java_language_version=17
-test --java_language_version=17 --java_runtime_version=17
+build --java_language_version=17 --javacopt=-source --javacopt=8 --javacopt=-target --javacopt=8
+test  --java_language_version=17 --javacopt=-source --javacopt=8 --javacopt=-target --javacopt=8 --java_runtime_version=17


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: closes #4069 

# Description of this change
This is required in order to import projects using JVM < 17 (because
our aspects run some Java apps, like PackageParser), as well as IntelliJ
instances hosted on JVMs older than 17.

