### PR TITLE
Go: Add well-known proto type to example project

### DIFF
--- a/examples/go/with_proto/proto/BUILD.bazel
+++ b/examples/go/with_proto/proto/BUILD.bazel
@@ -1,11 +1,12 @@
-load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 proto_library(
     name = "fooproto_proto",
     srcs = ["fooserver.proto"],
     visibility = ["//visibility:public"],
+    deps = ["@com_google_protobuf//:empty_proto"],
 )
 
 go_proto_library(

--- a/examples/go/with_proto/proto/fooserver.proto
+++ b/examples/go/with_proto/proto/fooserver.proto
@@ -1,7 +1,17 @@
+syntax = "proto3";
+
 package fooproto;
+
+import "google/protobuf/empty.proto";
 
 service FooService {
   rpc SayHello (HelloRequest) returns (HelloReply) {}
+  // This function exists to validate that the well known types (such as google.protobuf.Empty)
+  // are picked up by the plugin.
+  // To validate that they are working, navigate to "External Libraries" > "Go Libraries" >
+  //   "github.com/bazelbuild/intellij/examples/go/with_proto/proto/fooserver.pb.go",
+  // and validate that "google.golang.org/protobuf/types/known/emptypb" is resolved correctly.
+  rpc EmptyFunction (google.protobuf.Empty) returns (google.protobuf.Empty);
 }
 
 message HelloRequest {


### PR DESCRIPTION
# Checklist

- [X] I have filed an issue about this change and discussed potential changes with the maintainers.
- [X] I have received the approval from the maintainers to make this change.
- [X] This is not a stylistic, refactoring, or cleanup change.

# Discussion thread for this change

Issue number: #3248 added support for well-known protobuf types in go. This change just adds an illustrative case to demonstrate the impact of those changes.


