### PR TITLE
Add checks for bazel projects in bazel-only code

### DIFF
--- a/base/src/com/google/idea/blaze/base/lang/AdditionalLanguagesHelper.java
+++ b/base/src/com/google/idea/blaze/base/lang/AdditionalLanguagesHelper.java
@@ -93,6 +93,10 @@ public class AdditionalLanguagesHelper
   @Nullable
   @Override
   public EditorNotificationPanel createNotificationPanel(VirtualFile file, FileEditor fileEditor) {
+    if (Blaze.getProjectType(project).equals(ProjectType.UNKNOWN)) {
+      return null;
+    }
+
     String ext = file.getExtension();
     if (ext == null) {
       return null;

--- a/skylark/src/com/google/idea/blaze/skylark/debugger/SkylarkDebuggingUtils.java
+++ b/skylark/src/com/google/idea/blaze/skylark/debugger/SkylarkDebuggingUtils.java
@@ -35,6 +35,10 @@ public final class SkylarkDebuggingUtils {
       new BoolExperiment("skylark.debugging.enabled", true);
 
   public static boolean debuggingEnabled(Project project) {
+    if (Blaze.getProjectType(project).equals(ProjectType.UNKNOWN)) {
+      return false;
+    }
+
     if (Blaze.getProjectType(project).equals(ProjectType.QUERY_SYNC)) {
       // Skylark debugging only needs a blaze version past EARLIEST_SUPPORTED_BLAZE_CL, which
       // greatly predates query sync


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [X] I have received the approval from the maintainers to make this change.
- [X] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #5655

# Description of this change

After the 0ec12bf5e79bc5d6ac68f004997f0 the "non-blaze project" exceptions is thrown from places where bazel project data is accessed for non-bazel project. This hints us to places where we should introduce an extra check to avoid running bazel-related code for non-bazel projects.
