### PR TITLE
Remove `is_new_external_version` temporary field

### DIFF
--- a/aspect/artifacts.bzl
+++ b/aspect/artifacts.bzl
@@ -43,8 +43,7 @@ def to_artifact_location(exec_path, root_exec_path_fragment, is_source, is_exter
         relative_path = relative_path,
         is_source = is_source,
         is_external = is_external,
-        root_execution_path_fragment = root_exec_path_fragment,
-        is_new_external_version = True,
+        root_execution_path_fragment = root_exec_path_fragment
     )
 
 def is_external_artifact(label):

--- a/base/src/com/google/idea/blaze/base/ideinfo/ArtifactLocation.java
+++ b/base/src/com/google/idea/blaze/base/ideinfo/ArtifactLocation.java
@@ -15,14 +15,12 @@
  */
 package com.google.idea.blaze.base.ideinfo;
 
-import com.google.common.base.Joiner;
 import com.google.common.base.Objects;
 import com.google.common.collect.ComparisonChain;
 import com.google.devtools.intellij.aspect.Common;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
-import com.intellij.openapi.util.text.StringUtil;
+
 import java.nio.file.Paths;
-import java.util.List;
 
 /** Represents a blaze-produced artifact. */
 public final class ArtifactLocation
@@ -41,35 +39,12 @@ public final class ArtifactLocation
   }
 
   public static ArtifactLocation fromProto(Common.ArtifactLocation proto) {
-    proto = fixProto(proto);
     return ProjectDataInterner.intern(
         new ArtifactLocation(
             proto.getRootExecutionPathFragment().intern(),
             proto.getRelativePath(),
             proto.getIsSource(),
             proto.getIsExternal()));
-  }
-
-  private static Common.ArtifactLocation fixProto(Common.ArtifactLocation proto) {
-    if (!proto.getIsNewExternalVersion() && proto.getIsExternal()) {
-      String relativePath = proto.getRelativePath();
-      String rootExecutionPathFragment = proto.getRootExecutionPathFragment();
-      // fix up incorrect paths created with older aspect version
-      // Note: bazel always uses the '/' separator here, even on windows.
-      List<String> components = StringUtil.split(relativePath, "/");
-      if (components.size() > 2) {
-        relativePath = Joiner.on('/').join(components.subList(2, components.size()));
-        String prefix = components.get(0) + "/" + components.get(1);
-        rootExecutionPathFragment =
-            rootExecutionPathFragment.isEmpty() ? prefix : rootExecutionPathFragment + "/" + prefix;
-        return proto
-            .toBuilder()
-            .setRootExecutionPathFragment(rootExecutionPathFragment)
-            .setRelativePath(relativePath)
-            .build();
-      }
-    }
-    return proto;
   }
 
   @Override

--- a/base/tests/unittests/com/google/idea/blaze/base/sync/workspace/ArtifactLocationDecoderTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/sync/workspace/ArtifactLocationDecoderTest.java
@@ -58,66 +58,6 @@ public class ArtifactLocationDecoderTest extends BlazeTestCase {
   }
 
   @Test
