### PR TITLE
Stringify "@//foo:bar" labels for instrumentation test targets

### DIFF
--- a/aspect/intellij_info_impl.bzl
+++ b/aspect/intellij_info_impl.bzl
@@ -846,7 +846,7 @@ def _collect_android_ide_info(target, ctx, semantics, ide_info, ide_info_file, o
 
     instruments = None
     if hasattr(ctx.rule.attr, "instruments") and ctx.rule.attr.instruments:
-        instruments = str(ctx.rule.attr.instruments.label)
+        instruments = str(stringify_label(ctx.rule.attr.instruments.label))
 
     render_resolve_jar = None
     if android_semantics and hasattr(android_semantics, "build_render_resolve_jar"):
@@ -891,7 +891,7 @@ def _collect_android_instrumentation_info(target, ctx, semantics, ide_info, ide_
         return False
 
     android_instrumentation_info = struct_omit_none(
-        test_app = str(ctx.rule.attr.test_app.label),
+        test_app = str(stringify_label(ctx.rule.attr.test_app.label)),
         target_device = str(ctx.rule.attr.target_device.label),
     )
     ide_info["android_instrumentation_info"] = android_instrumentation_info


### PR DESCRIPTION
# Checklist
- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
see https://github.com/bazelbuild/bazel/issues/15916

- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

**Change**
Follow up patch for https://github.com/bazelbuild/intellij/commit/41d1964a6c2871c5458a26c94d667574b3e7c487
we also need to stringify target label for instrumentation test targets as well. Otherwise, test button for android_instrumentation_test rule will not work
<img width="539" alt="Screenshot 2023-02-28 at 4 00 11 PM" src="https://user-images.githubusercontent.com/6951238/222020131-12a11c4d-4aef-4c18-b2d6-05378f15def6.png">


