### PR TITLE
Prepare for 2023.3: Don't use JDK_X in tests

### DIFF
--- a/java/tests/integrationtests/com/google/idea/blaze/java/sync/projectstructure/JdksTest.java
+++ b/java/tests/integrationtests/com/google/idea/blaze/java/sync/projectstructure/JdksTest.java
@@ -237,7 +237,7 @@ public class JdksTest extends BlazeIntegrationTestCase {
   @NotNull
   private static LanguageLevelWithPreview getLatestLevelWithPreview() {
     return stream(LanguageLevel.values())
-            .filter(it -> it.getPreviewLevel() != null)
+            .filter(it -> it.getPreviewLevel() != null && !it.getPreviewLevel().name().endsWith("_X"))
             .map(it -> new LanguageLevelWithPreview(it, it.getPreviewLevel()))
             .max(Comparator.comparingInt(it -> it.stableLevel.toJavaVersion().feature))
             .orElseThrow(() -> new RuntimeException("Test can't be run, no preview language levels found in this IntelliJ version"));


### PR DESCRIPTION
Recently, a new special language level X has been introduced to IntelliJ. It's different from the other one, because it's an alway's preview level (there's no non-preview version). Hence, we don't want to run a test that distinguishes preview and non-preview on that particlar level.

https://github.com/JetBrains/intellij-community/commit/89a73e97da2a4f0cb83ac0b535b5da97b246d0eb

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

