### PR TITLE
Allow running Bazel commands in a workspace that doesn't belong to the current project.

### DIFF
--- a/base/src/com/google/idea/blaze/base/run/state/BlazeCommandRunConfigurationCommonState.java
+++ b/base/src/com/google/idea/blaze/base/run/state/BlazeCommandRunConfigurationCommonState.java
@@ -41,16 +41,19 @@ public class BlazeCommandRunConfigurationCommonState extends RunConfigurationCom
   protected final RunConfigurationFlagsState exeFlags;
   protected final BlazeBinaryState blazeBinary;
 
+  protected final BlazeWorkspaceState blazeWorkspace;
+
   public BlazeCommandRunConfigurationCommonState(BuildSystemName buildSystemName) {
     command = new BlazeCommandState();
     blazeFlags = new RunConfigurationFlagsState(USER_BLAZE_FLAG_TAG, buildSystemName + " flags:");
     exeFlags = new RunConfigurationFlagsState(USER_EXE_FLAG_TAG, "Executable flags:");
     blazeBinary = new BlazeBinaryState();
+    blazeWorkspace = new BlazeWorkspaceState();
   }
 
   @Override
   protected ImmutableList<RunConfigurationState> initializeStates() {
-    return ImmutableList.of(command, blazeFlags, exeFlags, blazeBinary);
+    return ImmutableList.of(command, blazeFlags, exeFlags, blazeBinary, blazeWorkspace);
   }
 
   /** @return The list of blaze flags that the user specified manually. */
@@ -65,6 +68,10 @@ public class BlazeCommandRunConfigurationCommonState extends RunConfigurationCom
 
   public BlazeBinaryState getBlazeBinaryState() {
     return blazeBinary;
+  }
+
+  public BlazeWorkspaceState getBlazeWorkspaceState() {
+    return blazeWorkspace;
   }
 
   public BlazeCommandState getCommandState() {

--- a/base/src/com/google/idea/blaze/base/run/state/BlazeWorkspaceState.java
+++ b/base/src/com/google/idea/blaze/base/run/state/BlazeWorkspaceState.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2016 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.run.state;
+
+import com.google.common.base.Strings;
+import com.google.idea.blaze.base.settings.Blaze;
+import com.google.idea.blaze.base.ui.UiUtil;
+import com.intellij.openapi.project.Project;
+import com.intellij.ui.components.JBTextField;
+import javax.annotation.Nullable;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import org.jdom.Element;
+
+/** State for a Blaze binary to run configurations with. */
+public final class BlazeWorkspaceState implements RunConfigurationState {
+  private static final String BLAZE_WORKSPACE_ATTR = "blaze-workspace";
+
+  @Nullable private String blazeWorkspace;
+
+  public BlazeWorkspaceState() {}
+
+  @Nullable
+  public String getBlazeWorkspace() {
+    return blazeWorkspace;
+  }
+
+  public void setBlazeWorkspace(@Nullable String blazeWorkspace) {
+    this.blazeWorkspace = blazeWorkspace;
+  }
+
+  @Override
+  public void readExternal(Element element) {
+    blazeWorkspace = element.getAttributeValue(BLAZE_WORKSPACE_ATTR);
+  }
+
+  @Override
+  public void writeExternal(Element element) {
+    if (!Strings.isNullOrEmpty(blazeWorkspace)) {
+      element.setAttribute(BLAZE_WORKSPACE_ATTR, blazeWorkspace);
+    } else {
+      element.removeAttribute(BLAZE_WORKSPACE_ATTR);
+    }
+  }
+
+  @Override
+  public RunConfigurationStateEditor getEditor(Project project) {
+    return new BlazeWorkspaceStateEditor(project);
+  }
+
+  private static class BlazeWorkspaceStateEditor implements RunConfigurationStateEditor {
+    private final String buildSystemName;
+
+    private final JBTextField blazeWorkspaceField = new JBTextField(1);
+
+    BlazeWorkspaceStateEditor(Project project) {
+      buildSystemName = Blaze.buildSystemName(project);
+      blazeWorkspaceField.getEmptyText().setText("(Same as current project)");
+    }
+
+    @Override
+    public void setComponentEnabled(boolean enabled) {
+      blazeWorkspaceField.setEnabled(enabled);
+    }
+
+    @Override
+    public void resetEditorFrom(RunConfigurationState genericState) {
+      BlazeWorkspaceState state = (BlazeWorkspaceState) genericState;
+      blazeWorkspaceField.setText(Strings.nullToEmpty(state.getBlazeWorkspace()));
+    }
+
+    @Override
+    public void applyEditorTo(RunConfigurationState genericState) {
+      BlazeWorkspaceState state = (BlazeWorkspaceState) genericState;
+      state.setBlazeWorkspace(Strings.emptyToNull(blazeWorkspaceField.getText()));
+    }
+
+    @Override
+    public JComponent createComponent() {
+      return UiUtil.createBox(new JLabel(buildSystemName + " workspace:"), blazeWorkspaceField);
+    }
+  }
+}


### PR DESCRIPTION
This is useful for developing aspects that are going to be injected into arbitrary workspaces. 

Unfortunately, aspect debugging seems to be unsupported...

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #4455

# Description of this change

