### PR TITLE
Support kt_android and kt_android_local_test

### DIFF
--- a/aspect/build_dependencies.bzl
+++ b/aspect/build_dependencies.bzl
@@ -680,7 +680,7 @@ FOLLOW_JAVA_ATTRIBUTES_BY_RULE_KIND = [
     ("_aspect_proto_toolchain_for_javalite", []),
     ("_aspect_java_proto_toolchain", []),
     ("runtime", ["proto_lang_toolchain", "java_rpc_toolchain"]),
-    ("_toolchain", ["_java_grpc_library", "_java_lite_grpc_library", "kt_jvm_library_helper", "android_library"]),
+    ("_toolchain", ["_java_grpc_library", "_java_lite_grpc_library", "kt_jvm_library_helper", "android_library", "kt_android_library"]),
     ("kotlin_libs", ["kt_jvm_toolchain"]),
 ]
 

--- a/aspect/intellij_info_impl.bzl
+++ b/aspect/intellij_info_impl.bzl
@@ -1046,7 +1046,7 @@ def intellij_info_aspect_impl(target, ctx, semantics):
         for export in direct_exports:
             export_deps.extend(export.intellij_info.export_deps)
 
-        if ctx.rule.kind == "android_library":
+        if ctx.rule.kind == "android_library" or ctx.rule.kind == "kt_android_library":
             # Empty android libraries export all their dependencies.
             if not hasattr(rule_attrs, "srcs") or not ctx.rule.attr.srcs:
                 export_deps.extend(compiletime_deps)

