### PR TITLE
- Allow to suppress automatic Bazel project opening if `.ijwb` or so …

### DIFF
--- a/base/src/com/google/idea/blaze/base/project/AutoImportProjectOpenProcessor.java
+++ b/base/src/com/google/idea/blaze/base/project/AutoImportProjectOpenProcessor.java
@@ -1,16 +1,12 @@
 package com.google.idea.blaze.base.project;
 
-import com.google.idea.blaze.base.model.primitives.WorkspacePath;
+import static com.google.idea.blaze.base.project.BlazeProjectOpenProcessor.getIdeaSubdirectory;
+
 import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
 import com.google.idea.blaze.base.projectview.ProjectView;
 import com.google.idea.blaze.base.projectview.ProjectView.Builder;
 import com.google.idea.blaze.base.projectview.ProjectViewSet;
 import com.google.idea.blaze.base.projectview.parser.ProjectViewParser;
-import com.google.idea.blaze.base.projectview.section.ListSection;
-import com.google.idea.blaze.base.projectview.section.ScalarSection;
-import com.google.idea.blaze.base.projectview.section.sections.AutomaticallyDeriveTargetsSection;
-import com.google.idea.blaze.base.projectview.section.sections.DirectoryEntry;
-import com.google.idea.blaze.base.projectview.section.sections.DirectorySection;
 import com.google.idea.blaze.base.projectview.section.sections.TextBlock;
 import com.google.idea.blaze.base.projectview.section.sections.TextBlockSection;
 import com.google.idea.blaze.base.settings.Blaze;
@@ -24,7 +20,6 @@ import com.google.idea.blaze.base.wizard2.CreateFromScratchProjectViewOption;
 import com.google.idea.blaze.base.wizard2.WorkspaceTypeData;
 import com.google.idea.sdkcompat.general.BaseSdkCompat;
 import com.intellij.ide.SaveAndSyncHandler;
-import com.intellij.ide.impl.OpenProjectTask;
 import com.intellij.ide.impl.ProjectUtil;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
@@ -89,8 +84,10 @@ public class AutoImportProjectOpenProcessor extends ProjectOpenProcessor {
 
   @Override
   public boolean canOpenProject(@NotNull VirtualFile virtualFile) {
+    // Auto import activated only if it is not disabled, there is no existing project model in the folder
+    // and Bazel workspace is detected.
     return !Registry.is("bazel.auto.import.disabled")
-            && isBazelWorkspace(virtualFile);
+            && getIdeaSubdirectory(virtualFile) == null && isBazelWorkspace(virtualFile);
   }
 
   private boolean isBazelWorkspace(VirtualFile virtualFile) {

--- a/base/src/com/google/idea/blaze/base/project/BlazeProjectOpenProcessor.java
+++ b/base/src/com/google/idea/blaze/base/project/BlazeProjectOpenProcessor.java
@@ -19,6 +19,7 @@ import com.google.idea.blaze.base.settings.Blaze;
 import com.google.idea.blaze.base.sync.data.BlazeDataStorage;
 import com.google.idea.sdkcompat.general.BaseSdkCompat;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.registry.Registry;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.projectImport.ProjectOpenProcessor;
 import icons.BlazeIcons;
@@ -42,7 +43,7 @@ public class BlazeProjectOpenProcessor extends ProjectOpenProcessor {
   private static final String DEPRECATED_PROJECT_DATA_SUBDIRECTORY = ".project";
 
   @Nullable
-  private static VirtualFile getIdeaSubdirectory(VirtualFile file) {
+  public static VirtualFile getIdeaSubdirectory(VirtualFile file) {
     VirtualFile projectSubdirectory = file.findChild(BlazeDataStorage.PROJECT_DATA_SUBDIRECTORY);
     if (projectSubdirectory == null || !projectSubdirectory.isDirectory()) {
       projectSubdirectory = file.findChild(DEPRECATED_PROJECT_DATA_SUBDIRECTORY);
@@ -68,7 +69,7 @@ public class BlazeProjectOpenProcessor extends ProjectOpenProcessor {
 
   @Override
   public boolean isStrongProjectInfoHolder() {
-    return true;
+    return Registry.is("bazel.project.auto.open.if.present", true);
   }
 
   @Override


### PR DESCRIPTION
…already exists by setting `bazel.project.auto.open.if.present` to `false`

- Avoid activation of Bazel project auto import if `.ijwb` or other model that corresponds to current Bazel project mode is present.

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change
Currently, if there is `.ijwb` present Bazel plugin instructs IJ to open project and ignore the rest of models. This is happening because the very first `ProjectOpenProcessor#isStrongProjectInfoHolder` is a winner and used to open the project.
Registry key is introduced to have more control over Bazel project opening, and to allow to yield to other project models if they known(to the person who disbled Bazel default behavior) to be present.

Bazel has project openers and there is also a change to not activate auto import if the model already present.


