### PR TITLE
Allow targeting single methods in kotlin tests

### DIFF
--- a/kotlin/src/com/google/idea/blaze/kotlin/run/producers/KotlinTestContextProvider.java
+++ b/kotlin/src/com/google/idea/blaze/kotlin/run/producers/KotlinTestContextProvider.java
@@ -86,8 +86,18 @@ class KotlinTestContextProvider implements TestContextProvider {
 
   @Nullable
   private static String getTestFilter(KtClass testClass, @Nullable KtNamedFunction testMethod) {
-    FqName fqName = testMethod != null ? testMethod.getFqName() : testClass.getFqName();
-    return fqName != null ? fqName.toString() : null;
+    FqName testClassFqName = testClass.getFqName();
+    if (testClassFqName == null) {
+      return null;
+    }
+    if (testMethod == null) {
+      return testClassFqName.toString();
+    }
+    FqName testMethodFqName = testMethod.getFqName();
+    if (testMethodFqName == null || !testMethodFqName.toString().startsWith(testClassFqName.toString())) {
+      return testClassFqName.toString();
+    }
+    return testMethodFqName.toString().replace(testClassFqName + ".", testClassFqName + "#");
   }
 
   @Nullable
@@ -95,6 +105,6 @@ class KotlinTestContextProvider implements TestContextProvider {
     if (testMethod == null) {
       return testClass.getName();
     }
-    return testClass.getName() + "." + testMethod.getName();
+    return testClass.getName() + "#" + testMethod.getName();
   }
 }

--- a/kotlin/tests/integrationtests/com/google/idea/blaze/kotlin/run/producers/KotlinTestContextProviderTest.java
+++ b/kotlin/tests/integrationtests/com/google/idea/blaze/kotlin/run/producers/KotlinTestContextProviderTest.java
@@ -151,7 +151,7 @@ public class KotlinTestContextProviderTest extends BlazeRunConfigurationProducer
             TestBlazeCall.create(
                 BlazeCommandName.TEST,
                 TargetExpression.fromStringSafe("//com/google/test:TestClass"),
-                "--test_filter=com.google.test#TestClass"));
+                "--test_filter=com.google.test.TestClass"));
   }
 
   @Test
@@ -220,7 +220,7 @@ public class KotlinTestContextProviderTest extends BlazeRunConfigurationProducer
             TestBlazeCall.create(
                 BlazeCommandName.TEST,
                 TargetExpression.fromStringSafe("//com/google/test:TestClass"),
-                "--test_filter=com.google.test.TestClass.testMethod1"));
+                "--test_filter=com.google.test.TestClass#testMethod1"));
   }
 
   @Test

--- a/kotlin/tests/integrationtests/com/google/idea/blaze/kotlin/run/producers/KotlinTestContextProviderTest.java
+++ b/kotlin/tests/integrationtests/com/google/idea/blaze/kotlin/run/producers/KotlinTestContextProviderTest.java
@@ -151,7 +151,7 @@ public class KotlinTestContextProviderTest extends BlazeRunConfigurationProducer
             TestBlazeCall.create(
                 BlazeCommandName.TEST,
                 TargetExpression.fromStringSafe("//com/google/test:TestClass"),
-                "--test_filter=com.google.test.TestClass"));
+                "--test_filter=com.google.test#TestClass"));
   }
 
   @Test


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: [#2301](https://github.com/bazelbuild/intellij/issues/2301)

# Description of this change
Fix the longstanding issue of not being able to target single tests in kotlin
--target_filter needs # on method reference