### PR TITLE
Fix partial query for Macro Test Targets

### DIFF
--- a/base/src/com/google/idea/blaze/base/dependencies/BlazeQuerySourceToTargetProvider.java
+++ b/base/src/com/google/idea/blaze/base/dependencies/BlazeQuerySourceToTargetProvider.java
@@ -183,7 +183,7 @@ public class BlazeQuerySourceToTargetProvider implements SourceToTargetProvider 
     String expr = "\"" + Joiner.on("\"+\"").join(sources) + "\"";
     String packageName = getPackageName(project, context, type, expr);
     String rdepsQuery =
-        String.format("kind(\".*_test\", rdeps(%s:all, %s, 2))", packageName, sources.toArray()[0]);
+        String.format("kind(\".*_test\", rdeps(%s:all, %s))", packageName, sources.toArray()[0]);
     BlazeCommand command =
         getBlazeCommand(
             project, type, rdepsQuery, ImmutableList.of("--output=label_kind"), context);


### PR DESCRIPTION
**Background**
https://github.com/bazelbuild/intellij/issues/4464
The hardcoded `rdeps(%s:all, %s, 2)` affects all the test macro defined in the repo. Any partial sync action performed on test source files will not sync any target.

**Repro step**
Define a unit test macro:
```
def unit_test(
        name,
        **kwargs):
        kt_android_local_test(
            name = name,
            **kwargs
        )
```

Try partial sync `StubTest.kt` defined under any `unit_test` target.
```
Command: bazelisk query --tool_tag=ijwb:AndroidStudio --tool_tag=version:2022.09.07 --output=label_kind --keep_going same_pkg_direct_rdeps(\"//test/src/androidTest:java/com/ms/test/vision/StubTest.kt\") --

Command: bazelisk query --tool_tag=ijwb:AndroidStudio --tool_tag=version:2022.09.07 --output=package --keep_going \"//test/src/androidTest:java/com/ms/test/vision/StubTest.kt\" --

Command: bazelisk query --tool_tag=ijwb:AndroidStudio --tool_tag=version:2022.09.07 --output=label_kind --keep_going "kind(\".*_test\", rdeps(test/src/androidTest:all, //test/src/androidTest:java/com/ms/test/vision/StubTest.kt, 2))" --
```
the query returns none and no target will be synced

Meanwhile, if we remove the `2` depth limit, the query
```
bazelisk test "kind(\".*_test\", rdeps(test/src/androidTest:all, //test/src/androidTest:java/com/ms/test/vision/StubTest.kt))"
```
returns the target

**Change**
remove the depth level restriction.
This shouldn't change the overall ide experience too much since it's only used by partial sync.
