### PR TITLE
Pass `--path` to buildifier when possible

### DIFF
--- a/base/src/com/google/idea/blaze/base/buildmodifier/BuildFileFormatOnSaveHandler.java
+++ b/base/src/com/google/idea/blaze/base/buildmodifier/BuildFileFormatOnSaveHandler.java
@@ -61,7 +61,7 @@ public class BuildFileFormatOnSaveHandler extends FileDocumentManagerAdapter {
       return;
     }
     // DO not use formatter here, instead we format the entire file.
-    BlazeFileType type = ((BuildFile) psiFile).getBlazeFileType();
+    BuildFile buildFile = (BuildFile) psiFile;
     ListenableFuture<Void> future =
         FileBasedFormattingSynchronizer.applyReplacements(
             psiFile,
@@ -72,7 +72,7 @@ public class BuildFileFormatOnSaveHandler extends FileDocumentManagerAdapter {
               }
               ImmutableList<TextRange> toFormat =
                   ImmutableList.of(TextRange.allOf(fileContents.getInitialFileContents()));
-              Replacements replacements = getReplacements(type, fileContents, toFormat);
+              Replacements replacements = getReplacements(buildFile, fileContents, toFormat);
               return new Formatter.Result<>(null, replacements);
             });
     FormatUtils.formatWithProgressDialog(project, "Running buildifier", future);

--- a/base/src/com/google/idea/blaze/base/buildmodifier/BuildFileFormatOnSaveHandler.java
+++ b/base/src/com/google/idea/blaze/base/buildmodifier/BuildFileFormatOnSaveHandler.java
@@ -25,7 +25,6 @@ import com.google.idea.blaze.base.formatter.FormatUtils;
 import com.google.idea.blaze.base.formatter.FormatUtils.FileContentsProvider;
 import com.google.idea.blaze.base.formatter.FormatUtils.Replacements;
 import com.google.idea.blaze.base.lang.buildfile.psi.BuildFile;
-import com.google.idea.blaze.base.lang.buildfile.psi.BuildFile.BlazeFileType;
 import com.google.idea.blaze.base.settings.BlazeUserSettings;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.fileEditor.FileDocumentManagerAdapter;

--- a/base/src/com/google/idea/blaze/base/buildmodifier/BuildifierCustomFormatter.java
+++ b/base/src/com/google/idea/blaze/base/buildmodifier/BuildifierCustomFormatter.java
@@ -43,8 +43,8 @@ final class BuildifierCustomFormatter implements CustomFormatter {
     if (!(fileContents.file instanceof BuildFile)) {
       return null;
     }
-    BlazeFileType type = ((BuildFile) fileContents.file).getBlazeFileType();
-    return BuildFileFormatter.getReplacements(type, fileContents, ranges);
+    BuildFile buildFile = (BuildFile) fileContents.file;
+    return BuildFileFormatter.getReplacements(buildFile, fileContents, ranges);
   }
 
   @Override

--- a/base/src/com/google/idea/blaze/base/buildmodifier/BuildifierFormattingService.java
+++ b/base/src/com/google/idea/blaze/base/buildmodifier/BuildifierFormattingService.java
@@ -23,10 +23,7 @@ import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.CharStreams;
-import com.google.idea.blaze.base.bazel.BazelWorkspaceRootProvider;
 import com.google.idea.blaze.base.lang.buildfile.psi.BuildFile;
-import com.google.idea.blaze.base.lang.buildfile.psi.BuildFile.BlazeFileType;
-import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
 import com.google.idea.common.experiments.FeatureRolloutExperiment;
 import com.intellij.formatting.service.AsyncDocumentFormattingService;
 import com.intellij.formatting.service.AsyncFormattingRequest;
@@ -34,8 +31,6 @@ import com.intellij.psi.PsiFile;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.nio.file.Path;
-import java.util.Collections;
 import java.util.Optional;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
@@ -48,20 +43,13 @@ public final class BuildifierFormattingService extends AsyncDocumentFormattingSe
 
   static final Supplier<Optional<String>> binaryPath = Suppliers.memoize(() -> getBinary());
 
-  static ImmutableList<String> getCommandLineArgs(String binary, BuildFile buildFile) {
-    ImmutableList.Builder<String> cmd = ImmutableList.builder();
-    cmd.add(binary);
-    BlazeFileType type = buildFile.getBlazeFileType();
-    return cmd.add(fileTypeArg(type)).addAll(pathArg(buildFile)).build();
-  }
-
   @Override
   @Nullable
   protected FormattingTask createFormattingTask(AsyncFormattingRequest request) {
     BuildFile buildFile = (BuildFile) request.getContext().getContainingFile();
     return binaryPath
         .get()
-        .map(binary -> getCommandLineArgs(binary, buildFile))
+        .map(binary -> BuildFileFormatter.getCommandLineArgs(binary, buildFile))
         .map(args -> new BuildifierFormattingTask(request, args))
         .orElse(null);
   }
@@ -98,26 +86,6 @@ public final class BuildifierFormattingService extends AsyncDocumentFormattingSe
       }
     }
     return Optional.empty();
-  }
-
-  private static String fileTypeArg(BlazeFileType fileType) {
-    return fileType == BlazeFileType.SkylarkExtension ? "--type=bzl" : "--type=build";
-  }
-
-  private static Iterable<String> pathArg(@Nullable BuildFile buildFile) {
-    if (buildFile == null) {
-      return Collections.emptyList();
-    } else {
-      Path pathToFormat = buildFile.getVirtualFile().toNioPath();
-      WorkspaceRoot root = BazelWorkspaceRootProvider.INSTANCE.findWorkspaceRoot(pathToFormat.toFile());
-
-      if (root == null) {
-        return Collections.emptyList();
-      } else {
-        Path relativePath = root.path().relativize(pathToFormat);
-        return Collections.singletonList("--path=" + relativePath);
-      }
-    }
   }
 
   private static final class BuildifierFormattingTask implements FormattingTask {


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #4496 

# Description of this change

Previously, when formatting a file, buildifier would be called without passing the `--path` argument. Because buildifier will receive the content of the file to format via stdin, buildifier cannot determine to which package the file being formatted belongs.

Unfortunately, this can lead to unexpected results during formatting. For instance, if `StripLabelLeadingSlashes` and
`ShortenAbsoluteLabelsToRelative` are enabled, then the absolute label of a target at the root of the workspace such as `//:label` will be rewritten to the relative label `:label`, which has a different meaning if the build file being formatted is not at the root of the workspace.

We fix this issue by passing `--path=<path relative to workspace root>` to buildifier when formatting a file.