### PR TITLE
feat: Add support for Starlark float literals

### DIFF
--- a/base/src/com/google/idea/blaze/base/lang/buildfile/highlighting/BuildSyntaxHighlighter.java
+++ b/base/src/com/google/idea/blaze/base/lang/buildfile/highlighting/BuildSyntaxHighlighter.java
@@ -75,6 +75,7 @@ public class BuildSyntaxHighlighter extends SyntaxHighlighterBase {
   static {
     addAttribute(TokenKind.COMMENT, BUILD_LINE_COMMENT);
     addAttribute(TokenKind.INT, BUILD_NUMBER);
+    addAttribute(TokenKind.FLOAT, BUILD_NUMBER);
     addAttribute(TokenKind.STRING, BUILD_STRING);
 
     addAttribute(TokenKind.LBRACE, BUILD_BRACES);

--- a/base/src/com/google/idea/blaze/base/lang/buildfile/language/semantics/BuiltInNamesProvider.java
+++ b/base/src/com/google/idea/blaze/base/lang/buildfile/language/semantics/BuiltInNamesProvider.java
@@ -41,6 +41,7 @@ public class BuiltInNamesProvider {
           "enumerate",
           "fail",
           "False",
+          "float",
           "getattr",
           "hasattr",
           "hash",

--- a/base/src/com/google/idea/blaze/base/lang/buildfile/lexer/TokenKind.java
+++ b/base/src/com/google/idea/blaze/base/lang/buildfile/lexer/TokenKind.java
@@ -38,6 +38,7 @@ public enum TokenKind {
   EQUALS_EQUALS("=="),
   EXCEPT("except"),
   FINALLY("finally"),
+  FLOAT("float"),
   FOR("for"),
   FROM("from"),
   GLOBAL("global"),

--- a/base/src/com/google/idea/blaze/base/lang/buildfile/parser/ExpressionParsing.java
+++ b/base/src/com/google/idea/blaze/base/lang/buildfile/parser/ExpressionParsing.java
@@ -249,6 +249,9 @@ public class ExpressionParsing extends Parsing {
       case INT:
         buildTokenElement(BuildElementTypes.INTEGER_LITERAL);
         return;
+      case FLOAT:
+        buildTokenElement(BuildElementTypes.FLOAT_LITERAL);
+        return;
       case STRING:
         parseStringLiteral(true);
         return;

--- a/base/src/com/google/idea/blaze/base/lang/buildfile/psi/BuildElementTypes.java
+++ b/base/src/com/google/idea/blaze/base/lang/buildfile/psi/BuildElementTypes.java
@@ -71,6 +71,7 @@ public interface BuildElementTypes {
   BuildElementType DOT_EXPRESSION = new BuildElementType("dot_expr", DotExpression.class);
   BuildElementType STRING_LITERAL = new BuildElementType("string", StringLiteral.class);
   BuildElementType INTEGER_LITERAL = new BuildElementType("int", IntegerLiteral.class);
+  BuildElementType FLOAT_LITERAL = new BuildElementType("float", FloatLiteral.class);
   BuildElementType LIST_LITERAL = new BuildElementType("list", ListLiteral.class);
   BuildElementType GLOB_EXPRESSION = new BuildElementType("glob", GlobExpression.class);
   BuildElementType REFERENCE_EXPRESSION =
@@ -92,6 +93,7 @@ public interface BuildElementTypes {
           DOT_EXPRESSION,
           STRING_LITERAL,
           INTEGER_LITERAL,
+          FLOAT_LITERAL,
           LIST_LITERAL,
           PARENTHESIZED_EXPRESSION,
           TUPLE_EXPRESSION,

--- a/base/src/com/google/idea/blaze/base/lang/buildfile/psi/BuildElementVisitor.java
+++ b/base/src/com/google/idea/blaze/base/lang/buildfile/psi/BuildElementVisitor.java
@@ -104,6 +104,10 @@ public class BuildElementVisitor extends PsiElementVisitor {
     visitElement(node);
   }
 
+  public void visitFloatLiteral(FloatLiteral node) {
+    visitElement(node);
+  }
+
   public void visitListLiteral(ListLiteral node) {
     visitElement(node);
   }

--- a/base/src/com/google/idea/blaze/base/lang/buildfile/psi/FloatLiteral.java
+++ b/base/src/com/google/idea/blaze/base/lang/buildfile/psi/FloatLiteral.java
@@ -1,0 +1,15 @@
+package com.google.idea.blaze.base.lang.buildfile.psi;
+
+import com.intellij.lang.ASTNode;
+
+public class FloatLiteral extends BuildElementImpl implements LiteralExpression {
+
+  public FloatLiteral(ASTNode astNode) {
+    super(astNode);
+  }
+
+  @Override
+  protected void acceptVisitor(BuildElementVisitor visitor) {
+    visitor.visitFloatLiteral(this);
+  }
+}

--- a/base/tests/unittests/com/google/idea/blaze/base/lang/buildfile/lexer/BlazeLexerTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/lang/buildfile/lexer/BlazeLexerTest.java
@@ -63,28 +63,28 @@ public class BlazeLexerTest extends AbstractLexerTest {
     assertEquals("", names(tokens("")));
     assertEquals("", names(tokens("# foo")));
     assertEquals("INT INT INT INT", names(tokens("1 2 3 4")));
-    assertEquals("INT DOT INT", names(tokens("1.234")));
+    assertEquals("FLOAT", names(tokens("1.234")));
     assertEquals(
         "IDENTIFIER LPAREN IDENTIFIER COMMA IDENTIFIER RPAREN", names(tokens("foo(bar, wiz)")));
   }
 
   @Test
   public void testIntegersAndDot() throws Exception {
-    assertEquals("INT(1) DOT INT(2345)", values(tokens("1.2345")));
+    assertEquals("FLOAT(1.2345)", values(tokens("1.2345")));
 
-    assertEquals("INT(1) DOT INT(2) DOT INT(345)", values(tokens("1.2.345")));
+    assertEquals("FLOAT(1.2) FLOAT(0.345)", values(tokens("1.2.345")));
 
-    assertEquals("INT(1) DOT INT(0)", values(tokens("1.23E10")));
-    assertEquals("invalid base-10 integer constant: 23E10", lastError);
+    assertEquals("FLOAT(1.23E10)", values(tokens("1.23E10")));
 
-    assertEquals("INT(1) DOT INT(0) MINUS INT(10)", values(tokens("1.23E-10")));
-    assertEquals("invalid base-10 integer constant: 23E", lastError);
+    assertEquals("FLOAT(0.0)", values(tokens("1.23E")));
+    assertEquals("invalid float constant: 1.23E", lastError);
 
+    assertEquals("FLOAT(1.23E-10)", values(tokens("1.23E-10")));
     assertEquals("DOT INT(123)", values(tokens(". 123")));
-    assertEquals("DOT INT(123)", values(tokens(".123")));
+    assertEquals("FLOAT(0.123)", values(tokens(".123")));
     assertEquals("DOT IDENTIFIER(abc)", values(tokens(".abc")));
 
-    assertEquals("IDENTIFIER(foo) DOT INT(123)", values(tokens("foo.123")));
+    assertEquals("IDENTIFIER(foo) FLOAT(0.123)", values(tokens("foo.123")));
     assertEquals(
         "IDENTIFIER(foo) DOT IDENTIFIER(bcd)", values(tokens("foo.bcd"))); // 'b' are hex chars
     assertEquals("IDENTIFIER(foo) DOT IDENTIFIER(xyz)", values(tokens("foo.xyz")));

--- a/base/tests/unittests/com/google/idea/blaze/base/lang/buildfile/lexer/BlazeLexerTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/lang/buildfile/lexer/BlazeLexerTest.java
@@ -85,6 +85,7 @@ public class BlazeLexerTest extends AbstractLexerTest {
     assertEquals("DOT IDENTIFIER(abc)", values(tokens(".abc")));
 
     assertEquals("IDENTIFIER(foo) FLOAT(0.123)", values(tokens("foo.123")));
+    assertEquals("IDENTIFIER(foo456) FLOAT(0.123)", values(tokens("foo456.123")));
     assertEquals(
         "IDENTIFIER(foo) DOT IDENTIFIER(bcd)", values(tokens("foo.bcd"))); // 'b' are hex chars
     assertEquals("IDENTIFIER(foo) DOT IDENTIFIER(xyz)", values(tokens("foo.xyz")));

--- a/base/tests/unittests/com/google/idea/blaze/base/lang/buildfile/lexer/HighlightingLexerTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/lang/buildfile/lexer/HighlightingLexerTest.java
@@ -63,7 +63,8 @@ public class HighlightingLexerTest extends AbstractLexerTest {
     assertEquals("", names(tokens("")));
     assertEquals("COMMENT", names(tokens("# foo")));
     assertEquals("INT WHITESPACE INT WHITESPACE INT WHITESPACE INT", names(tokens("1 2 3 4")));
-    assertEquals("INT DOT INT", names(tokens("1.234")));
+    assertEquals("FLOAT", names(tokens("1.234")));
+    assertEquals("DOT IDENTIFIER", names(tokens(".a")));
     assertEquals(
         "IDENTIFIER LPAREN IDENTIFIER COMMA WHITESPACE IDENTIFIER RPAREN",
         names(tokens("foo(bar, wiz)")));
@@ -71,21 +72,21 @@ public class HighlightingLexerTest extends AbstractLexerTest {
 
   @Test
   public void testIntegersAndDot() throws Exception {
-    assertEquals("INT(1) DOT INT(2345)", values(tokens("1.2345")));
+    assertEquals("FLOAT(1.2345)", values(tokens("1.2345")));
 
-    assertEquals("INT(1) DOT INT(2) DOT INT(345)", values(tokens("1.2.345")));
+    assertEquals("FLOAT(1.2) FLOAT(0.345)", values(tokens("1.2.345")));
 
-    assertEquals("INT(1) DOT INT(0)", values(tokens("1.23E10")));
-    assertEquals("invalid base-10 integer constant: 23E10", lastError);
+    assertEquals("FLOAT(1.23E10)", values(tokens("1.23E10")));
 
-    assertEquals("INT(1) DOT INT(0) MINUS INT(10)", values(tokens("1.23E-10")));
-    assertEquals("invalid base-10 integer constant: 23E", lastError);
+    assertEquals("FLOAT(0.0)", values(tokens("1.23E")));
+    assertEquals("invalid float constant: 1.23E", lastError);
 
+    assertEquals("FLOAT(1.23E-10)", values(tokens("1.23E-10")));
     assertEquals("DOT WHITESPACE INT(123)", values(tokens(". 123")));
-    assertEquals("DOT INT(123)", values(tokens(".123")));
+    assertEquals("FLOAT(0.123)", values(tokens(".123")));
     assertEquals("DOT IDENTIFIER(abc)", values(tokens(".abc")));
 
-    assertEquals("IDENTIFIER(foo) DOT INT(123)", values(tokens("foo.123")));
+    assertEquals("IDENTIFIER(foo) FLOAT(0.123)", values(tokens("foo.123")));
     assertEquals(
         "IDENTIFIER(foo) DOT IDENTIFIER(bcd)", values(tokens("foo.bcd"))); // 'b' are hex chars
     assertEquals("IDENTIFIER(foo) DOT IDENTIFIER(xyz)", values(tokens("foo.xyz")));

--- a/base/tests/unittests/com/google/idea/blaze/base/lang/buildfile/lexer/HighlightingLexerTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/lang/buildfile/lexer/HighlightingLexerTest.java
@@ -87,6 +87,7 @@ public class HighlightingLexerTest extends AbstractLexerTest {
     assertEquals("DOT IDENTIFIER(abc)", values(tokens(".abc")));
 
     assertEquals("IDENTIFIER(foo) FLOAT(0.123)", values(tokens("foo.123")));
+    assertEquals("IDENTIFIER(foo456) FLOAT(0.123)", values(tokens("foo456.123")));
     assertEquals(
         "IDENTIFIER(foo) DOT IDENTIFIER(bcd)", values(tokens("foo.bcd"))); // 'b' are hex chars
     assertEquals("IDENTIFIER(foo) DOT IDENTIFIER(xyz)", values(tokens("foo.xyz")));

--- a/skylark/src/com/google/idea/blaze/skylark/debugger/impl/SkylarkDebugValue.java
+++ b/skylark/src/com/google/idea/blaze/skylark/debugger/impl/SkylarkDebugValue.java
@@ -61,7 +61,7 @@ class SkylarkDebugValue extends XNamedValue {
   // TODO(brendandouglas): move this logic onto the server side?
   private static final ImmutableSet<String> ARRAY_TYPES = ImmutableSet.of("dict", "list", "depset");
   private static final ImmutableSet<String> PRIMITIVE_TYPES =
-      ImmutableSet.of("bool", "string", "int");
+      ImmutableSet.of("bool", "string", "int", "float");
   private static final ImmutableSet<String> FUNCTION_TYPES =
       ImmutableSet.of("function", "Provider");
 


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #5677

# Description of this change

Add support for Starlark floating-point literals. Also add `float` as a built-in function, and consider float values primitives in the debugger.

Before:
<img width="138" alt="not highlighted" src="https://github.com/bazelbuild/intellij/assets/140534739/850b6e59-5c40-4a1d-8421-9247e978f7a1">

After:
<img width="136" alt="highlighted correctly" src="https://github.com/bazelbuild/intellij/assets/140534739/dd877f3e-e477-4b1d-b659-df047bebc29d">

Much of the lexer implementation is ported from [starlark-go](https://github.com/google/starlark-go/blob/556fd59b42f68a2fb1f84957741b72811c714e51/syntax/scan.go#L909)