### PR TITLE
Merge IntellijWithPluginClasspathHelper from google branch

### DIFF
--- a/plugin_dev/src/com/google/idea/blaze/plugin/run/IntellijWithPluginClasspathHelper.java
+++ b/plugin_dev/src/com/google/idea/blaze/plugin/run/IntellijWithPluginClasspathHelper.java
@@ -29,13 +29,11 @@ import com.intellij.util.PathsList;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.Reader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
 /**

--- a/plugin_dev/src/com/google/idea/blaze/plugin/run/IntellijWithPluginClasspathHelper.java
+++ b/plugin_dev/src/com/google/idea/blaze/plugin/run/IntellijWithPluginClasspathHelper.java
@@ -35,8 +35,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 
 /**
  * Boilerplate for running an IJ application with an additional plugin, copied from
@@ -44,7 +44,6 @@ import java.util.stream.Stream;
  */
 public class IntellijWithPluginClasspathHelper {
 
-  private static Logger logger = Logger.getInstance(IntellijWithPluginClasspathHelper.class);
   private static final ImmutableList<String> IJ_LIBRARIES =
       ImmutableList.of(
           "log4j.jar",
@@ -59,24 +58,6 @@ public class IntellijWithPluginClasspathHelper {
   private static final ImmutableList<String> IJ_LIBRARIES_AFTER_2022_1 =
       ImmutableList.of("util_rt.jar");
 
-  private static final ImmutableList<String> IJ_LIBRARIES_AFTER_2022_3 =
-      ImmutableList.of(
-          "3rd-party-rt.jar",
-          "app.jar",
-          "xml-dom.jar",
-          "xml-dom-impl.jar",
-          "jps-model.jar",
-          "protobuf.jar",
-          "rd.jar",
-          "stats.jar",
-          "external-system-rt.jar",
-          "forms_rt.jar",
-          "intellij-test-discovery.jar",
-          "annotations.jar",
-          "groovy.jar",
-          "jsp-base.jar"
-      );
-
   private static final ImmutableList<String> ASWB_LIBRARIES_AFTER_2022_3 =
       ImmutableList.of(
           "app.jar",
@@ -86,65 +67,79 @@ public class IntellijWithPluginClasspathHelper {
           "forms_rt.jar",
           "protobuf.jar",
           "stats.jar",
-          "annotations.jar"
-      );
+          "annotations.jar");
 
-  // #api222 remove once we drop support for 2022.2. Newer versions should use product-info.json
+  private static final Logger logger = Logger.getInstance(IntellijWithPluginClasspathHelper.class);
+
   private static void addIntellijLibraries(JavaParameters params, Sdk ideaJdk) {
     String libPath = ideaJdk.getHomePath() + File.separator + "lib";
     PathsList list = params.getClassPath();
-    addLibrariesToList(IJ_LIBRARIES, libPath, list);
-
+    for (String lib : IJ_LIBRARIES) {
+      list.addFirst(libPath + File.separator + lib);
+    }
     String buildNumberStr = IdeaJdkHelper.getBuildNumber(ideaJdk);
     BuildNumber buildNumber = BuildNumber.fromString(buildNumberStr);
     if (buildNumber != null) {
       if (buildNumber.getBaselineVersion() >= 221) {
-        addLibrariesToList(IJ_LIBRARIES_AFTER_2022_1, libPath, list);
+        for (String lib : IJ_LIBRARIES_AFTER_2022_1) {
+          list.addFirst(libPath + File.separator + lib);
+        }
       }
-      if (buildNumber.getBaselineVersion() >= 223) {
-        if (Objects.equals(IdeaJdkHelper.getPlatformPrefix(buildNumberStr),
-                "AndroidStudio")) {
-          addLibrariesToList(ASWB_LIBRARIES_AFTER_2022_3, libPath, list);
-        } else {
-          addLibrariesToList(IJ_LIBRARIES_AFTER_2022_3, libPath, list);
+
+      if (buildNumber.getBaselineVersion() >= 223
+          && Objects.equals(IdeaJdkHelper.getPlatformPrefix(buildNumberStr), "AndroidStudio")) {
+        for (String lib : ASWB_LIBRARIES_AFTER_2022_3) {
+          list.addFirst(libPath + File.separator + lib);
         }
       }
     }
+
     list.addFirst(((JavaSdkType) ideaJdk.getSdkType()).getToolsPath(ideaJdk));
   }
 
-  private static void addIntellijLibrariesFromProductInfoJson(JavaParameters params, Sdk ideaJdk, ProductInfoJson.LaunchInfo launchInfo) {
-    String libPath = ideaJdk.getHomePath() + File.separator + "lib";
-    PathsList list = params.getClassPath();
-    addLibrariesToList(ImmutableList.copyOf(launchInfo.bootClassPathJarNames), libPath, list);
-    list.addFirst(((JavaSdkType) ideaJdk.getSdkType()).getToolsPath(ideaJdk));
+  private static class ProductInfo {
+    List<Launch> launch;
   }
 
-  public static ProductInfoJson getProductInfoJson(Sdk ideaJdk) {
-    Path productJsonPath = findProductInfoJson(ideaJdk);
-    Gson gson = new Gson();
-    try (Reader reader = Files.newBufferedReader(productJsonPath)) {
-      return gson.fromJson(reader, ProductInfoJson.class);
-    } catch (IOException e) {
-      throw new RuntimeException(e);
+  private static class Launch {
+    List<String> additionalJvmArguments;
+    List<String> bootClassPathJarNames;
+    String os;
+    String arch;
+  }
+
+  @Nullable
+  static Launch readLaunchInfo(Sdk ideaJdk) {
+    Path location = Paths.get(ideaJdk.getHomePath());
+    if (SystemInfo.isMac) {
+      location = location.resolve("Resources");
     }
-  }
+    Path info = location.resolve("product-info.json");
+    String os = resolveOsName();
+    String arch = System.getProperty("os.arch");
 
-  private static Path findProductInfoJson(Sdk ideaJdk) {
-    final String PRODUCT_INFO_JSON = "product-info.json";
-    return Stream.of(
-                    Paths.get(ideaJdk.getHomePath(), PRODUCT_INFO_JSON),
-                    Paths.get(ideaJdk.getHomePath(), "Resources", PRODUCT_INFO_JSON)
-            )
-            .filter(p -> p.toFile().exists())
-            .findFirst()
-            .orElseThrow(() -> new RuntimeException("Could not find " + PRODUCT_INFO_JSON + " file in " + ideaJdk.getHomePath()));
-  }
+    if (Files.exists(info)) {
+      try {
+        String json = Files.readString(info);
+        ProductInfo productInfo = new Gson().fromJson(json, ProductInfo.class);
+        if (productInfo == null) {
+          logger.warn("Cannot parse product-info.json");
+          return null;
+        }
+        if (productInfo.launch.isEmpty()) {
+          logger.warn("No launch objects found in product-info.json");
+          return null;
+        }
 
-  private static void addLibrariesToList(ImmutableList<String> ijLibraries, String libPath, PathsList list) {
-    for (String lib : ijLibraries) {
-      list.addFirst(libPath + File.separator + lib);
+        return productInfo.launch.stream()
+                .filter(l -> Objects.equals(l.os, os) && Objects.equals(l.arch, arch))
+                .findFirst()
+                .orElse(null);
+      } catch (IOException e) {
+        logger.error("Error parsing product-info.json", e);
+      }
     }
+    return null;
   }
 
   public static void addRequiredVmParams(
@@ -154,7 +149,7 @@ public class IntellijWithPluginClasspathHelper {
 
     String libPath = ideaJdk.getHomePath() + File.separator + "lib";
     vm.add("-Xbootclasspath/a:" + libPath + File.separator + "boot.jar");
-    
+
     vm.defineProperty("idea.config.path", canonicalSandbox + File.separator + "config");
     vm.defineProperty("idea.system.path", canonicalSandbox + File.separator + "system");
     vm.defineProperty("idea.plugins.path", canonicalSandbox + File.separator + "plugins");
@@ -178,27 +173,28 @@ public class IntellijWithPluginClasspathHelper {
     params.setWorkingDirectory(ideaJdk.getHomePath() + File.separator + "bin" + File.separator);
     params.setJdk(ideaJdk);
 
-    BuildNumber buildNumber = BuildNumber.fromString(IdeaJdkHelper.getBuildNumber(ideaJdk));
-    if(buildNumber != null && buildNumber.getBaselineVersion() > 223) {
-      ProductInfoJson productInfoJson = getProductInfoJson(ideaJdk);
-      String os = resolveOsName();
-      String arch = System.getProperty("os.arch");
-      Optional<ProductInfoJson.LaunchInfo> launchInfo = productInfoJson.launch.stream().filter(l -> Objects.equals(l.os, os) && Objects.equals(l.arch, arch)).findFirst();
-      if(launchInfo.isPresent()) {
-          addIntellijLibrariesFromProductInfoJson(params, ideaJdk, launchInfo.get());
-          for (String productInfoJsonParams : launchInfo.get().additionalJvmArguments) {
-            // same logic as in Gradle Plugin https://github.com/JetBrains/gradle-intellij-plugin/blob/78fb3adbfafa804d08c637edca6e1655caddc539/src/main/kotlin/org/jetbrains/intellij/utils.kt#L108
-            String resolvedParam = productInfoJsonParams
-                    .replace("$APP_PACKAGE", ideaJdk.getHomePath())
-                    .replace("Contents/Contents", "Contents"); //
-            vm.add(resolvedParam);
-          }
-      } else {
-          logger.error(String.format("Could not find 'launch' settings in product-info.json for os:'%s' and arch:'%s'", os, arch));
+    Launch launch = readLaunchInfo(ideaJdk);
+    if (launch != null && launch.bootClassPathJarNames != null) {
+      for (String name : launch.bootClassPathJarNames) {
+        params.getClassPath().add(libPath + File.separator + name);
       }
-    } else { // #api223 Drop together with support for 2022.3
+    } else {
+      // Fall back to known libraries
       addIntellijLibraries(params, ideaJdk);
     }
+
+    String appPackage = Path.of(ideaJdk.getHomePath()).getParent().toString();
+    if (launch != null && launch.additionalJvmArguments != null) {
+      for (String arg : launch.additionalJvmArguments) {
+        arg = arg.replace("$IDE_HOME", ideaJdk.getHomePath());
+        if (SystemInfo.isMac) {
+          // Perform replacements that are done by the mac launcher here
+          arg = arg.replace("$APP_PACKAGE", appPackage);
+        }
+        vm.addAll(arg);
+      }
+    }
+
     params.setMainClass("com.intellij.idea.Main");
   }
 
@@ -207,26 +203,12 @@ public class IntellijWithPluginClasspathHelper {
    */
   private static String resolveOsName() {
     String osName = System.getProperty("os.name");
-    if(Objects.equals(osName, "Linux"))
+    if (Objects.equals(osName, "Linux"))
       return "Linux";
-    if(Objects.equals(osName, "Mac OS X"))
+    if (Objects.equals(osName, "Mac OS X"))
       return "macOS";
-    if(osName.startsWith("Windows"))
+    if (osName.startsWith("Windows"))
       return "Windows";
     throw new RuntimeException("Could not map Java property 'os.name' to product-info.json schema");
   }
-}
-
-
-/**
- * Class used only to deserialize product-info.json, that's why there are public fields.
- */
-class ProductInfoJson {
-  static class LaunchInfo {
-    public List<String> bootClassPathJarNames;
-    public List<String> additionalJvmArguments;
-    public String os;
-    public String arch;
-  }
-  public List<LaunchInfo> launch;
 }


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change
IntellijWithPluginClasspathHelper in the google branch significantly diverged from master branch version. It seems that the changes in both branches were supposed to introduce a new way of obtaining jvm arguments (from product-info.json file). 

This change merges code from `google` branch to `master` branch with one exception - it preservers master's code that handles case when there is more than one entry in `product-info.json`'s  field named `launch`. Google version was just taking the first entry, which was not always correct
