### PR TITLE
Do not add 2 import sections for the same project view

### DIFF
--- a/base/src/com/google/idea/blaze/base/wizard2/ui/BlazeEditProjectViewControl.java
+++ b/base/src/com/google/idea/blaze/base/wizard2/ui/BlazeEditProjectViewControl.java
@@ -37,7 +37,6 @@ import com.google.idea.blaze.base.projectview.section.sections.DirectorySection;
 import com.google.idea.blaze.base.projectview.section.sections.ImportSection;
 import com.google.idea.blaze.base.projectview.section.sections.Sections;
 import com.google.idea.blaze.base.projectview.section.sections.TargetSection;
-import com.google.idea.blaze.base.projectview.section.sections.TryImportSection;
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.scope.OutputSink.Propagation;
 import com.google.idea.blaze.base.scope.Scope;
@@ -599,9 +598,6 @@ public final class BlazeEditProjectViewControl {
           ProjectView.builder()
               .add(
                   ScalarSection.builder(ImportSection.KEY)
-                      .set(selectProjectViewOption.getSharedProjectView()))
-              .add(
-                  ScalarSection.builder(TryImportSection.KEY)
                       .set(selectProjectViewOption.getSharedProjectView()))
               .build();
       projectViewSet =


### PR DESCRIPTION
https://github.com/bazelbuild/intellij/pull/5689 introduced `try_import` section but I think the change to [BlazeEditProjectViewControl.java](https://github.com/bazelbuild/intellij/pull/5689/files#diff-49f8d8450be94cc89e30a9344e44da4e57410c4bfd4e079cfad8c8a878fe7a84) is not necessary as it adds a `try_import` section for a project view file that already has an `import` section.