### PR TITLE
To view the PR author name in the logs

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,9 +13,11 @@ jobs:
   add_labels:
     runs-on: ubuntu-latest
     steps:
+      - name: View PR author
+        run: echo "This PR is opened by ${{ github.event.pull_request.user.login }}."
       - uses: actions/checkout@main
       - uses: actions-ecosystem/action-add-labels@v1
-        if: github.actor == 'copybara-service[bot]'
+        if: ${{ github.event.pull_request.user.login }} == 'copybara-service[bot]'
         with:
           labels: not stale
           debug-only: true


### PR DESCRIPTION
# Description of this change

1. To View the PR author and compare.  
2. Getting author details from github.event.pull_request.user.login instead of github.actor