### PR TITLE
Fix "slow operations exception" in welcome screen

### DIFF
--- a/base/src/com/google/idea/blaze/base/wizard2/UseExistingBazelWorkspaceOption.java
+++ b/base/src/com/google/idea/blaze/base/wizard2/UseExistingBazelWorkspaceOption.java
@@ -25,6 +25,7 @@ import com.intellij.openapi.fileChooser.FileChooserDescriptor;
 import com.intellij.openapi.fileChooser.FileChooserDialog;
 import com.intellij.openapi.fileChooser.FileChooserFactory;
 import com.intellij.openapi.options.ConfigurationException;
+import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.util.IconLoader;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -157,8 +158,11 @@ public class UseExistingBazelWorkspaceOption implements TopLevelSelectWorkspaceO
     final VirtualFile[] files;
     File existingLocation = new File(getDirectory());
     if (existingLocation.exists()) {
-      VirtualFile toSelect =
-          LocalFileSystem.getInstance().refreshAndFindFileByPath(existingLocation.getPath());
+      VirtualFile toSelect = ProgressManager.getInstance().runProcessWithProgressSynchronously(
+              () -> LocalFileSystem.getInstance().refreshAndFindFileByPath(existingLocation.getPath()),
+              "Refreshing Location",
+              false,
+              null);
       files = chooser.choose(null, toSelect);
     } else {
       files = chooser.choose(null);


### PR DESCRIPTION
Happens when you try to choose directory you want to import. Happens only on fresh IntelliJ process

closes #5597

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

