### PR TITLE
[gazelle] Mock bazel in the integration tests

### DIFF
--- a/gazelle/BUILD
+++ b/gazelle/BUILD
@@ -6,6 +6,7 @@ load(
     "//build_defs:build_defs.bzl",
     "intellij_plugin",
     "intellij_plugin_library",
+    "merged_plugin_xml",
     "optional_plugin_xml",
     "stamped_plugin_xml",
 )
@@ -30,10 +31,20 @@ java_library(
     ],
 )
 
+merged_plugin_xml(
+    name = "gazelle_xml",
+    srcs = [
+        "src/META-INF/gazelle.xml",
+        "src/META-INF/gazelle-mocked.xml",
+    ],
+)
+
 intellij_plugin_library(
     name = "plugin_library",
     optional_plugin_xmls = [],
-    plugin_xmls = ["src/META-INF/blaze-gazelle.xml"],
+    plugin_xmls = [
+        ":gazelle_xml",
+    ],
     visibility = PLUGIN_PACKAGES_VISIBILITY,
     deps = [":gazelle"],
 )
@@ -44,12 +55,31 @@ stamped_plugin_xml(
     plugin_name = "com.google.idea.blaze.gazelle",
 )
 
+merged_plugin_xml(
+    name = "gazelle_xml_for_tests",
+    srcs = [
+        "src/META-INF/gazelle.xml",
+        "tests/integrationtests/gazelle-mocks.xml",
+    ],
+)
+
+# We create a separate plugin library with its own xml
+# so that we can mock out certain interfaces for testing.
+intellij_plugin_library(
+    name = "integration_test_plugin_library",
+    plugin_xmls = [
+        ":gazelle_xml_for_tests",
+    ],
+    visibility = PLUGIN_PACKAGES_VISIBILITY,
+    deps = [":gazelle"],
+)
+
 intellij_plugin(
     name = "gazelle_integration_test_plugin",
     testonly = 1,
     plugin_xml = ":gazelle_plugin_xml",
     deps = [
-        ":plugin_library",
+        ":integration_test_plugin_library",
         "//base:plugin_library",
     ],
 )

--- a/gazelle/src/META-INF/gazelle-mocked.xml
+++ b/gazelle/src/META-INF/gazelle-mocked.xml
@@ -1,0 +1,26 @@
+<!--
+  ~ Copyright 2017 The Bazel Authors. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!--
+  This file contains the services and extensions that are mocked in tests.
+  We need them to be in a separate file to allow us to compose a different xml for testing.
+-->
+<idea-plugin>
+  <extensions defaultExtensionNs="com.intellij">
+    <applicationService serviceInterface="com.google.idea.blaze.gazelle.GazelleRunner"
+      serviceImplementation="com.google.idea.blaze.gazelle.GazelleRunnerImpl"/>
+  </extensions>
+</idea-plugin>

--- a/gazelle/src/META-INF/gazelle.xml
+++ b/gazelle/src/META-INF/gazelle.xml
@@ -20,8 +20,6 @@
     <SettingsUiContributor implementation="com.google.idea.blaze.gazelle.GazelleUserSettingsConfigurable$UiContributor" />
   </extensions>
   <extensions defaultExtensionNs="com.intellij">
-    <applicationService serviceInterface="com.google.idea.blaze.gazelle.BlazeGazelleRunner"
-                        serviceImplementation="com.google.idea.blaze.gazelle.BlazeGazelleRunnerImpl"/>
     <applicationService id="GazelleUserSettings" serviceImplementation="com.google.idea.blaze.gazelle.GazelleUserSettings"/>
   </extensions>
 </idea-plugin>

--- a/gazelle/src/com/google/idea/blaze/gazelle/GazelleRunner.java
+++ b/gazelle/src/com/google/idea/blaze/gazelle/GazelleRunner.java
@@ -2,20 +2,38 @@ package com.google.idea.blaze.gazelle;
 
 import com.google.common.collect.ImmutableList;
 import com.google.idea.blaze.base.bazel.BuildSystem.BuildInvoker;
