### PR TITLE
Make the default projectview empty during autoimport and add some com…

### DIFF
--- a/base/src/com/google/idea/blaze/base/project/AutoImportProjectOpenProcessor.java
+++ b/base/src/com/google/idea/blaze/base/project/AutoImportProjectOpenProcessor.java
@@ -196,22 +196,21 @@ public class AutoImportProjectOpenProcessor extends ProjectOpenProcessor {
 
   private ProjectView defaultEmptyProjectView() {
     Builder projectViewBuilder = ProjectView.builder();
-
-    projectViewBuilder.add(
-        ListSection
-            .builder(DirectorySection.KEY)
-            .add(DirectoryEntry.include(new WorkspacePath(".")))
-            .build()
-    );
-
-    projectViewBuilder.add(TextBlockSection.of(TextBlock.newLine()));
-
-    projectViewBuilder.add(
-        ScalarSection
-            .builder(AutomaticallyDeriveTargetsSection.KEY)
-            .set(false)
-            .build()
-    );
+    projectViewBuilder.add(TextBlockSection.of(TextBlock.of(
+            "# This is a projectview file generated automatically during bazel project auto-import ",
+            "# For more documentation, please visit https://ij.bazel.build/docs/project-views.html",
+            "# If your repository contains predefined .projectview files, you use 'import' directive to include them.",
+            "# Otherwise, please specify 'directories' and 'targets' you want to be imported",
+            "# ",
+            "# By default we keep your 'directories' and 'targets' sections empty, so nothing is imported.",
+            "# Please uncomment them and put the correct data there, and then run 'Sync' again" ,
+            "",
+            "# directories: ",
+            "#  <your directory here>",
+            "# targets: ",
+            "#  <your directory here>",
+            ""
+    )));
 
     return projectViewBuilder.build();
   }


### PR DESCRIPTION
…ments there

The difference between autoimport and regular import is that, during autoimport the user has no chance to edit the project view file before the import actually happens. Hence, if a repository is large, the current default "directory" value (".") caused the whole repository to be traversed.

This means the user sometimes has to wait a long time only to reduce the import scope. It would be better to import nothing by default and let the users choose what they want to import.

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

