### PR TITLE
Check whether the glogin command exists before running it.

### DIFF
--- a/base/src/com/google/idea/blaze/base/actions/FileGitHubIssueAction.java
+++ b/base/src/com/google/idea/blaze/base/actions/FileGitHubIssueAction.java
@@ -62,7 +62,11 @@ public final class FileGitHubIssueAction extends BlazeProjectAction {
   private static final NotNullLazyValue<Boolean> isCorpMachine =
       NotNullLazyValue.createValue(
           () -> {
-            int retVal = ExternalTask.builder().args("glogin", "-version").build().run();
+            String which = SystemInfo.isWindows ? "where" : "which";
+            int retVal = ExternalTask.builder().args(which, "glogin").build().run();
+            if (retVal == 0) {
+              retVal = ExternalTask.builder().args("glogin", "-version").build().run();
+            }
             return retVal == 0;
           });
 


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #1341 

# Description of this change

The attempt to run `glogin` is expected to fail for all users outside the Google's infrastructure. This causes a stack trace which litters the idea.log and makes it harder to look for any actual problems.

