### PR TITLE
Mark module as clion's own module

### DIFF
--- a/cpp/src/META-INF/blaze-cpp.xml
+++ b/cpp/src/META-INF/blaze-cpp.xml
@@ -42,6 +42,7 @@
     <autoImportHelper implementation="com.google.idea.blaze.cpp.BlazeCppAutoImportHelper"/>
     <customHeaderProvider implementation="com.google.idea.blaze.cpp.BlazeCustomHeaderProvider"/>
     <includeHelper implementation="com.google.idea.blaze.cpp.BlazeIncludeHelper"/>
+    <ownModuleDetector implementation="com.google.idea.blaze.cpp.BlazeOwnModuleDetector"/>
   </extensions>
   <extensions defaultExtensionNs="com.intellij">
     <projectService serviceImplementation="com.google.idea.blaze.cpp.BlazeCompilerInfoMapService"/>

--- a/cpp/src/com/google/idea/blaze/cpp/BlazeOwnModuleDetector.java
+++ b/cpp/src/com/google/idea/blaze/cpp/BlazeOwnModuleDetector.java
@@ -1,0 +1,14 @@
+package com.google.idea.blaze.cpp;
+
+import com.google.idea.sdkcompat.cpp.CidrOwnModuleDetectorWrapper;
+import com.intellij.openapi.module.Module;
+import org.jetbrains.annotations.NotNull;
+
+import static com.google.idea.blaze.base.settings.Blaze.isBlazeProject;
+
+public class BlazeOwnModuleDetector implements CidrOwnModuleDetectorWrapper {
+    @Override
+    public boolean isOwnModule(@NotNull Module module) {
+        return isBlazeProject(module.getProject());
+    }
+}

--- a/sdkcompat/v212/com/google/idea/sdkcompat/cpp/CidrOwnModuleDetectorWrapper.java
+++ b/sdkcompat/v212/com/google/idea/sdkcompat/cpp/CidrOwnModuleDetectorWrapper.java
@@ -1,0 +1,11 @@
+package com.google.idea.sdkcompat.cpp;
+
+import com.intellij.openapi.module.Module;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * #api222
+ */
+public interface CidrOwnModuleDetectorWrapper {
+    boolean isOwnModule(@NotNull Module module);
+}

--- a/sdkcompat/v213/com/google/idea/sdkcompat/cpp/CidrOwnModuleDetectorWrapper.java
+++ b/sdkcompat/v213/com/google/idea/sdkcompat/cpp/CidrOwnModuleDetectorWrapper.java
@@ -1,0 +1,11 @@
+package com.google.idea.sdkcompat.cpp;
+
+import com.intellij.openapi.module.Module;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * #api222
+ */
+public interface CidrOwnModuleDetectorWrapper {
+    boolean isOwnModule(@NotNull Module module);
+}

--- a/sdkcompat/v221/com/google/idea/sdkcompat/cpp/CidrOwnModuleDetectorWrapper.java
+++ b/sdkcompat/v221/com/google/idea/sdkcompat/cpp/CidrOwnModuleDetectorWrapper.java
@@ -1,0 +1,11 @@
+package com.google.idea.sdkcompat.cpp;
+
+import com.intellij.openapi.module.Module;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * #api222
+ */
+public interface CidrOwnModuleDetectorWrapper {
+    boolean isOwnModule(@NotNull Module module);
+}

--- a/sdkcompat/v222/com/google/idea/sdkcompat/cpp/CidrOwnModuleDetectorWrapper.java
+++ b/sdkcompat/v222/com/google/idea/sdkcompat/cpp/CidrOwnModuleDetectorWrapper.java
@@ -1,0 +1,11 @@
+package com.google.idea.sdkcompat.cpp;
+
+import com.intellij.openapi.module.Module;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * #api222
+ */
+public interface CidrOwnModuleDetectorWrapper {
+    boolean isOwnModule(@NotNull Module module);
+}

--- a/sdkcompat/v223/com/google/idea/sdkcompat/cpp/CidrOwnModuleDetectorWrapper.java
+++ b/sdkcompat/v223/com/google/idea/sdkcompat/cpp/CidrOwnModuleDetectorWrapper.java
@@ -1,0 +1,9 @@
+package com.google.idea.sdkcompat.cpp;
+
+import com.jetbrains.cidr.project.workspace.CidrOwnModuleDetector;
+
+/**
+ * #api222
+ */
+public interface CidrOwnModuleDetectorWrapper extends CidrOwnModuleDetector {
+}


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #4168 

# Description of this change
This prevents "This file does not belong to any project target; code insight features might not work properly" popup

