### PR TITLE
Do not suggest to add `.ijwb` and others to project view.

### DIFF
--- a/base/src/com/google/idea/blaze/base/dependencies/ExternalFileProjectManagementHelper.java
+++ b/base/src/com/google/idea/blaze/base/dependencies/ExternalFileProjectManagementHelper.java
@@ -33,6 +33,7 @@ import com.google.idea.blaze.base.settings.ui.BlazeUserSettingsConfigurable;
 import com.google.idea.blaze.base.sync.SyncListener;
 import com.google.idea.blaze.base.sync.SyncMode;
 import com.google.idea.blaze.base.sync.SyncResult;
+import com.google.idea.blaze.base.sync.data.BlazeDataStorage;
 import com.google.idea.blaze.base.sync.projectview.LanguageSupport;
 import com.google.idea.common.experiments.BoolExperiment;
 import com.intellij.ide.actions.ShowSettingsUtilImpl;
@@ -124,7 +125,10 @@ public class ExternalFileProjectManagementHelper
     }
     boolean inProjectDirectories = AddSourceToProjectHelper.sourceInProjectDirectories(context);
     boolean alreadyBuilt = AddSourceToProjectHelper.sourceCoveredByProjectViewTargets(context);
-    if (alreadyBuilt && inProjectDirectories) {
+    // We do not want to add `/.ijwb` to the project view since it has no BUILD files
+    // This helps to avoid `ERROR: Skipping '//.ijwb/...:all': no targets found beneath '.ijwb'`
+    if (context.file.getPath().contains(String.format("/%s/", BlazeDataStorage.PROJECT_DATA_SUBDIRECTORY))
+            || (alreadyBuilt && inProjectDirectories)) {
       return null;
     }
 


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

The following suggestion doesn't make much sense 
<img width="1355" alt="image" src="https://github.com/bazelbuild/intellij/assets/50216138/ac1d52f5-d8d0-48ed-a020-c7b54b211ba7">
since it results in 
```
(14:21:46) Loading: 
(14:21:46) Loading: 
(14:21:46) Loading: 0 packages loaded
(14:21:46) ERROR: Skipping '//.ijwb/...:all': no targets found beneath '.ijwb'
(14:21:46) WARNING: Target pattern parsing failed.
(14:21:46) Analyzing: 0 targets (0 packages loaded, 0 targets configured)
(14:21:46) INFO: Analyzed 0 targets (0 packages loaded, 0 targets configured).
(14:21:46) INFO: Found 0 targets...
(14:21:47) [0 / 1] [Prepa] BazelWorkspaceStatusAction stable-status.txt
(14:21:47) ERROR: command succeeded, but there were errors parsing the target pattern
(14:21:47) INFO: Elapsed time: 3.584s, Critical Path: 0.00s
```
Issue number: `<please reference the issue number or url here>`

# Description of this change
Condition added to not render the suggestion to add a file to the project if the file is located somewhere in `.ijwb` or in a similar folder for other products.
