### PR TITLE
Scala source attachment: use full jars instead of ijars

### DIFF
--- a/aspect/intellij_info_impl.bzl
+++ b/aspect/intellij_info_impl.bzl
@@ -150,13 +150,19 @@ def get_source_jars(output):
         return [output.source_jar]
     return []
 
-def library_artifact(java_output):
+def library_artifact(java_output, rule_kind = None):
     """Creates a LibraryArtifact representing a given java_output."""
     if java_output == None or java_output.class_jar == None:
         return None
     src_jars = get_source_jars(java_output)
+
+    if rule_kind != None and rule_kind.startswith("scala"):
+        interface_jar = None
+    else:
+        interface_jar = artifact_location(java_output.ijar)
+
     return struct_omit_none(
-        interface_jar = artifact_location(java_output.ijar),
+        interface_jar = interface_jar,
         jar = artifact_location(java_output.class_jar),
         source_jar = artifact_location(src_jars[0]) if src_jars else None,
         source_jars = [artifact_location(f) for f in src_jars],
@@ -597,7 +603,7 @@ def collect_java_info(target, ctx, semantics, ide_info, ide_info_file, output_gr
 
     ide_info_files = []
     sources = sources_from_target(ctx)
-    jars = [library_artifact(output) for output in java_outputs]
+    jars = [library_artifact(output, ctx.rule.kind) for output in java_outputs]
     class_jars = [output.class_jar for output in java_outputs if output and output.class_jar]
     output_jars = [jar for output in java_outputs for jar in jars_from_output(output)]
     resolve_files = output_jars


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

# Discussion thread for this change

Issue number: #4108 

# Description of this change
Use full jars instead of ijars. See:
https://youtrack.jetbrains.com/issue/SCL-16975/Navigation-to-attached-Scala-sources-for-interface-jar-does-not-work
