### PR TITLE
bazelrc: set java_runtime_version for builds too

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,4 @@
-build --java_language_version=17
-test  --java_language_version=17 --java_runtime_version=17
+build --java_language_version=17 --java_runtime_version=17
 
 # delete testdata package needed for bazel integration tests
 build --deleted_packages=//aspect/testing/tests/src/com/google/idea/blaze/aspect/integration/testdata


### PR DESCRIPTION
If the default Java version on the host is "lower" (in my case, 11), the following happens on master:

```
$ java -version
openjdk version "11.0.21" 2023-10-17
OpenJDK Runtime Environment (build 11.0.21+9-post-Ubuntu-0ubuntu122.04)
OpenJDK 64-Bit Server VM (build 11.0.21+9-post-Ubuntu-0ubuntu122.04, mixed mode, sharing)
$ bazel build //base:integration_tests --define=ij_product=intellij-2023.3
ERROR: /home/motiejus/code/intellij/base/BUILD:535:32: Building base/integration_tests.jar (72 source files) failed: (Exit 1): java failed: error executing Javac command (from target //base:integration_tests) external/remotejdk17_linux/bin/java '--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED' '--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED' ... (remaining 19 arguments skipped)
base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/search/GlobalWordIndexTest.java:81: warning: [removal] SERVICE in CacheManager has been deprecated and marked for removal
          CacheManager.SERVICE
                      ^
base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/references/BuildReferenceManagerTest.java:47: error: cannot find symbol
            .toList();
            ^
  symbol:   method toList()
  location: interface Stream<String>
base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/references/BuildReferenceManagerTest.java:68: error: cannot find symbol
            .toList();
            ^
  symbol:   method toList()
  location: interface Stream<String>
Use --verbose_failures to see the command lines of failed build steps.
```

The current behaviour is "technically" correct, because `bazel test` succeeds. However, it is very confusing: we should be able to build our tests, not only run them.

Fixes #5835

# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

# Discussion thread for this change

Issue number: #5835