### PR TITLE
fix(cpp): Only register Xcode settings provider on macOS

### DIFF
--- a/cpp/src/META-INF/blaze-cpp.xml
+++ b/cpp/src/META-INF/blaze-cpp.xml
@@ -46,8 +46,18 @@
   </extensions>
   <extensions defaultExtensionNs="com.intellij">
     <projectService serviceImplementation="com.google.idea.blaze.cpp.BlazeCompilerInfoMapService"/>
+    <!-- It may look like we're registering the same service twice, but this is intentional.
+     In non-macOS systems, we don't want to return any Xcode compiler settings.
+     Therefore, we register a service that returns nothing.
+     We override this registration on macOS systems later. -->
     <projectService serviceInterface="com.google.idea.blaze.cpp.XcodeCompilerSettingsProvider"
-                    serviceImplementation="com.google.idea.blaze.cpp.XcodeCompilerSettingsProviderImpl"/>
+      serviceImplementation="com.google.idea.blaze.cpp.XcodeCompilerSettingsProviderNoopImpl"
+    />
+    <projectService serviceInterface="com.google.idea.blaze.cpp.XcodeCompilerSettingsProvider"
+                    serviceImplementation="com.google.idea.blaze.cpp.XcodeCompilerSettingsProviderImpl"
+                    os="mac"
+                    overrides="true"
+    />
     <registryKey defaultValue="false" description="Disable absolute path trimming in debug clang builds" key="bazel.trim.absolute.path.disabled"/>
     <applicationService serviceInterface="com.google.idea.blaze.cpp.CompilerVersionChecker"
                         serviceImplementation="com.google.idea.blaze.cpp.CompilerVersionCheckerImpl"/>

--- a/cpp/src/com/google/idea/blaze/cpp/XcodeCompilerSettingsProviderNoopImpl.java
+++ b/cpp/src/com/google/idea/blaze/cpp/XcodeCompilerSettingsProviderNoopImpl.java
@@ -1,0 +1,20 @@
+package com.google.idea.blaze.cpp;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.idea.blaze.base.scope.BlazeContext;
+import com.intellij.openapi.project.Project;
+import java.util.Optional;
+
+/**
+ * Empty implementation of the {@link XcodeCompilerSettingsProvider}, to use in OSes other than
+ * macOS.
+ * Always returns an empty setting, since Xcode doesn't make sense outside of macOS.
+ */
+public class XcodeCompilerSettingsProviderNoopImpl implements XcodeCompilerSettingsProvider {
+
+  @Override
+  public Optional<XcodeCompilerSettings> fromContext(BlazeContext context, Project project)
+      throws XcodeCompilerSettingsException {
+    return Optional.empty();
+  }
+}


### PR DESCRIPTION
# Checklist

- [X] I have filed an issue about this change and discussed potential changes with the maintainers.
- [X] I have received the approval from the maintainers to make this change.
- [X] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #4971, #4965

# Description of this change

Register a noop provider for Xcode settings. This will run on every OS and not even try to fetch the Xcode information. In macOS, we override that registration with the existing Xcode settings provider.

Tested on `examples/cpp/simple_project` in CLion 2023.1.2 running in Ubuntu. The project fails to sync in `2023.05.30.0.1-api-version-231`, but syncs correctly after this change.