### PR TITLE
feat(ijwb): add environment variables to the run configuration

### DIFF
--- a/base/src/com/google/idea/blaze/base/run/confighandler/BlazeCommandGenericRunConfigurationRunner.java
+++ b/base/src/com/google/idea/blaze/base/run/confighandler/BlazeCommandGenericRunConfigurationRunner.java
@@ -296,6 +296,7 @@ public final class BlazeCommandGenericRunConfigurationRunner
       return new ScopedBlazeProcessHandler(
           project,
           blazeCommand,
+          handlerState.getEnvVarsState().getData(),
           workspaceRoot,
           new ScopedBlazeProcessHandler.ScopedProcessHandlerDelegate() {
             @Override

--- a/base/src/com/google/idea/blaze/base/run/processhandler/ScopedBlazeProcessHandler.java
+++ b/base/src/com/google/idea/blaze/base/run/processhandler/ScopedBlazeProcessHandler.java
@@ -27,6 +27,7 @@ import com.google.idea.blaze.base.sync.aspects.BuildResult;
 import com.google.idea.blaze.base.util.ProcessGroupUtil;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.Platform;
+import com.intellij.execution.configuration.EnvironmentVariablesData;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.process.KillableColoredProcessHandler;
 import com.intellij.execution.process.ProcessAdapter;
@@ -35,6 +36,7 @@ import com.intellij.execution.process.ProcessListener;
 import com.intellij.openapi.project.Project;
 import java.io.File;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Scoped process handler.
@@ -72,21 +74,24 @@ public final class ScopedBlazeProcessHandler extends KillableColoredProcessHandl
   public ScopedBlazeProcessHandler(
       Project project,
       BlazeCommand blazeCommand,
+      EnvironmentVariablesData envData,
       WorkspaceRoot workspaceRoot,
       ScopedProcessHandlerDelegate scopedProcessHandlerDelegate)
       throws ExecutionException {
-    this(project, blazeCommand.toList(), workspaceRoot, scopedProcessHandlerDelegate);
+    this(project, blazeCommand.toList(), envData.getEnvs(), workspaceRoot, scopedProcessHandlerDelegate);
   }
 
   public ScopedBlazeProcessHandler(
       Project project,
       List<String> command,
+      Map<String, String> environment,
       WorkspaceRoot workspaceRoot,
       ScopedProcessHandlerDelegate scopedProcessHandlerDelegate)
       throws ExecutionException {
     super(
         ProcessGroupUtil.newProcessGroupFor(
             new CommandLineWithRemappedPath(command)
+                    .withEnvironment(environment)
                 .withWorkDirectory(workspaceRoot.directory().getPath())
                 .withRedirectErrorStream(true)));
 

--- a/base/src/com/google/idea/blaze/base/run/processhandler/ScopedBlazeProcessHandler.java
+++ b/base/src/com/google/idea/blaze/base/run/processhandler/ScopedBlazeProcessHandler.java
@@ -91,7 +91,7 @@ public final class ScopedBlazeProcessHandler extends KillableColoredProcessHandl
     super(
         ProcessGroupUtil.newProcessGroupFor(
             new CommandLineWithRemappedPath(command)
-                    .withEnvironment(environment)
+                .withEnvironment(environment)
                 .withWorkDirectory(workspaceRoot.directory().getPath())
                 .withRedirectErrorStream(true)));
 

--- a/base/src/com/google/idea/blaze/base/run/state/BlazeCommandRunConfigurationCommonState.java
+++ b/base/src/com/google/idea/blaze/base/run/state/BlazeCommandRunConfigurationCommonState.java
@@ -37,12 +37,14 @@ public class BlazeCommandRunConfigurationCommonState extends RunConfigurationCom
   private static final String TEST_FILTER_FLAG_PREFIX = BlazeFlags.TEST_FILTER + '=';
 
   protected final BlazeCommandState command;
+  protected final EnvironmentVariablesState envVarsState;
   protected final RunConfigurationFlagsState blazeFlags;
   protected final RunConfigurationFlagsState exeFlags;
   protected final BlazeBinaryState blazeBinary;
 
   public BlazeCommandRunConfigurationCommonState(BuildSystemName buildSystemName) {
     command = new BlazeCommandState();
+    envVarsState = new EnvironmentVariablesState(command);
     blazeFlags = new RunConfigurationFlagsState(USER_BLAZE_FLAG_TAG, buildSystemName + " flags:");
     exeFlags = new RunConfigurationFlagsState(USER_EXE_FLAG_TAG, "Executable flags:");
     blazeBinary = new BlazeBinaryState();
@@ -50,7 +52,12 @@ public class BlazeCommandRunConfigurationCommonState extends RunConfigurationCom
 
   @Override
   protected ImmutableList<RunConfigurationState> initializeStates() {
-    return ImmutableList.of(command, blazeFlags, exeFlags, blazeBinary);
+    return ImmutableList.of(command, envVarsState, blazeFlags, exeFlags, blazeBinary);
+  }
+
+  /** @return The list of blaze flags that the user specified manually. */
+  public EnvironmentVariablesState getEnvVarsState() {
+    return envVarsState;
   }
 
   /** @return The list of blaze flags that the user specified manually. */

--- a/base/src/com/google/idea/blaze/base/run/state/EnvironmentVariablesState.java
+++ b/base/src/com/google/idea/blaze/base/run/state/EnvironmentVariablesState.java
@@ -108,7 +108,7 @@ public class EnvironmentVariablesState implements RunConfigurationState {
       component.setEnabled(enabled);
 
       // Only enable when the env variables are settable
-      component.setVisible(this.command != null && SUPPORTED_COMMANDS.contains(this.command.getCommand()));
+      component.setVisible(this.command != null && this.command.getCommand() != null && SUPPORTED_COMMANDS.contains(this.command.getCommand()));
     }
   }
 }

--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrLauncher.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrLauncher.java
@@ -186,6 +186,7 @@ public final class BlazeCidrLauncher extends CidrLauncher {
     return new ScopedBlazeProcessHandler(
         project,
         command,
+        handlerState.getEnvVarsState().getData(),
         workspaceRoot,
         new ScopedBlazeProcessHandler.ScopedProcessHandlerDelegate() {
           @Override

--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrRunConfigState.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrRunConfigState.java
@@ -38,10 +38,6 @@ final class BlazeCidrRunConfigState extends BlazeCommandRunConfigurationCommonSt
     return ImmutableList.of(command, blazeFlags, exeFlags, envVars, debugPortState, blazeBinary);
   }
 
-  EnvironmentVariablesState getEnvVarsState() {
-    return envVars;
-  }
-
   DebugPortState getDebugPortState() {
     return debugPortState;
   }

--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrRunConfigState.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrRunConfigState.java
@@ -26,7 +26,7 @@ import com.google.idea.blaze.base.settings.BuildSystemName;
 final class BlazeCidrRunConfigState extends BlazeCommandRunConfigurationCommonState {
   private static final int DEFAULT_DEBUG_PORT = 5006;
 
-  private final EnvironmentVariablesState envVars = new EnvironmentVariablesState();
+  private final EnvironmentVariablesState envVars = new EnvironmentVariablesState(command);
   private final DebugPortState debugPortState = new DebugPortState(DEFAULT_DEBUG_PORT);
 
   BlazeCidrRunConfigState(BuildSystemName buildSystemName) {

--- a/golang/src/com/google/idea/blaze/golang/run/BlazeGoRunConfigurationRunner.java
+++ b/golang/src/com/google/idea/blaze/golang/run/BlazeGoRunConfigurationRunner.java
@@ -60,6 +60,7 @@ import com.intellij.execution.ExecutionResult;
 import com.intellij.execution.Executor;
 import com.intellij.execution.RunCanceledByUserException;
 import com.intellij.execution.RunManager;
+import com.intellij.execution.configuration.EnvironmentVariablesData;
 import com.intellij.execution.configurations.RunProfileState;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.runners.ExecutionUtil;
@@ -173,14 +174,17 @@ public class BlazeGoRunConfigurationRunner implements BlazeCommandRunConfigurati
       nativeConfig.setParams(ParametersListUtil.join(getParameters(executable)));
       nativeConfig.setWorkingDirectory(executable.workingDir.getPath());
 
+      EnvironmentVariablesData envState = this.state.getEnvVarsState().getData();
       Map<String, String> customEnvironment = new HashMap<>(nativeConfig.getCustomEnvironment());
-      for (Map.Entry<String, String> entry : executable.envVars.entrySet()) {
-        customEnvironment.put(entry.getKey(), entry.getValue());
-      }
+      customEnvironment.putAll(executable.envVars);
+      customEnvironment.putAll(envState.getEnvs());
+
       String testFilter = getTestFilter();
       if (testFilter != null) {
         customEnvironment.put("TESTBRIDGE_TEST_ONLY", testFilter);
       }
+
+      nativeConfig.setPassParentEnvironment(envState.isPassParentEnvs());
       nativeConfig.setCustomEnvironment(customEnvironment);
 
       Module module =

--- a/java/src/com/google/idea/blaze/java/run/BlazeJavaRunProfileState.java
+++ b/java/src/com/google/idea/blaze/java/run/BlazeJavaRunProfileState.java
@@ -63,6 +63,7 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
 
@@ -155,6 +156,7 @@ public final class BlazeJavaRunProfileState extends BlazeJavaDebuggableRunProfil
     return new ScopedBlazeProcessHandler(
         project,
         command,
+        Collections.EMPTY_MAP,
         workspaceRoot,
         new ScopedBlazeProcessHandler.ScopedProcessHandlerDelegate() {
           @Override

--- a/python/src/com/google/idea/blaze/python/run/BlazePyRunConfigState.java
+++ b/python/src/com/google/idea/blaze/python/run/BlazePyRunConfigState.java
@@ -24,7 +24,7 @@ import com.google.idea.blaze.base.settings.BuildSystemName;
 /** A version of the common state allowing environment variables to be set when debugging. */
 final class BlazePyRunConfigState extends BlazeCommandRunConfigurationCommonState {
 
-  private final EnvironmentVariablesState envVars = new EnvironmentVariablesState();
+  private final EnvironmentVariablesState envVars = new EnvironmentVariablesState(command);
 
   BlazePyRunConfigState(BuildSystemName buildSystemName) {
     super(buildSystemName);
@@ -33,9 +33,5 @@ final class BlazePyRunConfigState extends BlazeCommandRunConfigurationCommonStat
   @Override
   protected ImmutableList<RunConfigurationState> initializeStates() {
     return ImmutableList.of(command, blazeFlags, exeFlags, envVars, blazeBinary);
-  }
-
-  EnvironmentVariablesState getEnvVarsState() {
-    return envVars;
   }
 }


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #2042

# Description of this change

This adds the option to set environment variables to your run configuration for any target type. For `Test` configurations `--test_env` should be used and thus this field is only shown when set to `Run`.

Reused the `EnvironmentVariablesData` that was used in the Python module and applied it everywhere by passing it as an argument to `ScopedBlazeProcessHandler`, which then passes it onto the ProcessGroup using `.withEnvironment`.

Since `Go` handles the Run Configuration differently, we make sure to add the environment variables there as well, in this case as the last one so the user can override variables set elsewhere.

Screenshots:

<img width="504" alt="env_vars_new_1" src="https://user-images.githubusercontent.com/1273267/204400109-d5f0ca07-9bf1-444f-9814-9155bb2a2462.png">
(this was a go_binary target but I had to modify it for reasons, so it changed it to generic handler)
<img width="733" alt="env_vars_new_2" src="https://user-images.githubusercontent.com/1273267/204400113-022bbd31-613a-4a55-b1fb-641281a2b836.png">
<img width="734" alt="env_vars_new_3" src="https://user-images.githubusercontent.com/1273267/204400114-9ee11847-be46-4140-9266-bae7091a98e9.png">
<img width="791" alt="env_vars_new_py" src="https://user-images.githubusercontent.com/1273267/204400115-f2283fbd-ebc0-456c-b310-70f1dad6bc06.png">
