### PR TITLE
fix(cc): Run main function-style tests in CLion

### DIFF
--- a/clwb/src/com/google/idea/blaze/clwb/run/producers/CppTestContextProvider.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/producers/CppTestContextProvider.java
@@ -15,21 +15,31 @@
  */
 package com.google.idea.blaze.clwb.run.producers;
 
+import com.google.common.base.Function;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.idea.blaze.base.dependencies.TargetInfo;
 import com.google.idea.blaze.base.run.ExecutorType;
 import com.google.idea.blaze.base.run.TestTargetHeuristic;
 import com.google.idea.blaze.base.run.producers.RunConfigurationContext;
 import com.google.idea.blaze.base.run.producers.TestContext;
 import com.google.idea.blaze.base.run.producers.TestContextProvider;
+import com.google.idea.blaze.base.run.targetfinder.FuturesUtil;
 import com.google.idea.blaze.clwb.run.test.GoogleTestLocation;
 import com.google.idea.blaze.clwb.run.test.GoogleTestSpecification;
+import com.google.idea.blaze.cpp.CppBlazeRules.RuleTypes;
 import com.intellij.execution.Location;
 import com.intellij.execution.actions.ConfigurationContext;
 import com.intellij.openapi.actionSystem.LangDataKeys;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
+import com.jetbrains.cidr.lang.psi.OCDeclarator;
+import com.jetbrains.cidr.lang.types.OCFunctionType;
+import java.util.concurrent.Executor;
 import javax.annotation.Nullable;
+import org.jetbrains.ide.PooledThreadExecutor;
 
 /** Provides run configurations related to C/C++ test classes in Blaze. */
 class CppTestContextProvider implements TestContextProvider {
@@ -44,6 +54,68 @@ class CppTestContextProvider implements TestContextProvider {
     if (file == null) {
       return null;
     }
+
+    // Test each test context provider and return the one that matches.
+
+    // Is it a Gtest?
+    RunConfigurationContext gTestContext = getGTestContext(element, file, context);
+    if (gTestContext != null) {
+      return gTestContext;
+    }
+
+    // Is it just a main function inside a `cc_test`?
+    RunConfigurationContext bazelTargetContext = getBazelTargetContext(element, file, context);
+    if (bazelTargetContext != null) {
+      return bazelTargetContext;
+    }
+    return null;
+  }
+
+  private static RunConfigurationContext getBazelTargetContext(PsiElement element, PsiFile file, ConfigurationContext context) {
+    // Ensure we're in a main function, as defined by the C++ standard:
+    //   - https://en.cppreference.com/w/cpp/language/main_function
+    if (!(element.getContext() instanceof OCDeclarator)) {
+      return null;
+    }
+    OCDeclarator psiDeclaration = (OCDeclarator) element.getContext();
+    if (!(psiDeclaration.getResolvedType() instanceof OCFunctionType)) {
+      return null;
+    }
+
+    String funcName = psiDeclaration.getName();
+    String retTypeName = ((OCFunctionType) psiDeclaration.getResolvedType()).getReturnType()
+        .getName();
+    if (!(funcName.equals("main") && retTypeName.equals("int"))) {
+      return null;
+    }
+
+    // We pass null as the test size because the TestTargetHeuristicts that we expect to accept this
+    // don't care about the test size.
+    ListenableFuture<TargetInfo> targetFuture = TestTargetHeuristic.targetFutureForPsiElement(
+      element, null);
+    if (targetFuture == null
+        || targetFuture.isCancelled()
+        || (targetFuture.isDone() && FuturesUtil.getIgnoringErrors(targetFuture) == null)) {
+      return null;
+    }
+    Executor executor =
+        ApplicationManager.getApplication().isUnitTestMode()
+            ? MoreExecutors.directExecutor()
+            : PooledThreadExecutor.INSTANCE;
+    ListenableFuture<TargetInfo> ccTestFuture = Futures.transform(targetFuture,
+        targetInfo -> {
+          if (targetInfo.getKind().equals(RuleTypes.CC_TEST.getKind())) {
+            return targetInfo;
+          } else {
+            return null;
+          }
+        }, executor);
+    return TestContext.builder(element, ExecutorType.DEBUG_SUPPORTED_TYPES)
+        .setTarget(ccTestFuture)
+        .build();
+  }
+
+  private static RunConfigurationContext getGTestContext(PsiElement element, PsiFile file, ConfigurationContext context) {
     GoogleTestLocation test = GoogleTestLocation.findGoogleTest(element, context.getProject());
     if (test == null) {
       return null;

--- a/clwb/src/com/google/idea/blaze/clwb/run/producers/NonBlazeProducerSuppressor.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/producers/NonBlazeProducerSuppressor.java
@@ -26,9 +26,18 @@ public class NonBlazeProducerSuppressor implements StartupActivity {
 
   private static final ImmutableList<String> PRODUCERS_TO_SUPPRESS =
       ImmutableList.of(
+          // Gutter icons in different cpp files of different tests.
           "com.jetbrains.cidr.cpp.execution.testing.boost.CMakeBoostTestRunConfigurationProducer",
           "com.jetbrains.cidr.cpp.execution.testing.google.CMakeGoogleTestRunConfigurationProducer",
-          "com.jetbrains.cidr.cpp.execution.testing.tcatch.CMakeCatchTestRunConfigurationProducer");
+          "com.jetbrains.cidr.cpp.execution.testing.tcatch.CMakeCatchTestRunConfigurationProducer",
+
+          // Gutter icons in CMake files.
+          "com.jetbrains.cidr.cpp.execution.CMakeTargetRunConfigurationProducer",
+          "com.jetbrains.cidr.cpp.execution.debugger.CMakeRunConfigurationProducer",
+
+          // Gutter icons that sometimes appear in `cpp` files with a `main` function.
+          "com.jetbrains.cidr.cpp.runfile.CppFileTargetRunConfigurationProducer"
+      );
 
   @Override
   public void runActivity(Project project) {

--- a/examples/cpp/simple_project/src/BUILD
+++ b/examples/cpp/simple_project/src/BUILD
@@ -1,7 +1,15 @@
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_test")
 
 cc_binary(
     name = "hello_world",
+    srcs = ["hello_world.cc"],
+    deps = [
+        "//src/lib:greeting_lib",
+    ],
+)
+
+cc_test(
+    name = "hello_world_test",
     srcs = ["hello_world.cc"],
     deps = [
         "//src/lib:greeting_lib",

--- a/examples/cpp/simple_project/src/hello_world.cc
+++ b/examples/cpp/simple_project/src/hello_world.cc
@@ -1,6 +1,7 @@
-#include "lib/greeting_lib.h"
 #include <iostream>
 #include <string>
+#include <vector>
+#include "src/lib/greeting_lib.h"
 
 int main(int argc, char** argv) {
     std::vector<std::string> names;


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `N/A`

# Description of this change

Previously, if you had a main function, CLion would try to run the program as just a C program.
This somehow broke indexing as well, which is undesirable.

Solution:

- Stop it from doing the wrong thing: To suppress the regular "just run a C program" run configurations in CLion.
- Do the right thing: Make the Test Contex Provider return a valid context if someone clicks on a gutter icon, next to an int main function in a file that belongs to a cc_test target.
- Not do yet: Debugging that file doesn't work yet, because we have to plumb the right things to the debugger.
