### PR TITLE
Update Bazel minimum supported version

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -471,9 +471,11 @@ http_archive(
 # specify a minimum version for bazel otherwise users on old versions may see
 # unexpressive errors when new features are used
 load("@bazel_skylib//lib:versions.bzl", "versions")
+
 versions.check(minimum_bazel_version = "5.2.0")
 
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
 bazel_skylib_workspace()
 
 http_archive(
@@ -486,10 +488,15 @@ http_archive(
 )
 
 load("@contrib_rules_bazel_integration_test//bazel_integration_test:deps.bzl", "bazel_integration_test_rules_dependencies")
+
 bazel_integration_test_rules_dependencies()
 
 load("@contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl", "bazel_binaries")
-bazel_binaries(versions = ["6.0.0", "0.28.1", "0.27.2"])
+
+bazel_binaries(versions = [
+    "6.0.0",
+    "1.2.0",
+])
 
 # LICENSE: The Apache Software License, Version 2.0
 http_archive(
@@ -509,6 +516,7 @@ rules_proto_toolchains()
 
 # LICENSE: The Apache Software License, Version 2.0
 rules_scala_version = "a0235fda820c635732d0d7cce86710eec92909ef"
+
 http_archive(
     name = "io_bazel_rules_scala",
     sha256 = "8981e4c5bb0f854b1c5da738876093249cf16b4b533cfec2d87dcdd1c867ffee",

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/integration/BUILD
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/integration/BUILD
@@ -21,8 +21,7 @@ bazel_integration_tests(
     name = "bazel_invocation_integration_tests",
     bazel_versions = [
         "6.0.0",
-        "0.28.1",
-        "0.27.2",
+        "1.2.0",
     ],
     # set tags = [] because otherwise bazel_integration_tests sets
     # tags = ["manual"] and the target is not be detected via test //pkg/...

--- a/base/src/com/google/idea/blaze/base/plugin/BazelVersionChecker.java
+++ b/base/src/com/google/idea/blaze/base/plugin/BazelVersionChecker.java
@@ -25,27 +25,16 @@ import com.google.idea.common.experiments.FeatureRolloutExperiment;
 /** Verifies that the available Bazel version is supported by this plugin. */
 public class BazelVersionChecker implements BuildSystemVersionChecker {
 
-  // version 0.23 introduced a backwards-incompatible change to the Py struct providers.
-  // See: https://github.com/bazelbuild/bazel/issues/7298
-  private static final BazelVersion OLDEST_SUPPORTED_VERSION = new BazelVersion(0, 23, 0);
-
   // version 1.2.0 introduced experimental_run_validations flag which is used in
   // {@code BlazeIdeInterfaceAspectsImpl}
-  private static final BazelVersion NEW_OLDEST_SUPPORTED_VERSION = new BazelVersion(1, 2, 0);
-
-  static final FeatureRolloutExperiment NEW_OLDEST_BAZEL_VERSION_ENABLED =
-      new FeatureRolloutExperiment("new.oldest.bazel.version.enabled");
+  private static final BazelVersion OLDEST_SUPPORTED_VERSION = new BazelVersion(1, 2, 0);
 
   @Override
   public boolean versionSupported(BlazeContext context, BlazeVersionData version) {
     if (version.buildSystem() != BuildSystemName.Bazel) {
       return true;
     }
-    BazelVersion oldestBazelVersion = OLDEST_SUPPORTED_VERSION;
-    if (NEW_OLDEST_BAZEL_VERSION_ENABLED.isEnabled()) {
-      oldestBazelVersion = NEW_OLDEST_SUPPORTED_VERSION;
-    }
-    if (version.bazelIsAtLeastVersion(oldestBazelVersion)) {
+    if (version.bazelIsAtLeastVersion(OLDEST_SUPPORTED_VERSION)) {
       return true;
     }
     IssueOutput.error(
@@ -53,7 +42,7 @@ public class BazelVersionChecker implements BuildSystemVersionChecker {
                 "Bazel version %s is not supported by this version of the Bazel plugin. "
                     + "Please upgrade to Bazel version %s+.\n"
                     + "Upgrade instructions are available at https://bazel.build",
-                version, oldestBazelVersion))
+                version, OLDEST_SUPPORTED_VERSION))
         .submit(context);
     return false;
   }

--- a/common/experiments/src/com/google/idea/common/experiments/experiment.properties
+++ b/common/experiments/src/com/google/idea/common/experiments/experiment.properties
@@ -9,6 +9,3 @@ formatter.api.buildifier=5
 # Flags used by ASwB
 # Use Studio's deployer: b/197761450
 aswb.use.studio.deployer.2=0
-
-# [Rollout %] Move minimum supported version of Bazel to 1.2.0
-new.oldest.bazel.version.enabled=100


### PR DESCRIPTION
Remove experiment and set the minimum supported Bazel version to 1.2.0 by default.