### PR TITLE
Disable Bzlmod explicitly in .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -4,3 +4,7 @@ test  --java_language_version=17 --java_runtime_version=17
 # delete testdata package needed for bazel integration tests
 build --deleted_packages=//aspect/testing/tests/src/com/google/idea/blaze/aspect/integration/testdata
 query --deleted_packages=//aspect/testing/tests/src/com/google/idea/blaze/aspect/integration/testdata
+
+# TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
+# https://github.com/bazelbuild/intellij/issues/5432
+common --noenable_bzlmod

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,2 @@
+# TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
+# https://github.com/bazelbuild/intellij/issues/5432


### PR DESCRIPTION
This will help make sure [Bazel Downstream Pipeline](https://github.com/bazelbuild/continuous-integration/blob/master/docs/downstream-testing.md) is green after enabling Bzlmod at Bazel@HEAD

See https://github.com/bazelbuild/bazel/issues/18958#issuecomment-1749058780

Related https://github.com/bazelbuild/intellij/issues/5432
