### PR TITLE
Allow optional_xml to depend on more than one plugin

### DIFF
--- a/aswb/BUILD
+++ b/aswb/BUILD
@@ -37,7 +37,7 @@ load(
 
 optional_plugin_xml(
     name = "optional_ndk_xml",
-    module = "com.android.tools.ndk",
+    module = ["com.android.tools.ndk"],
     plugin_xml = "src/META-INF/ndk_contents.xml",
 )
 

--- a/build_defs/intellij_plugin.bzl
+++ b/build_defs/intellij_plugin.bzl
@@ -16,7 +16,7 @@ file.
 optional_plugin_xml(
   name = "optional_python_xml",
   plugin_xml = "my_optional_python_plugin.xml",
-  module = "com.idea.python.module.id",
+  module = ["com.idea.python.module.id"],
 )
 
 intellij_plugin_library(
@@ -62,7 +62,7 @@ optional_plugin_xml = rule(
     implementation = _optional_plugin_xml_impl,
     attrs = {
         "plugin_xml": attr.label(mandatory = True, allow_single_file = [".xml"]),
-        "module": attr.string(mandatory = True),
+        "module": attr.string_list(mandatory = True),
     },
 )
 
@@ -118,6 +118,56 @@ def _merge_plugin_xmls(ctx):
     )
     return merged_file
 
+def _synthetic_plugin_id(modules):
+    return struct(name = "___".join(modules), is_synthetic = len(modules) > 1)
+
+def _synthetic_dep_file(ctx, modules):
+    synthname = ctx.actions.declare_file("synthetic_"+ "_".join(modules[:-1]) + ".xml")
+    file = _filename_for_module_dependency(_synthetic_plugin_id(modules).name)
+    ctx.actions.write(
+        synthname,
+        """
+        <idea-plugin>
+           <depends optional="true" config-file="{0}">{1}</depends>
+        </idea-plugin>
+        """.format (file, modules[-1]))
+    return synthname
+
+"""
+IntelliJ allows plugins to have code that is executed only if a particular external plugin is active. In order to do
+this, one have to create a separate config XML file and include it with <depends optional=true> directive.
+
+Unfortunately, the directive does not cover case when one wants to write code dependent on more than one plugin
+i. e. make it active only if all required plugins are installed and enabled.
+
+A trick to overcome this limitation is to create a synthetic file, which only purpose is to be conditionally activated
+by a `<depends>first_plugin</depends>` directive on the and contain another <depends>second_plugin</depends> directive
+for the second plugin.
+
+Te purpose of `_create_dependency_file_chain` method is to implement this trick. It receives a `_OptionalPluginXmlInfo`
+structure, which contains the xml file and N of its plugin dependencies. Then it creates actions to generate N-1
+.xml files that make up the dependency chain.
+
+It returns a dictionary, which values are the file names (including the original one from the provider), and its keys
+are either module names, or synthetic module names it depends on. If a file is expected to contain a code
+dependent on plugin.A and plugin.B, then its synthetic module name will be `module.A___module.B`.
+
+Once the file is processed through _merge_xml_binary, its content is copied to `optional-module.A___module.B.xml' file.
+This file will be included in `optional-module.A.xml` file via a dependents directive like this:
+```
+<depends optional="true" config-file="optional-module.A___module.B.xml">module.B</depends>
+```
+
+https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html#optional-plugin-dependencies
+"""
+def _create_dependency_file_chain(ctx, xml):
+    module = sorted(xml.module)
+    chained_files_dict = {}
+    for i in range(1, len(module) + 1):
+        synthname = _synthetic_dep_file(ctx, module[:(i+1)]) if i < len(module) else xml.plugin_xml
+        chained_files_dict[_synthetic_plugin_id(module[:i])] = synthname
+    return chained_files_dict
+
 def _merge_optional_plugin_xmls(ctx):
     # Collect optional plugin xmls for both deps and the optional_plugin_xmls attribute
     module_to_xmls = {}
@@ -132,14 +182,15 @@ def _merge_optional_plugin_xmls(ctx):
     )
     for provider in optional_plugin_xml_providers:
         for xml in provider.optional_plugin_xmls:
