### PR TITLE
plugin_dev: Do not pass host IntelliJ's vmOptionsFile to guest IJ instance

### DIFF
--- a/plugin_dev/src/com/google/idea/blaze/plugin/run/BlazeIntellijPluginConfigurationType.java
+++ b/plugin_dev/src/com/google/idea/blaze/plugin/run/BlazeIntellijPluginConfigurationType.java
@@ -178,11 +178,6 @@ public class BlazeIntellijPluginConfigurationType implements ConfigurationType {
               .splitToStream(vmoptionsText)
               .filter(opt -> !opt.startsWith("#"))
               .collect(toCollection(ArrayList::new));
-
-      String vmoptionsFile = System.getProperty("jb.vmOptionsFile");
-      if (vmoptionsFile != null) {
-        vmoptions.add("-Djb.vmOptionsFile=" + vmoptionsFile);
-      }
       vmoptions.add("-Didea.is.internal=true");
 
       return ParametersListUtil.join(vmoptions);


### PR DESCRIPTION
It could cause crashes for non-IJ IDEs, as well as was causing interference between host and guest instance settings.

closes #4802

# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

