### PR TITLE
Support embedded `go_source` rule type in `go_test` and `go_library` rules

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -38,6 +38,6 @@ awaiting-review:
 
 'product: GoLand':
 - base/**/*
-- examples/go/with_proto/**/*
+- examples/go/**/*
 - gazelle/**/*
 - golang/**/*

--- a/examples/go/with_go_source/BUILD.bazel
+++ b/examples/go/with_go_source/BUILD.bazel
@@ -1,0 +1,4 @@
+load("@bazel_gazelle//:def.bzl", "gazelle")
+
+# gazelle:prefix github.com/bazelbuild/intellij/examples/go/with_go_source
+gazelle(name = "gazelle")

--- a/examples/go/with_go_source/WORKSPACE
+++ b/examples/go/with_go_source/WORKSPACE
@@ -1,0 +1,36 @@
+workspace(name = "bazel-playground")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "io_bazel_rules_go",
+    sha256 = "278b7ff5a826f3dc10f04feaf0b70d48b68748ccd512d7f98bf442077f043fe3",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip",
+    ],
+)
+
+http_archive(
+    name = "bazel_gazelle",
+    sha256 = "29218f8e0cebe583643cbf93cae6f971be8a2484cdcfa1e45057658df8d54002",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.32.0/bazel-gazelle-v0.32.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.32.0/bazel-gazelle-v0.32.0.tar.gz",
+    ],
+)
+
+load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk", "go_register_toolchains", "go_rules_dependencies")
+
+go_download_sdk(
+    name = "go_sdk",
+    version = "1.21.0",
+)
+
+go_rules_dependencies()
+
+go_register_toolchains()
+
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+
+gazelle_dependencies()

--- a/examples/go/with_go_source/otherlib/BUILD.bazel
+++ b/examples/go/with_go_source/otherlib/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+package(default_visibility = ["//:__subpackages__"])
+
+go_library(
+    name = "otherlib",
+    srcs = ["otherlib.go"],
+    importpath = "github.com/bazelbuild/intellij/examples/go/with_go_source/otherlib",
+)

--- a/examples/go/with_go_source/otherlib/otherlib.go
+++ b/examples/go/with_go_source/otherlib/otherlib.go
@@ -1,0 +1,3 @@
+package otherlib
+
+func Foo() {}

--- a/examples/go/with_go_source/testa/BUILD.bazel
+++ b/examples/go/with_go_source/testa/BUILD.bazel
@@ -1,0 +1,42 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_source")
+
+package(default_visibility = ["//:__subpackages__"])
+
+genrule(
+    name = "gen",
+    outs = ["gen.go"],
+    cmd = """
+cat <<EOF > "$@"
+package testa
+
+import (
+	"github.com/bazelbuild/intellij/examples/go/with_go_source/otherlib"
+)
+
+func FromGeneratedFile() {
+	otherlib.Foo()
+}
+EOF
+""",
+)
+
+go_source(
+    name = "srcs",
+    srcs = [
+        "src.go",  # A Go source file for package testa
+        ":gen",  # A generated Go file for package testa
+    ],
+    deps = ["//otherlib"],  # A simple Go library dependency
+)
+
+#
+# Test with a Go library embedding our `go_source` rule target.
+#
+
+go_library(
+    name = "testa",
+    srcs = ["testa.go"],  # keep
+    embed = [":srcs"],  # keep
+    importpath = "github.com/bazelbuild/intellij/examples/go/with_go_source/testa",
+    deps = [],  # keep
+)

--- a/examples/go/with_go_source/testa/src.go
+++ b/examples/go/with_go_source/testa/src.go
@@ -1,0 +1,9 @@
+package testa
+
+import (
+	"github.com/bazelbuild/intellij/examples/go/with_go_source/otherlib"
+)
+
+func FromSourceFile() {
+	otherlib.Foo()
+}

