### PR TITLE
Add override_repository flags at project import

### DIFF
--- a/base/src/com/google/idea/blaze/base/wizard2/BlazeNewProjectBuilder.java
+++ b/base/src/com/google/idea/blaze/base/wizard2/BlazeNewProjectBuilder.java
@@ -35,9 +35,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.text.StringUtil;
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import javax.annotation.Nullable;
 
 /** Contains the state to build a new project throughout the new project wizard process. */
@@ -72,6 +70,7 @@ public final class BlazeNewProjectBuilder {
   private String projectName;
   private String projectDataDirectory;
   private WorkspaceRoot workspaceRoot;
+  private HashMap<String, String> overrideFlags = new HashMap<>();
 
   public BlazeNewProjectBuilder() {
     this.userSettings = BlazeWizardUserSettingsStorage.getInstance().copyUserSettings();
@@ -180,6 +179,15 @@ public final class BlazeNewProjectBuilder {
   public BlazeNewProjectBuilder setProjectDataDirectory(String projectDataDirectory) {
     this.projectDataDirectory = projectDataDirectory;
     return this;
+  }
+
+  public BlazeNewProjectBuilder setOverrideFlags (String overrideFlagsName, String overrideFlagsPath){
+    this.overrideFlags.put(overrideFlagsName, overrideFlagsPath);
+    return this;
+  }
+
+  public HashMap<String, String> getOverrideFlags (){
+    return overrideFlags;
   }
 
   /** Commits the project. May report errors. */

--- a/base/src/com/google/idea/blaze/base/wizard2/BlazeSelectProjectViewImportWizardStep.java
+++ b/base/src/com/google/idea/blaze/base/wizard2/BlazeSelectProjectViewImportWizardStep.java
@@ -15,18 +15,20 @@
  */
 package com.google.idea.blaze.base.wizard2;
 
+import com.google.idea.blaze.base.wizard2.ui.BlazeAddOverrideFlagsControl;
 import com.google.idea.blaze.base.wizard2.ui.BlazeSelectProjectViewControl;
 import com.intellij.ide.util.projectWizard.WizardContext;
 import com.intellij.ide.wizard.CommitStepException;
 import com.intellij.openapi.options.ConfigurationException;
-import java.awt.BorderLayout;
+import java.awt.*;
 import javax.swing.JComponent;
 import javax.swing.JPanel;
 
 class BlazeSelectProjectViewImportWizardStep extends ProjectImportWizardStep {
 
-  private final JPanel component = new JPanel(new BorderLayout());
+  private final JPanel component = new JPanel(new GridLayout(2,1));
   private BlazeSelectProjectViewControl control;
+  private BlazeAddOverrideFlagsControl flagControl;
   private boolean settingsInitialised;
 
   public BlazeSelectProjectViewImportWizardStep(WizardContext context) {
@@ -50,11 +52,14 @@ class BlazeSelectProjectViewImportWizardStep extends ProjectImportWizardStep {
   private void init() {
     control = new BlazeSelectProjectViewControl(getProjectBuilder());
     this.component.add(control.getUiComponent());
+    flagControl = new BlazeAddOverrideFlagsControl(getProjectBuilder());
+    this.component.add(flagControl.getUiComponent());
     settingsInitialised = true;
   }
 
   @Override
   public void validateAndUpdateModel() throws ConfigurationException {
+    flagControl.validateAndUpdateModel(getProjectBuilder());
     control.validateAndUpdateModel(getProjectBuilder());
   }
 

--- a/base/src/com/google/idea/blaze/base/wizard2/ui/BlazeAddOverrideFlagsControl.java
+++ b/base/src/com/google/idea/blaze/base/wizard2/ui/BlazeAddOverrideFlagsControl.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2016 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.wizard2.ui;
+
+import com.google.idea.blaze.base.ui.UiUtil;
+import com.google.idea.blaze.base.wizard2.*;
+import com.intellij.openapi.fileChooser.FileChooserDescriptor;
+import com.intellij.openapi.options.ConfigurationException;
+import com.intellij.openapi.ui.TextComponentAccessor;
+import com.intellij.openapi.ui.TextFieldWithBrowseButton;
+import com.intellij.ui.components.panels.VerticalLayout;
+import com.intellij.util.ui.JBUI;
+
+import javax.swing.*;
+import java.io.File;
+
+/** UI for setting the override repository flags during the import process. */
+public class BlazeAddOverrideFlagsControl {
+
+    private static final FileChooserDescriptor PROJECT_FOLDER_DESCRIPTOR =
+            new FileChooserDescriptor(false, true, false, false, false, false);
+    private TextFieldWithBrowseButton flagsPathTextField;
+    private JTextField flagsRepoNameField;
+    private final JPanel canvas;
+
+  public BlazeAddOverrideFlagsControl(BlazeNewProjectBuilder builder) {
+      JPanel canvas = new JPanel(new VerticalLayout(4));
+      flagsPathTextField = new TextFieldWithBrowseButton();
+      flagsRepoNameField = new JTextField();
+      JLabel flagsPathLabel = new JLabel("Override repository flag path:");
+      JLabel flagsRepoNameLabel = new JLabel("Override repository name:");
+      flagsPathTextField.setName("override-flags-path-field");
+      flagsRepoNameField.setName("override-flags-repo-name-field");
+      flagsPathTextField.addBrowseFolderListener(
+              "",
+              builder.getBuildSystemName() + " override repository flags",
+              null,
+              PROJECT_FOLDER_DESCRIPTOR,
+              TextComponentAccessor.TEXT_FIELD_WHOLE_TEXT,
+              false);
+      final String flagsPathToolTipText = "Set override flag path here";
+      final String flagsTextFieldToolTipText = "Select repository to override.";
+      final String flagsNameToolTipText = "Set override flag name here";
+      flagsPathTextField.setToolTipText(flagsTextFieldToolTipText);
+      flagsPathLabel.setToolTipText(flagsPathToolTipText);
+      flagsRepoNameField.setToolTipText(flagsNameToolTipText);
+
+      JComponent flagsBox =
+              UiUtil.createHorizontalBox(
+                      10, flagsPathLabel, flagsPathTextField, flagsRepoNameLabel, flagsRepoNameField);
+      canvas.add(flagsBox);
+      canvas.setBorder(JBUI.Borders.empty(20,20,0,20));
+
+      this.canvas= canvas;
+  }
+
+  public JComponent getUiComponent() { return canvas; }
+
+  public void validateAndUpdateModel(BlazeNewProjectBuilder builder) throws ConfigurationException {
+      File file = new File(getOverrideFlagPath());
+      if (!getOverrideFlagPath().isEmpty()) {
+          if (getOverrideFlagRepoName().isEmpty()) {
+              throw new ConfigurationException("Must specify target name to override repository");
+          }
+          if (!file.exists()) {
+              throw new ConfigurationException("This path does not exist.");
+          }
+          if (!file.isDirectory()) {
+              throw new ConfigurationException("Specified override repository path is a file, not a directory");
+          }
+          if (builder.getOverrideFlags().get(getOverrideFlagRepoName()) != null) {
+              throw new ConfigurationException("You cannot create the same flag twice.");
+          }
+          if (builder.getOverrideFlags().containsValue(getOverrideFlagPath())) {
+              throw new ConfigurationException("You cannot create the same flag twice.");
+          }
+          builder.setOverrideFlags(getOverrideFlagRepoName(), getOverrideFlagPath());
+      }
+  }
+  public String getOverrideFlagRepoName() { return flagsRepoNameField.getText().trim();}
+  public String getOverrideFlagPath() { return flagsPathTextField.getText().trim(); }
+
+}

--- a/base/src/com/google/idea/blaze/base/wizard2/ui/BlazeEditProjectViewControl.java
+++ b/base/src/com/google/idea/blaze/base/wizard2/ui/BlazeEditProjectViewControl.java
@@ -28,15 +28,8 @@ import com.google.idea.blaze.base.projectview.ProjectViewSet.ProjectViewFile;
 import com.google.idea.blaze.base.projectview.ProjectViewStorageManager;
 import com.google.idea.blaze.base.projectview.ProjectViewVerifier;
 import com.google.idea.blaze.base.projectview.parser.ProjectViewParser;
-import com.google.idea.blaze.base.projectview.section.ProjectViewDefaultValueProvider;
-import com.google.idea.blaze.base.projectview.section.ScalarSection;
-import com.google.idea.blaze.base.projectview.section.SectionKey;
-import com.google.idea.blaze.base.projectview.section.SectionParser;
-import com.google.idea.blaze.base.projectview.section.sections.DirectoryEntry;
-import com.google.idea.blaze.base.projectview.section.sections.DirectorySection;
-import com.google.idea.blaze.base.projectview.section.sections.ImportSection;
-import com.google.idea.blaze.base.projectview.section.sections.Sections;
-import com.google.idea.blaze.base.projectview.section.sections.TargetSection;
+import com.google.idea.blaze.base.projectview.section.*;
+import com.google.idea.blaze.base.projectview.section.sections.*;
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.scope.OutputSink.Propagation;
 import com.google.idea.blaze.base.scope.Scope;
@@ -52,10 +45,7 @@ import com.google.idea.blaze.base.sync.workspace.WorkspacePathResolver;
 import com.google.idea.blaze.base.ui.BlazeValidationError;
 import com.google.idea.blaze.base.ui.BlazeValidationResult;
 import com.google.idea.blaze.base.ui.UiUtil;
-import com.google.idea.blaze.base.wizard2.BlazeNewProjectBuilder;
-import com.google.idea.blaze.base.wizard2.BlazeSelectProjectViewOption;
-import com.google.idea.blaze.base.wizard2.ProjectDataDirectoryValidator;
-import com.google.idea.blaze.base.wizard2.WorkspaceTypeData;
+import com.google.idea.blaze.base.wizard2.*;
 import com.google.idea.common.experiments.BoolExperiment;
 import com.intellij.icons.AllIcons.General;
 import com.intellij.ide.RecentProjectsManager;
@@ -77,8 +67,7 @@ import java.awt.Component;
 import java.awt.GridBagLayout;
 import java.io.File;
 import java.io.IOException;
-import java.util.Comparator;
-import java.util.List;
+import java.util.*;
 import javax.annotation.Nullable;
 import javax.swing.BorderFactory;
 import javax.swing.ButtonGroup;
@@ -208,6 +197,7 @@ public final class BlazeEditProjectViewControl {
     WorkspaceRoot workspaceRoot = workspaceData.workspaceRoot();
     WorkspacePath workspacePath = projectViewOption.getSharedProjectView();
     String initialProjectViewText = projectViewOption.getInitialProjectViewText();
+    HashMap<String, String> overrideFlags = builder.getOverrideFlags();
     boolean allowAddDefaultValues =
         projectViewOption.allowAddDefaultProjectViewValues()
             && allowAddprojectViewDefaultValues.getValue();
@@ -231,6 +221,7 @@ public final class BlazeEditProjectViewControl {
           workspacePathResolver,
           workspacePath,
           initialProjectViewText,
+          overrideFlags,
           allowAddDefaultValues);
       this.isInitialising = false;
     }
@@ -238,17 +229,9 @@ public final class BlazeEditProjectViewControl {
 
   private static String modifyInitialProjectView(
       BuildSystemName buildSystemName,
-      String initialProjectViewText,
+      ProjectView projectView,
+      ProjectViewSet projectViewSet,
       WorkspacePathResolver workspacePathResolver) {
-    BlazeContext context = BlazeContext.create();
-    ProjectViewParser projectViewParser = new ProjectViewParser(context, workspacePathResolver);
-    projectViewParser.parseProjectView(initialProjectViewText);
-    ProjectViewSet projectViewSet = projectViewParser.getResult();
-    ProjectViewFile projectViewFile = projectViewSet.getTopLevelProjectViewFile();
-    if (projectViewFile == null) {
-      return initialProjectViewText;
-    }
-    ProjectView projectView = projectViewFile.projectView;
 
     // Sort default value providers to match the section order
     List<SectionKey<?, ?>> sectionKeys =
@@ -265,15 +248,42 @@ public final class BlazeEditProjectViewControl {
     return ProjectViewParser.projectViewToString(projectView);
   }
 
+  private ProjectView addOverrideFlags(ProjectView projectView, HashMap<String, String> overrideFlags) {
+    if (overrideFlags.isEmpty()) {
+      return projectView;
+    }
+
+    ArrayList<String> fullFlags = mkOverrideFlag(overrideFlags);
+    for (String flag : fullFlags) {
+      projectView = projectView.builder(projectView)
+              .add(ListSection.builder(BuildFlagsSection.KEY).add(flag))
+              .add(ListSection.builder(SyncFlagsSection.KEY).add(flag))
+              .add(ListSection.builder(TestFlagsSection.KEY).add(flag))
+              .build();
+    }
+    return projectView;
+  }
+
+  private static ArrayList<String> mkOverrideFlag(HashMap<String, String> overrideFlags) {
+    ArrayList<String> fullFlags = new ArrayList();
+    for(Map.Entry<String, String> entry : overrideFlags.entrySet()) {
+      String name = entry.getKey();
+      String path = entry.getValue();
+      fullFlags.add("--override_repository=" + name + "=" + path);
+    }
+    return fullFlags;
+  }
+
   private void init(
       BuildSystemName buildSystemName,
       WorkspacePathResolver workspacePathResolver,
       @Nullable WorkspacePath sharedProjectView,
       @Nullable String initialProjectViewText,
+      @Nullable HashMap overrideFlags,
       boolean allowAddDefaultValues) {
     if (allowAddDefaultValues && initialProjectViewText != null) {
       initialProjectViewText =
-          modifyInitialProjectView(buildSystemName, initialProjectViewText, workspacePathResolver);
+          modifyInitialProjectView(buildSystemName, mkProjectView(initialProjectViewText),mkProjectViewSet(initialProjectViewText), workspacePathResolver);
     }
     this.workspacePathResolver = workspacePathResolver;
 
@@ -301,6 +311,9 @@ public final class BlazeEditProjectViewControl {
       logger.assertTrue(projectViewText != null);
     }
 
+    ProjectView pv = addOverrideFlags(mkProjectView(projectViewText), overrideFlags);
+    projectViewText = ProjectViewParser.projectViewToString(pv);
+
     projectViewUi.init(
         workspacePathResolver,
         projectViewText,
@@ -308,6 +321,19 @@ public final class BlazeEditProjectViewControl {
         sharedProjectView,
         sharedProjectView != null,
         false /* allowEditShared - not allowed during import */);
+  }
+
+  private ProjectViewSet mkProjectViewSet(String initialProjectViewText) {
+    BlazeContext context = BlazeContext.create();
+    ProjectViewParser projectViewParser = new ProjectViewParser(context, workspacePathResolver);
+    projectViewParser.parseProjectView(initialProjectViewText);
+    return projectViewParser.getResult();
+  }
+
+  private ProjectView mkProjectView(String initialProjectViewText) {
+    ProjectViewSet projectViewSet= mkProjectViewSet(initialProjectViewText);
+    ProjectViewFile projectViewFile = projectViewSet.getTopLevelProjectViewFile();
+    return projectViewFile.projectView;
   }
 
   private void updateDefaultProjectNameUiState() {
@@ -590,16 +616,21 @@ public final class BlazeEditProjectViewControl {
 
     // If we're using a shared project view, synthesize a local one that imports the shared one
     ProjectViewSet parseResult = projectViewUi.parseProjectView(Lists.newArrayList());
+    ArrayList<String> fullFlags = mkOverrideFlag(builder.getOverrideFlags());
 
     final ProjectView projectView;
     final ProjectViewSet projectViewSet;
     if (useSharedProjectView && selectProjectViewOption.getSharedProjectView() != null) {
-      projectView =
-          ProjectView.builder()
-              .add(
-                  ScalarSection.builder(ImportSection.KEY)
-                      .set(selectProjectViewOption.getSharedProjectView()))
-              .build();
+      ProjectView pv =
+              ProjectView.builder()
+                      .add(
+                              ScalarSection.builder(ImportSection.KEY)
+                                      .set(selectProjectViewOption.getSharedProjectView()))
+                      .build();
+
+      pv= addOverrideFlags(pv, builder.getOverrideFlags());
+      projectView = pv;
+
       projectViewSet =
           ProjectViewSet.builder()
               .addAll(parseResult.getProjectViewFiles())


### PR DESCRIPTION
# Checklist

- [X] I have filed an issue about this change and discussed potential changes with the maintainers.
- [X] I have received the approval from the maintainers to make this change.
- [X] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

Allows user to choose override_repository flags at project import. Added section in project import wizard for setting the override flags.