+import com.google.idea.blaze.base.command.BlazeCommand;
+import com.google.idea.blaze.base.command.BlazeCommandName;
 import com.google.idea.blaze.base.issueparser.BlazeIssueParser.Parser;
 import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.model.primitives.WorkspacePath;
 import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
 import com.google.idea.blaze.base.scope.BlazeContext;
-import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.application.ApplicationManager;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /** Runs the blaze run command, on gazelle. The results may be cached in the workspace. */
-public abstract class BlazeGazelleRunner {
+public abstract class GazelleRunner {
 
-  public static BlazeGazelleRunner getInstance() {
-    return ServiceManager.getService(BlazeGazelleRunner.class);
+  public static GazelleRunner getInstance() {
+    return ApplicationManager.getApplication().getService(GazelleRunner.class);
+  }
+
+  protected static BlazeCommand createGazelleCommand(
+      BuildInvoker invoker,
+      List<String> blazeFlags,
+      Label gazelleTarget,
+      Collection<WorkspacePath> directories
+  ) {
+    BlazeCommand.Builder builder = BlazeCommand.builder(invoker, BlazeCommandName.RUN);
+    builder.addBlazeFlags(blazeFlags);
+    builder.addTargets(gazelleTarget);
+    List<String> directoriesToRegenerate =
+        directories.stream().map(WorkspacePath::toString).collect(Collectors.toList());
+    builder.addExeFlags(directoriesToRegenerate);
+    return builder.build();
   }
 
   /**

--- a/gazelle/src/com/google/idea/blaze/gazelle/GazelleRunnerImpl.java
+++ b/gazelle/src/com/google/idea/blaze/gazelle/GazelleRunnerImpl.java
@@ -5,7 +5,6 @@ import com.google.idea.blaze.base.async.process.ExternalTask;
 import com.google.idea.blaze.base.async.process.LineProcessingOutputStream;
 import com.google.idea.blaze.base.bazel.BuildSystem.BuildInvoker;
 import com.google.idea.blaze.base.command.BlazeCommand;
-import com.google.idea.blaze.base.command.BlazeCommandName;
 import com.google.idea.blaze.base.issueparser.BlazeIssueParser.Parser;
 import com.google.idea.blaze.base.issueparser.IssueOutputLineProcessor;
 import com.google.idea.blaze.base.model.primitives.Label;
@@ -15,9 +14,8 @@ import com.google.idea.blaze.base.scope.BlazeContext;
 import java.io.ByteArrayOutputStream;
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
 
-public class BlazeGazelleRunnerImpl extends BlazeGazelleRunner {
+public class GazelleRunnerImpl extends GazelleRunner {
 
   @Override
   public GazelleRunResult runBlazeGazelle(
@@ -28,13 +26,7 @@ public class BlazeGazelleRunnerImpl extends BlazeGazelleRunner {
       Label gazelleTarget,
       Collection<WorkspacePath> directories,
       ImmutableList<Parser> issueParsers) {
-    BlazeCommand.Builder builder = BlazeCommand.builder(invoker, BlazeCommandName.RUN);
-    builder.addBlazeFlags(blazeFlags);
-    builder.addTargets(gazelleTarget);
-    List<String> directoriesToRegenerate =
-        directories.stream().map(WorkspacePath::toString).collect(Collectors.toList());
-    builder.addExeFlags(directoriesToRegenerate);
-    BlazeCommand command = builder.build();
+    BlazeCommand command = GazelleRunner.createGazelleCommand(invoker, blazeFlags, gazelleTarget, directories);
     ByteArrayOutputStream stdout = new ByteArrayOutputStream();
     int exitCode =
         ExternalTask.builder(workspaceRoot)

--- a/gazelle/src/com/google/idea/blaze/gazelle/GazelleSyncListener.java
+++ b/gazelle/src/com/google/idea/blaze/gazelle/GazelleSyncListener.java
@@ -66,7 +66,7 @@ public class GazelleSyncListener implements SyncListener {
     BuildSystem.BuildInvoker invoker =
         Blaze.getBuildSystemProvider(project).getBuildSystem().getBuildInvoker(project, context);
 
-    return BlazeGazelleRunner.getInstance()
+    return GazelleRunner.getInstance()
         .runBlazeGazelle(
             context,
             invoker,

--- a/gazelle/tests/integrationtests/com/google/idea/blaze/gazelle/sync/MockBlazeGazelleRunnerImpl.java
+++ b/gazelle/tests/integrationtests/com/google/idea/blaze/gazelle/sync/MockBlazeGazelleRunnerImpl.java
@@ -1,0 +1,37 @@
+package com.google.idea.blaze.gazelle.sync;
+
+import com.google.common.collect.ImmutableList;
+import com.google.idea.blaze.base.bazel.BuildSystem.BuildInvoker;
+import com.google.idea.blaze.base.command.BlazeCommand;
+import com.google.idea.blaze.base.issueparser.BlazeIssueParser.Parser;
+import com.google.idea.blaze.base.model.primitives.Label;
+import com.google.idea.blaze.base.model.primitives.WorkspacePath;
+import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
+import com.google.idea.blaze.base.scope.BlazeContext;
+import com.google.idea.blaze.gazelle.GazelleRunner;
+import com.google.idea.blaze.gazelle.GazelleRunResult;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+public class MockBlazeGazelleRunnerImpl extends GazelleRunner {
+
+  Optional<BlazeCommand> command = Optional.empty();
+
+  @Override
+  public GazelleRunResult runBlazeGazelle(BlazeContext context, BuildInvoker invoker,
+      WorkspaceRoot workspaceRoot, List<String> blazeFlags, Label gazelleTarget,
+      Collection<WorkspacePath> directories, ImmutableList<Parser> issueParsers) {
+    command = Optional.of(
+        GazelleRunner.createGazelleCommand(invoker, blazeFlags, gazelleTarget, directories));
+    return GazelleRunResult.SUCCESS;
+  }
+
+  /**
+   * A utility method to clean internal state.
+   * Used mainly to reset state between tests.
+   */
+  public void clean() {
+    this.command = Optional.empty();
+  }
+}

--- a/gazelle/tests/integrationtests/gazelle-mocks.xml
+++ b/gazelle/tests/integrationtests/gazelle-mocks.xml
@@ -1,0 +1,21 @@
+<!--
+  ~ Copyright 2017 The Bazel Authors. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<idea-plugin>
+  <extensions defaultExtensionNs="com.intellij">
+    <applicationService serviceInterface="com.google.idea.blaze.gazelle.GazelleRunner"
+      serviceImplementation="com.google.idea.blaze.gazelle.sync.MockBlazeGazelleRunnerImpl"/>
+  </extensions>
+</idea-plugin>


### PR DESCRIPTION
# Checklist

- [X] I have filed an issue about this change and discussed potential changes with the maintainers.
- [X] I have received the approval from the maintainers to make this change.
- [X] This is not a stylistic, refactoring, or cleanup change.

# Discussion thread for this change

Offline discussion with @mai93 

# Description of this change

## Problem

Some downstream tests are run with a non-standard bazel. While #4115  addressed that concern, it does rely on the particular bazel binary being in the machine.
However, sometimes these test are run in a remote execution environment, which means that bazel is not available.

## Solution

Instead of running gazelle on a full mock repository, we will mock `BlazeGazelleRunner` (now renamed to `GazelleRunner`), and make assertions on the bazel command it would have run in the real world.

This diminishes the guarantees, of the code, but it tests all the codepaths of the Gazelle integration itself. In addition to that, it makes the tests significantly faster and easier to maintain.

A caveat:
- We want to mock the gazelle runner without modifying the plugin code. To accomplish that, we leverage the services architecture, so that we implement the `GazelleRunner` interface with our mock.
  - This means that we need to build different plugin xmls for tests and regular code, as we need to select the right implementation of `GazelleRunner` each time.
