### PR TITLE
fix: Force JarCache to be on on JarCache tests

### DIFF
--- a/java/tests/unittests/com/google/idea/blaze/java/libraries/JarCacheTest.java
+++ b/java/tests/unittests/com/google/idea/blaze/java/libraries/JarCacheTest.java
@@ -127,6 +127,7 @@ public class JarCacheTest extends BlazeTestCase {
         .registerExtension(new BlazeJavaSyncPlugin(), testDisposable);
     registerExtensionPoint(BlazeLibrarySorter.EP_NAME, BlazeLibrarySorter.class);
     applicationServices.register(BlazeJavaUserSettings.class, new BlazeJavaUserSettings());
+    BlazeJavaUserSettings.getInstance().setUseJarCache(true); // It's turned off by default for Bazel users, but we absolutely want to test it here.
     applicationServices.register(ExperimentService.class, new MockExperimentService());
     applicationServices.register(BlazeExecutor.class, new MockBlazeExecutor());
   }
@@ -135,7 +136,7 @@ public class JarCacheTest extends BlazeTestCase {
   protected BuildSystemProvider createBuildSystemProvider() {
     return new BuildSystemProviderWrapper(
         FakeBuildSystemProvider.builder()
-            .setBuildSystem(FakeBuildSystem.builder(BuildSystemName.Blaze).build())
+            .setBuildSystem(FakeBuildSystem.builder(BuildSystemName.Bazel).build())
             .build());
   }
 


### PR DESCRIPTION
# Checklist

- [X] I have filed an issue about this change and discussed potential changes with the maintainers.
- [X] I have received the approval from the maintainers to make this change.
- [X] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Discovered while trying to set up CI for our internal mirror of the plugin.

# Description of this change

The combination of running these tests from macOS in bazel doesn't seem to work for these tests, because the `BlazeJavaUserSettings` default to `useJarCache=false` when we're not running with Blaze.

To solve it, we:
- Force `BlazeJavaUserSettings.useJarCache` to `true`, because that's what we're testing. 
- Make the tests believe that they are running under Bazel, because JarCaches are only allowed in Mac if they are under Bazel (and not Blaze).