### PR TITLE
Fix typo - allow_manual_tags_sync should be allow_manual_targets_sync

### DIFF
--- a/base/src/com/google/idea/blaze/base/projectview/section/sections/SyncManualTargetsSection.java
+++ b/base/src/com/google/idea/blaze/base/projectview/section/sections/SyncManualTargetsSection.java
@@ -49,8 +49,8 @@ public class SyncManualTargetsSection {
         return false;
       }
       parseContext.addError(
-          "'allow_manual_tags_sync' must be set to 'true' or 'false' (e.g."
-              + " 'allow_manual_tags_sync: true')");
+          "'allow_manual_targets_sync' must be set to 'true' or 'false' (e.g."
+              + " 'allow_manual_targets_sync: true')");
       return null;
     }
 


### PR DESCRIPTION
# Checklist

- [X] I have filed an issue about this change and discussed potential changes with the maintainers.
- [X] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

