### PR TITLE
Fix warnings when syncing a workspace containing a bazelignore file

### DIFF
--- a/base/src/com/google/idea/blaze/base/dependencies/BlazeQueryDirectoryToTargetProvider.java
+++ b/base/src/com/google/idea/blaze/base/dependencies/BlazeQueryDirectoryToTargetProvider.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.List;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /** Runs a blaze query to derive a set of targets from the project's {@link ImportRoots}. */
@@ -64,7 +65,7 @@ public class BlazeQueryDirectoryToTargetProvider implements DirectoryToTargetPro
         directories.rootDirectories().stream()
             .map(w -> TargetExpression.allFromPackageRecursive(w).toString())
             .collect(joining(" + ")));
-    for (WorkspacePath excluded : directories.excludeDirectories()) {
+    for (WorkspacePath excluded : directories.excludePathsForBazelQuery()) {
       targets.append(" - " + TargetExpression.allFromPackageRecursive(excluded).toString());
     }
 

--- a/base/tests/integrationtests/com/google/idea/blaze/base/sync/ImportRootsTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/sync/ImportRootsTest.java
@@ -32,6 +32,8 @@ import com.google.idea.blaze.base.settings.BuildSystemName;
 import com.google.idea.blaze.base.sync.data.BlazeDataStorage;
 import com.google.idea.blaze.base.sync.projectview.BazelIgnoreParser;
 import com.google.idea.blaze.base.sync.projectview.ImportRoots;
+
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -314,5 +316,21 @@ public class ImportRootsTest extends BlazeIntegrationTestCase {
             .build();
 
     assertThat(importRoots.containsWorkspacePath(new WorkspacePath("root1/a/b/c"))).isFalse();
+  }
+
+  @Test
+  public void testPathsFromBazelIgnoreNotPartOfExcludesForQuery() throws Exception {
+    workspace.createFile(new WorkspacePath(".bazelignore"), "root0/a");
+
+    ImportRoots importRoots =
+        ImportRoots.builder(workspaceRoot, BuildSystemName.Bazel)
+            .add(DirectoryEntry.include(new WorkspacePath("root0")))
+            .exclude(new WorkspacePath("root0/a"))
+            .exclude(new WorkspacePath("root0/b"))
+            .build();
+
+    Set<WorkspacePath> excludePathsForQuery = importRoots.excludePathsForBazelQuery();
+    assertThat(excludePathsForQuery.contains(new WorkspacePath("root0/a"))).isFalse();
+    assertThat(excludePathsForQuery.contains(new WorkspacePath("root0/b"))).isTrue();
   }
 }

--- a/base/tests/unittests/com/google/idea/blaze/base/sync/projectview/TargetExpressionListTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/sync/projectview/TargetExpressionListTest.java
@@ -181,7 +181,9 @@ public class TargetExpressionListTest extends BlazeTestCase {
             ImmutableList.of(),
             new ProjectDirectoriesHelper(
                 /* rootDirectories= */ ImmutableList.of(new WorkspacePath("foo")),
-                /* excludeDirectories= */ ImmutableSet.of()));
+                /* excludeDirectories= */ ImmutableSet.of(),
+                /* excludePathsForBazelQuery= */ ImmutableSet.of()
+                ));
 
     assertThat(helper.includesTarget(Label.create("//foo:target"))).isTrue();
     assertThat(helper.includesTarget(Label.create("//foo/bar:target"))).isTrue();
@@ -200,7 +202,9 @@ public class TargetExpressionListTest extends BlazeTestCase {
                 TargetExpression.fromString("//bar:target")),
             new ProjectDirectoriesHelper(
                 /* rootDirectories= */ ImmutableList.of(new WorkspacePath("foo")),
-                /* excludeDirectories= */ ImmutableSet.of(new WorkspacePath("bar"))));
+                /* excludeDirectories= */ ImmutableSet.of(new WorkspacePath("bar")),
+                /* excludePathsForBazelQuery= */ ImmutableSet.of()
+                ));
 
     assertThat(helper.includesTarget(Label.create("//foo:target"))).isFalse();
     assertThat(helper.includesTarget(Label.create("//foo:other"))).isTrue();
@@ -219,7 +223,9 @@ public class TargetExpressionListTest extends BlazeTestCase {
             ImmutableList.of(),
             new ProjectDirectoriesHelper(
                 /* rootDirectories= */ ImmutableList.of(new WorkspacePath("foo")),
-                /* excludeDirectories= */ ImmutableSet.of(new WorkspacePath("foo/bar"))));
+                /* excludeDirectories= */ ImmutableSet.of(new WorkspacePath("foo/bar")),
+                /* excludePathsForBazelQuery= */ ImmutableSet.of()
+                ));
 
     assertThat(helper.includesTarget(Label.create("//foo:target"))).isTrue();
     assertThat(helper.includesTarget(Label.create("//foo/bar:target"))).isFalse();


### PR DESCRIPTION
The warnings look like this

WARNING: Pattern '//dist/...:all' was filtered out by ignored directory 'dist'

They occur because the plugin passes paths from bazelignore into "bazel query" as exclusions. Bazel warns about this, as excluding a path that Bazel already knows should be ignored is likely a user error.

The reason bazelignore paths are ending up in the query is that we want the IDE to mark the paths as excluded from the project. For that reason, the plugin parses the bazelignore file, and adds the paths to an exclusion list. That list happens to also be passed to "bazel query".

This commit keeps bazelignore paths in the general exclusion list, but generates a separate list of paths to use for "bazel query", which only contains exclusions not listed in bazelignore.
