### PR TITLE
Fix references for repo-relative labels in external workspaces

### DIFF
--- a/base/src/com/google/idea/blaze/base/lang/buildfile/references/LabelUtils.java
+++ b/base/src/com/google/idea/blaze/base/lang/buildfile/references/LabelUtils.java
@@ -82,6 +82,17 @@ public class LabelUtils {
     }
     int colonIndex = labelString.indexOf(':');
     if (isAbsolute(labelString)) {
+      if (labelString.startsWith("//") && blazePackage != null) {
+        // Labels of the form //packagePath:packageRelativeTarget inside an external workspace need
+        // to be resolved within that workspace.
+        Label originLabel = blazePackage.getPackageLabel();
+        if (originLabel != null) {
+          String originWorkspace = originLabel.externalWorkspaceName();
+          if (originWorkspace != null) {
+            labelString = "@" + originWorkspace + labelString;
+          }
+        }
+      }
       if (colonIndex != -1) {
         return Label.createIfValid(labelString);
       }


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #4310

# Description of this change

`load`s of non-repo-absolute labels in external workspace are now resolved correctly.

