### PR TITLE
Select source roots for library jars that have interim folders like `…

### DIFF
--- a/base/src/com/google/idea/blaze/base/sync/libraries/LibraryModifier.java
+++ b/base/src/com/google/idea/blaze/base/sync/libraries/LibraryModifier.java
@@ -20,15 +20,20 @@ import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.LibraryFilesProvider;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.externalSystem.service.project.IdeModifiableModelsProvider;
+import com.intellij.openapi.progress.EmptyProgressIndicator;
 import com.intellij.openapi.roots.OrderRootType;
 import com.intellij.openapi.roots.libraries.Library;
 import com.intellij.openapi.roots.libraries.Library.ModifiableModel;
+import com.intellij.openapi.roots.ui.configuration.JavaVfsSourceRootDetectionUtil;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.io.FileUtilRt;
 import com.intellij.openapi.vfs.StandardFileSystems;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.VirtualFileManager;
 import com.intellij.util.io.URLUtil;
 import java.io.File;
+import java.util.Collections;
+import java.util.List;
 
 /** Modifies {@link Library} content in {@link Library.ModifiableModel}. */
 public class LibraryModifier {
@@ -73,7 +78,20 @@ public class LibraryModifier {
       logger.warn("No local file found for " + file);
       return;
     }
-    modifiableModel.addRoot(pathToUrl(file), orderRootType);
+    if (orderRootType == OrderRootType.SOURCES) {
+      VirtualFile jarfile = VirtualFileManager.getInstance().findFileByUrl(pathToUrl(file));
+      List<VirtualFile> candidates = Collections.emptyList();
+      if (jarfile != null) {
+        candidates = JavaVfsSourceRootDetectionUtil.suggestRoots(jarfile, new EmptyProgressIndicator());
+      }
+      if (candidates.size() == 1) {
+        modifiableModel.addRoot(candidates.get(0), orderRootType);
+      } else {
+        modifiableModel.addRoot(pathToUrl(file), orderRootType);
+      }
+    } else {
+      modifiableModel.addRoot(pathToUrl(file), orderRootType);
+    }
   }
 
   private String pathToUrl(File path) {


### PR DESCRIPTION
…/src/...`. IJ UI logic is reused and suggested candidate selected if and only if there is one candidate exists.

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

