### PR TITLE
fix(clion): Handle (possibly broken) CommandLineTools installations

### DIFF
--- a/cpp/src/com/google/idea/blaze/cpp/BlazeConfigurationToolchainResolver.java
+++ b/cpp/src/com/google/idea/blaze/cpp/BlazeConfigurationToolchainResolver.java
@@ -377,7 +377,9 @@ public final class BlazeConfigurationToolchainResolver {
           try {
             return XcodeCompilerSettingsProvider.getInstance(project).fromContext(context, project);
           } catch (XcodeCompilerSettingsException e) {
-            IssueOutput.warn(String.format("There was an error fetching the Xcode information from the build: %s\n\nSome C++ functionality may not be available.", e.toString()));
+            IssueOutput.warn(
+                String.format("There was an error fetching the Xcode information from the build: %s\n\nSome C++ functionality may not be available.", e.toString())
+            ).submit(childContext);
             return Optional.empty();
           }
         });


### PR DESCRIPTION
# Checklist

- [X] I have filed an issue about this change and discussed potential changes with the maintainers.
- [X] I have received the approval from the maintainers to make this change.
- [X] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: https://github.com/bazelbuild/intellij/issues/5006

# Description of this change

We add support for CommandLineTools. If Bazel selects these, it will return "None" in the Xcode version of the query.

Tested with the following setups:
- Neither Xcode nor CommandLineTools installed: Either Bazel fails to start, or ([if Bazel had a mis-cached state and thinks that you have a working xcode](https://github.com/bazelbuild/bazel/issues/3041#issuecomment-1451727802)):
<img width="1234" alt="Screenshot 2023-06-21 at 14 24 27" src="https://github.com/bazelbuild/intellij/assets/5861182/8e957b47-21e9-493c-913e-d95e2ef06608">

- A broken CommandLineTools installation (an installation without a working `clang`): 
<img width="423" alt="Screenshot 2023-06-21 at 15 17 16" src="https://github.com/bazelbuild/intellij/assets/5861182/28c5845a-6a5d-4284-82c7-feb34dbde9c5">

- A CommandLineTools installation but no Xcode: It works.
- A working Xcode and a working CommandLineTools installation: Uses whatever Bazel uses, most likely the Xcode installation.
