### PR TITLE
Fix bazel sync errors when using non-default convenience symlinks

### DIFF
--- a/base/src/com/google/idea/blaze/base/dependencies/BlazeQueryDirectoryToTargetProvider.java
+++ b/base/src/com/google/idea/blaze/base/dependencies/BlazeQueryDirectoryToTargetProvider.java
@@ -39,6 +39,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -66,7 +67,11 @@ public class BlazeQueryDirectoryToTargetProvider implements DirectoryToTargetPro
             .map(w -> TargetExpression.allFromPackageRecursive(w).toString())
             .collect(joining(" + ")));
     for (WorkspacePath excluded : directories.excludePathsForBazelQuery()) {
-      targets.append(" - " + TargetExpression.allFromPackageRecursive(excluded).toString());
+      // Bazel produces errors for paths that don't exist (e.g. bazel-out in a project that overrides the default symlinks),
+      // so only include paths that actually exist.
+      if (Files.exists(excluded.asPath())) {
+        targets.append(" - " + TargetExpression.allFromPackageRecursive(excluded).toString());
+      }
     }
 
     if (allowManualTargetsSync) {


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: https://github.com/bazelbuild/intellij/issues/5909

# Description of this change

Bazel allows overriding the names of the default symlinks via --symlink_prefix, or omitting them entirely via --experimental_convenience_symlinks=ignore.

When a workspace does this, the default symlinks with names like bazel-out and bazel-bin don't exist. This causes Bazel to emit an error when running "bazel query", since the plugin hardcodes these names as excluded paths.

This commit addresses this by only including paths in "bazel query" that actually exist. Workspaces that change the symlink names can then exclude the new names explicitly via bazelignore.