### PR TITLE
Support embedded go_proto_library

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -346,20 +346,6 @@ http_archive(
     url = PYTHON_PLUGIN_233_URL,
 )
 
-http_archive(
-    name = "python_2023_1",
-    build_file_content = _PYTHON_CE_BUILD_FILE,
-    sha256 = "825c30d2cbcce405fd18fddf356eb1f425607e9c780f8eff95d21ac23f8d90fd",
-    url = "https://plugins.jetbrains.com/maven/com/jetbrains/plugins/PythonCore/231.8770.65/PythonCore-231.8770.65.zip",
-)
-
-http_archive(
-    name = "python_2023_2",
-    build_file_content = _PYTHON_CE_BUILD_FILE,
-    sha256 = "e744349f353568c18a9e11ec5e3a205f62bbdc1b65c9abc96783c479fe2aa51b",
-    url = "https://plugins.jetbrains.com/maven/com/jetbrains/plugins/PythonCore/232.9921.47/PythonCore-232.9921.47.zip",
-)
-
 _GO_BUILD_FILE = """
 java_import(
     name = "go",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1001,3 +1001,53 @@ compat_repositories()
 
 # Register custom java 17 toolchain
 register_toolchains("//:custom_java_17_toolchain_definition")
+
+# Dependency needed for Go test library
+http_archive(
+    name = "bazel_gazelle",
+    sha256 = "29218f8e0cebe583643cbf93cae6f971be8a2484cdcfa1e45057658df8d54002",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.32.0/bazel-gazelle-v0.32.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.32.0/bazel-gazelle-v0.32.0.tar.gz",
+    ],
+)
+
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
+
+go_repository(
+    name = "org_golang_google_grpc",
+    build_file_proto_mode = "disable",
+    importpath = "google.golang.org/grpc",
+    sum = "h1:zvIju4sqAGvwKspUQOhwnpcqSbzi7/H6QomNNjTL4sk=",
+    version = "v1.27.1",
+)
+
+go_repository(
+    name = "org_golang_x_net",
+    importpath = "golang.org/x/net",
+    sum = "h1:oWX7TPOiFAMXLq8o0ikBYfCJVlRHBcsciT5bXOrH628=",
+    version = "v0.0.0-20190311183353-d8887717615a",
+)
+
+go_repository(
+    name = "org_golang_x_text",
+    importpath = "golang.org/x/text",
+    sum = "h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=",
+    version = "v0.3.0",
+)
+
+load("@io_bazel_rules_go//tests:grpc_repos.bzl", "grpc_dependencies")
+
+grpc_dependencies()
+
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+
+go_rules_dependencies()
+
+go_register_toolchains(version = "1.19.3")
+
+gazelle_dependencies()
+
+rules_proto_dependencies()
+
+rules_proto_toolchains()

--- a/aspect/intellij_info_impl.bzl
+++ b/aspect/intellij_info_impl.bzl
@@ -413,7 +413,7 @@ def collect_go_info(target, ctx, semantics, ide_info, ide_info_file, output_grou
             library_labels = [stringify_label(ctx.rule.attr.library.label)]
         elif getattr(ctx.rule.attr, "embed", None) != None:
             for library in ctx.rule.attr.embed:
-                if library.intellij_info.kind == "go_source":
+                if library.intellij_info.kind == "go_source" or library.intellij_info.kind == "go_proto_library":
                     l = library.intellij_info.output_groups["intellij-sources-go-outputs"].to_list()
                     sources += l
                     generated += [f for f in l if not f.is_source]

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/go/go_proto_library/BUILD
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/go/go_proto_library/BUILD
@@ -1,0 +1,50 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+load(
+    "//aspect/testing/rules:intellij_aspect_test_fixture.bzl",
+    "intellij_aspect_test_fixture",
+)
+
+proto_library(
+    name = "fooproto_proto",
+    srcs = ["fooserver.proto"],
+    visibility = ["//visibility:public"],
+    deps = ["@com_google_protobuf//:empty_proto"],
+)
+
+go_proto_library(
+    name = "fooproto_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+    importpath = "github.com/bazelbuild/intellij/examples/go/with_proto/proto",
+    proto = ":fooproto_proto",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "proto",
+    srcs = ["translators.go"],
+    embed = [":fooproto_go_proto"],
+    importpath = "github.com/bazelbuild/intellij/examples/go/with_proto/proto",
+    visibility = ["//visibility:public"],
+)
+
+intellij_aspect_test_fixture(
+    name = "simple_fixture",
+    deps = [":proto"],
+)
+
+java_test(
+    name = "GoTest",
+    srcs = ["GoTest.java"],
+    data = [":simple_fixture"],
+    deps = [
+        "//aspect/testing:BazelIntellijAspectTest",
+        "//aspect/testing:guava",
+        "//aspect/testing/rules:IntellijAspectTest",
+        "//aspect/testing/rules:intellij_aspect_test_fixture_java_proto",
+        "//intellij_platform_sdk:test_libs",
+        "//proto:intellij_ide_info_java_proto",
+        "@junit//jar",
+    ],
+)

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/go/go_proto_library/GoTest.java
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/go/go_proto_library/GoTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.aspect.go.go_proto_library;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.devtools.intellij.IntellijAspectTestFixtureOuterClass.IntellijAspectTestFixture;
+import com.google.devtools.intellij.ideinfo.IntellijIdeInfo.TargetIdeInfo;
+import com.google.idea.blaze.BazelIntellijAspectTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+
+/** Tests go_proto_library */
+@RunWith(JUnit4.class)
+public class GoTest extends BazelIntellijAspectTest {
+  @Test
+  public void testGoTest() throws Exception {
+    IntellijAspectTestFixture testFixture = loadTestFixture(":simple_fixture");
+    TargetIdeInfo target = findTarget(testFixture, ":proto");
+    assertThat(target.getKindString()).isEqualTo("go_library");
+    assertThat(relativePathsForArtifacts(target.getGoIdeInfo().getSourcesList()))
+        .contains(testRelative("translators.go"));
+    assertThat(relativePathsForArtifacts(target.getGoIdeInfo().getSourcesList()))
+        .contains(testRelative("fooproto_go_proto_/github.com/bazelbuild/intellij/examples/go/with_proto/proto/fooserver.pb.go"));
+  }
+}

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/go/go_proto_library/fooserver.proto
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/go/go_proto_library/fooserver.proto
@@ -1,0 +1,27 @@
+syntax = "proto3";
+
+package fooproto;
+
+import "google/protobuf/empty.proto";
+
+service FooService {
+  rpc SayHello (HelloRequest) returns (HelloReply) {}
+  // This function exists to validate that the well known types (such as google.protobuf.Empty)
+  // are picked up by the plugin.
+  // To validate that they are working, navigate to "External Libraries" > "Go Libraries" >
+  //   "github.com/bazelbuild/intellij/examples/go/with_proto/proto/fooserver.pb.go",
+  // and validate that "google.golang.org/protobuf/types/known/emptypb" is resolved correctly.
+  rpc EmptyFunction (google.protobuf.Empty) returns (google.protobuf.Empty);
+}
+
+message HelloRequest {
+  optional string name = 1;
+}
+
+message HelloReply {
+  optional string message = 1;
+}
+
+message Time {
+  string value = 1;
+}

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/go/go_proto_library/setup.bzl
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/go/go_proto_library/setup.bzl
@@ -1,0 +1,4 @@
+def setup_tests():
+    """
+    Setup the dependencies for testing the rules.
+    """

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/go/go_proto_library/simple.go
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/go/go_proto_library/simple.go
@@ -1,0 +1,1 @@
+package simple

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/go/go_proto_library/translators.go
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/go/go_proto_library/translators.go
@@ -1,0 +1,11 @@
+package proto
+
+import (
+	"time"
+)
+
+// Time translation functions.
+
+func ToProtoTime(t time.Time) Time {
+	return Time{Value: t.Format(time.RFC3339Nano)}
+}

--- a/examples/go/with_proto/proto/BUILD.bazel
+++ b/examples/go/with_proto/proto/BUILD.bazel
@@ -19,6 +19,7 @@ go_proto_library(
 
 go_library(
     name = "proto",
+    srcs = ["translators.go"],
     embed = [":fooproto_go_proto"],
     importpath = "github.com/bazelbuild/intellij/examples/go/with_proto/proto",
     visibility = ["//visibility:public"],

--- a/examples/go/with_proto/proto/fooserver.proto
+++ b/examples/go/with_proto/proto/fooserver.proto
@@ -21,3 +21,7 @@ message HelloRequest {
 message HelloReply {
   optional string message = 1;
 }
+
+message Time {
+  string value = 1;
+}

--- a/examples/go/with_proto/proto/translators.go
+++ b/examples/go/with_proto/proto/translators.go
@@ -1,0 +1,11 @@
+package proto
+
+import (
+	"time"
+)
+
+// Time translation functions.
+
+func ToProtoTime(t time.Time) Time {
+	return Time{Value: t.Format(time.RFC3339Nano)}
+}


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: https://github.com/bazelbuild/intellij/issues/5566

# Description of this change

Support embedded go_proto_library as source files in the same Go package. 

With this change, proto refers to the pb.go as source files which is what we intend to do:
```
cat bazel-bin/proto/proto-106940904.intellij-info.txt
build_file_artifact_location {
  is_external: false
  is_source: true
  relative_path: "proto/BUILD.bazel"
  root_execution_path_fragment: ""
}
deps {
  dependency_type: 0
  target {
    label: "//proto:fooproto_go_proto"
  }
}
go_ide_info {
  import_path: "github.com/bazelbuild/intellij/examples/go/with_proto/proto"
  sources {
    is_external: false
    is_source: true
    relative_path: "proto/translators.go"
    root_execution_path_fragment: ""
  }
  sources {
    is_external: false
    is_source: false
    relative_path: "proto/fooproto_go_proto_/github.com/bazelbuild/intellij/examples/go/with_proto/proto/fooserver.pb.go"
    root_execution_path_fragment: "bazel-out/darwin_arm64-fastbuild/bin"
  }
}
key {
  label: "//proto:proto"
}
kind_string: "go_library"
```

