### PR TITLE
Remove javacopt from bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,5 @@
-build --java_language_version=17 --javacopt=-source --javacopt=8 --javacopt=-target --javacopt=8
-test  --java_language_version=17 --javacopt=-source --javacopt=8 --javacopt=-target --javacopt=8 --java_runtime_version=17
+build --java_language_version=17 
+test  --java_language_version=17 --java_runtime_version=17
 
 # delete testdata package needed for bazel integration tests
 build --deleted_packages=//aspect/testing/tests/src/com/google/idea/blaze/aspect/integration/testdata


### PR DESCRIPTION
We have some usage ([example](https://github.com/bazelbuild/intellij/blame/53cf0680dab7ea2dac3c1589ac69b268d596aee3/aswb/sdkcompat/asdev/com/android/tools/idea/run/tasks/DeployTasksCompat.java#L38)) of Java features which are not compatible with Java8, yet we still specify java 8 for both `source` and `target` javac options in the bazelrc.

Unless specified to override those, the build is failing:
```
bazel build //aswb:aswb_bazel_zip --define=ij_product=android-studio-canary
...
...
aswb/sdkcompat/as231/com/google/idea/blaze/android/run/runner/BlazeAndroidDebuggerService.java:132: error: private interface methods are not supported in -source 8
  private static boolean isNdkPluginLoaded() {
                                          ^
  (use -source 9 or higher to enable private interface methods)
```