### PR TITLE
Make bazel run configurations dumbaware

### DIFF
--- a/base/src/com/google/idea/blaze/base/run/BlazeCommandRunConfigurationType.java
+++ b/base/src/com/google/idea/blaze/base/run/BlazeCommandRunConfigurationType.java
@@ -20,19 +20,20 @@ import com.intellij.execution.BeforeRunTask;
 import com.intellij.execution.configurations.ConfigurationFactory;
 import com.intellij.execution.configurations.ConfigurationType;
 import com.intellij.execution.configurations.ConfigurationTypeUtil;
+import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Key;
 import icons.BlazeIcons;
 import javax.swing.Icon;
 
 /** A type for run configurations that execute Blaze commands. */
-public class BlazeCommandRunConfigurationType implements ConfigurationType {
+public class BlazeCommandRunConfigurationType implements ConfigurationType, DumbAware {
 
   private final BlazeCommandRunConfigurationFactory factory =
       new BlazeCommandRunConfigurationFactory(this);
 
   /** A run configuration factory */
-  public static class BlazeCommandRunConfigurationFactory extends ConfigurationFactory {
+  public static class BlazeCommandRunConfigurationFactory extends ConfigurationFactory implements DumbAware {
     private BlazeCommandRunConfigurationFactory(ConfigurationType type) {
       super(type);
     }


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Description of this change

This change makes the Bazel run configurations dumb aware. As far as I can tell,  none of the run configurations use any of the indexes and simply invokes bazel run. Because of this, there is no reason to rely on "smart" mode.