### PR TITLE
Automatically assign issues to triage team and add "type" labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,10 @@
 name: Bug Report
 description: File a bug report
+labels: ["type: bug", "awaiting-maintainer"]
+assignees:
+  - pavank1992
+  - sgowroji
+  - iancha1992
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,10 @@
 name: Feature Request
 description: Suggest a new feature
+labels: ["type: feature request", "awaiting-maintainer"]
+assignees:
+  - pavank1992
+  - sgowroji
+  - iancha1992
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
This PR is to automatically assign issues to the triage team and add "type" labels.
Once the triage team takes a look and adds other labels/assignees as appropriate, they will unassign themselves, similar to the process for the main Bazel repository.
