### PR TITLE
Fix detecting custom test_suite macros

### DIFF
--- a/base/src/com/google/idea/blaze/base/model/primitives/Kind.java
+++ b/base/src/com/google/idea/blaze/base/model/primitives/Kind.java
@@ -201,6 +201,6 @@ public abstract class Kind {
 
   private static boolean isTestSuite(String ruleName) {
     // handle plain test_suite targets and macros producing a test/test_suite
-    return "test_suite".equals(ruleName) || ruleName.endsWith("test_suites");
+    return ruleName.endsWith("test_suite") || ruleName.endsWith("test_suites");
   }
 }


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #5183 

# Description of this change

Update the heuristic for detecting test_suites to check if a rule ends in `"test_suite"`.