### PR TITLE
Remove fail soft for ASwB Canary

### DIFF
--- a/.bazelci/android-studio.yml
+++ b/.bazelci/android-studio.yml
@@ -36,8 +36,6 @@ tasks:
       - --test_output=errors
     test_targets:
       - //:aswb_tests
-    soft_fail:
-      - exit_status: 1
   Android-Studio-OSS-oldest-stable:
     name: Android Studio OSS Oldest Stable
     platform: ubuntu1804
@@ -74,5 +72,3 @@ tasks:
       - --test_output=errors
     test_targets:
       - //:aswb_tests
-    soft_fail:
-      - exit_status: 1


### PR DESCRIPTION
So the internal team can know if their changes break the canary version.