### PR TITLE
Fix path separator in run configuration generator

### DIFF
--- a/base/src/com/google/idea/blaze/base/model/primitives/WorkspacePath.java
+++ b/base/src/com/google/idea/blaze/base/model/primitives/WorkspacePath.java
@@ -16,6 +16,8 @@
 package com.google.idea.blaze.base.model.primitives;
 
 import com.google.idea.blaze.base.ideinfo.ProtoWrapper;
+import com.intellij.openapi.util.SystemInfo;
+
 import java.io.Serializable;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -50,12 +52,17 @@ public class WorkspacePath implements ProtoWrapper<String>, Serializable {
    * @throws IllegalArgumentException if the path is invalid
    */
   public WorkspacePath(String relativePath) {
-    String error = validate(relativePath);
+    String normalizedRelativePath = normalizePathSeparator(relativePath);
+    String error = validate(normalizedRelativePath);
     if (error != null) {
       throw new IllegalArgumentException(
           String.format("Invalid workspace path '%s': %s", relativePath, error));
     }
-    this.relativePath = relativePath;
+    this.relativePath = normalizedRelativePath;
+  }
+
+  private static String normalizePathSeparator(String relativePath) {
+    return SystemInfo.isWindows ? relativePath.replace('\\', BLAZE_COMPONENT_SEPARATOR) : relativePath;
   }
 
   public WorkspacePath(WorkspacePath parentPath, String childPath) {


### PR DESCRIPTION
closes #3380

# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #3380 

# Description of this change
Fix path separator in run configuration generator
