### PR TITLE
feat: Support gutter icons in `java_test_suite`

### DIFF
--- a/java/src/com/google/idea/blaze/java/JavaBlazeRules.java
+++ b/java/src/com/google/idea/blaze/java/JavaBlazeRules.java
@@ -33,6 +33,7 @@ public final class JavaBlazeRules implements Kind.Provider {
   public enum RuleTypes {
     JAVA_LIBRARY("java_library", LanguageClass.JAVA, RuleType.LIBRARY),
     JAVA_TEST("java_test", LanguageClass.JAVA, RuleType.TEST),
+    JAVA_TEST_SUITE("java_test_suite", LanguageClass.JAVA, RuleType.TEST),
     JAVA_BINARY("java_binary", LanguageClass.JAVA, RuleType.BINARY),
     JAVA_IMPORT("java_import", LanguageClass.JAVA, RuleType.UNKNOWN),
     JAVA_TOOLCHAIN("java_toolchain", LanguageClass.JAVA, RuleType.UNKNOWN),

--- a/java/src/com/google/idea/blaze/java/TargetKindUtil.java
+++ b/java/src/com/google/idea/blaze/java/TargetKindUtil.java
@@ -32,7 +32,8 @@ public final class TargetKindUtil {
   }
 
   public static boolean isJavaTest(Kind targetKind) {
-    return targetKind != null && targetKind.equals(JavaBlazeRules.RuleTypes.JAVA_TEST.getKind());
+    return targetKind != null && (targetKind.equals(JavaBlazeRules.RuleTypes.JAVA_TEST.getKind()) ||
+            targetKind.equals(JavaBlazeRules.RuleTypes.JAVA_TEST_SUITE.getKind()));
   }
 
   private TargetKindUtil() {}

--- a/java/src/com/google/idea/blaze/java/sync/source/JavaLikeLanguage.java
+++ b/java/src/com/google/idea/blaze/java/sync/source/JavaLikeLanguage.java
@@ -97,13 +97,15 @@ public interface JavaLikeLanguage {
     public ImmutableSet<Kind> getDebuggableKinds() {
       return ImmutableSet.of(
           JavaBlazeRules.RuleTypes.JAVA_BINARY.getKind(),
-          JavaBlazeRules.RuleTypes.JAVA_TEST.getKind());
+          JavaBlazeRules.RuleTypes.JAVA_TEST.getKind(),
+          JavaBlazeRules.RuleTypes.JAVA_TEST_SUITE.getKind());
     }
 
     @Override
     public ImmutableSet<Kind> getHandledTestKinds() {
       return ImmutableSet.of(
           JavaBlazeRules.RuleTypes.JAVA_TEST.getKind(),
+          JavaBlazeRules.RuleTypes.JAVA_TEST_SUITE.getKind(),
           JavaBlazeRules.RuleTypes.GWT_TEST.getKind(),
           JavaBlazeRules.RuleTypes.JAVA_WEB_TEST.getKind());
     }

--- a/java/tests/unittests/com/google/idea/blaze/java/run/BlazeJavaRunProfileStateTest.java
+++ b/java/tests/unittests/com/google/idea/blaze/java/run/BlazeJavaRunProfileStateTest.java
@@ -191,6 +191,31 @@ public class BlazeJavaRunProfileStateTest extends BlazeTestCase {
   }
 
   @Test
+  public void debugFlagShouldBeIncludedForJavaTestSuite() {
+      configuration.setTargetInfo(
+              TargetInfo.builder(Label.create("//label:java_test_suite_rule"), "java_test_suite").build());
+      BlazeCommandRunConfigurationCommonState handlerState =
+              (BlazeCommandRunConfigurationCommonState) configuration.getHandler().getState();
+      handlerState.getCommandState().setCommand(BlazeCommandName.fromString("test"));
+      assertThat(
+          BlazeJavaRunProfileState.getBlazeCommandBuilder(
+              project,
+              configuration,
+              ImmutableList.of(),
+              ExecutorType.DEBUG,
+              /*kotlinxCoroutinesJavaAgent=*/ null)
+              .build()
+              .toList())
+          .isEqualTo(
+              ImmutableList.of(
+              "/usr/bin/blaze",
+              "test",
+              BlazeFlags.getToolTagFlag(),
+              "--",
+              "//label:java_test_suite_rule",
+              "--wrapper_script_flag=--debug=5005"));
+  }
+  @Test
   public void debugFlagShouldBeIncludedForJavaBinary() {
     configuration.setTargetInfo(
         TargetInfo.builder(Label.create("//label:java_binary_rule"), "java_binary").build());

--- a/java/tests/unittests/com/google/idea/blaze/java/run/BlazeJavaRunProfileStateTest.java
+++ b/java/tests/unittests/com/google/idea/blaze/java/run/BlazeJavaRunProfileStateTest.java
@@ -211,9 +211,10 @@ public class BlazeJavaRunProfileStateTest extends BlazeTestCase {
               "/usr/bin/blaze",
               "test",
               BlazeFlags.getToolTagFlag(),
+              "--java_debug",
+              "--test_arg=--wrapper_script_flag=--debug=5005",
               "--",
-              "//label:java_test_suite_rule",
-              "--wrapper_script_flag=--debug=5005"));
+              "//label:java_test_suite_rule"));
   }
   @Test
   public void debugFlagShouldBeIncludedForJavaBinary() {


### PR DESCRIPTION
# Checklist

- [X] I have filed an issue about this change and discussed potential changes with the maintainers.
- [X] I have received the approval from the maintainers to make this change.
- [X] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: Change implemented internally, upstreaming.

# Description of this change

[`java_test_suite`](https://github.com/bazel-contrib/rules_jvm#java_test_suite) is a common way to define java tests for users of https://github.com/bazel-contrib/rules_jvm. Running them is roughly trivial as it acts just like a `test_suite` that generates `java_test` targets. Just making the plugin aware of the target kind is enough to make it work. All of the individual `java_test` are indexed by the aspect normally.