### PR TITLE
Remove automatic label `product: Android Studio` for PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -14,16 +14,6 @@ awaiting-review:
 - intellij_platform_sdk/BUILD.clion231
 - intellij_platform_sdk/BUILD.clion232
 
-'product: Android Studio':
-- aswb/**/*
-- base/**/*
-- intellij_platform_sdk/BUILD.android_studio213
-- intellij_platform_sdk/BUILD.android_studio221
-- intellij_platform_sdk/BUILD.android_studio222
-- intellij_platform_sdk/BUILD.android_studio223
-- intellij_platform_sdk/BUILD.android_studio231
-- intellij_platform_sdk/BUILD.android_studiodev
-
 'product: IntelliJ':
 - base/**/*
 - examples/java/greetings_project/**/*


### PR DESCRIPTION
Remove automatic label `product: Android Studio` because pull-requests based on the `master` branch will not affect the Android studio plugin as it is released from the `google` branch.

