### PR TITLE
feat: Enable debugging the gazelle binary

### DIFF
--- a/golang/src/com/google/idea/blaze/golang/GoBlazeRules.java
+++ b/golang/src/com/google/idea/blaze/golang/GoBlazeRules.java
@@ -29,6 +29,7 @@ public final class GoBlazeRules implements Kind.Provider {
 
   /** Go-specific blaze rules. */
   public enum RuleTypes {
+    GO_GAZELLE_BINARY("gazelle_binary", LanguageClass.GO, RuleType.BINARY),
     GO_TEST("go_test", LanguageClass.GO, RuleType.TEST),
     GO_APPENGINE_TEST("go_appengine_test", LanguageClass.GO, RuleType.TEST),
     GO_BINARY("go_binary", LanguageClass.GO, RuleType.BINARY),


### PR DESCRIPTION
Allow debugging gazelle (use the `gazelle_binary` target and not the `gazelle` one).