### PR TITLE
doc: Do not recommend to manually set jdk17 vm options

### DIFF
--- a/DEV_IDE_SETUP.md
+++ b/DEV_IDE_SETUP.md
@@ -35,7 +35,3 @@ Once the project is imported, create a new Run configuration: `Run -> Edit Confi
 Click the `+` sign, and create a new `Bazel IntelliJ Plugin` run configuration.
 Configure the `Plugin SDK` field to use the SDK you've just installed.
 
-### If Using JDK17
-
-You'll need to add some additional flags to the VM Options to open the required modules.
-You can find an up to date list in [the JetBrains/intellij-community repository](https://raw.githubusercontent.com/JetBrains/intellij-community/master/plugins/devkit/devkit-core/src/run/OpenedPackages.txt)


### PR DESCRIPTION
They are now set automatically via product-info.json

https://github.com/bazelbuild/intellij/pull/4408

# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

