### PR TITLE
Add override_repository flags at project import

### DIFF
--- a/base/src/com/google/idea/blaze/base/wizard2/BlazeNewProjectBuilder.java
+++ b/base/src/com/google/idea/blaze/base/wizard2/BlazeNewProjectBuilder.java
@@ -35,9 +35,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.text.StringUtil;
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import javax.annotation.Nullable;
 
 /** Contains the state to build a new project throughout the new project wizard process. */
@@ -72,6 +70,7 @@ public final class BlazeNewProjectBuilder {
   private String projectName;
   private String projectDataDirectory;
   private WorkspaceRoot workspaceRoot;
+  private HashMap<String, String> overrideFlags = new HashMap<>();
 
   public BlazeNewProjectBuilder() {
     this.userSettings = BlazeWizardUserSettingsStorage.getInstance().copyUserSettings();
@@ -180,6 +179,15 @@ public final class BlazeNewProjectBuilder {
   public BlazeNewProjectBuilder setProjectDataDirectory(String projectDataDirectory) {
     this.projectDataDirectory = projectDataDirectory;
     return this;
+  }
+
+  public BlazeNewProjectBuilder addOverrideFlags(String overrideFlagsName, String overrideFlagsPath){
+    this.overrideFlags.put(overrideFlagsName, overrideFlagsPath);
+    return this;
+  }
+
+  public HashMap<String, String> getOverrideFlags (){
+    return overrideFlags;
   }
 
   /** Commits the project. May report errors. */

--- a/base/src/com/google/idea/blaze/base/wizard2/BlazeSelectProjectViewImportWizardStep.java
+++ b/base/src/com/google/idea/blaze/base/wizard2/BlazeSelectProjectViewImportWizardStep.java
@@ -15,18 +15,20 @@
  */
 package com.google.idea.blaze.base.wizard2;
 
+import com.google.idea.blaze.base.wizard2.ui.BlazeAddOverrideFlagsControl;
 import com.google.idea.blaze.base.wizard2.ui.BlazeSelectProjectViewControl;
 import com.intellij.ide.util.projectWizard.WizardContext;
 import com.intellij.ide.wizard.CommitStepException;
 import com.intellij.openapi.options.ConfigurationException;
-import java.awt.BorderLayout;
+import java.awt.*;
 import javax.swing.JComponent;
 import javax.swing.JPanel;
 
 class BlazeSelectProjectViewImportWizardStep extends ProjectImportWizardStep {
 
-  private final JPanel component = new JPanel(new BorderLayout());
+  private final JPanel component = new JPanel(new GridLayout(2,1));
   private BlazeSelectProjectViewControl control;
+  private BlazeAddOverrideFlagsControl flagControl;
   private boolean settingsInitialised;
 
   public BlazeSelectProjectViewImportWizardStep(WizardContext context) {
@@ -50,11 +52,14 @@ class BlazeSelectProjectViewImportWizardStep extends ProjectImportWizardStep {
   private void init() {
     control = new BlazeSelectProjectViewControl(getProjectBuilder());
     this.component.add(control.getUiComponent());
+    flagControl = new BlazeAddOverrideFlagsControl(getProjectBuilder());
+    this.component.add(flagControl.getUiComponent());
     settingsInitialised = true;
   }
 
   @Override
   public void validateAndUpdateModel() throws ConfigurationException {
+    flagControl.validateAndUpdateModel(getProjectBuilder());
     control.validateAndUpdateModel(getProjectBuilder());
   }
 

--- a/base/src/com/google/idea/blaze/base/wizard2/ui/BlazeAddOverrideFlagsControl.java
+++ b/base/src/com/google/idea/blaze/base/wizard2/ui/BlazeAddOverrideFlagsControl.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2016 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.wizard2.ui;
+
+import com.google.idea.blaze.base.ui.UiUtil;
+import com.google.idea.blaze.base.wizard2.*;
+import com.intellij.openapi.fileChooser.FileChooserDescriptor;
+import com.intellij.openapi.options.ConfigurationException;
+import com.intellij.openapi.ui.TextComponentAccessor;
+import com.intellij.openapi.ui.TextFieldWithBrowseButton;
+import com.intellij.ui.components.panels.VerticalLayout;
+import com.intellij.util.ui.JBUI;
+
+import javax.swing.*;
+import java.awt.*;
+import java.io.File;
+
+/** UI for setting the override repository flags during the import process. */
+public class BlazeAddOverrideFlagsControl {
+
+    private static final FileChooserDescriptor PROJECT_FOLDER_DESCRIPTOR =
+            new FileChooserDescriptor(false, true, false, false, false, false);
+    private TextFieldWithBrowseButton flagsPathTextField;
+    private JTextField flagsRepoNameTextField;
+    private final JPanel canvas;
+
+  public BlazeAddOverrideFlagsControl(BlazeNewProjectBuilder builder) {
+      JPanel canvas = new JPanel(new VerticalLayout(4));
+
+      flagsPathTextField = new TextFieldWithBrowseButton();
+      flagsRepoNameTextField = new JTextField();
+      JLabel selectOverridesLabel = new JLabel("Select Overrides");
+      JLabel flagsPathLabel = new JLabel("Override repository flag path:");
+      JLabel flagsRepoNameLabel = new JLabel("Override repository name:");
+      flagsPathTextField.setName("override-flags-path-field");
+      flagsRepoNameTextField.setName("override-flags-repo-name-field");
+      flagsPathTextField.addBrowseFolderListener(
+              "",
+              builder.getBuildSystemName() + " override repository flags",
+              null,
+              PROJECT_FOLDER_DESCRIPTOR,
+              TextComponentAccessor.TEXT_FIELD_WHOLE_TEXT,
+              false);
+      final String flagsPathToolTipText = "Set override flag path here";
+      final String flagsTextFieldToolTipText = "Select repository to override.";
+      final String flagsNameToolTipText = "Set override flag name here";
+      flagsPathTextField.setToolTipText(flagsTextFieldToolTipText);
+      flagsPathLabel.setToolTipText(flagsPathToolTipText);
+      flagsRepoNameTextField.setToolTipText(flagsNameToolTipText);
+
+      canvas.add(selectOverridesLabel);
+      canvas.add(new JSeparator());
+
+      JPanel flagsPathBox = new JPanel(new VerticalLayout(4));
+      JPanel flagsNameBox = new JPanel(new VerticalLayout(4));
+      flagsPathBox.add(flagsPathLabel);
+      flagsPathBox.add(flagsPathTextField);
+      flagsNameBox.add(flagsRepoNameLabel);
+      flagsNameBox.add(flagsRepoNameTextField);
+
+      JPanel inner = new JPanel(new GridLayout(1,2));
+      inner.add(flagsPathBox);
+      inner.add(flagsNameBox);
+      canvas.add(inner);
+
+      canvas.setBorder(JBUI.Borders.empty(20,20,0,20));
+
+      this.canvas= canvas;
+  }
+
+  public JComponent getUiComponent() { return canvas; }
+
+  public void validateAndUpdateModel(BlazeNewProjectBuilder builder) throws ConfigurationException {
+      File file = new File(getOverrideFlagPath());
+      if (!getOverrideFlagPath().isEmpty()) {
+          if (getOverrideFlagRepoName().isEmpty()) {
+              throw new ConfigurationException("Must specify target name to override repository");
+          }
+          if (!file.exists()) {
+              throw new ConfigurationException("This path does not exist.");
+          }
+          if (!file.isDirectory()) {
+              throw new ConfigurationException("Specified override repository path is a file, not a directory");
+          }
+          if (builder.getOverrideFlags().get(getOverrideFlagRepoName()) != null) {
+              throw new ConfigurationException("You cannot create the same flag twice.");
+          }
+          if (builder.getOverrideFlags().containsValue(getOverrideFlagPath())) {
+              throw new ConfigurationException("You cannot create the same flag twice.");
+          }
+          builder.addOverrideFlags(getOverrideFlagRepoName(), getOverrideFlagPath());
+      }
+  }
+  public String getOverrideFlagRepoName() { return flagsRepoNameTextField.getText().trim();}
+  public String getOverrideFlagPath() { return flagsPathTextField.getText().trim(); }
+
+}


### PR DESCRIPTION
# Checklist

- [X] I have filed an issue about this change and discussed potential changes with the maintainers.
- [X] I have received the approval from the maintainers to make this change.
- [X] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

Allows user to choose override_repository flags at project import. Added section in project import wizard for setting the override flags.

