### PR TITLE
fix: Mark package with BUILD.bazel file in completion

### DIFF
--- a/base/src/com/google/idea/blaze/base/lang/buildfile/references/FileLookupData.java
+++ b/base/src/com/google/idea/blaze/base/lang/buildfile/references/FileLookupData.java
@@ -15,6 +15,7 @@
  */
 package com.google.idea.blaze.base.lang.buildfile.references;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.idea.blaze.base.lang.buildfile.completion.FilePathLookupElement;
 import com.google.idea.blaze.base.lang.buildfile.psi.BuildFile;
 import com.google.idea.blaze.base.lang.buildfile.psi.StringLiteral;
@@ -38,6 +39,7 @@ import javax.swing.Icon;
 
 /** The data relevant to finding file lookups. */
 public class FileLookupData {
+  private static final ImmutableSet<String> BUILDFILE_NAMES = ImmutableSet.of("BUILD", "BUILD.bazel");
 
   /** The type of path string format */
   public enum PathFormat {
@@ -163,8 +165,10 @@ public class FileLookupData {
         new NullableLazyValue<Icon>() {
           @Override
           protected Icon compute() {
-            if (file.findChild("BUILD") != null) {
-              return BlazeIcons.BuildFile;
+            for (String buildfileName : BUILDFILE_NAMES) {
+              if (file.findChild(buildfileName) != null) {
+                return BlazeIcons.BuildFile;
+              }
             }
             if (file.isDirectory()) {
               return PlatformIcons.FOLDER_ICON;


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

# Discussion thread for this change

Discussed offline with @blorente. This looks like a regression.

# Description of this change

Mark package with BUILD.bazel file in completion

## Diff of the behavior

### The base branch for this PR, before change

In this repo under example/go/with_proto

Behavior: proto is a directory, it should be a package

![image](https://github.com/bazelbuild/intellij/assets/98589981/3fff839c-5f15-42d6-b7bc-e46e5c4469fa)


### After the change

In this repo under example/go/with_proto

Behavior: proto is a package, as expected

![image](https://github.com/bazelbuild/intellij/assets/98589981/c7628a21-bd6c-4e83-9206-47d97060d031)
