### PR TITLE
fix: Depend on upstream jna instead of the bundled one

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -858,6 +858,16 @@ jvm_maven_import_external(
     server_urls = ["https://repo1.maven.org/maven2"],
 )
 
+# Usually, we'd get this from the JetBrains SDK, but the bundled one not aware of Bazel platforms,
+# so it fails on certain setups.
+jvm_maven_import_external(
+    name = "jna",
+    artifact = "net.java.dev.jna:jna:5.13.0",
+    artifact_sha256 = "66d4f819a062a51a1d5627bffc23fac55d1677f0e0a1feba144aabdd670a64bb",
+    licenses = ["notice"],  # Apache 2.0
+    server_urls = ["https://repo1.maven.org/maven2"],
+)
+
 # io_grpc_grpc_java dependencies
 load("@io_grpc_grpc_java//:repositories.bzl", "IO_GRPC_GRPC_JAVA_ARTIFACTS", "IO_GRPC_GRPC_JAVA_OVERRIDE_TARGETS", "grpc_java_repositories")
 

--- a/testing/test_defs.bzl
+++ b/testing/test_defs.bzl
@@ -192,6 +192,9 @@ def intellij_integration_test_suite(
     deps = list(deps)
     deps.extend([
         "//testing:lib",
+        # Usually, we'd get this from the JetBrains SDK, but the bundled one not aware of Bazel platforms,
+        # so it fails on certain setups.
+        "@jna",
     ])
     runtime_deps = list(runtime_deps)
     runtime_deps.extend([


### PR DESCRIPTION
# Checklist

- [X] I have filed an issue about this change and discussed potential changes with the maintainers.
- [X] I have received the approval from the maintainers to make this change.
- [X] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Discovered while trying to set up CI for our internal mirror of the plugin.

# Description of this change

We test cross-platform (from mac arm to linux x86, for instance). Most of the tests  complained that they couldn't find the JNA library. As far as I can tell, we just rely on the JNA that comes bundled with the plugin SDK. However, that implicit dependency doesn't handle Bazel's platform definition.

Therefore, we add a dependency to proper `jna` upstream to be able to run the tests from any combination of platforms.