-            module = xml.module
-            plugin_xmls = module_to_xmls.setdefault(module, [])
-            plugin_xmls.append(xml.plugin_xml)
+            dependency_file_chain = _create_dependency_file_chain(ctx, xml)
+            for module, plugin_xml in dependency_file_chain.items():
+                plugin_xmls = module_to_xmls.setdefault(module, [])
+                plugin_xmls.append(plugin_xml)
 
     # Merge xmls with the same module dependency
     module_to_merged_xmls = {}
     for module, plugin_xmls in module_to_xmls.items():
-        merged_name = "merged_xml_for_" + module + "_" + ctx.label.name + ".xml"
+        merged_name = "merged_xml_for_" + module.name + "_" + ctx.label.name + ".xml"
         merged_file = ctx.actions.declare_file(merged_name)
         ctx.actions.run(
             executable = ctx.executable._merge_xml_binary,
@@ -188,7 +239,7 @@ def _package_meta_inf_files(ctx, final_plugin_xml_file, module_to_merged_xmls):
     args.extend([final_plugin_xml_file.path, "plugin.xml"])
     for module, merged_xml in module_to_merged_xmls.items():
         args.append(merged_xml.path)
-        args.append(_filename_for_module_dependency(module))
+        args.append(_filename_for_module_dependency(module.name))
     for plugin_icon_file in ctx.files.plugin_icons:
         args.append(plugin_icon_file.path)
         args.append(plugin_icon_file.basename)
@@ -219,7 +270,7 @@ _intellij_plugin_java_deps = rule(
 def _intellij_plugin_jar_impl(ctx):
     augmented_xml = _merge_plugin_xmls(ctx)
     module_to_merged_xmls = _merge_optional_plugin_xmls(ctx)
-    final_plugin_xml_file = _add_optional_dependencies_to_plugin_xml(ctx, augmented_xml, module_to_merged_xmls.keys())
+    final_plugin_xml_file = _add_optional_dependencies_to_plugin_xml(ctx, augmented_xml, [k.name for k in module_to_merged_xmls.keys() if not k.is_synthetic])
     jar_file = _package_meta_inf_files(ctx, final_plugin_xml_file, module_to_merged_xmls)
     files = depset([jar_file])
 

--- a/clwb/BUILD
+++ b/clwb/BUILD
@@ -38,7 +38,7 @@ intellij_plugin_library(
 
 optional_plugin_xml(
     name = "optional_clwb_oclang",
-    module = "com.intellij.modules.cidr.lang",
+    module = ["com.intellij.modules.cidr.lang"],
     plugin_xml = "src/META-INF/clwb-oclang.xml",
 )
 

--- a/cpp/BUILD
+++ b/cpp/BUILD
@@ -51,7 +51,7 @@ stamped_plugin_xml(
 
 optional_plugin_xml(
     name = "optional_cidr",
-    module = "com.intellij.modules.cidr.lang",
+    module = ["com.intellij.modules.cidr.lang"],
     plugin_xml = "src/META-INF/blaze-cpp-oclang.xml",
 )
 

--- a/golang/BUILD
+++ b/golang/BUILD
@@ -36,7 +36,7 @@ java_library(
 
 optional_plugin_xml(
     name = "optional_xml",
-    module = "org.jetbrains.plugins.go",
+    module = ["org.jetbrains.plugins.go"],
     plugin_xml = "src/META-INF/go-contents.xml",
 )
 

--- a/ijwb/BUILD
+++ b/ijwb/BUILD
@@ -32,7 +32,7 @@ licenses(["notice"])
 
 optional_plugin_xml(
     name = "optional_java",
-    module = "com.intellij.java",
+    module = ["com.intellij.java"],
     plugin_xml = "src/META-INF/java-contents.xml",
 )
 

--- a/java/BUILD
+++ b/java/BUILD
@@ -82,14 +82,20 @@ stamped_plugin_xml(
 
 optional_plugin_xml(
     name = "optional_java",
-    module = "JUnit",
+    module = ["JUnit"],
     plugin_xml = "src/META-INF/java-contents.xml",
 )
 
 optional_plugin_xml(
     name = "optional_coverage",
-    module = "com.intellij.modules.coverage",
+    module = ["com.intellij.modules.coverage"],
     plugin_xml = "src/META-INF/coverage-contents.xml",
+)
+
+optional_plugin_xml(
+    name = "optional_java_coverage",
+    module = ["com.intellij.modules.coverage", "com.intellij.java"],
+    plugin_xml = "src/META-INF/java-coverage-contents.xml",
 )
 
 intellij_plugin_library(
@@ -97,6 +103,7 @@ intellij_plugin_library(
     optional_plugin_xmls = [
         ":optional_java",
         ":optional_coverage",
+        ":optional_java_coverage",
     ],
     plugin_xmls = ["src/META-INF/blaze-java.xml"],
     visibility = PLUGIN_PACKAGES_VISIBILITY,

--- a/java/src/META-INF/java-coverage-contents.xml
+++ b/java/src/META-INF/java-coverage-contents.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2017 The Bazel Authors. All rights reserved.
+  ~ Copyright 2023 The Bazel Authors. All rights reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -14,12 +14,7 @@
   ~ limitations under the License.
   -->
 <idea-plugin>
-
-  <extensions defaultExtensionNs="com.intellij">
-    <coverageEngine implementation="com.google.idea.blaze.java.run.coverage.BlazeCoverageEngine"/>
-    <coverageRunner implementation="com.google.idea.blaze.java.run.coverage.BlazeCoverageRunner"/>
-    <programRunner implementation="com.google.idea.blaze.java.run.coverage.BlazeCoverageProgramRunner"/>
-    <projectService serviceImplementation="com.google.idea.blaze.java.run.coverage.BlazeCoverageAnnotator"/>
-  </extensions>
-
+    <extensions defaultExtensionNs="com.intellij">
+        <projectViewNodeDecorator implementation="com.google.idea.blaze.java.run.coverage.BlazeCoverageProjectViewClassDecorator"/>
+    </extensions>
 </idea-plugin>

--- a/javascript/BUILD
+++ b/javascript/BUILD
@@ -35,7 +35,7 @@ java_library(
 
 optional_plugin_xml(
     name = "optional_xml",
-    module = "JavaScript",
+    module = ["JavaScript"],
     plugin_xml = "src/META-INF/javascript-contents.xml",
 )
 

--- a/kotlin/BUILD
+++ b/kotlin/BUILD
@@ -43,7 +43,7 @@ java_library(
 
 optional_plugin_xml(
     name = "optional_xml",
-    module = "org.jetbrains.kotlin",
+    module = ["org.jetbrains.kotlin"],
     plugin_xml = "src/META-INF/kotlin-contents.xml",
 )
 

--- a/plugin_dev/BUILD
+++ b/plugin_dev/BUILD
@@ -36,7 +36,7 @@ java_library(
 
 optional_plugin_xml(
     name = "optional_xml",
-    module = "DevKit",
+    module = ["DevKit"],
     plugin_xml = "src/META-INF/blaze-plugin-dev.xml",
 )
 

--- a/python/BUILD
+++ b/python/BUILD
@@ -35,7 +35,7 @@ java_library(
 
 optional_plugin_xml(
     name = "optional_xml",
-    module = "com.intellij.modules.python",
+    module = ["com.intellij.modules.python"],
     plugin_xml = "src/META-INF/python-contents.xml",
 )
 

--- a/scala/BUILD
+++ b/scala/BUILD
@@ -33,7 +33,7 @@ java_library(
 
 optional_plugin_xml(
     name = "optional_xml",
-    module = "org.intellij.scala",
+    module = ["org.intellij.scala"],
     plugin_xml = "src/META-INF/scala-contents.xml",
 )
 

--- a/terminal/BUILD
+++ b/terminal/BUILD
@@ -23,7 +23,7 @@ java_library(
 
 optional_plugin_xml(
     name = "optional_xml",
-    module = "org.jetbrains.plugins.terminal",
+    module = ["org.jetbrains.plugins.terminal"],
     plugin_xml = "src/META-INF/terminal-contents.xml",
 )
 


### PR DESCRIPTION
fixes #2053
Description in `build_defs/intellij_plugin.bzl`

# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

