### PR TITLE
Stop allowing `ScalaTestContextProvider` to deal with targets of `scala_junit_test` kind

### DIFF
--- a/java/src/com/google/idea/blaze/java/run/producers/JavaTestContextProvider.java
+++ b/java/src/com/google/idea/blaze/java/run/producers/JavaTestContextProvider.java
@@ -32,11 +32,8 @@ import com.intellij.execution.actions.ConfigurationContext;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiMethod;
 import com.intellij.psi.PsiModifier;
-import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
@@ -68,7 +65,7 @@ class JavaTestContextProvider implements TestContextProvider {
 
   @Nullable
   private static TestContext fromClass(PsiClass testClass) {
-    String testFilter = getTestFilterForClass(testClass);
+    String testFilter = ProducerUtils.getTestFilterForClass(testClass);
     if (testFilter == null) {
       return null;
     }
@@ -143,17 +140,5 @@ class JavaTestContextProvider implements TestContextProvider {
       return null;
     }
     return ProducerUtils.getTestClass(location);
-  }
-
-  @Nullable
-  private static String getTestFilterForClass(PsiClass testClass) {
-    Set<PsiClass> innerTestClasses = ProducerUtils.getInnerTestClasses(testClass);
-    if (innerTestClasses.isEmpty()) {
-      return BlazeJUnitTestFilterFlags.testFilterForClass(testClass);
-    }
-    innerTestClasses.add(testClass);
-    Map<PsiClass, Collection<Location<?>>> methodsPerClass =
-        innerTestClasses.stream().collect(Collectors.toMap(c -> c, c -> ImmutableList.of()));
-    return BlazeJUnitTestFilterFlags.testFilterForClassesAndMethods(methodsPerClass);
   }
 }

--- a/java/src/com/google/idea/blaze/java/run/producers/ProducerUtils.java
+++ b/java/src/com/google/idea/blaze/java/run/producers/ProducerUtils.java
@@ -15,6 +15,7 @@
  */
 package com.google.idea.blaze.java.run.producers;
 
+import com.google.common.collect.ImmutableList;
 import com.intellij.codeInsight.AnnotationUtil;
 import com.intellij.execution.Location;
 import com.intellij.execution.PsiLocation;
@@ -39,8 +40,10 @@ import com.intellij.psi.util.CachedValuesManager;
 import com.intellij.psi.util.PsiClassUtil;
 import com.intellij.psi.util.PsiModificationTracker;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -145,6 +148,18 @@ public class ProducerUtils {
             CachedValueProvider.Result.create(
                 hasTestOrSuiteMethods(psiClass),
                 PsiModificationTracker.JAVA_STRUCTURE_MODIFICATION_COUNT));
+  }
+
+  @Nullable
+  public static String getTestFilterForClass(PsiClass testClass) {
+    Set<PsiClass> innerTestClasses = ProducerUtils.getInnerTestClasses(testClass);
+    if (innerTestClasses.isEmpty()) {
+      return BlazeJUnitTestFilterFlags.testFilterForClass(testClass);
+    }
+    innerTestClasses.add(testClass);
+    Map<PsiClass, Collection<Location<?>>> methodsPerClass =
+            innerTestClasses.stream().collect(Collectors.toMap(c -> c, c -> ImmutableList.of()));
+    return BlazeJUnitTestFilterFlags.testFilterForClassesAndMethods(methodsPerClass);
   }
 
   private static boolean isJUnit4Class(PsiClass psiClass) {

--- a/scala/src/com/google/idea/blaze/scala/run/producers/ScalaTestContextProvider.java
+++ b/scala/src/com/google/idea/blaze/scala/run/producers/ScalaTestContextProvider.java
@@ -37,6 +37,9 @@ import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 /**
@@ -61,6 +64,14 @@ class ScalaTestContextProvider implements TestContextProvider {
             testClass, TestSizeFinder.getTestSize(testClass));
     if (target == null) {
       return null;
+    } else {
+      try {
+        if(target.get(3, TimeUnit.SECONDS).kindString.equals("scala_junit_test")) {
+          return null;
+        }
+      } catch (InterruptedException | ExecutionException | TimeoutException e){
+        //ignore
+      }
     }
 
     return TestContext.builder(testClass, ExecutorType.DEBUG_SUPPORTED_TYPES)


### PR DESCRIPTION
I found that `ScalaTestContextProvider` allows to add special scalatest flags (which were introduced in [3744](https://github.com/bazelbuild/intellij/pull/3744)) for runner even if test target is of `scala_junit_test` kind. It introduces a problem for such targets - `--test_filter` flag is not added so tests are not filtered in any way (`-s` and `-t` flags are not respected by JUnit runner)

This change exclude `scala_junit_test` targets  from creating their context in the `ScalaTestContextProvider`, so they are treated as they were before [3744](https://github.com/bazelbuild/intellij/pull/3744).
