### PR TITLE
feat: Allow environment variables in run configurations

### DIFF
--- a/base/src/com/google/idea/blaze/base/command/BlazeCommand.java
+++ b/base/src/com/google/idea/blaze/base/command/BlazeCommand.java
@@ -17,6 +17,7 @@ package com.google.idea.blaze.base.command;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.idea.blaze.base.bazel.BuildSystem.BuildInvoker;
 import com.google.idea.blaze.base.model.primitives.TargetExpression;
@@ -101,6 +102,7 @@ public final class BlazeCommand {
     private final ImmutableList.Builder<TargetExpression> targets = ImmutableList.builder();
     private final ImmutableList.Builder<String> blazeCmdlineFlags = ImmutableList.builder();
     private final ImmutableList.Builder<String> exeFlags = ImmutableList.builder();
+    private final ImmutableMap.Builder<String, String> envVars = ImmutableMap.builder();
 
     public Builder(String binaryPath, BlazeCommandName name) {
       this.binaryPath = binaryPath;

--- a/base/src/com/google/idea/blaze/base/command/BlazeCommandRunner.java
+++ b/base/src/com/google/idea/blaze/base/command/BlazeCommandRunner.java
@@ -25,6 +25,7 @@ import com.google.idea.blaze.exception.BuildException;
 import com.intellij.openapi.project.Project;
 import java.io.InputStream;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /** Runs a blaze command. */
@@ -38,7 +39,8 @@ public interface BlazeCommandRunner {
       Project project,
       BlazeCommand.Builder blazeCommandBuilder,
       BuildResultHelper buildResultHelper,
-      BlazeContext context)
+      BlazeContext context,
+      Map<String, String> envVars)
       throws BuildException;
 
   /**
@@ -46,11 +48,12 @@ public interface BlazeCommandRunner {
    * the given {@link BuildResultHelper}.
    */
   BlazeTestResults runTest(
-      Project project,
-      BlazeCommand.Builder blazeCommandBuilder,
-      BuildResultHelper buildResultHelper,
-      BlazeContext context)
-      throws BuildException;
+          Project project,
+          BlazeCommand.Builder blazeCommandBuilder,
+          BuildResultHelper buildResultHelper,
+          BlazeContext context,
+          Map<String, String> envVars)
+          throws BuildException;
 
   /**
    * Runs a blaze query command.

--- a/base/src/com/google/idea/blaze/base/qsync/BazelAppInspectorBuilder.java
+++ b/base/src/com/google/idea/blaze/base/qsync/BazelAppInspectorBuilder.java
@@ -18,6 +18,7 @@ package com.google.idea.blaze.base.qsync;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.idea.blaze.base.bazel.BazelExitCodeException;
 import com.google.idea.blaze.base.bazel.BuildSystem;
 import com.google.idea.blaze.base.bazel.BuildSystem.BuildInvoker;
@@ -70,7 +71,7 @@ public class BazelAppInspectorBuilder implements AppInspectorBuilder {
               .addBlazeFlags(additionalBlazeFlags);
 
       BlazeBuildOutputs outputs =
-          invoker.getCommandRunner().run(project, builder, buildResultHelper, context);
+          invoker.getCommandRunner().run(project, builder, buildResultHelper, context, ImmutableMap.of());
       BazelExitCodeException.throwIfFailed(builder, outputs.buildResult);
 
       return createAppInspectorInfo(outputs);

--- a/base/src/com/google/idea/blaze/base/qsync/BazelDependencyBuilder.java
+++ b/base/src/com/google/idea/blaze/base/qsync/BazelDependencyBuilder.java
@@ -23,6 +23,7 @@ import static java.util.stream.Collectors.joining;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
@@ -186,7 +187,7 @@ public class BazelDependencyBuilder implements DependencyBuilder {
       buildDepsStatsBuilder.ifPresent(
           stats -> stats.setBuildFlags(builder.build().toArgumentList()));
       BlazeBuildOutputs outputs =
-          invoker.getCommandRunner().run(project, builder, buildResultHelper, context);
+          invoker.getCommandRunner().run(project, builder, buildResultHelper, context, ImmutableMap.of());
       buildDepsStatsBuilder.ifPresent(
           stats -> {
             stats.setBuildIds(outputs.getBuildIds());

--- a/base/src/com/google/idea/blaze/base/qsync/BazelRenderJarBuilder.java
+++ b/base/src/com/google/idea/blaze/base/qsync/BazelRenderJarBuilder.java
@@ -18,6 +18,7 @@ package com.google.idea.blaze.base.qsync;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.idea.blaze.base.bazel.BazelExitCodeException;
 import com.google.idea.blaze.base.bazel.BuildSystem;
 import com.google.idea.blaze.base.bazel.BuildSystem.BuildInvoker;
@@ -76,7 +77,7 @@ public class BazelRenderJarBuilder implements RenderJarBuilder {
               .addBlazeFlags("--output_groups=intellij-render-resolve-android");
 
       BlazeBuildOutputs outputs =
-          invoker.getCommandRunner().run(project, builder, buildResultHelper, context);
+          invoker.getCommandRunner().run(project, builder, buildResultHelper, context, ImmutableMap.of());
       BazelExitCodeException.throwIfFailed(builder, outputs.buildResult);
 
       return createRenderJarInfo(outputs);

--- a/base/src/com/google/idea/blaze/base/run/processhandler/ScopedBlazeProcessHandler.java
+++ b/base/src/com/google/idea/blaze/base/run/processhandler/ScopedBlazeProcessHandler.java
@@ -69,7 +69,6 @@ public final class ScopedBlazeProcessHandler extends KillableColoredProcessHandl
    *     context.
    * @throws ExecutionException
    */
