### PR TITLE
Fix "Non-blaze project is provided" error

### DIFF
--- a/base/src/com/google/idea/blaze/base/dependencies/ExternalFileProjectManagementHelper.java
+++ b/base/src/com/google/idea/blaze/base/dependencies/ExternalFileProjectManagementHelper.java
@@ -26,6 +26,7 @@ import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.primitives.LanguageClass;
 import com.google.idea.blaze.base.projectview.ProjectViewSet;
 import com.google.idea.blaze.base.scope.BlazeContext;
+import com.google.idea.blaze.base.settings.Blaze;
 import com.google.idea.blaze.base.settings.BlazeImportSettings;
 import com.google.idea.blaze.base.settings.BlazeUserSettings;
 import com.google.idea.blaze.base.settings.ui.BlazeUserSettingsCompositeConfigurable;
@@ -108,6 +109,10 @@ public class ExternalFileProjectManagementHelper
   @Nullable
   @Override
   public EditorNotificationPanel createNotificationPanel(VirtualFile vf, FileEditor fileEditor) {
+    if(Blaze.getProjectType(project) == BlazeImportSettings.ProjectType.UNKNOWN) {
+      return null;
+    }
+
     if (!enabled.getValue()) {
       return null;
     }

--- a/base/src/com/google/idea/blaze/base/syncstatus/SyncStatusEditorTabColorProvider.java
+++ b/base/src/com/google/idea/blaze/base/syncstatus/SyncStatusEditorTabColorProvider.java
@@ -15,6 +15,8 @@
  */
 package com.google.idea.blaze.base.syncstatus;
 
+import com.google.idea.blaze.base.settings.Blaze;
+import com.google.idea.blaze.base.settings.BlazeImportSettings;
 import com.google.idea.blaze.base.sync.autosync.ProjectTargetManager.SyncStatus;
 import com.intellij.openapi.fileEditor.impl.EditorTabColorProvider;
 import com.intellij.openapi.project.Project;
@@ -31,6 +33,9 @@ public class SyncStatusEditorTabColorProvider implements EditorTabColorProvider 
   @Nullable
   @Override
   public Color getEditorTabColor(Project project, VirtualFile file) {
+    if(Blaze.getProjectType(project) == BlazeImportSettings.ProjectType.UNKNOWN) {
+      return null;
+    }
     if (SyncStatusContributor.getSyncStatus(project, file) == SyncStatus.UNSYNCED) {
       return UNSYNCED_COLOR;
     }

--- a/base/src/com/google/idea/blaze/base/syncstatus/SyncStatusEditorTabTitleProvider.java
+++ b/base/src/com/google/idea/blaze/base/syncstatus/SyncStatusEditorTabTitleProvider.java
@@ -15,6 +15,8 @@
  */
 package com.google.idea.blaze.base.syncstatus;
 
+import com.google.idea.blaze.base.settings.Blaze;
+import com.google.idea.blaze.base.settings.BlazeImportSettings;
 import com.google.idea.blaze.base.sync.autosync.ProjectTargetManager.SyncStatus;
 import com.intellij.openapi.fileEditor.impl.EditorTabTitleProvider;
 import com.intellij.openapi.project.DumbAware;
@@ -27,6 +29,9 @@ public class SyncStatusEditorTabTitleProvider implements EditorTabTitleProvider,
   @Nullable
   @Override
   public String getEditorTabTitle(Project project, VirtualFile file) {
+    if(Blaze.getProjectType(project) == BlazeImportSettings.ProjectType.UNKNOWN) {
+      return null;
+    }
     SyncStatus status = SyncStatusContributor.getSyncStatus(project, file);
     if (status == SyncStatus.UNSYNCED) {
       return file.getPresentableName() + " (unsynced)";


### PR DESCRIPTION
The commit 0ec12bf5e79bc5d6ac68f004997f060d2a2d070d changed the way how elegatingBlazeProjectDataManager works. Previously, for non-bazel projects it used to use AspectSyncProjectDataManager under the hood. After the change, it started throwing a "Non-blaze project is provided" error

Thanks to the change, it turned out that some of our extensions are run even for non-bazel projects. In order to avoid it I added guards at the beginning of these extensions implementations

# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

