### PR TITLE
Fix mobile install step

### DIFF
--- a/aswb/src/com/google/idea/blaze/android/run/binary/mobileinstall/MobileInstallBuildStep.java
+++ b/aswb/src/com/google/idea/blaze/android/run/binary/mobileinstall/MobileInstallBuildStep.java
@@ -186,7 +186,7 @@ public class MobileInstallBuildStep implements ApkBuildStep {
                         + " to the default adb server.")
                 .submit(context);
           } else {
-            deviceFlag += ":tcp:" + adbAddr.getPort();
+            command.addBlazeFlags(BlazeFlags.ADB_ARG + "-P ", BlazeFlags.ADB_ARG + adbAddr.getPort());
           }
         }
         command.addBlazeFlags(BlazeFlags.DEVICE, deviceFlag);

--- a/aswb/tests/integrationtests/com/google/idea/blaze/android/functional/MobileInstallBuildStepIntegrationTest.java
+++ b/aswb/tests/integrationtests/com/google/idea/blaze/android/functional/MobileInstallBuildStepIntegrationTest.java
@@ -71,6 +71,7 @@ public final class MobileInstallBuildStepIntegrationTest extends MobileInstallBu
     assertThat(externalTaskInterceptor.getContext()).isEqualTo(context);
     assertThat(externalTaskInterceptor.getCommand()).containsAllIn(blazeFlags);
     assertThat(externalTaskInterceptor.getCommand()).containsAllIn(execFlags);
+    assertThat(externalTaskInterceptor.getCommand()).containsAllOf("--adb_arg=-P ", "--adb_arg=0");
     assertThat(externalTaskInterceptor.getCommand())
         .containsAnyOf("serial-number", "serial-number:tcp:0");
     assertThat(externalTaskInterceptor.getCommand()).contains(buildTarget.toString());
@@ -109,6 +110,7 @@ public final class MobileInstallBuildStepIntegrationTest extends MobileInstallBu
     assertThat(externalTaskInterceptor.getContext()).isEqualTo(context);
     assertThat(externalTaskInterceptor.getCommand()).containsAllIn(blazeFlags);
     assertThat(externalTaskInterceptor.getCommand()).containsAllIn(execFlags);
+    assertThat(externalTaskInterceptor.getCommand()).containsAllOf("--adb_arg=-P ", "--adb_arg=0");
     assertThat(externalTaskInterceptor.getCommand()).contains("--device");
     // workaround for inconsistent stateful AndroidDebugBridge class.
     assertThat(externalTaskInterceptor.getCommand())
@@ -184,6 +186,7 @@ public final class MobileInstallBuildStepIntegrationTest extends MobileInstallBu
     assertThat(externalTaskInterceptor.getContext()).isEqualTo(context);
     assertThat(externalTaskInterceptor.getCommand()).containsAllIn(blazeFlags);
     assertThat(externalTaskInterceptor.getCommand()).containsAllIn(execFlags);
+    assertThat(externalTaskInterceptor.getCommand()).containsAllOf("--adb_arg=-P ", "--adb_arg=0");
     assertThat(externalTaskInterceptor.getCommand()).contains("--device");
     // workaround for inconsistent stateful AndroidDebugBridge class.
     assertThat(externalTaskInterceptor.getCommand())


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

#1922 

# Description of this change
Without an active tunnel config, the existing logic is adding ":tcp:port" to the device serial passed to adb, where port is the adb server port configured in the IDE.

The original intention was to use the right adb server port configured in the IDE, and unless running an adb connect, or different command that will modify the device serial we should simply use the -P option for that.

