### PR TITLE
Fix manual targets sync for target explicitly specified

### DIFF
--- a/base/src/com/google/idea/blaze/base/sync/SyncProjectTargetsHelper.java
+++ b/base/src/com/google/idea/blaze/base/sync/SyncProjectTargetsHelper.java
@@ -89,7 +89,7 @@ public final class SyncProjectTargetsHelper {
     return viewSet.getScalarValue(AutomaticallyDeriveTargetsSection.KEY).orElse(false);
   }
 
-  private static boolean shouldSyncManualTargets(ProjectViewSet viewSet) {
+  public static boolean shouldSyncManualTargets(ProjectViewSet viewSet) {
     return viewSet.getScalarValue(SyncManualTargetsSection.KEY).orElse(false);
   }
 

--- a/base/src/com/google/idea/blaze/base/sync/sharding/BlazeBuildTargetSharder.java
+++ b/base/src/com/google/idea/blaze/base/sync/sharding/BlazeBuildTargetSharder.java
@@ -31,6 +31,7 @@ import com.google.idea.blaze.base.model.primitives.WildcardTargetPattern;
 import com.google.idea.blaze.base.projectview.ProjectViewManager;
 import com.google.idea.blaze.base.projectview.ProjectViewSet;
 import com.google.idea.blaze.base.projectview.section.sections.ShardBlazeBuildsSection;
+import com.google.idea.blaze.base.projectview.section.sections.SyncManualTargetsSection;
 import com.google.idea.blaze.base.projectview.section.sections.TargetShardSizeSection;
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.scope.Scope;
@@ -87,7 +88,9 @@ public class BlazeBuildTargetSharder {
   }
 
   private static boolean shardingRequested(ProjectViewSet projectViewSet) {
-    return projectViewSet.getScalarValue(ShardBlazeBuildsSection.KEY).orElse(false);
+    // We need to perform expansion of query targets if we are to allow for manual targets to be synced.
+    return projectViewSet.getScalarValue(ShardBlazeBuildsSection.KEY).orElse(false) ||
+            projectViewSet.getScalarValue(SyncManualTargetsSection.KEY).orElse(false);
   }
 
   /** Number of individual targets per blaze build shard. */

--- a/base/src/com/google/idea/blaze/base/sync/sharding/WildcardTargetExpander.java
+++ b/base/src/com/google/idea/blaze/base/sync/sharding/WildcardTargetExpander.java
@@ -40,6 +40,7 @@ import com.google.idea.blaze.base.scope.output.StatusOutput;
 import com.google.idea.blaze.base.scope.scopes.TimingScope;
 import com.google.idea.blaze.base.scope.scopes.TimingScope.EventType;
 import com.google.idea.blaze.base.settings.Blaze;
+import com.google.idea.blaze.base.sync.SyncProjectTargetsHelper;
 import com.google.idea.blaze.base.sync.aspects.BuildResult;
 import com.google.idea.blaze.base.sync.aspects.BuildResult.Status;
 import com.google.idea.blaze.base.sync.projectview.LanguageSupport;
@@ -64,6 +65,7 @@ import javax.annotation.Nullable;
 /** Expands wildcard target patterns into individual blaze targets. */
 public class WildcardTargetExpander {
 
+  public static final String MANUAL_EXCLUDE_TAG = "^((?!manual).)*$";
   private static final BoolExperiment filterByRuleType =
       new BoolExperiment("blaze.build.filter.by.rule.type", true);
 
@@ -195,7 +197,7 @@ public class WildcardTargetExpander {
             BlazeCommandName.BUILD,
             context,
             BlazeInvocationContext.SYNC_CONTEXT)
-        .contains("--build_manual_tests");
+        .contains("--build_manual_tests") && !SyncProjectTargetsHelper.shouldSyncManualTargets(projectView);
   }
 
   /** Runs a blaze query to expand the input target patterns to individual blaze targets. */
@@ -272,7 +274,7 @@ public class WildcardTargetExpander {
       return targetList;
     }
     return excludeManualTargets
-        ? String.format("attr('tags', '^((?!manual).)*$', %s)", targetList)
+        ? String.format("attr('tags', '%s', %s)", MANUAL_EXCLUDE_TAG, targetList)
         : targetList;
   }
 }


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

This PR is a continuation of https://github.com/bazelbuild/intellij/issues/4546. One issue is that for manual targets specified, they are also excluded without this change (see https://github.com/bazelbuild/intellij/issues/4546#issuecomment-1741969833).

This fix will only work currently if the [shard_sync: true](https://ij.bazel.build/docs/project-views.html#shard_sync). Otherwise the query will not be performed. I pushed a [second commit](https://github.com/bazelbuild/intellij/pull/5458/commits/680862626c3fc88f8be0a1437450e73ed33dd118) to make this change explicit. Otherwise, two flags must be set for this part to work.

Issue number: https://github.com/bazelbuild/intellij/issues/4546

# Description of this change

When `allow_manual_targets_sync: true` is set, this change will allow manual targets to be part of the target query. Because expansion of build targets currently only occur when the sharding approach is enabled, this change would also switch on the `shard_sync: true` option to enable this query to occur. The alternative would be to create another option to expand the query, so I wanted to get feedback about it.

I've also modified unit tests to perform the check for both on/off, asserting the presence of the manual attr query.