### PR TITLE
Prepare for 2023.3: In ProjectConverterProvider, use methods available in 2023.3

### DIFF
--- a/base/src/com/google/idea/blaze/base/qsync/ProjectConverterProvider.java
+++ b/base/src/com/google/idea/blaze/base/qsync/ProjectConverterProvider.java
@@ -34,7 +34,7 @@ import org.jetbrains.annotations.Nullable;
 public class ProjectConverterProvider extends ConverterProvider {
 
   protected ProjectConverterProvider() {
-    super("query.sync.project.converter");
+    super();
   }
 
   @Override
@@ -73,12 +73,12 @@ public class ProjectConverterProvider extends ConverterProvider {
               throw new CannotConvertException(
                   "The project is created with a newer sync schema that is not supported "
                       + "with the current configuration of the IDE. In order to open this project "
-                      + "switch the IDE to use query sync instead. See: go/query-sync.");
+                      + "switch the IDE to use query sync instead. See: go/query-sync.", null);
             } else {
               throw new CannotConvertException(
                   "The IDE is configured to use query sync, and is not compatible "
                       + "with projects created with the old sync. Please re-create the "
-                      + "project on a new directory. More information: go/query-sync.");
+                      + "project on a new directory. More information: go/query-sync.", null);
             }
           }
         };


### PR DESCRIPTION
ConverterProvider's constructor has been removed here: https://github.com/JetBrains/intellij-community/commit/c62f59ea40010803eeaf9fd56c69210b31a4ba29#diff-b11d7e0a8ed641f0b3f916aa97160bffe4dbcdc144cb944def87da342c372e69L32-L35

CannotConvertException's constructor has been removed here: https://github.com/JetBrains/intellij-community/commit/c62f59ea40010803eeaf9fd56c69210b31a4ba29#diff-597cb52e0b67434962fd7e827bbcb129e3d00d809e913f9155e96512cf518bb1L34

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

