### PR TITLE
Update java example

### DIFF
--- a/examples/java/greetings_project/WORKSPACE
+++ b/examples/java/greetings_project/WORKSPACE
@@ -2,8 +2,8 @@ load("@bazel_tools//tools/build_defs/repo:jvm.bzl", "jvm_maven_import_external")
 
 jvm_maven_import_external(
     name = "junit",
-    artifact = "org.junit.jupiter:junit-jupiter-api:5.9.1",
-    artifact_sha256 = "5d2fe4d719dffb25a95d77e9c7a34893cbbb1b4cc6c86f2726af7e0fb7035b2f",
+    artifact = "junit:junit:4.13.2",
+    artifact_sha256 = "8e495b634469d64fb8acfa3495a065cbacc8a0fff55ce1e31007be4c16dc57d3",
     licenses = ["notice"],  # Common Public License 1.0
     server_urls = ["https://repo1.maven.org/maven2"],
 )

--- a/examples/java/greetings_project/hello/hello.bazelproject
+++ b/examples/java/greetings_project/hello/hello.bazelproject
@@ -19,3 +19,6 @@ additional_languages:
   # kotlin
   # python
   # scala
+
+build_flags:
+  --explicit_java_test_deps

--- a/examples/java/greetings_project/hello/hello.bazelproject
+++ b/examples/java/greetings_project/hello/hello.bazelproject
@@ -21,4 +21,5 @@ additional_languages:
   # scala
 
 build_flags:
+  # make sure the junit version loaded in the WORKSPACE is the one used
   --explicit_java_test_deps


### PR DESCRIPTION
The java example loaded `org.junit.jupiter:junit-jupiter-api:5.9.1` in its WORKSPACE but it was not used and the library from `Runner_deploy-ijar.jar` was used instead. Fixing this to make it clear which version of junit is used. I think junit 5 is not yet supported by the plugin.