### PR TITLE
Make the dependencies on CLion's bundled test plugins optional.

### DIFF
--- a/clwb/BUILD
+++ b/clwb/BUILD
@@ -7,6 +7,7 @@ load(
     "//build_defs:build_defs.bzl",
     "intellij_plugin",
     "intellij_plugin_library",
+    "optional_plugin_xml",
     "plugin_deploy_zip",
     "repackaged_files",
     "stamped_plugin_xml",
@@ -27,9 +28,32 @@ load(
 
 licenses(["notice"])
 
+optional_plugin_xml(
+    name = "optional_bundled_boost_plugin",
+    module = "org.jetbrains.plugins.clion.test.boost",
+    plugin_xml = "src/META-INF/clion-test-boost.xml",
+)
+
+optional_plugin_xml(
+    name = "optional_bundled_catch_plugin",
+    module = "org.jetbrains.plugins.clion.test.catch",
+    plugin_xml = "src/META-INF/clion-test-catch.xml",
+)
+
+optional_plugin_xml(
+    name = "optional_bundled_gtest_plugin",
+    module = "org.jetbrains.plugins.clion.test.google",
+    plugin_xml = "src/META-INF/clion-test-google.xml",
+)
+
 intellij_plugin_library(
     name = "plugin_library",
     plugin_xmls = ["src/META-INF/clwb.xml"],
+    optional_plugin_xmls = [
+        ":optional_bundled_boost_plugin",
+        ":optional_bundled_catch_plugin",
+        ":optional_bundled_gtest_plugin",
+        ],
     visibility = PLUGIN_PACKAGES_VISIBILITY,
     deps = [":clwb_lib"],
 )

--- a/clwb/src/META-INF/clion-test-boost.xml
+++ b/clwb/src/META-INF/clion-test-boost.xml
@@ -1,0 +1,6 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <backgroundPostStartupActivity
+                implementation="com.google.idea.blaze.clwb.run.producers.RunConfigurationProducerSuppressor$Boost"/>
+    </extensions>
+</idea-plugin>

--- a/clwb/src/META-INF/clion-test-catch.xml
+++ b/clwb/src/META-INF/clion-test-catch.xml
@@ -1,0 +1,6 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <backgroundPostStartupActivity
+                implementation="com.google.idea.blaze.clwb.run.producers.RunConfigurationProducerSuppressor$Catch"/>
+    </extensions>
+</idea-plugin>

--- a/clwb/src/META-INF/clion-test-google.xml
+++ b/clwb/src/META-INF/clion-test-google.xml
@@ -1,0 +1,6 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <backgroundPostStartupActivity
+                implementation="com.google.idea.blaze.clwb.run.producers.RunConfigurationProducerSuppressor$Google"/>
+    </extensions>
+</idea-plugin>

--- a/clwb/src/META-INF/clwb.xml
+++ b/clwb/src/META-INF/clwb.xml
@@ -17,9 +17,6 @@
   <vendor>Google</vendor>
 
   <depends>com.intellij.modules.clion</depends>
-  <depends>org.jetbrains.plugins.clion.test.boost</depends>
-  <depends>org.jetbrains.plugins.clion.test.catch</depends>
-  <depends>org.jetbrains.plugins.clion.test.google</depends>
 
   <extensions defaultExtensionNs="com.intellij">
     <consoleFilterProvider implementation="com.google.idea.blaze.clwb.run.BlazeCppPathConsoleFilter$Provider"/>
@@ -28,7 +25,6 @@
 
     <editorNotificationProvider implementation="com.google.idea.blaze.plugin.CMakeNotificationFilter" />
     <moduleType id="BLAZE_CPP_MODULE" implementationClass="com.google.idea.blaze.clwb.BlazeCppModuleType"/>
-    <postStartupActivity implementation="com.google.idea.blaze.clwb.run.producers.NonBlazeProducerSuppressor"/>
     <actionConfigurationCustomizer implementation="com.google.idea.blaze.plugin.ClwbHideMakeActions"/>
   </extensions>
 


### PR DESCRIPTION
To build the plugin:
```
bazel build //clwb:clwb_bazel_zip --define=ij_product=clion-2023.1
```

# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #4664, #4481
# Description of this change

