### PR TITLE
fix(go) Correctly identify subscoped tests

### DIFF
--- a/examples/go/with_proto/go/lib/lib_test.go
+++ b/examples/go/with_proto/go/lib/lib_test.go
@@ -1,6 +1,15 @@
+// Testing Package
+//
+// This file tests varied configurations of tests.
+// One should be able to click any of the '>' buttons
+// on the right margin and have that specific test or subtest run,
+// and nothing else.
 package lib
 
-import "testing"
+import (
+	"log"
+	"testing"
+)
 
 func TestAdd(t *testing.T) {
 	t.Run("2 + 3 = 5", func(t *testing.T) {
@@ -15,6 +24,20 @@ func TestAdd(t *testing.T) {
 			t.Fatalf("Maths are broken")
 		}
 	})
+	t.Run("with_nested", func(t *testing.T) {
+		// TestAdd/with_nested/subtest
+		t.Run("subtest", func(t *testing.T) {})
+	})
+	t.Run("This should always fail", func(t *testing.T) {
+		t.Fatalf("Failing on purpose")
+	})
+
+}
+
+func TestFoo(t *testing.T) {
+	t.Run("with_nested", func(t *testing.T) {
+		t.Run("subtest", func(t *testing.T) {})
+	})
 }
 
 func TestSub(t *testing.T) {
@@ -24,4 +47,27 @@ func TestSub(t *testing.T) {
 			t.Fatalf("Maths are broken")
 		}
 	})
+}
+
+func TestMultipleCases(t *testing.T) {
+	testCases := []struct {
+		name string
+		fn   func(*testing.T)
+	}{
+		{
+			name: "TestCase1",
+			fn:   func(t *testing.T) { log.Println("I Succeed! ") },
+		},
+		{
+			name: "TestCase2",
+			fn:   func(t *testing.T) { t.Fatal("I fail! ") },
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			log.Println("running test: " + tc.name)
+			tc.fn(t)
+		})
+	}
 }

--- a/golang/src/com/google/idea/blaze/golang/run/producers/GoTestContextProvider.java
+++ b/golang/src/com/google/idea/blaze/golang/run/producers/GoTestContextProvider.java
@@ -16,6 +16,7 @@
 package com.google.idea.blaze.golang.run.producers;
 
 import com.goide.execution.testing.GoTestFinder;
+import com.goide.execution.testing.GoTestRunConfigurationProducerBase;
 import com.goide.psi.GoFile;
 import com.goide.psi.GoFunctionOrMethodDeclaration;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -31,6 +32,33 @@ import com.intellij.psi.PsiFile;
 import javax.annotation.Nullable;
 
 class GoTestContextProvider implements TestContextProvider {
+
+  /**
+   * Given a code element, calculate the test filter we'd need to run exactly that element.
+   * It takes into account nested tests.
+   * Here is an example of the expected results of clicking on each section:
+   * ```
+   * func Test(t *testing.T) {                    // returns "Test"
+   *   t.Run("with_nested", func(t *testing.T) {  // returns "Test/with_nested"
+   * 	    t.Run("subtest", func(t *testing.T) {}) // returns "Test/with_nested/subtest"
+   *   })
+   * }
+   * ```
+   * When a user clicks in the ">" button, we get pointed to the "Run" part of "t.Run".
+   * We need to walk the tree up to see the function call that has the actual argument.
+   *
+   * @param element: Element the user has clicked on.
+   * @param enclosingFunction: Go function encompassing this test.
+   * @return String representation of the proper test filter.
+   */
+  private String calculateTestFilter(PsiElement element, GoFunctionOrMethodDeclaration enclosingFunction) {
+    if (element.getParent().isEquivalentTo(enclosingFunction)) {
+      return enclosingFunction.getName();
+    } else {
+      return GoTestRunConfigurationProducerBase.findSubTestInContext(element, enclosingFunction);
+    }
+  }
+
   public static final String GO_TEST_WRAP_TESTV = "GO_TEST_WRAP_TESTV=1";
   @Nullable
   @Override
@@ -56,10 +84,11 @@ class GoTestContextProvider implements TestContextProvider {
           .setDescription(file.getName())
           .build();
     }
+    String testFilter = calculateTestFilter(element, function);
     return TestContext.builder(/* sourceElement= */ function, ExecutorType.DEBUG_SUPPORTED_TYPES)
         .addTestEnv(GO_TEST_WRAP_TESTV)
         .setTarget(target)
-        .setTestFilter("^" + function.getName() + "$")
+        .setTestFilter("^" + testFilter + "$")
         .setDescription(String.format("%s#%s", file.getName(), function.getName()))
         .build();
   }

--- a/golang/tests/integrationtests/com/google/idea/blaze/golang/resolve/BlazeGoPackageTest.java
+++ b/golang/tests/integrationtests/com/google/idea/blaze/golang/resolve/BlazeGoPackageTest.java
@@ -20,25 +20,17 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.goide.psi.GoFile;
 import com.goide.psi.GoFunctionDeclaration;
-import com.goide.psi.impl.GoPackage;
 import com.goide.psi.impl.imports.GoImportResolver;
