### PR TITLE
Add missing testing compat class for 2022.3

### DIFF
--- a/testing/testcompat/v223/com/google/idea/sdkcompat/roots/ex/ProjectRootManagerExWrapper.java
+++ b/testing/testcompat/v223/com/google/idea/sdkcompat/roots/ex/ProjectRootManagerExWrapper.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.sdkcompat.roots.ex;
+
+import com.intellij.openapi.project.RootsChangeRescanningInfo;
+import com.intellij.openapi.roots.ex.ProjectRootManagerEx;
+import org.jetbrains.annotations.NotNull;
+
+/** Shim for #api222 compat */
+public abstract class ProjectRootManagerExWrapper extends ProjectRootManagerEx {
+  @Override
+  public void makeRootsChange(
+      @NotNull Runnable runnable, @NotNull RootsChangeRescanningInfo rootsChangeRescanningInfo) {}
+
+  @Override
+  public @NotNull AutoCloseable withRootsChange(
+          @NotNull RootsChangeRescanningInfo rootsChangeRescanningInfo) {
+    return new AutoCloseable() {
+      @Override
+      public void close() throws Exception {}
+    };
+  }
+}


### PR DESCRIPTION
[ProjectRootManagerExWrapper.java](https://github.com/bazelbuild/intellij/blob/google/testing/testcompat/v223/com/google/idea/sdkcompat/roots/ex/ProjectRootManagerExWrapper.java) is needed by AS 2022.3, we need to add it to the main branch to make cherry-picking from `google` branch easier.