### PR TITLE
Fix NPE when accessing xcodeProperties

### DIFF
--- a/cpp/src/com/google/idea/blaze/cpp/BlazeConfigurationResolverResult.java
+++ b/cpp/src/com/google/idea/blaze/cpp/BlazeConfigurationResolverResult.java
@@ -105,7 +105,7 @@ final class BlazeConfigurationResolverResult {
         ImmutableMap.of();
     ImmutableMap<CToolchainIdeInfo, BlazeCompilerSettings> compilerSettings = ImmutableMap.of();
     ImmutableSet<File> validHeaderRoots = ImmutableSet.of();
-    Optional<XcodeCompilerSettings> xcodeSettings;
+    Optional<XcodeCompilerSettings> xcodeSettings = Optional.empty();
     private ImmutableMap<String, String> setTargetToVersionMap;
 
     public Builder() {}


### PR DESCRIPTION
The problem occured when a user:
- imported a project with empty targets list in projectview OR
- ran incremental sync without any changes in targets list

closes #5695

# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

