### PR TITLE
Prepare for 2023.3: Do not depend on MacroManager.getInstance()

### DIFF
--- a/base/src/com/google/idea/blaze/base/command/BlazeFlags.java
+++ b/base/src/com/google/idea/blaze/base/command/BlazeFlags.java
@@ -23,11 +23,10 @@ import com.google.idea.blaze.base.projectview.section.sections.BuildFlagsSection
 import com.google.idea.blaze.base.projectview.section.sections.SyncFlagsSection;
 import com.google.idea.blaze.base.projectview.section.sections.TestFlagsSection;
 import com.google.idea.blaze.base.scope.BlazeContext;
-import com.intellij.execution.configurations.ParametersList;
 import com.intellij.execution.util.ProgramParametersConfigurator;
-import com.intellij.ide.macro.MacroManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.util.PlatformUtils;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -124,13 +123,6 @@ public final class BlazeFlags {
 
   /** Expands any macros in the passed build flags. */
   public static List<String> expandBuildFlags(List<String> flags) {
-    // The code below depends on there being a globally registered `MacroManager`.
-    // `MacroManager` is a final class with a private constructor, and therefore it can't be mocked.
-    // We have tests that manipulate flags, but are not interested in exercising this code.
-    // Therefore, we return early in those cases.
-    if (MacroManager.getInstance() == null) {
-      return flags;
-    }
     // This built-in IntelliJ class will do macro expansion using
     // both your environment and your Settings > Behavior > Path Variables
     List<String> expandedFlags = new ArrayList<>();

--- a/base/tests/utils/unit/com/google/idea/blaze/base/BlazeTestCase.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/BlazeTestCase.java
@@ -33,6 +33,7 @@ import com.intellij.openapi.extensions.impl.ExtensionsAreaImpl;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.SystemInfo;
+import com.intellij.openapi.util.registry.Registry;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -94,6 +95,7 @@ public class BlazeTestCase {
 
   @Before
   public final void setup() {
+    Registry.get("allow.macros.for.run.configurations").setValue(false);
     testDisposable = new RootDisposable();
     MockApplication application = TestUtils.createMockApplication(testDisposable);
     MockProject mockProject = TestUtils.mockProject(application.getPicoContainer(), testDisposable);


### PR DESCRIPTION
Probably caused by this change
https://github.com/JetBrains/intellij-community/commit/b3ed61706fbed5e04c88d1ab3f69160246fd87e8#diff-737d7a5e2b283fc8b2a9c7f301e689e29a83629c1a3533053b813570da2e59f4R21

Before that, MacroManager was instantiated only if it was present in LangExtensions.xml (not a thing in Bazel Plugin tests). Now, it is instantiated always, which results in a crash in expandMacros call in tests. Hence, we need a new way to disable macro expansion in tests.

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

