### PR TITLE
fix(clion): Correctly parse flags with spaces in a single string.

### DIFF
--- a/cpp/src/com/google/idea/blaze/cpp/UnfilteredCompilerOptions.java
+++ b/cpp/src/com/google/idea/blaze/cpp/UnfilteredCompilerOptions.java
@@ -171,7 +171,7 @@ final class UnfilteredCompilerOptions {
         return this;
       }
       if (optionValue.startsWith(optionName)) {
-        values.add(optionValue.substring(optionName.length()));
+        values.add(optionValue.substring(optionName.length()).trim());
         return baseOptionParser;
       }
       Preconditions.checkState(

--- a/cpp/tests/unittests/com/google/idea/blaze/cpp/UnfilteredCompilerOptionsTest.java
+++ b/cpp/tests/unittests/com/google/idea/blaze/cpp/UnfilteredCompilerOptionsTest.java
@@ -101,4 +101,27 @@ public class UnfilteredCompilerOptionsTest extends BlazeTestCase {
     assertThat(defines).containsExactly("MACRO1=1", "MACRO2").inOrder();
     assertThat(flags).containsExactly("-fno-exceptions", "-Werror", "-Wall").inOrder();
   }
+
+  @Test
+  public void testFlagAndValueInSameString() {
+    // This is a functionality considered by the parser, so it should be tested.
+    ImmutableList<String> unfilteredOptions =
+        ImmutableList.of(
+            "-I foo/headers1",
+            "-isystem foo/headers2");
+    UnfilteredCompilerOptions compilerOptions =
+        UnfilteredCompilerOptions.builder()
+            .registerSingleOrSplitOption("-I")
+            .registerSingleOrSplitOption("-isystem")
+            .build(unfilteredOptions);
+
+    List<String> bigIIncludes = compilerOptions.getExtractedOptionValues("-I");
+    assertThat(bigIIncludes)
+        .containsExactly("foo/headers1")
+        .inOrder();
+    List<String> systemIncludes = compilerOptions.getExtractedOptionValues("-isystem");
+    assertThat(systemIncludes)
+        .containsExactly("foo/headers2")
+        .inOrder();
+  }
 }


### PR DESCRIPTION
# Checklist

- [X] I have filed an issue about this change and discussed potential changes with the maintainers.
- [X] I have received the approval from the maintainers to make this change.
- [X] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

This is a functionality considered by the parser, so it should work and be tested.