### PR TITLE
Bazel 'info' command doesn't require target specification

### DIFF
--- a/base/src/com/google/idea/blaze/base/run/BlazeCommandRunConfiguration.java
+++ b/base/src/com/google/idea/blaze/base/run/BlazeCommandRunConfiguration.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.idea.blaze.base.command.BlazeCommandName;
 import com.google.idea.blaze.base.dependencies.TargetInfo;
 import com.google.idea.blaze.base.lang.buildfile.references.LabelUtils;
 import com.google.idea.blaze.base.logging.EventLoggingService;
@@ -408,15 +409,19 @@ public class BlazeCommandRunConfiguration
     }
     ImmutableList<String> targetPatterns = this.targetPatterns;
     if (targetPatterns.isEmpty()) {
-      throw new RuntimeConfigurationError(
-          String.format(
-              "You must specify a %s target expression.", Blaze.buildSystemName(getProject())));
+      if (handler.getCommandName() != BlazeCommandName.INFO) {
+        throw new RuntimeConfigurationError(
+                String.format(
+                        "You must specify a %s target expression.", Blaze.buildSystemName(getProject())));
+      }
     }
     for (String pattern : targetPatterns) {
-      if (Strings.isNullOrEmpty(pattern)) {
-        throw new RuntimeConfigurationError(
-            String.format(
-                "You must specify a %s target expression.", Blaze.buildSystemName(getProject())));
+      if (handler.getCommandName() != BlazeCommandName.INFO) {
+        if (Strings.isNullOrEmpty(pattern)) {
+          throw new RuntimeConfigurationError(
+                  String.format(
+                          "You must specify a %s target expression.", Blaze.buildSystemName(getProject())));
+        }
       }
       if (!pattern.startsWith("//") && !pattern.startsWith("@")) {
         throw new RuntimeConfigurationError(


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x ] I have received the approval from the maintainers to make this change.
- [x ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

Bazel commands currently require target specifications for run configurations but these are unnecessary for the 'info' command. Removed the requirement for just that command