### PR TITLE
Update glob validation to support allow_empty parameter

### DIFF
--- a/base/src/com/google/idea/blaze/base/lang/buildfile/validation/GlobErrorAnnotator.java
+++ b/base/src/com/google/idea/blaze/base/lang/buildfile/validation/GlobErrorAnnotator.java
@@ -41,6 +41,8 @@ public class GlobErrorAnnotator extends BuildAnnotator {
         checkListContents("exclude", arg.getValue());
       } else if ("exclude_directories".equals(name)) {
         checkExcludeDirsNode(arg);
+      } else if ("allow_empty".equals(name)) {
+        checkAllowEmptyNode(arg);
       } else {
         markError(arg, "Unrecognized glob argument");
       }
@@ -54,6 +56,13 @@ public class GlobErrorAnnotator extends BuildAnnotator {
     Expression value = arg.getValue();
     if (value == null || !(value.getText().equals("0") || value.getText().equals("1"))) {
       markError(arg, "exclude_directories parameter to glob must be 0 or 1");
+    }
+  }
+
+  private void checkAllowEmptyNode(Argument arg) {
+    Expression value = arg.getValue();
+    if (value == null || !(value.getText().equals("True") || value.getText().equals("False"))) {
+      markError(arg, "allow_empty parameter to glob must be True or False");
     }
   }
 

--- a/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/validation/GlobValidationTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/validation/GlobValidationTest.java
@@ -56,7 +56,7 @@ public class GlobValidationTest extends BuildFileIntegrationTestCase {
     BuildFile file =
         createBuildFile(
             new WorkspacePath("java/com/google/BUILD"),
-            "glob(['**/*.java'], exclude = ['test/*.java'], exclude_directories = 0)");
+            "glob(['**/*.java'], exclude = ['test/*.java'], exclude_directories = 0, allow_empty = False)");
 
     assertNoErrors(file);
   }
@@ -103,6 +103,16 @@ public class GlobValidationTest extends BuildFileIntegrationTestCase {
             "glob(['**/*.java'], exclude = ['test/*.java'], exclude_directories = true)");
 
     assertHasError(file, "exclude_directories parameter to glob must be 0 or 1");
+  }
+
+  @Test
+  public void testInvalidAllowEmptyValue() {
+    BuildFile file =
+        createBuildFile(
+            new WorkspacePath("java/com/google/BUILD"),
+            "glob(['**/*.java'], exclude = ['test/*.java'], allow_empty = 0)");
+
+    assertHasError(file, "allow_empty parameter to glob must be True or False");
   }
 
   @Test


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: https://github.com/bazelbuild/intellij/issues/5854

# Description of this change
Adds handling of the `allow_empty` parameter for the `glob` function, so that the IDE doesn't annotate it as an unrecognized argument.
