### PR TITLE
Add associates to dep attributes

### DIFF
--- a/aspect/intellij_info_impl.bzl
+++ b/aspect/intellij_info_impl.bzl
@@ -42,6 +42,7 @@ DEPS = [
     "instruments",  # android_instrumentation_test
     "tests",  # From test_suite
     "compilers",  # From go_proto_library
+    "associates",  # From kotlin rules
 ]
 
 # Run-time dependency attributes, grouped by type.


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: https://github.com/bazelbuild/intellij/issues/4914

# Description of this change

Add `associates` as a known dep-like attribute to the aspect. This fixes the simple reproducing example from the issue and works on our internal repository.