-  public void testExternalSourceArtifactOldFormat() {
-    ArtifactLocation artifactLocation =
-        ArtifactLocation.fromProto(
-            Common.ArtifactLocation.newBuilder()
-                .setRelativePath("external/repo_name/com/google/Bla.java")
-                .setIsSource(true)
-                .setIsExternal(true)
-                .build());
-
-    assertThat(artifactLocation.getRelativePath()).isEqualTo("com/google/Bla.java");
-    assertThat(artifactLocation.getExecutionRootRelativePath())
-        .isEqualTo("external/repo_name/com/google/Bla.java");
-
-    ArtifactLocationDecoder decoder =
-        new ArtifactLocationDecoderImpl(
-            BlazeInfo.createMockBlazeInfo(
-                OUTPUT_BASE,
-                EXECUTION_ROOT,
-                EXECUTION_ROOT + "/blaze-out/crosstool/bin",
-                EXECUTION_ROOT + "/blaze-out/crosstool/genfiles",
-                EXECUTION_ROOT + "/blaze-out/crosstool/testlogs"),
-            null,
-            RemoteOutputArtifacts.EMPTY);
-
-    assertThat(decoder.decode(artifactLocation).getPath())
-        .isEqualTo(EXECUTION_ROOT + "/external/repo_name/com/google/Bla.java");
-  }
-
-  @Test
-  public void testExternalDerivedArtifactOldFormat() {
-    ArtifactLocation artifactLocation =
-        ArtifactLocation.fromProto(
-            Common.ArtifactLocation.newBuilder()
-                .setRelativePath("external/repo_name/com/google/Bla.java")
-                .setRootExecutionPathFragment("blaze-out/crosstool/bin")
-                .setIsSource(false)
-                .setIsExternal(true)
-                .build());
-
-    assertThat(artifactLocation.getRelativePath()).isEqualTo("com/google/Bla.java");
-    assertThat(artifactLocation.getExecutionRootRelativePath())
-        .isEqualTo("blaze-out/crosstool/bin/external/repo_name/com/google/Bla.java");
-
-    ArtifactLocationDecoder decoder =
-        new ArtifactLocationDecoderImpl(
-            BlazeInfo.createMockBlazeInfo(
-                OUTPUT_BASE,
-                EXECUTION_ROOT,
-                EXECUTION_ROOT + "/blaze-out/crosstool/bin",
-                EXECUTION_ROOT + "/blaze-out/crosstool/genfiles",
-                EXECUTION_ROOT + "/blaze-out/crosstool/testlogs"),
-            null,
-            RemoteOutputArtifacts.EMPTY);
-
-    assertThat(decoder.decode(artifactLocation).getPath())
-        .isEqualTo(
-            EXECUTION_ROOT + "/blaze-out/crosstool/bin/external/repo_name/com/google/Bla.java");
-  }
-
-  @Test
   public void testExternalSourceArtifactNewFormat() {
     ArtifactLocation artifactLocation =
         ArtifactLocation.fromProto(
@@ -126,7 +66,6 @@ public class ArtifactLocationDecoderTest extends BlazeTestCase {
                 .setRootExecutionPathFragment("../repo_name")
                 .setIsSource(true)
                 .setIsExternal(true)
-                .setIsNewExternalVersion(true)
                 .build());
 
     assertThat(artifactLocation.getRelativePath()).isEqualTo("com/google/Bla.java");
@@ -156,7 +95,6 @@ public class ArtifactLocationDecoderTest extends BlazeTestCase {
                 .setRelativePath("com/google/Bla.java")
                 .setRootExecutionPathFragment("../repo_name/blaze-out/crosstool/bin")
                 .setIsSource(false)
-                .setIsNewExternalVersion(true)
                 .build());
 
     assertThat(artifactLocation.getRelativePath()).isEqualTo("com/google/Bla.java");

--- a/base/tests/unittests/com/google/idea/blaze/base/sync/workspace/ArtifactLocationDecoderTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/sync/workspace/ArtifactLocationDecoderTest.java
@@ -58,7 +58,7 @@ public class ArtifactLocationDecoderTest extends BlazeTestCase {
   }
 
   @Test
-  public void testExternalSourceArtifactNewFormat() {
+  public void testExternalSourceArtifact() {
     ArtifactLocation artifactLocation =
         ArtifactLocation.fromProto(
             Common.ArtifactLocation.newBuilder()
@@ -88,7 +88,7 @@ public class ArtifactLocationDecoderTest extends BlazeTestCase {
   }
 
   @Test
-  public void testExternalDerivedArtifactNewFormat() {
+  public void testExternalDerivedArtifact() {
     ArtifactLocation artifactLocation =
         ArtifactLocation.fromProto(
             Common.ArtifactLocation.newBuilder()

--- a/java/src/com/google/idea/blaze/java/sync/source/PackageManifestReader.java
+++ b/java/src/com/google/idea/blaze/java/sync/source/PackageManifestReader.java
@@ -18,7 +18,6 @@ package com.google.idea.blaze.java.sync.source;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 
-import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -51,7 +50,6 @@ import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.util.text.StringUtil;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -201,17 +199,6 @@ public class PackageManifestReader {
   private static ArtifactLocation fromProto(Common.ArtifactLocation location) {
     String relativePath = location.getRelativePath();
     String rootExecutionPathFragment = location.getRootExecutionPathFragment();
-    if (!location.getIsNewExternalVersion() && location.getIsExternal()) {
-      // fix up incorrect paths created with older aspect version
-      // Note: bazel always uses the '/' separator here, even on windows.
-      List<String> components = StringUtil.split(relativePath, "/");
-      if (components.size() > 2) {
-        relativePath = Joiner.on('/').join(components.subList(2, components.size()));
-        String prefix = components.get(0) + "/" + components.get(1);
-        rootExecutionPathFragment =
-            rootExecutionPathFragment.isEmpty() ? prefix : rootExecutionPathFragment + "/" + prefix;
-      }
-    }
     return ArtifactLocation.builder()
         .setRootExecutionPathFragment(rootExecutionPathFragment)
         .setRelativePath(relativePath)

--- a/proto/common.proto
+++ b/proto/common.proto
@@ -29,9 +29,4 @@ message ArtifactLocation {
   string root_execution_path_fragment = 4;
   // whether this artifact comes from an external repository (bazel only)
   bool is_external = 5;
-
-  // The contents of relative_path and root_execution_path_fragment have changed
-  // for external workspaces. This is a temporary field to distinguish between
-  // the two versions.
-  bool is_new_external_version = 6;
 }


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Description of this change
This temporary field was used to cover old bazel behavior, which is not the case now.

By the way there was a bug here because `toProto` was not setting the "is_new_external_version" field so if an already-serialized data was deserialized again, the fixProto method was applied again