-import com.google.common.collect.ImmutableList;
 import com.google.idea.blaze.base.BlazeIntegrationTestCase;
 import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.model.primitives.WorkspacePath;
+import com.google.idea.blaze.golang.utils.MockGoImportResolver;
 import com.intellij.openapi.extensions.Extensions;
 import com.intellij.openapi.extensions.LoadingOrder;
-import com.intellij.openapi.module.Module;
-import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
-import com.intellij.psi.ResolveState;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import javax.annotation.Nullable;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -188,22 +180,4 @@ public class BlazeGoPackageTest extends BlazeIntegrationTestCase {
                 .collect(toImmutableList())));
   }
 
-  private static class MockGoImportResolver implements GoImportResolver {
-    private final Map<String, GoPackage> map = new HashMap<>();
-
-    @Nullable
-    @Override
-    public Collection<GoPackage> resolve(
-        String importPath,
-        Project project,
-        @Nullable Module module,
-        @Nullable ResolveState resolveState) {
-      GoPackage goPackage = map.get(importPath);
-      return goPackage != null ? ImmutableList.of(goPackage) : null;
-    }
-
-    void put(String importPath, GoPackage goPackage) {
-      map.put(importPath, goPackage);
-    }
-  }
 }

--- a/golang/tests/integrationtests/com/google/idea/blaze/golang/utils/MockGoImportResolver.java
+++ b/golang/tests/integrationtests/com/google/idea/blaze/golang/utils/MockGoImportResolver.java
@@ -1,0 +1,34 @@
+package com.google.idea.blaze.golang.utils;
+
+import com.goide.psi.impl.GoPackage;
+import com.goide.psi.impl.imports.GoImportResolver;
+import com.google.common.collect.ImmutableList;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.ResolveState;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class MockGoImportResolver implements GoImportResolver {
+
+  private final Map<String, GoPackage> map = new HashMap<>();
+
+
+  public void put(String importPath, GoPackage goPackage) {
+    map.put(importPath, goPackage);
+  }
+
+  @Override
+  public @Nullable Collection<GoPackage> resolve(
+      @NotNull String importPath,
+      @NotNull Project project,
+      @Nullable Module module,
+      @Nullable ResolveState resolveState
+  ) {
+    GoPackage goPackage = map.get(importPath);
+    return goPackage != null ? ImmutableList.of(goPackage) : null;
+  }
+}

--- a/golang/tests/integrationtests/com/google/idea/blaze/golang/utils/MockGoPackageFactory.java
+++ b/golang/tests/integrationtests/com/google/idea/blaze/golang/utils/MockGoPackageFactory.java
@@ -1,0 +1,45 @@
+package com.google.idea.blaze.golang.utils;
+
+import com.goide.project.GoPackageFactory;
+import com.goide.psi.GoFile;
+import com.goide.psi.impl.GoPackage;
+import com.intellij.psi.PsiDirectory;
+import java.util.HashMap;
+import org.jetbrains.annotations.NotNull;
+import java.util.Map;
+import org.jetbrains.annotations.Nullable;
+
+
+/**
+ * A testing facility to mock go package resolution.
+ * When resolving Go symbols, the Go plugin creates artificial Go packages from individual files,
+ * in an attempt to extract the go import path (e.g. golang.org/x/tools) from them.
+ *
+ * For most packages, this process is fine.
+ * However, we may not want to import entire copies of the Go standard library
+ * or other third party packages, just to fuel that resolution in a test case.
+ *
+ * This factory can be used in the {@link GoPackageFactory} extension point,
+ * hence allowing us to mock the GoFile -> GoPackage translation with prebuilt go packages.
+ *
+ * Implementation-wise, everything is stored in a regular map with {@link String} keys,
+ * and each function has its own interpretation of how to extract that String from its arguments.
+ */
+public class MockGoPackageFactory implements GoPackageFactory {
+
+  Map<String, GoPackage> packages = new HashMap<>();
+
+  public void put(String packageName, GoPackage pkgs) {
+    packages.put(packageName, pkgs);
+  }
+
+  @Override
+  public @Nullable GoPackage createPackage(@NotNull String packageName, PsiDirectory ... psiDirectories) {
+    return packages.get(packageName);
+  }
+
+  @Override
+  public @Nullable GoPackage createPackage(@NotNull GoFile goFile) {
+    return packages.get(goFile.getCanonicalPackageName());
+  }
+}


### PR DESCRIPTION
# Checklist

- [X] I have filed an issue about this change and discussed potential changes with the maintainers.
- [X] I have received the approval from the maintainers to make this change.
- [X] This is not a stylistic, refactoring, or cleanup change.

# Discussion thread for this change

Issue number: #3691 

# Description of this change

Bazel and rules_go support subtests using the `--test_filter` flag. However, the plugin doesn't currently recognise any test beyond a top-level function.
This change improves the granularity of recognition somewhat, allowing for nested tests inside a single function.

The actual change is small, just calling to the Go plugin's very handy `GoTestRunConfigurationProducerBase.findSubTestInContext` in `GoTestContextProvider`. The bulk of the change is made up of improvements to the testing infrastructure to support these tests.

Commits can be reviewed independently.
 
 Fixes #3691 