### PR TITLE
Fix buildifier formatting for `MODULE.bazel` and `WORKSPACE`

### DIFF
--- a/base/src/com/google/idea/blaze/base/buildmodifier/BuildFileFormatter.java
+++ b/base/src/com/google/idea/blaze/base/buildmodifier/BuildFileFormatter.java
@@ -93,7 +93,13 @@ public class BuildFileFormatter {
   }
 
   private static String fileTypeArg(BlazeFileType fileType) {
-    return fileType == BlazeFileType.SkylarkExtension ? "--type=bzl" : "--type=build";
+    return "--type="
+        + switch (fileType) {
+          case SkylarkExtension -> "bzl";
+          case BuildPackage -> "build";
+          case Workspace -> "workspace";
+          case MODULE -> "module";
+        };
   }
 
   private static Iterable<String> pathArg(@Nullable BuildFile buildFile) {


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

Ensures that `MODULE.bazel` and `WORKSPACE` file contents are formatted according to the specific file type.