### PR TITLE
Prepare for 2024.1: convert kotlin's Sequence to java's Iterable

### DIFF
--- a/kotlin/tests/unittests/com/google/idea/blaze/kotlin/sync/importer/KotlinSyncAugmenterTest.java
+++ b/kotlin/tests/unittests/com/google/idea/blaze/kotlin/sync/importer/KotlinSyncAugmenterTest.java
@@ -49,6 +49,9 @@ import com.google.idea.common.experiments.ExperimentService;
 import com.google.idea.common.experiments.MockExperimentService;
 import com.intellij.openapi.extensions.impl.ExtensionPointImpl;
 import java.util.ArrayList;
+
+import kotlin.sequences.Sequence;
+import kotlin.sequences.SequencesKt;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -123,7 +126,7 @@ public class KotlinSyncAugmenterTest extends BlazeTestCase {
             .build();
     ArrayList<BlazeJarLibrary> genJars = new ArrayList<>();
 
-    for (BlazeJavaSyncAugmenter augmenter : augmenters) {
+    for (BlazeJavaSyncAugmenter augmenter : toIterable(augmenters)) { // #api233 - in 2024.1 ExtensionPointImpl implements Sequenec instead of Iterable
       augmenter.addJarsForSourceTarget(
           workspaceLanguageSettings, projectViewSet, target, new ArrayList<>(), genJars);
     }
@@ -166,7 +169,8 @@ public class KotlinSyncAugmenterTest extends BlazeTestCase {
             .build();
     ArrayList<BlazeJarLibrary> genJars = new ArrayList<>();
 
-    for (BlazeJavaSyncAugmenter augmenter : augmenters) {
+    for (BlazeJavaSyncAugmenter augmenter : toIterable(augmenters)) { // #api233 - in 2024.1 ExtensionPointImpl implements Sequence instead of Iterable
+
       augmenter.addJarsForSourceTarget(
           workspaceLanguageSettings, projectViewSet, target, new ArrayList<>(), genJars);
     }
@@ -183,5 +187,13 @@ public class KotlinSyncAugmenterTest extends BlazeTestCase {
 
   private static ArtifactLocation source(String relativePath) {
     return ArtifactLocation.builder().setRelativePath(relativePath).setIsSource(true).build();
+  }
+
+  private static <T> Iterable<T> toIterable(Iterable<T> iterable) {
+    return iterable;
+  }
+
+  private static <T> Iterable<T> toIterable(Sequence<T> sequence) {
+    return SequencesKt.asIterable(sequence);
   }
 }


### PR DESCRIPTION
ExtensionPointImpl is now writen in Kotlin and extends Sequence instead of Iterable

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