--- a/java/src/com/google/idea/blaze/java/AndroidBlazeRules.java
+++ b/java/src/com/google/idea/blaze/java/AndroidBlazeRules.java
@@ -38,6 +38,7 @@ public final class AndroidBlazeRules implements Kind.Provider {
     ANDROID_TEST("android_test", LanguageClass.ANDROID, RuleType.TEST),
     ANDROID_ROBOLECTRIC_TEST("android_robolectric_test", LanguageClass.ANDROID, RuleType.TEST),
     ANDROID_LOCAL_TEST("android_local_test", LanguageClass.ANDROID, RuleType.TEST),
+    KT_ANDROID_LOCAL_TEST("kt_android_local_test", LanguageClass.ANDROID, RuleType.TEST),
     ANDROID_INSTRUMENTATION_TEST(
         "android_instrumentation_test", LanguageClass.ANDROID, RuleType.TEST),
     ANDROID_SDK("android_sdk", LanguageClass.ANDROID, RuleType.UNKNOWN),

--- a/java/src/com/google/idea/blaze/java/AndroidBlazeRules.java
+++ b/java/src/com/google/idea/blaze/java/AndroidBlazeRules.java
@@ -35,6 +35,7 @@ public final class AndroidBlazeRules implements Kind.Provider {
   public enum RuleTypes {
     ANDROID_BINARY("android_binary", LanguageClass.ANDROID, RuleType.BINARY),
     ANDROID_LIBRARY("android_library", LanguageClass.ANDROID, RuleType.LIBRARY),
+    KT_ANDROID_LIBRARY("kt_android_library", LanguageClass.ANDROID, RuleType.LIBRARY),
     ANDROID_TEST("android_test", LanguageClass.ANDROID, RuleType.TEST),
     ANDROID_ROBOLECTRIC_TEST("android_robolectric_test", LanguageClass.ANDROID, RuleType.TEST),
     ANDROID_LOCAL_TEST("android_local_test", LanguageClass.ANDROID, RuleType.TEST),

--- a/java/src/com/google/idea/blaze/java/TargetKindUtil.java
+++ b/java/src/com/google/idea/blaze/java/TargetKindUtil.java
@@ -28,7 +28,9 @@ public final class TargetKindUtil {
   }
 
   public static boolean isAndroidLocalTest(Kind targetKind) {
-    return targetKind != null && targetKind.equals(RuleTypes.ANDROID_LOCAL_TEST.getKind());
+    return targetKind != null
+        && (targetKind.equals(RuleTypes.ANDROID_LOCAL_TEST.getKind())
+            || targetKind.equals(RuleTypes.KT_ANDROID_LOCAL_TEST.getKind()));
   }
 
   public static boolean isJavaTest(Kind targetKind) {

--- a/java/src/com/google/idea/blaze/java/fastbuild/FastBuildServiceImpl.java
+++ b/java/src/com/google/idea/blaze/java/fastbuild/FastBuildServiceImpl.java
@@ -87,6 +87,7 @@ final class FastBuildServiceImpl implements FastBuildService, ProjectComponent {
               BuildSystemName.Blaze,
               AndroidBlazeRules.RuleTypes.ANDROID_ROBOLECTRIC_TEST.getKind(),
               AndroidBlazeRules.RuleTypes.ANDROID_LOCAL_TEST.getKind(),
+              AndroidBlazeRules.RuleTypes.KT_ANDROID_LOCAL_TEST.getKind(),
               JavaBlazeRules.RuleTypes.JAVA_TEST.getKind())
           .build();
 

--- a/java/src/com/google/idea/blaze/java/run/fastbuild/AndroidLocalTestEnvironmentModifier.java
+++ b/java/src/com/google/idea/blaze/java/run/fastbuild/AndroidLocalTestEnvironmentModifier.java
@@ -30,7 +30,8 @@ abstract class AndroidLocalTestEnvironmentModifier implements FastBuildTestEnvir
       FastBuildInfo fastBuildInfo,
       BlazeInfo blazeInfo)
       throws ExecutionException {
-    if (!kind.equals(RuleTypes.ANDROID_LOCAL_TEST.getKind())) {
+    if (!kind.equals(RuleTypes.ANDROID_LOCAL_TEST.getKind())
+        && !kind.equals(RuleTypes.KT_ANDROID_LOCAL_TEST.getKind())) {
       return;
     }
 

--- a/java/src/com/google/idea/blaze/java/sync/source/AndroidJavaLikeLanguage.java
+++ b/java/src/com/google/idea/blaze/java/sync/source/AndroidJavaLikeLanguage.java
@@ -30,14 +30,16 @@ class AndroidJavaLikeLanguage implements JavaLikeLanguage {
   public ImmutableSet<Kind> getDebuggableKinds() {
     return ImmutableSet.of(
         AndroidBlazeRules.RuleTypes.ANDROID_ROBOLECTRIC_TEST.getKind(),
-        AndroidBlazeRules.RuleTypes.ANDROID_LOCAL_TEST.getKind());
+        AndroidBlazeRules.RuleTypes.ANDROID_LOCAL_TEST.getKind(),
+        AndroidBlazeRules.RuleTypes.KT_ANDROID_LOCAL_TEST.getKind());
   }
 
   @Override
   public ImmutableSet<Kind> getHandledTestKinds() {
     return ImmutableSet.of(
         AndroidBlazeRules.RuleTypes.ANDROID_ROBOLECTRIC_TEST.getKind(),
-        AndroidBlazeRules.RuleTypes.ANDROID_LOCAL_TEST.getKind());
+        AndroidBlazeRules.RuleTypes.ANDROID_LOCAL_TEST.getKind(),
+        AndroidBlazeRules.RuleTypes.KT_ANDROID_LOCAL_TEST.getKind());
   }
 
   @Override

--- a/kotlin/src/com/google/idea/blaze/kotlin/KotlinBlazeRules.java
+++ b/kotlin/src/com/google/idea/blaze/kotlin/KotlinBlazeRules.java
@@ -66,7 +66,7 @@ public final class KotlinBlazeRules implements Kind.Provider {
   @Override
   public Function<TargetIdeInfo, Kind> getTargetKindHeuristics() {
     return proto ->
-        proto.getKindString().startsWith("kt_jvm_")
+        proto.getKindString().startsWith("kt_jvm_") || proto.getKindString().startsWith("kt_android_")
             ? Kind.Provider.create(proto.getKindString(), LanguageClass.KOTLIN, RuleType.UNKNOWN)
             : null;
   }

--- a/querysync/java/com/google/idea/blaze/qsync/query/QuerySummary.java
+++ b/querysync/java/com/google/idea/blaze/qsync/query/QuerySummary.java
@@ -101,7 +101,8 @@ public abstract class QuerySummary {
               "_java_grpc_library",
               "_java_lite_grpc_library",
               "kt_jvm_library_helper",
-              "android_library"));
+              "android_library",
+              "kt_android_library"));
 
   // Runtime dependency attributes
   private static final ImmutableSet<String> RUNTIME_DEP_ATTRIBUTES =


### PR DESCRIPTION
The Bazel Intellij/Aswb plugins internally iterate over the `RuleTypes` enum values when deciding what target kinds to recognize. Example [KotlinBlazeRules](https://github.com/bazelbuild/intellij/blob/google/kotlin/src/com/google/idea/blaze/kotlin/KotlinBlazeRules.java#L60-L64)

`rules_kotlin` internally has native rules backing the `kt_jvm_` targets which is why targets of these rule kinds are recognized today.

The `kt_android_` rules in rules_kotlin are using a macro/rule "sandwich" where the top level `kt_android_` targets are just macros that eventually create a `android_library`/`android_local_test` target that's recognized by Aswb/ijwb.

We have a branch of `rules_kotlin` that drops the macro/rule sandwiches in favor of a single `kt_android_` rule. This pull request simply enables support for that branch allowing aswb/ijwb to recognize those proper `kt_android_` rule kinds, allowing features like resource resolution, running tests from the gutter, and debugging tests. 