### PR TITLE
Adapt paths and line breaks for Windows

### DIFF
--- a/DEV_IDE_SETUP.md
+++ b/DEV_IDE_SETUP.md
@@ -8,11 +8,11 @@ When asked, use the bundled project view file (`ijwb/ijwb.bazelproject`). This w
 - Set the plugin to build with the latest development version by default.
 - Automatically import the relevant target, and exclude the irrelevant ones.
 
-Depending on which JetBrains product you're targetting, you may want to adjust the `--define` flag in the `build_flags` section. For more information on which values you can pass, please refer to [Building the Plugin](README.md#building-the-plugin)
+Depending on which JetBrains product you're targeting, you may want to adjust the `--define` flag in the `build_flags` section. For more information on which values you can pass, please refer to [Building the Plugin](README.md#building-the-plugin)
 
 ## Download and Install the JetBrains Runtime SDK
 
-Most of the time, the IntelliJ Platform Plugin SDK bundled with your IntelliJ installation shuould be enuogh to compile and run the plugin.
+Most of the time, the IntelliJ Platform Plugin SDK bundled with your IntelliJ installation should be enough to compile and run the plugin.
 
 To install it, please head to the SDK menu (`Cmd+;` or `Ctrl+;`), and then to `Platform Settings -> SDKs`.
 

--- a/base/src/com/google/idea/blaze/base/settings/ui/ProjectViewUi.java
+++ b/base/src/com/google/idea/blaze/base/settings/ui/ProjectViewUi.java
@@ -40,6 +40,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.project.impl.ProjectImpl;
 import com.intellij.openapi.util.Disposer;
+import com.intellij.openapi.util.SystemInfo;
 import com.intellij.ui.LanguageTextField;
 import com.intellij.ui.LanguageTextField.SimpleDocumentCreator;
 import com.intellij.ui.components.JBLabel;
@@ -184,7 +185,11 @@ public class ProjectViewUi {
         .runWriteAction(
             () -> {
               projectViewEditor.getDocument().setReadOnly(false);
-              projectViewEditor.getDocument().setText(projectViewText.replace("\r", ""));
+              if (SystemInfo.isWindows) {
+                projectViewEditor.getDocument().setText(projectViewText.replace("\r", ""));
+              } else {
+                projectViewEditor.getDocument().setText(projectViewText);
+              }
             });
     updateTextAreasEnabled();
   }

--- a/base/src/com/google/idea/blaze/base/settings/ui/ProjectViewUi.java
+++ b/base/src/com/google/idea/blaze/base/settings/ui/ProjectViewUi.java
@@ -184,7 +184,7 @@ public class ProjectViewUi {
         .runWriteAction(
             () -> {
               projectViewEditor.getDocument().setReadOnly(false);
-              projectViewEditor.getDocument().setText(projectViewText);
+              projectViewEditor.getDocument().setText(projectViewText.replace("\r", ""));
             });
     updateTextAreasEnabled();
   }

--- a/base/src/com/google/idea/blaze/base/wizard2/ImportFromWorkspaceProjectViewOption.java
+++ b/base/src/com/google/idea/blaze/base/wizard2/ImportFromWorkspaceProjectViewOption.java
@@ -168,13 +168,13 @@ public class ImportFromWorkspaceProjectViewOption implements BlazeSelectProjectV
     }
     VirtualFile file = files[0];
 
-    if (!FileUtil.startsWith(file.getPath(), fileBrowserRoot.getPath())) {
+    if (!FileUtil.startsWith(file.getPath(), fileBrowserRoot.getPath().replace('\\', '/'))) {
       Messages.showErrorDialog(
           String.format(
               "You must choose a project view file under %s. "
                   + "To use an external project view, please use the 'Copy external' option.",
               fileBrowserRoot.getPath()),
-          "Cannot Use Project View File");
+              String.format("Cannot Use Project View File %s", file.getPath()));
       return;
     }
 

--- a/base/src/com/google/idea/blaze/base/wizard2/ImportFromWorkspaceProjectViewOption.java
+++ b/base/src/com/google/idea/blaze/base/wizard2/ImportFromWorkspaceProjectViewOption.java
@@ -24,6 +24,7 @@ import com.intellij.openapi.fileChooser.FileChooserDialog;
 import com.intellij.openapi.fileChooser.FileChooserFactory;
 import com.intellij.openapi.options.ConfigurationException;
 import com.intellij.openapi.ui.Messages;
+import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.LocalFileSystem;
@@ -168,7 +169,13 @@ public class ImportFromWorkspaceProjectViewOption implements BlazeSelectProjectV
     }
     VirtualFile file = files[0];
 
-    if (!FileUtil.startsWith(file.getPath(), fileBrowserRoot.getPath().replace('\\', '/'))) {
+    boolean startsWithPath;
+    if (SystemInfo.isWindows) {
+      startsWithPath = FileUtil.startsWith(file.getPath(), fileBrowserRoot.getPath().replace('\\', '/'));
+    } else {
+      startsWithPath = FileUtil.startsWith(file.getPath(), fileBrowserRoot.getPath());
+    }
+    if (!startsWithPath) {
       Messages.showErrorDialog(
           String.format(
               "You must choose a project view file under %s. "


### PR DESCRIPTION
Fix typos

# Checklist

- [X] I have filed an issue about this change and discussed potential changes with the maintainers.
- [X] I have received the approval from the maintainers to make this change.
- [X] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `5470`

# Description of this change
Fix directory separators and line-breaks on Windows, and fix some typos.

Closes #5470 
