### PR TITLE
[IJ 2022.3] Add annotations.jar and groovy.jr to the list of IJ libraries

### DIFF
--- a/plugin_dev/src/com/google/idea/blaze/plugin/run/IntellijWithPluginClasspathHelper.java
+++ b/plugin_dev/src/com/google/idea/blaze/plugin/run/IntellijWithPluginClasspathHelper.java
@@ -58,7 +58,9 @@ public class IntellijWithPluginClasspathHelper {
           "stats.jar",
           "external-system-rt.jar",
           "forms_rt.jar",
-          "intellij-test-discovery.jar"
+          "intellij-test-discovery.jar",
+          "annotations.jar",
+          "groovy.jar"
       );
   private static void addIntellijLibraries(JavaParameters params, Sdk ideaJdk) {
     String libPath = ideaJdk.getHomePath() + File.separator + "lib";


### PR DESCRIPTION
Without it, 2022.3 RC will throw an exception when you try to open module settings. Throws "ClassNotFoundException: org.intellij.lang.annotations.MagicConstant"

# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #4139 

# Description of this change

