### PR TITLE
Fix broken import package name

### DIFF
--- a/aswb/sdkcompat/as221/com/google/idea/blaze/android/run/binary/DeploymentTimingReporterTask.java
+++ b/aswb/sdkcompat/as221/com/google/idea/blaze/android/run/binary/DeploymentTimingReporterTask.java
@@ -15,7 +15,7 @@
  */
 package com.google.idea.blaze.android.run.binary;
 
-import com.android.tool.idea.BaseAsCompat;
+import com.android.tools.idea.BaseAsCompat;
 import com.android.tools.idea.run.ApkInfo;
 import com.android.tools.idea.run.tasks.LaunchContext;
 import com.android.tools.idea.run.tasks.LaunchResult;


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: https://github.com/bazelbuild/intellij/issues/4658

# Description of this change

Update the package name since it was mislabelled as `tool` instead of `tools` causing `bazel build //aswb:aswb_bazel_zip --define=ij_product=android-studio-2022.1` to fail for the 221 version.
