### PR TITLE
Fix missing "Bazel" item in main menu.

### DIFF
--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -139,7 +139,7 @@
         text="Add to project"
         icon="AllIcons.General.Add" />
 
-    <group id="Blaze.MainMenuActionGroup" class="com.google.idea.blaze.base.actions.BlazeMenuGroup">
+    <group id="Blaze.MainMenuActionGroup" class="com.google.idea.blaze.base.actions.BlazeMenuGroup" popup="true">
       <add-to-group group-id="MainMenu" anchor="before" relative-to-action="HelpMenu"/>
       <group id ="Blaze.SyncMenuGroup" text="_Sync" popup="true">
         <reference id="Blaze.IncrementalSyncProject"/>


### PR DESCRIPTION
There was no "Bazel" item in main menu in 2033.3. Instead, three child menus were shown as top-level ones:

- Sync
- Build
- Project
<img width="737" alt="Screenshot 2023-11-02 at 15 12 21" src="https://github.com/bazelbuild/intellij/assets/1066003/a34d9e7d-3151-412b-9b83-4f0bfb8a7641">

# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

