### PR TITLE
Fix broken task names in "Bazel" window in 2023.1

### DIFF
--- a/base/src/com/google/idea/blaze/base/toolwindow/TaskNodeDescriptor.java
+++ b/base/src/com/google/idea/blaze/base/toolwindow/TaskNodeDescriptor.java
@@ -48,7 +48,7 @@ public final class TaskNodeDescriptor extends PresentableNodeDescriptor<Task> {
   protected void update(PresentationData presentationData) {
     presentationData.setPresentableText(task.getName());
     presentationData.setIcon(iconForTask(task));
-    presentationData.addText(getName(), SimpleTextAttributes.REGULAR_BOLD_ATTRIBUTES);
+    presentationData.addText(task.getName(), SimpleTextAttributes.REGULAR_BOLD_ATTRIBUTES);
     if (!task.getState().isEmpty()) {
       presentationData.addText(" " + task.getState(), SimpleTextAttributes.SIMPLE_CELL_ATTRIBUTES);
     }


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change
BEFORE:
<img width="918" alt="Screenshot 2023-02-08 at 14 15 54" src="https://user-images.githubusercontent.com/1066003/217542836-1bcfd12f-4811-4484-b1c6-c62814b63dec.png">

AFTER:
<img width="918" alt="Screenshot 2023-02-08 at 14 19 46" src="https://user-images.githubusercontent.com/1066003/217542984-3d425ebe-71ea-477c-ae5e-27c923cbf3df.png">

