### PR TITLE
Bump GTest veresion in example project

### DIFF
--- a/examples/cpp/simple_project/.bazelrc
+++ b/examples/cpp/simple_project/.bazelrc
@@ -1,0 +1,1 @@
+build --cxxopt=--std=c++17

--- a/examples/cpp/simple_project/WORKSPACE
+++ b/examples/cpp/simple_project/WORKSPACE
@@ -2,7 +2,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "com_google_googletest",
-    sha256 = "ab78fa3f912d44d38b785ec011a25f26512aaedc5291f51f3807c592b506d33a",
-    strip_prefix = "googletest-58d77fa8070e8cec2dc1ed015d66b454c8d78850",
-    urls = ["https://github.com/google/googletest/archive/58d77fa8070e8cec2dc1ed015d66b454c8d78850.zip"],
+    sha256 = "ffa17fbc5953900994e2deec164bb8949879ea09b411e07f215bfbb1f87f4632",
+    strip_prefix = "googletest-1.13.0",
+    urls = ["https://github.com/google/googletest/archive/refs/tags/v1.13.0.zip"]
 )


### PR DESCRIPTION
New GTest requires c++ version 14 or newer

# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

