### PR TITLE
Pass -include compilation flags down to OC language model

### DIFF
--- a/cpp/src/META-INF/blaze-cpp.xml
+++ b/cpp/src/META-INF/blaze-cpp.xml
@@ -58,6 +58,7 @@
     />
     <registryKey defaultValue="false" description="Disable absolute path trimming in debug clang builds" key="bazel.trim.absolute.path.disabled"/>
     <registryKey defaultValue="true" description="Allow external targets from source directories be imported in" key="bazel.cpp.sync.external.targets.from.directories"/>
+    <registryKey defaultValue="false" description="Filter out some incompatible compiler flags (-include)" key="bazel.cpp.sync.workspace.filter.out.incompatible.flags"/>
     <applicationService serviceInterface="com.google.idea.blaze.cpp.CompilerVersionChecker"
                         serviceImplementation="com.google.idea.blaze.cpp.CompilerVersionCheckerImpl"/>
     <applicationService serviceInterface="com.google.idea.blaze.cpp.CompilerWrapperProvider"

--- a/cpp/src/com/google/idea/blaze/cpp/BlazeCWorkspace.java
+++ b/cpp/src/com/google/idea/blaze/cpp/BlazeCWorkspace.java
@@ -45,6 +45,7 @@ import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.registry.Registry;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.pom.Navigatable;
 import com.intellij.util.containers.ContainerUtil;
@@ -70,6 +71,7 @@ import com.jetbrains.cidr.lang.workspace.compiler.TempFilesPool;
 
 import java.io.File;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -204,8 +206,11 @@ public final class BlazeCWorkspace implements ProjectComponent {
             UnfilteredCompilerOptions.builder()
                 .registerSingleOrSplitOption("-I")
                 .build(targetIdeInfo.getcIdeInfo().getLocalCopts());
-        ImmutableList<String> plainLocalCopts =
-            filterIncompatibleFlags(coptsExtractor.getUninterpretedOptions());
+        List<String> plainLocalCopts = coptsExtractor.getUninterpretedOptions();
+        if (Registry.is("bazel.cpp.sync.workspace.filter.out.incompatible.flags")) {
+          plainLocalCopts = filterIncompatibleFlags(plainLocalCopts);
+        }
+
         ImmutableList<ExecutionRootPath> localIncludes =
             coptsExtractor.getExtractedOptionValues("-I").stream()
                 .map(ExecutionRootPath::new)


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: fixes #5497

# Description of this change

For some reason particularly -include was marked as unsupported back in 2018, and we don't know the reason due to the lack of knowledge. To address any possible issues with the change behavior a new registry flag bazel.cpp.sync.workspace.filter.out.incompatible.flags is introduced. It is false by default, so we enable -include support for everyone and the old behavior can be brought back by enabling the registry flag.
