### PR TITLE
Prepare for 2023.3: Use var to handle return type differences

### DIFF
--- a/kotlin/src/com/google/idea/blaze/kotlin/sync/BlazeKotlinSyncPlugin.java
+++ b/kotlin/src/com/google/idea/blaze/kotlin/sync/BlazeKotlinSyncPlugin.java
@@ -64,7 +64,6 @@ import org.jetbrains.kotlin.android.synthetic.AndroidCommandLineProcessor;
 import org.jetbrains.kotlin.cli.common.arguments.CommonCompilerArguments;
 import org.jetbrains.kotlin.cli.common.arguments.K2JVMCompilerArguments;
 import org.jetbrains.kotlin.config.CompilerSettings;
-import org.jetbrains.kotlin.config.KotlinFacetSettings;
 import org.jetbrains.kotlin.config.LanguageVersion;
 import org.jetbrains.kotlin.idea.compiler.configuration.Kotlin2JvmCompilerArgumentsHolder;
 import org.jetbrains.kotlin.idea.compiler.configuration.KotlinCommonCompilerArgumentsHolder;
@@ -273,7 +272,7 @@ public class BlazeKotlinSyncPlugin implements BlazeSyncPlugin {
    * @param newPluginOptions new plugin options to be updated to KotlinFacet settings
    */
   private static void updatePluginOptions(KotlinFacet kotlinFacet, List<String> newPluginOptions) {
-    KotlinFacetSettings facetSettings = kotlinFacet.getConfiguration().getSettings();
+    var facetSettings = kotlinFacet.getConfiguration().getSettings();
     // TODO: Unify this part with {@link
     // org.jetbrains.kotlin.android.sync.ng.KotlinSyncModels#setupKotlinAndroidExtensionAsFacetPluginOptions}?
     CommonCompilerArguments commonArguments = facetSettings.getCompilerArguments();


### PR DESCRIPTION
In 2023.2, kotlinFacet.getConfiguration().getSettings() returns KotlinFacetSetttings, while in 2023.3 it's IKotlinFacetSettings

https://github.com/JetBrains/intellij-community/commit/f0094db89cfcafd03584cb4f78752dc13103cacb

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