-
   public ScopedBlazeProcessHandler(
       Project project,
       GeneralCommandLine command,

--- a/base/src/com/google/idea/blaze/base/run/state/BlazeCommandRunConfigurationCommonState.java
+++ b/base/src/com/google/idea/blaze/base/run/state/BlazeCommandRunConfigurationCommonState.java
@@ -39,18 +39,20 @@ public class BlazeCommandRunConfigurationCommonState extends RunConfigurationCom
   protected final BlazeCommandState command;
   protected final RunConfigurationFlagsState blazeFlags;
   protected final RunConfigurationFlagsState exeFlags;
+  protected final EnvironmentVariablesState envVars;
   protected final BlazeBinaryState blazeBinary;
 
   public BlazeCommandRunConfigurationCommonState(BuildSystemName buildSystemName) {
     command = new BlazeCommandState();
     blazeFlags = new RunConfigurationFlagsState(USER_BLAZE_FLAG_TAG, buildSystemName + " flags:");
     exeFlags = new RunConfigurationFlagsState(USER_EXE_FLAG_TAG, "Executable flags:");
+    envVars = new EnvironmentVariablesState();
     blazeBinary = new BlazeBinaryState();
   }
 
   @Override
   protected ImmutableList<RunConfigurationState> initializeStates() {
-    return ImmutableList.of(command, blazeFlags, exeFlags, blazeBinary);
+    return ImmutableList.of(command, blazeFlags, exeFlags, envVars, blazeBinary);
   }
 
   /** @return The list of blaze flags that the user specified manually. */
@@ -61,6 +63,11 @@ public class BlazeCommandRunConfigurationCommonState extends RunConfigurationCom
   /** @return The list of executable flags the user specified manually. */
   public RunConfigurationFlagsState getExeFlagsState() {
     return exeFlags;
+  }
+
+  /** @return The environment variables the user specified manually. */
+  public EnvironmentVariablesState getUserEnvVarsState() {
+    return envVars;
   }
 
   public BlazeBinaryState getBlazeBinaryState() {

--- a/base/src/com/google/idea/blaze/base/run/state/EnvironmentVariablesState.java
+++ b/base/src/com/google/idea/blaze/base/run/state/EnvironmentVariablesState.java
@@ -15,7 +15,9 @@
  */
 package com.google.idea.blaze.base.run.state;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.idea.blaze.base.command.BlazeFlags;
 import com.intellij.execution.configuration.EnvironmentVariablesComponent;
 import com.intellij.execution.configuration.EnvironmentVariablesData;
 import com.intellij.openapi.project.Project;
@@ -23,6 +25,7 @@ import com.intellij.openapi.util.InvalidDataException;
 import com.intellij.openapi.util.WriteExternalException;
 import javax.swing.JComponent;
 import org.jdom.Element;
+import java.util.Map;
 
 /** State for user-defined environment variables. */
 public class EnvironmentVariablesState implements RunConfigurationState {
@@ -32,8 +35,18 @@ public class EnvironmentVariablesState implements RunConfigurationState {
   private EnvironmentVariablesData data =
       EnvironmentVariablesData.create(ImmutableMap.of(), /* passParentEnvs= */ true);
 
+  public EnvironmentVariablesState() {}
+
   public EnvironmentVariablesData getData() {
     return data;
+  }
+
+  public ImmutableList<String> asBlazeTestEnvFlags() {
+    ImmutableList.Builder<String> flags = ImmutableList.builder();
+    for (Map.Entry<String, String> env: data.getEnvs().entrySet()) {
+      flags.add(BlazeFlags.TEST_ENV, String.format("%s=%s", env.getKey(), env.getValue()));
+    }
+    return flags.build();
   }
 
   @Override

--- a/base/src/com/google/idea/blaze/base/sync/aspects/BlazeIdeInterfaceAspectsImpl.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/BlazeIdeInterfaceAspectsImpl.java
@@ -760,7 +760,7 @@ public class BlazeIdeInterfaceAspectsImpl implements BlazeIdeInterface {
       aspectStrategy.addAspectAndOutputGroups(
           builder, outputGroups, activeLanguages, onlyDirectDeps);
 
-      return invoker.getCommandRunner().run(project, builder, buildResultHelper, context);
+      return invoker.getCommandRunner().run(project, builder, buildResultHelper, context, ImmutableMap.of());
     }
   }
 }

--- a/base/tests/utils/unit/com/google/idea/blaze/base/bazel/FakeBlazeCommandRunner.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/bazel/FakeBlazeCommandRunner.java
@@ -30,6 +30,7 @@ import com.google.idea.blaze.base.sync.aspects.BuildResult;
 import com.google.idea.blaze.exception.BuildException;
 import com.intellij.openapi.project.Project;
 import java.io.InputStream;
+import java.util.Map;
 
 /**
  * A fake for {@link BlazeCommandRunner} that doesn't execute the build, but returns results from
@@ -58,10 +59,11 @@ public class FakeBlazeCommandRunner implements BlazeCommandRunner {
 
   @Override
   public BlazeBuildOutputs run(
-      Project project,
-      BlazeCommand.Builder blazeCommandBuilder,
-      BuildResultHelper buildResultHelper,
-      BlazeContext context)
+          Project project,
+          BlazeCommand.Builder blazeCommandBuilder,
+          BuildResultHelper buildResultHelper,
+          BlazeContext context,
+          Map<String, String> envVars)
       throws BuildException {
     command = blazeCommandBuilder.build();
     try {
@@ -76,10 +78,11 @@ public class FakeBlazeCommandRunner implements BlazeCommandRunner {
 
   @Override
   public BlazeTestResults runTest(
-      Project project,
-      BlazeCommand.Builder blazeCommandBuilder,
-      BuildResultHelper buildResultHelper,
-      BlazeContext context) {
+          Project project,
+          BlazeCommand.Builder blazeCommandBuilder,
+          BuildResultHelper buildResultHelper,
+          BlazeContext context,
+          Map<String, String> envVars) {
     return BlazeTestResults.NO_RESULTS;
   }
 

--- a/examples/java/greetings_project/hi/src/com/example/HiGreeter.java
+++ b/examples/java/greetings_project/hi/src/com/example/HiGreeter.java
@@ -16,3 +16,4 @@ public class HiGreeter {
         }
     }
 }
+

--- a/golang/src/com/google/idea/blaze/golang/run/BlazeGoRunConfigurationRunner.java
+++ b/golang/src/com/google/idea/blaze/golang/run/BlazeGoRunConfigurationRunner.java
@@ -141,7 +141,7 @@ public class BlazeGoRunConfigurationRunner implements BlazeCommandRunConfigurati
       return ImmutableList.<String>builder()
           .addAll(state.getExeFlagsState().getFlagsForExternalProcesses())
           .addAll(state.getTestArgs())
-          .addAll(executable.args)
+          .addAll(state.getUserEnvVarsState().asBlazeTestEnvFlags())
           .build();
     }
 

--- a/java/src/com/google/idea/blaze/java/run/BlazeJavaRunConfigState.java
+++ b/java/src/com/google/idea/blaze/java/run/BlazeJavaRunConfigState.java
@@ -35,7 +35,7 @@ public class BlazeJavaRunConfigState extends BlazeCommandRunConfigurationCommonS
 
   @Override
   protected ImmutableList<RunConfigurationState> initializeStates() {
-    return ImmutableList.of(command, blazeFlags, exeFlags, debugPortState, blazeBinary);
+    return ImmutableList.of(command, blazeFlags, exeFlags, envVars, debugPortState, blazeBinary);
   }
 
   public DebugPortState getDebugPortState() {

--- a/plugin_dev/src/com/google/idea/blaze/plugin/run/BuildPluginBeforeRunTaskProvider.java
+++ b/plugin_dev/src/com/google/idea/blaze/plugin/run/BuildPluginBeforeRunTaskProvider.java
@@ -15,6 +15,7 @@
  */
 package com.google.idea.blaze.plugin.run;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.idea.blaze.base.async.executor.ProgressiveTaskWithProgressIndicator;
@@ -227,7 +228,7 @@ public final class BuildPluginBeforeRunTaskProvider
                     BlazeBuildOutputs outputs =
                         invoker
                             .getCommandRunner()
-                            .run(project, command, buildResultHelper, context);
+                            .run(project, command, buildResultHelper, context, ImmutableMap.of());
                     if (!outputs.buildResult.equals(BuildResult.SUCCESS)) {
                       context.setHasError();
                     }


### PR DESCRIPTION


# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

Allow users to set their own env vars per run-configuration. It is not respected everywhere (see the list below), but it works on our example projects.

Main features:
- Env vars should work when **run**ing and **debug**ging any binary.
- Env vars should work when **run**ning any test.
- Env vars should work when **debug**ging Go and Java tests. Env vars for C++ test debugging are implemented internally, but they're part of a larger patch and I'll need some more work to untangle that (or maybe they're already covered in https://github.com/bazelbuild/intellij/pull/5771)

