### PR TITLE
Make the dependency on com.google.gct.test.recorder (a bundled plugin in Android Studio) optional.

### DIFF
--- a/aswb/BUILD
+++ b/aswb/BUILD
@@ -43,9 +43,18 @@ optional_plugin_xml(
     plugin_xml = "src/META-INF/ndk_contents.xml",
 )
 
+optional_plugin_xml(
+    name = "optional_gct_xml",
+    module = "com.android.tools.ndk",
+    plugin_xml = "src/META-INF/gct_contents.xml",
+)
+
 intellij_plugin_library(
     name = "plugin_library",
-    optional_plugin_xmls = [":optional_ndk_xml"],
+    optional_plugin_xmls = [
+        ":optional_ndk_xml",
+        ":optional_gct_xml",
+        ],
     plugin_xmls = ["src/META-INF/aswb.xml"],
     visibility = ASWB_PLUGIN_PACKAGES_VISIBILITY,
     deps = [":aswb_lib"],

--- a/aswb/src/META-INF/aswb.xml
+++ b/aswb/src/META-INF/aswb.xml
@@ -18,7 +18,6 @@
 
   <depends>com.intellij.modules.androidstudio</depends>
   <depends>org.jetbrains.android</depends>
-  <depends>com.google.gct.test.recorder</depends>
   <depends>com.intellij.modules.java</depends>
   <depends>com.android.tools.design</depends>
 
@@ -114,10 +113,6 @@
   <extensions defaultExtensionNs="com.android.rendering">
     <renderErrorContributor implementation="com.google.idea.blaze.android.rendering.BlazeRenderErrorContributor$Provider"/>
     <renderSecurityManagerOverrides implementation="com.google.idea.blaze.android.rendering.BlazeRenderSecurityManagerOverrides"/>
-  </extensions>
-
-  <extensions defaultExtensionNs="com.google.gct.testrecorder.run">
-    <testRecorderRunConfigurationProxyProvider implementation="com.google.idea.blaze.android.run.testrecorder.TestRecorderBlazeCommandRunConfigurationProxyProvider" />
   </extensions>
 
   <extensions defaultExtensionNs="com.android.tools.idea">

--- a/aswb/src/META-INF/gct_contents.xml
+++ b/aswb/src/META-INF/gct_contents.xml
@@ -1,0 +1,22 @@
+<!--
+  ~ Copyright 2023 The Bazel Authors. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<idea-plugin>
+
+  <extensions defaultExtensionNs="com.google.gct.testrecorder.run">
+    <testRecorderRunConfigurationProxyProvider implementation="com.google.idea.blaze.android.run.testrecorder.TestRecorderBlazeCommandRunConfigurationProxyProvider" />
+  </extensions>
+
+</idea-plugin>


### PR DESCRIPTION
On the SIG call on 2023-03-30, somebody mentioned in passing that the plugin for Android Studio has a problem similar to #4664 — that is, a non-optional dependency on a bundled plugin for "Google tests".

This pull request attempts to solve this problem by making one of these dependencies optional. However, I don't have Android Studio to test these changes, and I don't even know if this is actually the plugin that was causing trouble.

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #4664 

# Description of this change

