### PR TITLE
Applying permission to write only on pull-requests

### DIFF
--- a/.github/workflows/notstale.yml
+++ b/.github/workflows/notstale.yml
@@ -7,21 +7,15 @@ name: Label Not Stale PRs
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened]
 
 jobs:
   label-not-stale-prs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
-      - name: Check PR author
-        id: pr-author-check
-        uses: actions/github-script@v4
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const author = context.payload.pull_request.user.login;
-            return { author: author };
-
       - name: Add "not stale" label
         uses: actions/github-script@v4
         with:


### PR DESCRIPTION
Extension of https://github.com/bazelbuild/intellij/pull/4517 (add "not stale" label to copybara-service[bot] PRs)

Without permission it is throwning the resource integration error. Now it is fixed. Tested on dummy bot on a dummy repo https://github.com/sgowroji/DummyRepo/pull/15
