### PR TITLE
Intellijext osx regression

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -467,10 +467,10 @@ http_archive(
 
 http_archive(
     name = "rules_java",
+    sha256 = "7b0d9ba216c821ee8697dedc0f9d0a705959ace462a3885fe9ba0347ba950111",
     urls = [
         "https://github.com/bazelbuild/rules_java/releases/download/6.5.1/rules_java-6.5.1.tar.gz",
     ],
-    sha256 = "7b0d9ba216c821ee8697dedc0f9d0a705959ace462a3885fe9ba0347ba950111",
 )
 
 JUNIT_ARTIFACT = "junit:junit:4.13.2"
@@ -830,6 +830,22 @@ jvm_maven_import_external(
     name = "io_netty_netty_transport_native_epoll",
     artifact = "io.netty:netty-transport-classes-epoll:4.1.96.Final",
     artifact_sha256 = "1591b3ea061932677dc2bab6cb7d82e8f1837a52b3c781f4daa99984ec87a9cd",
+    licenses = ["notice"],  # Apache 2.0
+    server_urls = ["https://repo1.maven.org/maven2"],
+)
+
+jvm_maven_import_external(
+    name = "io_netty_netty_transport_native_kqueue",
+    artifact = "io.netty:netty-transport-native-kqueue:4.1.96.Final",
+    artifact_sha256 = "ccc3c040867d9512607af3639839f686a68d8ff836f304a71aa68c9ec6ef94c3",
+    licenses = ["notice"],  # Apache 2.0
+    server_urls = ["https://repo1.maven.org/maven2"],
+)
+
+jvm_maven_import_external(
+    name = "io_netty_netty_transport_classes_kqueue",
+    artifact = "io.netty:netty-transport-classes-kqueue:4.1.96.Final",
+    artifact_sha256 = "f2f1fab3b297aee20a3922c79b548c8b4b72bb10b635375434c108ee05f29430",
     licenses = ["notice"],  # Apache 2.0
     server_urls = ["https://repo1.maven.org/maven2"],
 )

--- a/ext/BUILD
+++ b/ext/BUILD
@@ -26,9 +26,10 @@ java_library(
         "@io_grpc_grpc_java//netty",
         "@io_netty_netty_common//jar",
         "@io_netty_netty_transport//jar",
+        "@io_netty_netty_transport_classes_kqueue//jar",
         "@io_netty_netty_transport_native_unix_common//jar",
     ] + select({
-        "@platforms//os:macos": ["@io_netty_netty_transport//jar_native_kqueue"],
+        "@platforms//os:macos": ["@io_netty_netty_transport_native_kqueue//jar"],
         "//conditions:default": ["@io_netty_netty_transport_native_epoll//jar"],
     }),
 )
@@ -44,14 +45,15 @@ java_binary(
     deps = [
         "//ext/proto:intellijext_java_grpc",
         "//ext/proto:intellijext_java_proto",
-        "//third_party/java/grpc:stub",
         "@io_grpc_grpc_java//core",
         "@io_grpc_grpc_java//netty",
+        "@io_grpc_grpc_java//stub",
         "@io_netty_netty_common//jar",
         "@io_netty_netty_transport//jar",
+        "@io_netty_netty_transport_classes_kqueue//jar",
         "@io_netty_netty_transport_native_unix_common//jar",
     ] + select({
-        "@platforms//os:macos": ["@io_netty_netty_transport//jar_native_kqueue"],
+        "@platforms//os:macos": ["@io_netty_netty_transport_native_kqueue//jar"],
         "//conditions:default": ["@io_netty_netty_transport_native_epoll//jar"],
     }),
 )
@@ -69,5 +71,6 @@ java_test(
         "@io_grpc_grpc_java//core",
         "@junit//jar",
         "@truth//jar",
+        "@truth8//jar",
     ],
 )

--- a/ext/tests/com/google/idea/blaze/ext/IntelliJExtServiceTest.java
+++ b/ext/tests/com/google/idea/blaze/ext/IntelliJExtServiceTest.java
@@ -16,9 +16,9 @@
 package com.google.idea.blaze.ext;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.common.truth.Truth8.assertThat;
 import static org.junit.Assert.assertThrows;
 
+import com.google.common.truth.Truth8;
 import com.google.idea.blaze.ext.IntelliJExtService.ServiceStatus;
 import io.grpc.StatusRuntimeException;
 import java.nio.file.Paths;
@@ -55,7 +55,7 @@ public class IntelliJExtServiceTest {
     assertThat(service.getVersion()).isEqualTo(TEST_VERSION);
     String pid = service.getStatus().get("pid");
     Optional<ProcessHandle> process = ProcessHandle.of(Integer.parseInt(pid));
-    assertThat(process).isPresent();
+    Truth8.assertThat(process).isPresent();
     process.get().destroyForcibly();
     // Server should restart nicely.
     assertThat(service.getVersion()).isEqualTo(TEST_VERSION);

--- a/ijwb/BUILD
+++ b/ijwb/BUILD
@@ -52,8 +52,8 @@ stamped_plugin_xml(
     plugin_name = "Bazel for IntelliJ",
     # #api212: We depend on an API which is only contained in 2021.2.1+.
     since_build_numbers = {"212": "212.5080.55"},
-    stamp_since_build = False,
-    stamp_until_build = False,
+    stamp_since_build = True,
+    stamp_until_build = True,
     version = VERSION,
 )
 

--- a/ijwb/BUILD
+++ b/ijwb/BUILD
@@ -52,8 +52,8 @@ stamped_plugin_xml(
     plugin_name = "Bazel for IntelliJ",
     # #api212: We depend on an API which is only contained in 2021.2.1+.
     since_build_numbers = {"212": "212.5080.55"},
-    stamp_since_build = True,
-    stamp_until_build = True,
+    stamp_since_build = False,
+    stamp_until_build = False,
     version = VERSION,
 )
 


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

Without this change I see
```
ERROR: /Users/dkashyn/Projects/intellij/ext/BUILD:9:13: no such package '@io_netty_netty_transport//jar_native_kqueue': BUILD file not found in directory 'jar_native_kqueue' of external repository @io_netty_netty_transport. Add a BUILD file to a directory to mark it as a package. and referenced by '//ext:intellijext'
```
and there is no such artifact indeed.