### PR TITLE
Make gazelle tests respect USE_BAZEL_VERSION

### DIFF
--- a/gazelle/tests/integrationtests/com/google/idea/blaze/gazelle/sync/RunGazelleOnSyncTest.java
+++ b/gazelle/tests/integrationtests/com/google/idea/blaze/gazelle/sync/RunGazelleOnSyncTest.java
@@ -19,6 +19,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.idea.blaze.base.model.primitives.WorkspacePath;
+import com.google.idea.blaze.base.settings.BlazeUserSettings;
 import com.google.idea.blaze.base.sync.BlazeSyncIntegrationTestCase;
 import com.google.idea.blaze.base.sync.BlazeSyncParams;
 import com.google.idea.blaze.base.sync.SyncMode;
@@ -93,6 +94,10 @@ public class RunGazelleOnSyncTest extends BlazeSyncIntegrationTestCase {
 
   private void runBazelSync() {
     GazelleUserSettings.getInstance().setGazelleHeadless(true);
+
+    // We set the desired bazel because the Gazelle plugin needs to read it.
+    BlazeUserSettings bazelUserSettings = BlazeUserSettings.getInstance();
+    bazelUserSettings.setBazelBinaryPath(System.getenv("USE_BAZEL_VERSION"));
 
     BlazeSyncParams syncParams =
         BlazeSyncParams.builder()


### PR DESCRIPTION
# Checklist

- [X] I have filed an issue about this change and discussed potential changes with the maintainers.
- [X] I have received the approval from the maintainers to make this change.
- [X] This is not a stylistic, refactoring, or cleanup change.

# Discussion thread for this change

@mai93 brought it to attention.

# Description of this change

Some downstream tests use the `USE_BAZEL_VERSION` env var to set up the Bazel executable. Normally, this would not be set up for tests, as most tests don't run Bazel themselves. However, the Gazelle integration tests do need to run Bazel, so we must set those global settings manually.