### PR TITLE
Plugin Development: add jsp-base.jar library to run configuration.

### DIFF
--- a/plugin_dev/src/com/google/idea/blaze/plugin/run/IntellijWithPluginClasspathHelper.java
+++ b/plugin_dev/src/com/google/idea/blaze/plugin/run/IntellijWithPluginClasspathHelper.java
@@ -60,7 +60,8 @@ public class IntellijWithPluginClasspathHelper {
           "forms_rt.jar",
           "intellij-test-discovery.jar",
           "annotations.jar",
-          "groovy.jar"
+          "groovy.jar",
+          "jsp-base.jar"
       );
   private static void addIntellijLibraries(JavaParameters params, Sdk ideaJdk) {
     String libPath = ideaJdk.getHomePath() + File.separator + "lib";


### PR DESCRIPTION
If you setup dev environment according to DEV_IDE_SETUP.md, indexing of some languages (for example Scala) won't work without this library.

# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.



# Description of this change

