### PR TITLE
Fix checksum of IntelliJ 2022.3

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -84,7 +84,7 @@ http_archive(
 http_archive(
     name = "intellij_ue_2022_3",
     build_file = "@//intellij_platform_sdk:BUILD.ue223",
-    sha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    sha256 = "edafdf5d7d2f69e2f861b0a6f6be388ec7073af5a47240a196dc01d298d2c87a",
     url = "https://www.jetbrains.com/intellij-repository/snapshots/com/jetbrains/intellij/idea/ideaIU/223.7401.7-EAP-SNAPSHOT/ideaIU-223.7401.7-EAP-SNAPSHOT.zip"
 )
 


### PR DESCRIPTION
Previously, it was (inserted by accident) the checksum of a newline
```
echo -n  "" | sha256sum
e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  -
```

Btw, we have a bug in CI config, so the CI report is green, despite particular jobs being red
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

