### PR TITLE
Adds not stale label on copybara-service[bot] PR's

### DIFF
--- a/.github/workflows/notstale.yml
+++ b/.github/workflows/notstale.yml
@@ -1,0 +1,43 @@
+# This workflow adds not stale label to only copybara[bot] PRs to avoid stale workflow 
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions-ecosystem/action-add-labels
+name: Label Not Stale PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  label-not-stale-prs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR author
+        id: pr-author-check
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const author = context.payload.pull_request.user.login;
+            return { author: author };
+
+      - name: Add "not stale" label
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            async function run() {
+              const author = context.payload.pull_request.user.login;
+              if (author === "copybara-service[bot]") {
+                const issue_number = context.payload.pull_request.number;
+                const labels = ["not stale"];
+                await github.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue_number,
+                  labels: labels
+                });
+              }
+            }
+            run();


### PR DESCRIPTION
# Description of this change
This Github action will add "not stale" label to all the copybara-service[bot] PR's. So that they are exempted from stale Github action workflow.
