### PR TITLE
fix: Allow multiple providers to contribute attribute specific references

### DIFF
--- a/base/src/com/google/idea/blaze/base/lang/buildfile/references/AttributeSpecificStringLiteralReferenceProvider.java
+++ b/base/src/com/google/idea/blaze/base/lang/buildfile/references/AttributeSpecificStringLiteralReferenceProvider.java
@@ -18,6 +18,8 @@ package com.google.idea.blaze.base.lang.buildfile.references;
 import com.google.idea.blaze.base.lang.buildfile.psi.StringLiteral;
 import com.intellij.openapi.extensions.ExtensionPointName;
 import com.intellij.psi.PsiReference;
+import java.util.ArrayList;
+import java.util.Arrays;
 
 /** Non-default reference provider for {@link StringLiteral} values for a given attribute type. */
 public interface AttributeSpecificStringLiteralReferenceProvider {
@@ -28,13 +30,11 @@ public interface AttributeSpecificStringLiteralReferenceProvider {
 
   /** Find a reference type specific to values of this attribute. */
   static PsiReference[] findReferences(String attributeName, StringLiteral literal) {
+    ArrayList<PsiReference> results = new ArrayList<>();
     for (AttributeSpecificStringLiteralReferenceProvider provider : EP_NAME.getExtensions()) {
-      PsiReference[] refs = provider.getReferences(attributeName, literal);
-      if (refs.length != 0) {
-        return refs;
-      }
+      results.addAll(Arrays.asList(provider.getReferences(attributeName, literal)));
     }
-    return PsiReference.EMPTY_ARRAY;
+    return results.toArray(PsiReference[]::new);
   }
 
   /** Find references specific to this attribute. */

--- a/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/references/AttributeSpecificStringLiteralReferenceProviderTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/references/AttributeSpecificStringLiteralReferenceProviderTest.java
@@ -1,0 +1,47 @@
+package com.google.idea.blaze.base.lang.buildfile.references;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.idea.blaze.base.lang.buildfile.BuildFileIntegrationTestCase;
+import com.google.idea.blaze.base.lang.buildfile.psi.BuildFile;
+import com.google.idea.blaze.base.lang.buildfile.psi.StringLiteral;
+import com.google.idea.blaze.base.lang.buildfile.psi.util.PsiUtils;
+import com.google.idea.blaze.base.model.primitives.WorkspacePath;
+import com.intellij.psi.PsiReference;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class AttributeSpecificStringLiteralReferenceProviderTest extends BuildFileIntegrationTestCase {
+    @Test
+    public void testFindReferencesWithMultipleProviders() {
+        registerExtension(AttributeSpecificStringLiteralReferenceProvider.EP_NAME, new MockProvider("srcs"));
+        registerExtension(AttributeSpecificStringLiteralReferenceProvider.EP_NAME, new MockProvider("srcs"));
+        registerExtension(AttributeSpecificStringLiteralReferenceProvider.EP_NAME, new MockProvider("hdrs"));
+
+        WorkspacePath wp = new WorkspacePath("java/com/google/BUILD");
+        String content = "\"//something\""; // The content is not important, we only need a string literal.
+        BuildFile file = createBuildFile(wp, content);
+        StringLiteral literal = PsiUtils.findFirstChildOfClassRecursive(file, StringLiteral.class);
+
+        PsiReference[] results = AttributeSpecificStringLiteralReferenceProvider.findReferences("srcs", literal);
+        assertThat(results).hasLength(2); // The first and second providers should contribute one reference each.
+    }
+
+    private static class MockProvider implements AttributeSpecificStringLiteralReferenceProvider {
+        String attributeName;
+
+        public MockProvider(String attributeName) {
+            this.attributeName = attributeName;
+        }
+
+        @Override
+        public PsiReference[] getReferences(String attributeName, StringLiteral literal) {
+            if (!this.attributeName.equals(attributeName)) {
+                return PsiReference.EMPTY_ARRAY;
+            }
+            return new PsiReference[]{new LabelReference(literal, true)};
+        }
+    }
+}


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

# Discussion thread for this change

Discussed offline with @blorente as part of implementing an attribute specific completion for visibility.

# Description of this change

Allow for multiple implementation of AttributeSpecificStringLiteralReferenceProvider to coexist. If more than one is registered, all the references should be considered.
