### PR TITLE
Open project view file after auto import of project

### DIFF
--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -185,6 +185,7 @@
     <postStartupActivity implementation="com.google.idea.blaze.base.project.DisableAndroidFrameworkActivity"/>
     <postStartupActivity implementation="com.google.idea.blaze.base.formatter.ExternalFormatterCodeStyleManager$Installer"/>
     <postStartupActivity implementation="com.google.idea.blaze.base.prefetch.PrefetchProjectInitializer" />
+    <postStartupActivity implementation="com.google.idea.blaze.base.project.OpenProjectViewStartupActivity"/>
 
 
     <toolWindow id="Blaze"
@@ -325,6 +326,9 @@
     <actionConfigurationCustomizer implementation="com.google.idea.blaze.base.plugin.BlazeHideMakeActions"/>
     <notificationGroup displayType="BALLOON" id="BuildifierBinaryMissing"/>
     <registryKey defaultValue="false" description="Disable auto import of bazel projects" key="bazel.auto.import.disabled"/>
+    <registryKey defaultValue="true"
+                 description="Enables opening the project view file the first time the project is imported"
+                 key="blaze.project.import.open_project_view"/>
   </extensions>
 
   <extensions defaultExtensionNs="com.intellij">

--- a/base/src/com/google/idea/blaze/base/project/AutoImportProjectOpenProcessor.java
+++ b/base/src/com/google/idea/blaze/base/project/AutoImportProjectOpenProcessor.java
@@ -30,6 +30,7 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.project.ex.ProjectManagerEx;
+import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.registry.Registry;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -58,6 +59,8 @@ import org.jetbrains.annotations.Nullable;
  * Must be loaded after {@link BlazeProjectOpenProcessor} to only import new projects.
  */
 public class AutoImportProjectOpenProcessor extends ProjectOpenProcessor {
+
+  static final Key<Boolean> PROJECT_AUTO_IMPORTED = Key.create("blaze.project.auto_imported");
 
   private static final Logger LOG = Logger.getInstance(AutoImportProjectOpenProcessor.class);
 
@@ -120,6 +123,7 @@ public class AutoImportProjectOpenProcessor extends ProjectOpenProcessor {
                     BaseSdkCompat.createOpenProjectTask(newProject)
             );
     SaveAndSyncHandler.getInstance().scheduleProjectSave(newProject);
+    newProject.putUserData(PROJECT_AUTO_IMPORTED, true);
     return newProject;
   }
 

--- a/base/src/com/google/idea/blaze/base/project/OpenProjectViewStartupActivity.java
+++ b/base/src/com/google/idea/blaze/base/project/OpenProjectViewStartupActivity.java
@@ -1,0 +1,21 @@
+package com.google.idea.blaze.base.project;
+
+import com.google.idea.blaze.base.settings.ui.OpenProjectViewAction;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.startup.StartupActivity;
+import com.intellij.openapi.util.registry.Registry;
+import org.jetbrains.annotations.NotNull;
+
+public class OpenProjectViewStartupActivity implements StartupActivity, DumbAware {
+    @Override
+    public void runActivity(@NotNull Project project) {
+        if (Boolean.TRUE.equals(project.getUserData(AutoImportProjectOpenProcessor.PROJECT_AUTO_IMPORTED)) &&
+                Registry.is("blaze.project.import.open_project_view")) {
+            ApplicationManager.getApplication().invokeLater(() -> {
+                OpenProjectViewAction.openLocalProjectViewFile(project);
+            });
+        }
+    }
+}


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

The change here is to open the project view file the first time the project is open if the auto import processor imported the project. The idea here is to provide a quick way for the user to customize the project since they did not go through the wizard. 
