### PR TITLE
Prepare for 2023.3: Move some tasks to background thread.

### DIFF
--- a/base/src/com/google/idea/blaze/base/projectview/ProjectViewStorageManagerImpl.java
+++ b/base/src/com/google/idea/blaze/base/projectview/ProjectViewStorageManagerImpl.java
@@ -20,7 +20,9 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.CharStreams;
 import com.google.idea.blaze.base.io.InputStreamProvider;
+import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.vfs.LocalFileSystem;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -43,6 +45,12 @@ final class ProjectViewStorageManagerImpl extends ProjectViewStorageManager {
     try (Writer fileWriter = Files.newBufferedWriter(projectViewFile.toPath(), UTF_8)) {
       fileWriter.write(projectViewText);
     }
-    LocalFileSystem.getInstance().refreshIoFiles(ImmutableList.of(projectViewFile));
+
+    ProgressManager.getInstance().runProcessWithProgressSynchronously(
+            () -> LocalFileSystem.getInstance().refreshIoFiles(ImmutableList.of(projectViewFile)),
+            "Updating VFS",
+            false,
+            null
+    );
   }
 }


### PR DESCRIPTION
Since the commit below, FSRecords update operations are forbidden in EDT thread. https://github.com/JetBrains/intellij-community/commit/78f74745498f981d66733bcba315f85cc86c11c6

For this reason, we delegate a few method calls to Background Thread in order to make sure it will not crash. We do it via a synchrounous BGT call, so EDT still stops and waits until the aciton is completed, like it was before this change.

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

