### PR TITLE
Escape regex-relevant characters in test filter

### DIFF
--- a/golang/tests/integrationtests/com/google/idea/blaze/golang/run/producers/BlazeGoTestConfigurationProducerTest.java
+++ b/golang/tests/integrationtests/com/google/idea/blaze/golang/run/producers/BlazeGoTestConfigurationProducerTest.java
@@ -155,12 +155,14 @@ public class BlazeGoTestConfigurationProducerTest extends BlazeRunConfigurationP
         "func TestFoo(t *testing.T) {",
         "   t.R<caret>un(\"with_nested\", func(t *testing.T) {",
         "     t.R<caret>un(\"subtest\", func(t *testing.T) {})",
+        "     t.R<caret>un(\"subtest (great)\", func(t *testing.T) {})",
         "   })",
         "}"
     );
 
     assertElementGeneratesTestFilter(getElementAtCaret(0, goFile), "^TestFoo/with_nested$");
     assertElementGeneratesTestFilter(getElementAtCaret(1, goFile), "^TestFoo/with_nested/subtest$");
+    assertElementGeneratesTestFilter(getElementAtCaret(2, goFile), "^TestFoo/with_nested/subtest_\\(great\\)$");
   }
   @Test
   public void testCodeBetweenTests() throws Throwable {

--- a/golang/tests/unittests/com/google/idea/blaze/golang/run/producers/GoTestContextProviderTest.java
+++ b/golang/tests/unittests/com/google/idea/blaze/golang/run/producers/GoTestContextProviderTest.java
@@ -1,0 +1,17 @@
+package com.google.idea.blaze.golang.run.producers;
+
+import com.google.idea.blaze.base.BlazeTestCase;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@RunWith(JUnit4.class)
+public class GoTestContextProviderTest extends BlazeTestCase {
+    @Test
+    public void testRegexifyTestFilter() {
+        String regexified = GoTestContextProvider.regexifyTestFilter("Test/with/subtest(good \\ or \\ bad)");
+        assertThat(regexified).isEqualTo("^Test/with/subtest\\(good \\\\ or \\\\ bad\\)$");
+    }
+}


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #5744

# Description of this change

Go tests can contain arbitrary characters because they're not tied to a symbol name in a source file. Accordingly, they may contain characters which have special meaning for regexes. Because the Go test runner interprets this flag as a regex, we need to escape these.

Without this, running a single test from the gutter, Bazel will exit 0 and look happy, but it won't have actually run the test (which perhaps would have failed if it had run).