### PR TITLE
Bump grpc-java version

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -900,9 +900,9 @@ http_archive(
 # gRPC Java
 http_archive(
     name = "io_grpc_grpc_java",
-    sha256 = "4a021ea9ebb96f5841a135c168209cf2413587a0f8ce71a2bf37b3aad847b0d0",
-    strip_prefix = "grpc-java-1.57.1",
-    url = "https://github.com/grpc/grpc-java/archive/v1.57.1.tar.gz",
+    sha256 = "3bcf6be49fc7ab8187577a5211421258cb8e6d179f46023cc82e42e3a6188e51",
+    strip_prefix = "grpc-java-1.59.0",
+    url = "https://github.com/grpc/grpc-java/archive/refs/tags/v1.59.0.tar.gz",
 )
 
 jvm_maven_import_external(


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

The new version of grpc-java has the fix for the migration of [Automatic Exec Groups - AEGs](https://github.com/bazelbuild/bazel/issues/19981). In order to move forward with enabling AEGs inside Bazel, this new release must be used.