--- a/examples/go/with_go_source/testa/testa.go
+++ b/examples/go/with_go_source/testa/testa.go
@@ -1,0 +1,6 @@
+package testa
+
+func MyFunction() {
+	FromSourceFile()
+	FromGeneratedFile()
+}

--- a/examples/go/with_go_source/testb/BUILD.bazel
+++ b/examples/go/with_go_source/testb/BUILD.bazel
@@ -1,0 +1,51 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_source", "go_test")
+
+package(default_visibility = ["//:__subpackages__"])
+
+genrule(
+    name = "gen",
+    outs = ["gen.go"],
+    cmd = """
+cat <<EOF > "$@"
+package testb
+
+import (
+	"github.com/bazelbuild/intellij/examples/go/with_go_source/otherlib"
+)
+
+func FromGeneratedFile() {
+	otherlib.Foo()
+}
+EOF
+""",
+)
+
+go_source(
+    name = "srcs",
+    srcs = [
+        "src.go",  # A Go source file for package testb
+        ":gen",  # A generated Go file for package testb
+    ],
+    deps = ["//otherlib"],  # A simple Go library dependency
+)
+
+#
+# Test with a Go test embedding our `go_source` rule target +
+#  the default library of the test to infer the importpath.
+#
+
+go_library(
+    name = "testb",
+    srcs = ["testb.go"],  # keep
+    importpath = "github.com/bazelbuild/intellij/examples/go/with_go_source/testb",
+    deps = [],  # keep
+)
+
+go_test(
+    name = "testb_test",
+    srcs = ["testb_test.go"],
+    embed = [
+        ":testb",
+        ":srcs",  # keep
+    ],
+)

--- a/examples/go/with_go_source/testb/src.go
+++ b/examples/go/with_go_source/testb/src.go
@@ -1,0 +1,9 @@
+package testb
+
+import (
+	"github.com/bazelbuild/intellij/examples/go/with_go_source/otherlib"
+)
+
+func FromSourceFile() {
+	otherlib.Foo()
+}

--- a/examples/go/with_go_source/testb/testb.go
+++ b/examples/go/with_go_source/testb/testb.go
@@ -1,0 +1,3 @@
+package testb
+
+func OtherFunction() {}

--- a/examples/go/with_go_source/testb/testb_test.go
+++ b/examples/go/with_go_source/testb/testb_test.go
@@ -1,0 +1,12 @@
+package testb
+
+import (
+	"testing"
+)
+
+func TestB(t *testing.T) {
+	OtherFunction()
+
+	FromSourceFile()
+	FromGeneratedFile()
+}

--- a/examples/go/with_go_source/with_go_source.bazelproject
+++ b/examples/go/with_go_source/with_go_source.bazelproject
@@ -1,0 +1,15 @@
+directories:
+  .
+
+derive_targets_from_directories: true
+
+additional_languages:
+  go
+
+gazelle_target: //:gazelle
+
+import_run_configurations:
+  # Test that validates that macro expansion works, as per issue:
+  #    https://github.com/bazelbuild/intellij/issues/4112#event-7958662669
+  # This configuration should be executed on both 'run' (the green arrow) and 'debug' (the bug) modes.
+  run_configurations/test_macro_expansion.xml

--- a/examples/go/with_proto/with_proto.bazelproject
+++ b/examples/go/with_proto/with_proto.bazelproject
@@ -1,4 +1,3 @@
-
 directories:
   .
 
@@ -8,9 +7,3 @@ additional_languages:
   go
 
 gazelle_target: //:gazelle
-
-import_run_configurations:
-  # Test that validates that macro expansion works, as per issue:
-  #    https://github.com/bazelbuild/intellij/issues/4112#event-7958662669
-  # This configuration should be executed on both 'run' (the green arrow) and 'debug' (the bug) modes.
-  run_configurations/test_macro_expansion.xml


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked.
See the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more details.

# Discussion thread for this change

Issue number: #1265 

# Description of this change

This change mark all source files and generated source files of all embedded `go_source` rules in `go_test` and `go_library` rules as source files.