### PR TITLE
This Github workflow will add 'not stale' label on copybara PR's

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,20 @@
+# This workflow adds not stale label to only copybara[bot] PRs to avoid stale workflow 
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions-ecosystem/action-add-labels
+name: Add not stale label to copybara-service pr
+
+on:
+  pull_request:
+    types: opened
+
+jobs:
+  add_labels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+      - uses: actions-ecosystem/action-add-labels@v1
+        if: github.actor == 'copybara-service[bot]'
+        with:
+          labels: not stale

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,9 +1,9 @@
-# This workflow adds not stale label to only copybara[bot] PRs to avoid stale workflow 
+# This workflow adds the "not stale" label to all PRs opened by copybara-service[bot] so that these are skipped from the stale workflow 
 #
 # You can adjust the behavior by modifying this file.
 # For more information, see:
 # https://github.com/actions-ecosystem/action-add-labels
-name: Add not stale label to copybara-service pr
+name: Add label to copybara-service PRs
 
 on:
   pull_request:
@@ -18,3 +18,4 @@ jobs:
         if: github.actor == 'copybara-service[bot]'
         with:
           labels: not stale
+          debug-only: true


### PR DESCRIPTION

# Description of this change

This Github workflow will add 'not stale' label on Copybara-service[bot] PR's, to avoid stale Github action workflow.