### PR TITLE
Add unittest for SkylarkDebuggingUtils to check that no exception occurs for non-bazel projects

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -36,6 +36,7 @@ test_suite(
         "//plugin_dev:integration_tests",
         "//scala:integration_tests",
         "//scala:unit_tests",
+        "//skylark:unit_tests",
     ],
 )
 
@@ -78,6 +79,7 @@ test_suite(
         "//dart:unit_tests",
         "//java:integration_tests",
         "//java:unit_tests",
+        "//skylark:unit_tests",
     ],
 )
 
@@ -98,6 +100,7 @@ test_suite(
         "//cpp:unit_tests",
         "//dart:unit_tests",
         "//python:unit_tests",
+        "//skylark:unit_tests",
     ],
 )
 

--- a/base/src/com/google/idea/blaze/base/settings/Blaze.java
+++ b/base/src/com/google/idea/blaze/base/settings/Blaze.java
@@ -69,8 +69,12 @@ public class Blaze {
       return ProjectType.UNKNOWN;
     }
 
-    BlazeImportSettings blazeImportSettings =
-        BlazeImportSettingsManager.getInstance(project).getImportSettings();
+    BlazeImportSettingsManager blazeImportSettingsManager =
+        BlazeImportSettingsManager.getInstance(project);
+    if (blazeImportSettingsManager == null) {
+      return ProjectType.UNKNOWN;
+    }
+    BlazeImportSettings blazeImportSettings = blazeImportSettingsManager.getImportSettings();
     if (blazeImportSettings == null) {
       return ProjectType.UNKNOWN;
     }

--- a/skylark/BUILD
+++ b/skylark/BUILD
@@ -1,8 +1,18 @@
 #
 # Description: A Skylark debugging client for IntelliJ.
 #
-
-load("//build_defs:build_defs.bzl", "intellij_plugin_library")
+load(
+    "//testing:test_defs.bzl",
+    "intellij_integration_test_suite",
+    "intellij_unit_test_suite",
+)
+load(
+    "//build_defs:build_defs.bzl",
+    "intellij_plugin",
+    "intellij_plugin_library",
+    "optional_plugin_xml",
+    "stamped_plugin_xml",
+)
 load(
     "//:build-visibility.bzl",
     "PLUGIN_PACKAGES_VISIBILITY",
@@ -29,4 +39,39 @@ intellij_plugin_library(
     plugin_xmls = ["src/META-INF/blaze-skylark.xml"],
     visibility = PLUGIN_PACKAGES_VISIBILITY,
     deps = [":skylark"],
+)
+
+stamped_plugin_xml(
+    name = "skylark_plugin_xml",
+    plugin_id = "com.google.idea.blaze.skylark",
+    plugin_name = "com.google.idea.blaze.skylark",
+)
+
+intellij_plugin(
+    name = "skylark_integration_test_plugin",
+    testonly = 1,
+    plugin_xml = ":skylark_plugin_xml",
+    tags = [
+        "incomplete-deps",  # remove this suppression and add any missing deps, see go/java-import-deps-checking-lsc
+    ],
+    deps = [
+        ":plugin_library",
+        "//base:plugin_library",
+    ],
+)
+
+intellij_unit_test_suite(
+    name = "unit_tests",
+    srcs = glob(["tests/unittests/**/*.java"]),
+    test_package_root = "com.google.idea.blaze.skylark",
+    deps = [
+        ":skylark",
+        "//base",
+        "//base:unit_test_utils",
+        "//intellij_platform_sdk:jsr305",
+        "//intellij_platform_sdk:plugin_api_for_tests",
+        "//intellij_platform_sdk:test_libs",
+        "//testing:lib",
+        "@junit//jar",
+    ],
 )

--- a/skylark/src/com/google/idea/blaze/skylark/debugger/SkylarkDebuggingUtils.java
+++ b/skylark/src/com/google/idea/blaze/skylark/debugger/SkylarkDebuggingUtils.java
@@ -35,6 +35,7 @@ public final class SkylarkDebuggingUtils {
       new BoolExperiment("skylark.debugging.enabled", true);
 
   public static boolean debuggingEnabled(Project project) {
+    // In non-bazel projects, don't even try to debug skylark.
     if (Blaze.getProjectType(project).equals(ProjectType.UNKNOWN)) {
       return false;
     }

--- a/skylark/tests/unittests/com/google/idea/blaze/skylark/debugger/SkylarkDebuggingUtilsTest.java
+++ b/skylark/tests/unittests/com/google/idea/blaze/skylark/debugger/SkylarkDebuggingUtilsTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.skylark.debugger;
+
+import static org.junit.Assert.fail;
+
+import com.google.idea.blaze.base.BlazeTestCase;
+import com.google.idea.blaze.base.model.MockBlazeProjectDataBuilder;
+import com.google.idea.blaze.base.model.MockBlazeProjectDataManager;
+import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for {@link SkylarkDebuggingUtils}
+ */
+@RunWith(JUnit4.class)
+public class SkylarkDebuggingUtilsTest extends BlazeTestCase {
+
+    @Test
+    public void testDoesntCrashOnUninitializedProject() {
+        try {
+            SkylarkDebuggingUtils.debuggingEnabled(getProject());
+        } catch (IllegalStateException e) {
+            fail("Debugging enabled check failed for uninitialized project.");
+        }
+    }
+}


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

This is a rebase of https://github.com/bazelbuild/intellij/pull/5674. While the issue was fixed by https://github.com/bazelbuild/intellij/commit/59ddcbe54739726f32e2953002d8a49d8f91c5cf, the tests might be useful.

