### PR TITLE
fix: Don't throw "Non-blaze project is provided error"

### DIFF
--- a/java/src/com/google/idea/blaze/java/libraries/AddLibraryTargetDirectoryToProjectViewAttachSourcesProvider.java
+++ b/java/src/com/google/idea/blaze/java/libraries/AddLibraryTargetDirectoryToProjectViewAttachSourcesProvider.java
@@ -42,7 +42,7 @@ public class AddLibraryTargetDirectoryToProjectViewAttachSourcesProvider
   public Collection<AttachSourcesAction> getAdapterActions(
       List<? extends LibraryOrderEntry> orderEntries, final PsiFile psiFile) {
     Project project = psiFile.getProject();
-    if (Blaze.getProjectType(project).equals(ProjectType.QUERY_SYNC)) {
+    if (!Blaze.getProjectType(project).equals(ProjectType.ASPECT_SYNC)) {
       return ImmutableList.of();
     }
     


### PR DESCRIPTION
closes #5827

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

