### PR TITLE
Make //clwb(plugin) and //cpp(plugin) dependency on cidr.lang optional: plugin xmls split

### DIFF
--- a/clwb/BUILD
+++ b/clwb/BUILD
@@ -7,6 +7,7 @@ load(
     "//build_defs:build_defs.bzl",
     "intellij_plugin",
     "intellij_plugin_library",
+    "optional_plugin_xml",
     "plugin_deploy_zip",
     "repackaged_files",
     "stamped_plugin_xml",
@@ -30,8 +31,15 @@ licenses(["notice"])
 intellij_plugin_library(
     name = "plugin_library",
     plugin_xmls = ["src/META-INF/clwb.xml"],
+    optional_plugin_xmls = ["optional_clwb_oclang"],
     visibility = PLUGIN_PACKAGES_VISIBILITY,
     deps = [":clwb_lib"],
+)
+
+optional_plugin_xml(
+    name = "optional_clwb_oclang",
+    module = "com.intellij.modules.cidr.lang",
+    plugin_xml = "src/META-INF/clwb-oclang.xml",
 )
 
 stamped_plugin_xml(

--- a/clwb/src/META-INF/clwb-oclang.xml
+++ b/clwb/src/META-INF/clwb-oclang.xml
@@ -19,6 +19,7 @@
   </extensions>
 
   <extensions defaultExtensionNs="com.google.idea.blaze">
+    <clwb.googleTestUtilAdapter implementation="com.google.idea.blaze.clwb.oclang.run.CidrGoogleTestUtilAdapter"/>
     <TestContextProvider implementation="com.google.idea.blaze.clwb.oclang.run.producers.CppTestContextProvider"/>
   </extensions>
 </idea-plugin>

--- a/clwb/src/META-INF/clwb-oclang.xml
+++ b/clwb/src/META-INF/clwb-oclang.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ Copyright 2023 The Bazel Authors. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<idea-plugin>
+  <extensions defaultExtensionNs="cidr.debugger">
+    <languageSupport language="" implementationClass="com.google.idea.blaze.clwb.oclang.run.BlazeCidrDebuggerSupportFactory"/>
+  </extensions>
+
+  <extensions defaultExtensionNs="com.google.idea.blaze">
+    <TestContextProvider implementation="com.google.idea.blaze.clwb.oclang.run.producers.CppTestContextProvider"/>
+  </extensions>
+</idea-plugin>

--- a/clwb/src/META-INF/clwb.xml
+++ b/clwb/src/META-INF/clwb.xml
@@ -31,15 +31,10 @@
     <registryKey defaultValue="false" description="Disable the extra debug flags in debug C/C++ builds" key="bazel.clwb.debug.extraflags.disabled"/>
   </extensions>
 
-  <extensions defaultExtensionNs="cidr.debugger">
-    <languageSupport language="" implementationClass="com.google.idea.blaze.clwb.run.BlazeCidrDebuggerSupportFactory"/>
-  </extensions>
-
   <extensions defaultExtensionNs="com.google.idea.blaze">
     <SyncPlugin implementation="com.google.idea.blaze.clwb.sync.BlazeCLionSyncPlugin"/>
     <BlazeCommandRunConfigurationHandlerProvider implementation="com.google.idea.blaze.clwb.run.BlazeCidrRunConfigurationHandlerProvider" order="first"/>
-    <BlazeTestEventsHandler implementation="com.google.idea.blaze.clwb.run.test.BlazeCidrTestEventsHandler"/>
-    <TestContextProvider implementation="com.google.idea.blaze.clwb.run.producers.CppTestContextProvider"/>
+    <BlazeTestEventsHandler implementation="com.google.idea.blaze.clwb.oclang.run.test.BlazeCidrTestEventsHandler"/>
   </extensions>
 
   <project-components>

--- a/clwb/src/META-INF/clwb.xml
+++ b/clwb/src/META-INF/clwb.xml
@@ -19,6 +19,10 @@
   <depends>com.intellij.modules.clion</depends>
   <depends>org.jetbrains.plugins.clion.test.google</depends>
 
+  <extensionPoints>
+    <extensionPoint qualifiedName="com.google.idea.blaze.clwb.googleTestUtilAdapter" interface="com.google.idea.blaze.clwb.run.GoogleTestUtilAdapter"/>
+  </extensionPoints>
+
   <extensions defaultExtensionNs="com.intellij">
     <consoleFilterProvider implementation="com.google.idea.blaze.clwb.run.BlazeCppPathConsoleFilter$Provider"/>
 

--- a/clwb/src/com/google/idea/blaze/clwb/oclang/run/BlazeCidrDebuggerSupportFactory.java
+++ b/clwb/src/com/google/idea/blaze/clwb/oclang/run/BlazeCidrDebuggerSupportFactory.java
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.idea.blaze.clwb.run;
+package com.google.idea.blaze.clwb.oclang.run;
 
 import com.google.idea.blaze.base.run.BlazeCommandRunConfiguration;
+import com.google.idea.blaze.clwb.run.RunConfigurationUtils;
 import com.intellij.execution.configurations.RunProfile;
 import com.intellij.xdebugger.evaluation.XDebuggerEditorsProvider;
 import com.jetbrains.cidr.execution.debugger.OCDebuggerLanguageSupport;

--- a/clwb/src/com/google/idea/blaze/clwb/oclang/run/CidrGoogleTestUtilAdapter.java
+++ b/clwb/src/com/google/idea/blaze/clwb/oclang/run/CidrGoogleTestUtilAdapter.java
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.idea.blaze.clwb;
+package com.google.idea.blaze.clwb.oclang.run;
 
 import com.google.common.collect.Iterables;
+import com.google.idea.blaze.clwb.run.GoogleTestUtilAdapter;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Couple;
 import com.intellij.psi.PsiElement;
@@ -33,12 +34,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 /** Adapter to bridge different SDK versions. */
-public class CidrGoogleTestUtilAdapter {
-  @Nullable
-  public static PsiElement findGoogleTestSymbol(Project project) {
-    return findGoogleTestSymbol(project, testScopeElement -> true);
-  }
-
+public class CidrGoogleTestUtilAdapter implements GoogleTestUtilAdapter {
   @Nullable
   public static PsiElement findGoogleTestSymbol(
       Project project, String suiteName, String testName) {
@@ -132,7 +128,7 @@ public class CidrGoogleTestUtilAdapter {
   }
 
   @Nullable
-  private static PsiElement findGoogleTestSymbol(
+  public PsiElement findGoogleTestSymbol(
       Project project, Predicate<CidrTestScopeElement> predicate) {
     CidrGoogleTestFramework instance = CidrGoogleTestFramework.getInstance();
     FindFirstWithPredicateProcessor<CidrTestScopeElement> processor =

--- a/clwb/src/com/google/idea/blaze/clwb/oclang/run/producers/CppTestContextProvider.java
+++ b/clwb/src/com/google/idea/blaze/clwb/oclang/run/producers/CppTestContextProvider.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.idea.blaze.clwb.run.producers;
+package com.google.idea.blaze.clwb.oclang.run.producers;
 
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -25,8 +25,8 @@ import com.google.idea.blaze.base.run.producers.RunConfigurationContext;
 import com.google.idea.blaze.base.run.producers.TestContext;
 import com.google.idea.blaze.base.run.producers.TestContextProvider;
 import com.google.idea.blaze.base.run.targetfinder.FuturesUtil;
-import com.google.idea.blaze.clwb.run.test.GoogleTestLocation;
-import com.google.idea.blaze.clwb.run.test.GoogleTestSpecification;
+import com.google.idea.blaze.clwb.oclang.run.test.GoogleTestLocation;
+import com.google.idea.blaze.clwb.oclang.run.test.GoogleTestSpecification;
 import com.google.idea.blaze.cpp.CppBlazeRules.RuleTypes;
 import com.intellij.execution.Location;
 import com.intellij.execution.actions.ConfigurationContext;

--- a/clwb/src/com/google/idea/blaze/clwb/oclang/run/test/BlazeCidrTestEventsHandler.java
+++ b/clwb/src/com/google/idea/blaze/clwb/oclang/run/test/BlazeCidrTestEventsHandler.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.idea.blaze.clwb.run.test;
+package com.google.idea.blaze.clwb.oclang.run.test;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 

--- a/clwb/src/com/google/idea/blaze/clwb/oclang/run/test/BlazeCppTestInfo.java
+++ b/clwb/src/com/google/idea/blaze/clwb/oclang/run/test/BlazeCppTestInfo.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.idea.blaze.clwb.run.test;
+package com.google.idea.blaze.clwb.oclang.run.test;
 
 import com.google.common.collect.ImmutableList;
 import com.google.idea.blaze.base.run.smrunner.SmRunnerUtils;

--- a/clwb/src/com/google/idea/blaze/clwb/oclang/run/test/BlazeCppTestLocator.java
+++ b/clwb/src/com/google/idea/blaze/clwb/oclang/run/test/BlazeCppTestLocator.java
@@ -16,7 +16,7 @@
 package com.google.idea.blaze.clwb.oclang.run.test;
 
 import com.google.common.collect.ImmutableList;
-import com.google.idea.blaze.clwb.CidrGoogleTestUtilAdapter;
+import com.google.idea.blaze.clwb.oclang.run.CidrGoogleTestUtilAdapter;
 import com.intellij.execution.Location;
 import com.intellij.execution.testframework.sm.runner.SMTestLocator;
 import com.intellij.openapi.project.Project;

--- a/clwb/src/com/google/idea/blaze/clwb/oclang/run/test/BlazeCppTestLocator.java
+++ b/clwb/src/com/google/idea/blaze/clwb/oclang/run/test/BlazeCppTestLocator.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.idea.blaze.clwb.run.test;
+package com.google.idea.blaze.clwb.oclang.run.test;
 
 import com.google.common.collect.ImmutableList;
 import com.google.idea.blaze.clwb.CidrGoogleTestUtilAdapter;

--- a/clwb/src/com/google/idea/blaze/clwb/oclang/run/test/GoogleTestLocation.java
+++ b/clwb/src/com/google/idea/blaze/clwb/oclang/run/test/GoogleTestLocation.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.idea.blaze.clwb.run.test;
+package com.google.idea.blaze.clwb.oclang.run.test;
 
 import com.google.idea.blaze.base.sync.autosync.ProjectTargetManager.SyncStatus;
 import com.google.idea.blaze.base.syncstatus.SyncStatusContributor;

--- a/clwb/src/com/google/idea/blaze/clwb/oclang/run/test/GoogleTestLocation.java
+++ b/clwb/src/com/google/idea/blaze/clwb/oclang/run/test/GoogleTestLocation.java
@@ -17,7 +17,7 @@ package com.google.idea.blaze.clwb.oclang.run.test;
 
 import com.google.idea.blaze.base.sync.autosync.ProjectTargetManager.SyncStatus;
 import com.google.idea.blaze.base.syncstatus.SyncStatusContributor;
-import com.google.idea.blaze.clwb.CidrGoogleTestUtilAdapter;
+import com.google.idea.blaze.clwb.oclang.run.CidrGoogleTestUtilAdapter;
 import com.intellij.execution.Location;
 import com.intellij.execution.PsiLocation;
 import com.intellij.openapi.project.Project;

--- a/clwb/src/com/google/idea/blaze/clwb/oclang/run/test/GoogleTestSpecification.java
+++ b/clwb/src/com/google/idea/blaze/clwb/oclang/run/test/GoogleTestSpecification.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.idea.blaze.clwb.run.test;
+package com.google.idea.blaze.clwb.oclang.run.test;
 
 import com.google.common.base.Joiner;
 import com.intellij.openapi.util.text.StringUtil;

--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrLauncher.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrLauncher.java
@@ -44,7 +44,6 @@ import com.google.idea.blaze.base.scope.scopes.ProblemsViewScope;
 import com.google.idea.blaze.base.settings.Blaze;
 import com.google.idea.blaze.base.settings.BlazeUserSettings;
 import com.google.idea.blaze.base.settings.BuildSystemName;
-import com.google.idea.blaze.clwb.CidrGoogleTestUtilAdapter;
 import com.google.idea.blaze.clwb.ToolchainUtils;
 import com.google.idea.blaze.cpp.CppBlazeRules;
 import com.intellij.execution.ExecutionException;
@@ -296,7 +295,7 @@ public final class BlazeCidrLauncher extends CidrLauncher {
         && handlerState.getTestFilterFlag() != null
         && !PropertiesComponent.getInstance()
             .getBoolean(DISABLE_BAZEL_GOOGLETEST_FILTER_WARNING, false)
-        && CidrGoogleTestUtilAdapter.findGoogleTestSymbol(getProject()) != null;
+        && GoogleTestUtilAdapter.findGoogleTestSymbol(getProject()) != null;
   }
 
   /**

--- a/clwb/src/com/google/idea/blaze/clwb/run/GoogleTestUtilAdapter.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/GoogleTestUtilAdapter.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.clwb.run;
+
+import com.intellij.openapi.extensions.ExtensionPointName;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
+import com.jetbrains.cidr.execution.testing.CidrTestScopeElement;
+import java.util.function.Predicate;
+import javax.annotation.Nullable;
+
+public interface GoogleTestUtilAdapter {
+  ExtensionPointName<GoogleTestUtilAdapter> EP_NAME =
+      ExtensionPointName.create("com.google.idea.blaze.clwb.googleTestUtilAdapter");
+
+  @Nullable
+  static PsiElement findGoogleTestSymbol(Project project) {
+    if (EP_NAME.getExtensionList().size() > 1) {
+      throw new IllegalStateException("More than 1 extension for " + EP_NAME.getName() + " is not supported");
+    }
+
+    GoogleTestUtilAdapter adapter = EP_NAME.getPoint().extensions().findFirst().orElse(null);
+    if (adapter != null) {
+      return adapter.findGoogleTestSymbol(project, testScopeElement -> true);
+    }
+
+    return null;
+  }
+
+  PsiElement findGoogleTestSymbol(
+      Project project, Predicate<CidrTestScopeElement> predicate);
+}

--- a/clwb/src/com/google/idea/blaze/clwb/run/RunConfigurationUtils.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/RunConfigurationUtils.java
@@ -30,7 +30,7 @@ public class RunConfigurationUtils {
         || kind == CppBlazeRules.RuleTypes.CC_BINARY.getKind();
   }
 
-  static boolean canUseClionRunner(BlazeCommandRunConfiguration config) {
+  public static boolean canUseClionRunner(BlazeCommandRunConfiguration config) {
     Kind kind = config.getTargetKind();
     BlazeCommandRunConfigurationCommonState handlerState =
         config.getHandlerStateIfType(BlazeCommandRunConfigurationCommonState.class);

--- a/clwb/tests/unittests/com/google/idea/blaze/clwb/oclang/run/test/BlazeCppTestInfoTest.java
+++ b/clwb/tests/unittests/com/google/idea/blaze/clwb/oclang/run/test/BlazeCppTestInfoTest.java
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.idea.blaze.clwb.run.test;
+package com.google.idea.blaze.clwb.oclang.run.test;
 
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.idea.blaze.base.run.smrunner.SmRunnerUtils;
+import com.google.idea.blaze.clwb.oclang.run.test.BlazeCppTestInfo;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;

--- a/cpp/BUILD
+++ b/cpp/BUILD
@@ -25,6 +25,7 @@ java_library(
         "src/com/google/idea/blaze/cpp/includes/*.java",
         "src/com/google/idea/blaze/cpp/syncstatus/*.java",
         "src/com/google/idea/blaze/cpp/navigation/*.java",
+        "src/com/google/idea/blaze/cpp/oclang/*.java",
     ]),
     visibility = PLUGIN_PACKAGES_VISIBILITY,
     deps = [
@@ -40,14 +41,20 @@ java_library(
     ],
 )
 
+stamped_plugin_xml(
+    name = "non_optional_cidr",
+    plugin_xml = "src/META-INF/blaze-cpp.xml",
+)
+
 optional_plugin_xml(
     name = "optional_cidr",
     module = "com.intellij.modules.cidr.lang",
-    plugin_xml = "src/META-INF/blaze-cpp.xml",
+    plugin_xml = "src/META-INF/blaze-cpp-oclang.xml",
 )
 
 intellij_plugin_library(
     name = "plugin_library",
+    plugin_xmls = [":non_optional_cidr"],
     optional_plugin_xmls = [":optional_cidr"],
     visibility = PLUGIN_PACKAGES_VISIBILITY,
     deps = [":cpp"],

--- a/cpp/src/META-INF/blaze-cpp-oclang.xml
+++ b/cpp/src/META-INF/blaze-cpp-oclang.xml
@@ -22,5 +22,6 @@
 
   <extensions defaultExtensionNs="com.google.idea.blaze">
     <SyncStatusContributor implementation="com.google.idea.blaze.cpp.oclang.CppSyncStatusContributor"/>
+    <cpp.SourceFileFinder implementation="com.google.idea.blaze.cpp.oclang.OCSourceFileFinder"/>
   </extensions>
 </idea-plugin>

--- a/cpp/src/META-INF/blaze-cpp-oclang.xml
+++ b/cpp/src/META-INF/blaze-cpp-oclang.xml
@@ -1,0 +1,26 @@
+<!--
+  ~ Copyright 2023 The Bazel Authors. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<idea-plugin>
+  <extensions defaultExtensionNs="cidr.lang">
+      <autoImportHelper implementation="com.google.idea.blaze.cpp.oclang.BlazeCppAutoImportHelper"/>
+      <customHeaderProvider implementation="com.google.idea.blaze.cpp.oclang.BlazeCustomHeaderProvider"/>
+      <includeHelper implementation="com.google.idea.blaze.cpp.oclang.BlazeIncludeHelper"/>
+  </extensions>
+
+  <extensions defaultExtensionNs="com.google.idea.blaze">
+    <SyncStatusContributor implementation="com.google.idea.blaze.cpp.oclang.CppSyncStatusContributor"/>
+  </extensions>
+</idea-plugin>

--- a/cpp/src/META-INF/blaze-cpp.xml
+++ b/cpp/src/META-INF/blaze-cpp.xml
@@ -25,6 +25,9 @@
   <extensionPoints>
     <extensionPoint qualifiedName="com.google.idea.blaze.cpp.BlazeCompilerFlagsProcessorProvider"
                     interface="com.google.idea.blaze.cpp.BlazeCompilerFlagsProcessor$Provider"/>
+
+    <extensionPoint qualifiedName="com.google.idea.blaze.cpp.SourceFileFinder"
+                    interface="com.google.idea.blaze.cpp.SourceFileFinder"/>
   </extensionPoints>
 
   <extensions defaultExtensionNs="com.google.idea.blaze">

--- a/cpp/src/META-INF/blaze-cpp.xml
+++ b/cpp/src/META-INF/blaze-cpp.xml
@@ -14,7 +14,6 @@
   ~ limitations under the License.
   -->
 <idea-plugin>
-  <depends>com.intellij.modules.cidr.lang</depends>
   <depends>com.intellij.modules.cidr.debugger</depends>
 
   <project-components>
@@ -31,7 +30,6 @@
   <extensions defaultExtensionNs="com.google.idea.blaze">
     <SyncPlugin implementation="com.google.idea.blaze.cpp.BlazeCSyncPlugin"/>
     <PrefetchFileSource implementation="com.google.idea.blaze.cpp.CPrefetchFileSource"/>
-    <SyncStatusContributor implementation="com.google.idea.blaze.cpp.syncstatus.CppSyncStatusContributor"/>
     <cpp.BlazeCompilerFlagsProcessorProvider implementation="com.google.idea.blaze.cpp.IncludeRootFlagsProcessor$Provider"/>
     <cpp.BlazeCompilerFlagsProcessorProvider implementation="com.google.idea.blaze.cpp.SysrootFlagsProcessor$Provider"/>
     <TargetKindProvider implementation="com.google.idea.blaze.cpp.CppBlazeRules"/>
@@ -39,9 +37,6 @@
 
   <extensions defaultExtensionNs="cidr.lang">
     <languageKindHelper implementation="com.google.idea.blaze.cpp.BlazeLanguageKindCalculatorHelper"/>
-    <autoImportHelper implementation="com.google.idea.blaze.cpp.BlazeCppAutoImportHelper"/>
-    <customHeaderProvider implementation="com.google.idea.blaze.cpp.BlazeCustomHeaderProvider"/>
-    <includeHelper implementation="com.google.idea.blaze.cpp.BlazeIncludeHelper"/>
     <ownModuleDetector implementation="com.google.idea.blaze.cpp.BlazeOwnModuleDetector"/>
   </extensions>
   <extensions defaultExtensionNs="com.intellij">

--- a/cpp/src/com/google/idea/blaze/cpp/BlazeResolveConfiguration.java
+++ b/cpp/src/com/google/idea/blaze/cpp/BlazeResolveConfiguration.java
@@ -31,7 +31,6 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.jetbrains.cidr.lang.CLanguageKind;
 import com.jetbrains.cidr.lang.OCFileTypeHelpers;
 import com.jetbrains.cidr.lang.OCLanguageKind;
-import com.jetbrains.cidr.lang.preprocessor.OCImportGraph;
 import com.jetbrains.cidr.lang.workspace.OCResolveConfiguration;
 import java.io.File;
 import java.util.Collection;
@@ -108,7 +107,7 @@ final class BlazeResolveConfiguration {
     }
 
     if (OCFileTypeHelpers.isHeaderFile(fileName)) {
-      return getLanguageKind(getSourceFileForHeaderFile(sourceOrHeaderFile));
+      return getLanguageKind(SourceFileFinder.findAndGetSourceFileForHeaderFile(project, sourceOrHeaderFile));
     }
 
     return null;
@@ -120,20 +119,6 @@ final class BlazeResolveConfiguration {
 
     OCLanguageKind kind = OCFileTypeHelpers.getLanguageKind(sourceFile.getName());
     return kind != null ? kind : getMaximumLanguageKind();
-  }
-
-  @Nullable
-  private VirtualFile getSourceFileForHeaderFile(VirtualFile headerFile) {
-    Collection<VirtualFile> roots =
-        OCImportGraph.getInstance(project).getAllHeaderRoots(headerFile);
-
-    final String headerNameWithoutExtension = headerFile.getNameWithoutExtension();
-    for (VirtualFile root : roots) {
-      if (root.getNameWithoutExtension().equals(headerNameWithoutExtension)) {
-        return root;
-      }
-    }
-    return null;
   }
 
   private static OCLanguageKind getMaximumLanguageKind() {

--- a/cpp/src/com/google/idea/blaze/cpp/BlazeResolveConfiguration.java
+++ b/cpp/src/com/google/idea/blaze/cpp/BlazeResolveConfiguration.java
@@ -32,7 +32,6 @@ import com.jetbrains.cidr.lang.CLanguageKind;
 import com.jetbrains.cidr.lang.OCFileTypeHelpers;
 import com.jetbrains.cidr.lang.OCLanguageKind;
 import com.jetbrains.cidr.lang.preprocessor.OCImportGraph;
-import com.jetbrains.cidr.lang.workspace.OCLanguageKindCalculator;
 import com.jetbrains.cidr.lang.workspace.OCResolveConfiguration;
 import java.io.File;
 import java.util.Collection;
@@ -116,7 +115,10 @@ final class BlazeResolveConfiguration {
   }
 
   private OCLanguageKind getLanguageKind(@Nullable VirtualFile sourceFile) {
-    OCLanguageKind kind = OCLanguageKindCalculator.tryFileTypeAndExtension(project, sourceFile);
+    if (sourceFile == null)
+      return getMaximumLanguageKind();
+
+    OCLanguageKind kind = OCFileTypeHelpers.getLanguageKind(sourceFile.getName());
     return kind != null ? kind : getMaximumLanguageKind();
   }
 

--- a/cpp/src/com/google/idea/blaze/cpp/SourceFileFinder.java
+++ b/cpp/src/com/google/idea/blaze/cpp/SourceFileFinder.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.cpp;
+
+import com.intellij.openapi.extensions.ExtensionPointName;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import javax.annotation.Nullable;
+
+public interface SourceFileFinder {
+  ExtensionPointName<SourceFileFinder> EP_NAME =
+      ExtensionPointName.create("com.google.idea.blaze.cpp.SourceFileFinder");
+
+  @Nullable
+  VirtualFile getSourceFileForHeaderFile(Project project, VirtualFile headerFile);
+
+  static VirtualFile findAndGetSourceFileForHeaderFile(Project project, VirtualFile headerFile) {
+    if (EP_NAME.getExtensionList().size() > 1) {
+      throw new IllegalStateException("More than 1 extension for " + EP_NAME.getName() + " is not supported");
+    }
+
+    SourceFileFinder finder = EP_NAME.getPoint().extensions().findFirst().orElse(null);
+    if (finder != null) {
+        return finder.getSourceFileForHeaderFile(project, headerFile);
+    }
+
+    return null;
+  }
+}

--- a/cpp/src/com/google/idea/blaze/cpp/oclang/BlazeCppAutoImportHelper.java
+++ b/cpp/src/com/google/idea/blaze/cpp/oclang/BlazeCppAutoImportHelper.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.idea.blaze.cpp;
+package com.google.idea.blaze.cpp.oclang;
 
 import com.google.common.collect.ImmutableList;
 import com.google.idea.blaze.base.settings.Blaze;

--- a/cpp/src/com/google/idea/blaze/cpp/oclang/BlazeCustomHeaderProvider.java
+++ b/cpp/src/com/google/idea/blaze/cpp/oclang/BlazeCustomHeaderProvider.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.idea.blaze.cpp;
+package com.google.idea.blaze.cpp.oclang;
 
 import com.google.idea.blaze.base.io.VirtualFileSystemProvider;
 import com.google.idea.blaze.base.model.BlazeProjectData;

--- a/cpp/src/com/google/idea/blaze/cpp/oclang/BlazeIncludeHelper.java
+++ b/cpp/src/com/google/idea/blaze/cpp/oclang/BlazeIncludeHelper.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.idea.blaze.cpp;
+package com.google.idea.blaze.cpp.oclang;
 
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;

--- a/cpp/src/com/google/idea/blaze/cpp/oclang/CppSyncStatusContributor.java
+++ b/cpp/src/com/google/idea/blaze/cpp/oclang/CppSyncStatusContributor.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.idea.blaze.cpp.syncstatus;
+package com.google.idea.blaze.cpp.oclang;
 
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.primitives.LanguageClass;

--- a/cpp/src/com/google/idea/blaze/cpp/oclang/OCSourceFileFinder.java
+++ b/cpp/src/com/google/idea/blaze/cpp/oclang/OCSourceFileFinder.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.cpp.oclang;
+
+import com.google.idea.blaze.cpp.SourceFileFinder;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.jetbrains.cidr.lang.preprocessor.OCImportGraph;
+import java.util.Collection;
+import javax.annotation.Nullable;
+
+public class OCSourceFileFinder implements SourceFileFinder {
+  @Nullable
+  public VirtualFile getSourceFileForHeaderFile(Project project, VirtualFile headerFile) {
+    Collection<VirtualFile> roots =
+        OCImportGraph.getInstance(project).getAllHeaderRoots(headerFile);
+
+    final String headerNameWithoutExtension = headerFile.getNameWithoutExtension();
+    for (VirtualFile root : roots) {
+      if (root.getNameWithoutExtension().equals(headerNameWithoutExtension)) {
+        return root;
+      }
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #5472

# Description of this change

Long story short: `com.intellij.modules.cidr.lang` is going to become optional in CLion at some point. All the usages of code exported from `com.intellij.modules.cidr.lang` are moved to optional plugin xmls, so plugin won't emit lots of exceptions and break the IDE if the mentioned module is not available. 

A little bit more detailed here. We (CLion team) are working on deprecation of the old language engine. Parts of it which are not going to be deprecated are moved to `cidr-base-plugin` library, which is a part of `CIDR Base (com.intellij.cidr.base)` essential CLion plugin, so any symbol from `cidr-base-plugin` will always be available. Though that does not apply to `c-plugin` library which is a part of `com.intellij.modules.cidr.lang` module. 

At this point the goal of this change is to make Bazel for CLion tolerant to disabled `com.intellij.modules.cidr.lang`. We're going to contribute further to adjust existing code which is moved to `*.oclang(.*)?` packages in the review to preserve the features when only the new language engine is available.