### PR TITLE
Use `runAfterOpened` instead of deprecated `registerPostStartupActivity

### DIFF
--- a/base/src/com/google/idea/blaze/base/wizard2/BlazeProjectCreator.java
+++ b/base/src/com/google/idea/blaze/base/wizard2/BlazeProjectCreator.java
@@ -91,7 +91,7 @@ class BlazeProjectCreator {
     projectBuilder.commit(newProject, null, ModulesProvider.EMPTY_MODULES_PROVIDER);
 
     StartupManager.getInstance(newProject)
-        .registerPostStartupActivity(
+        .runAfterOpened(
             () -> {
               // ensure the dialog is shown after all startup activities are done
               //noinspection SSBasedInspection


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number:  #4073 

# Description of this change
Before this change, an exception was thrown:
`Activities registered via registerPostStartupActivity must be dumb-aware`


