### PR TITLE
Prepare for 2024.1: Move Jdk Mock creation to testsdkcompat

### DIFF
--- a/java/tests/integrationtests/com/google/idea/blaze/java/sync/projectstructure/JdksTest.java
+++ b/java/tests/integrationtests/com/google/idea/blaze/java/sync/projectstructure/JdksTest.java
@@ -15,9 +15,6 @@
  */
 package com.google.idea.blaze.java.sync.projectstructure;
 
-import static com.google.common.truth.Truth.assertThat;
-import static java.util.Arrays.stream;
-
 import com.google.common.collect.ImmutableMap;
 import com.google.idea.blaze.base.BlazeIntegrationTestCase;
 import com.google.idea.blaze.java.sync.sdk.BlazeJdkProvider;
@@ -25,19 +22,21 @@ import com.intellij.openapi.application.WriteAction;
 import com.intellij.openapi.projectRoots.JavaSdk;
 import com.intellij.openapi.projectRoots.ProjectJdkTable;
 import com.intellij.openapi.projectRoots.Sdk;
-import com.intellij.openapi.projectRoots.impl.MockSdk;
-import com.intellij.openapi.projectRoots.impl.UnknownSdkType;
 import com.intellij.pom.java.LanguageLevel;
 import com.intellij.testFramework.IdeaTestUtil;
-import com.intellij.util.containers.MultiMap;
-import java.io.File;
-import java.util.Comparator;
-import java.util.Optional;
-
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+
+import java.io.File;
+import java.util.Comparator;
+import java.util.Optional;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.idea.java.JavaSdkCompat.getNonJavaMockSdk;
+import static com.google.idea.java.JavaSdkCompat.getUniqueMockJdk;
+import static java.util.Arrays.stream;
 
 /** Integration tests for {@link Jdks}. */
 @RunWith(JUnit4.class)
@@ -116,6 +115,7 @@ public class JdksTest extends BlazeIntegrationTestCase {
     assertThat(chosenSdk).isEqualTo(jdk8);
   }
 
+  /** #api233 remove test */
   @Test
   public void testChooseDifferentSdkIfCurrentNotJdk() {
     Sdk currentSdk = getNonJavaMockSdk();
@@ -300,19 +300,4 @@ public class JdksTest extends BlazeIntegrationTestCase {
                 .orElse(null));
   }
 
-  private static Sdk getUniqueMockJdk(LanguageLevel languageLevel) {
-    MockSdk jdk = (MockSdk) IdeaTestUtil.getMockJdk(languageLevel.toJavaVersion());
-    jdk.setName(jdk.getName() + "." + jdk.hashCode());
-    jdk.setHomePath(jdk.getHomePath() + "." + jdk.hashCode());
-    return jdk;
-  }
-
-  private static Sdk getNonJavaMockSdk() {
-    return new MockSdk(
-        /* name= */ "",
-        /* homePath= */ "",
-        /* versionString= */ "",
-        /* roots= */ MultiMap.empty(),
-        UnknownSdkType.getInstance(""));
-  }
 }

--- a/testing/BUILD
+++ b/testing/BUILD
@@ -30,18 +30,22 @@ java_library(
         "android-studio-2022.2": glob([
             "testcompat/v222/com/google/idea/sdkcompat/**/*.java",
             "testcompat/v222/com/google/idea/testing/**/*.java",
+            "testcompat/v222/com/google/idea/java/**/*.java",
         ]),
         "android-studio-2022.3": glob([
             "testcompat/v223/com/google/idea/sdkcompat/**/*.java",
             "testcompat/v223/com/google/idea/testing/**/*.java",
+            "testcompat/v223/com/google/idea/java/**/*.java",
         ]),
         "android-studio-2023.1": glob([
             "testcompat/v231/com/google/idea/sdkcompat/**/*.java",
             "testcompat/v231/com/google/idea/testing/**/*.java",
+            "testcompat/v231/com/google/idea/java/**/*.java",
         ]),
         "android-studio-2023.2": glob([
             "testcompat/v232/com/google/idea/sdkcompat/**/*.java",
             "testcompat/v232/com/google/idea/testing/**/*.java",
+            "testcompat/v232/com/google/idea/java/**/*.java",
         ]),
         "clion-2021.3": glob([
             "testcompat/v213/com/google/idea/sdkcompat/**/*.java",
@@ -100,34 +104,42 @@ java_library(
         "intellij-2022.3": glob([
             "testcompat/v223/com/google/idea/sdkcompat/**/*.java",
             "testcompat/v223/com/google/idea/testing/**/*.java",
+            "testcompat/v223/com/google/idea/java/**/*.java",
         ]),
         "intellij-ue-2022.3": glob([
             "testcompat/v223/com/google/idea/sdkcompat/**/*.java",
             "testcompat/v223/com/google/idea/testing/**/*.java",
+            "testcompat/v223/com/google/idea/java/**/*.java",
         ]),
         "intellij-2023.1": glob([
             "testcompat/v231/com/google/idea/sdkcompat/**/*.java",
             "testcompat/v231/com/google/idea/testing/**/*.java",
+            "testcompat/v231/com/google/idea/java/**/*.java",
         ]),
         "intellij-ue-2023.1": glob([
             "testcompat/v231/com/google/idea/sdkcompat/**/*.java",
             "testcompat/v231/com/google/idea/testing/**/*.java",
+            "testcompat/v231/com/google/idea/java/**/*.java",
         ]),
         "intellij-2023.2": glob([
             "testcompat/v232/com/google/idea/sdkcompat/**/*.java",
             "testcompat/v232/com/google/idea/testing/**/*.java",
+            "testcompat/v232/com/google/idea/java/**/*.java",
         ]),
         "intellij-ue-2023.2": glob([
             "testcompat/v232/com/google/idea/sdkcompat/**/*.java",
             "testcompat/v232/com/google/idea/testing/**/*.java",
+            "testcompat/v232/com/google/idea/java/**/*.java",
         ]),
         "intellij-2023.3": glob([
             "testcompat/v233/com/google/idea/sdkcompat/**/*.java",
             "testcompat/v233/com/google/idea/testing/**/*.java",
+            "testcompat/v233/com/google/idea/java/**/*.java",
         ]),
         "intellij-ue-2023.3": glob([
             "testcompat/v233/com/google/idea/sdkcompat/**/*.java",
             "testcompat/v233/com/google/idea/testing/**/*.java",
+            "testcompat/v233/com/google/idea/java/**/*.java",
         ]),
         "default": [],
     }),

--- a/testing/testcompat/v223/com/google/idea/java/JavaSdkCompat.java
+++ b/testing/testcompat/v223/com/google/idea/java/JavaSdkCompat.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.java;
+
+import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.openapi.projectRoots.impl.MockSdk;
+import com.intellij.openapi.projectRoots.impl.UnknownSdkType;
+import com.intellij.pom.java.LanguageLevel;
+import com.intellij.testFramework.IdeaTestUtil;
+import com.intellij.util.containers.MultiMap;
+
+/**
+ * Provides SDK compatibility shims for base plugin API classes, available to all IDEs during
+ * test-time.
+ */
+public final class JavaSdkCompat {
+  private JavaSdkCompat() {}
+  /** #api233 to inline */
+  public static Sdk getUniqueMockJdk(LanguageLevel languageLevel) {
+    MockSdk jdk = (MockSdk) IdeaTestUtil.getMockJdk(languageLevel.toJavaVersion());
+    jdk.setName(jdk.getName() + "." + jdk.hashCode());
+    jdk.setHomePath(jdk.getHomePath() + "." + jdk.hashCode());
+    return jdk;
+  }
+
+  /** #api233 to remove */
+  public static Sdk getNonJavaMockSdk() {
+    return new MockSdk(
+            /* name= */ "",
+            /* homePath= */ "",
+            /* versionString= */ "",
+            /* roots= */ MultiMap.empty(),
+            UnknownSdkType.getInstance(""));
+  }
+}

--- a/testing/testcompat/v231/com/google/idea/java/JavaSdkCompat.java
+++ b/testing/testcompat/v231/com/google/idea/java/JavaSdkCompat.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.java;
+
+import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.openapi.projectRoots.impl.MockSdk;
+import com.intellij.openapi.projectRoots.impl.UnknownSdkType;
+import com.intellij.pom.java.LanguageLevel;
+import com.intellij.testFramework.IdeaTestUtil;
+import com.intellij.util.containers.MultiMap;
+
+/**
+ * Provides SDK compatibility shims for base plugin API classes, available to all IDEs during
+ * test-time.
+ */
+public final class JavaSdkCompat {
+  private JavaSdkCompat() {}
+  /** #api233 to inline */
+  public static Sdk getUniqueMockJdk(LanguageLevel languageLevel) {
+    MockSdk jdk = (MockSdk) IdeaTestUtil.getMockJdk(languageLevel.toJavaVersion());
+    jdk.setName(jdk.getName() + "." + jdk.hashCode());
+    jdk.setHomePath(jdk.getHomePath() + "." + jdk.hashCode());
+    return jdk;
+  }
+
+  /** #api233 to remove */
+  public static Sdk getNonJavaMockSdk() {
+    return new MockSdk(
+            /* name= */ "",
+            /* homePath= */ "",
+            /* versionString= */ "",
+            /* roots= */ MultiMap.empty(),
+            UnknownSdkType.getInstance(""));
+  }
+}

--- a/testing/testcompat/v232/com/google/idea/java/JavaSdkCompat.java
+++ b/testing/testcompat/v232/com/google/idea/java/JavaSdkCompat.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.java;
+
+import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.openapi.projectRoots.impl.MockSdk;
+import com.intellij.openapi.projectRoots.impl.UnknownSdkType;
+import com.intellij.pom.java.LanguageLevel;
+import com.intellij.testFramework.IdeaTestUtil;
+import com.intellij.util.containers.MultiMap;
+
+/**
+ * Provides SDK compatibility shims for base plugin API classes, available to all IDEs during
+ * test-time.
+ */
+public final class JavaSdkCompat {
+  private JavaSdkCompat() {}
+  /** #api233 to inline */
+  public static Sdk getUniqueMockJdk(LanguageLevel languageLevel) {
+    MockSdk jdk = (MockSdk) IdeaTestUtil.getMockJdk(languageLevel.toJavaVersion());
+    jdk.setName(jdk.getName() + "." + jdk.hashCode());
+    jdk.setHomePath(jdk.getHomePath() + "." + jdk.hashCode());
+    return jdk;
+  }
+
+  /** #api233 to remove */
+  public static Sdk getNonJavaMockSdk() {
+    return new MockSdk(
+            /* name= */ "",
+            /* homePath= */ "",
+            /* versionString= */ "",
+            /* roots= */ MultiMap.empty(),
+            UnknownSdkType.getInstance(""));
+  }
+}

--- a/testing/testcompat/v233/com/google/idea/java/JavaSdkCompat.java
+++ b/testing/testcompat/v233/com/google/idea/java/JavaSdkCompat.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.java;
+
+import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.openapi.projectRoots.impl.MockSdk;
+import com.intellij.openapi.projectRoots.impl.UnknownSdkType;
+import com.intellij.pom.java.LanguageLevel;
+import com.intellij.testFramework.IdeaTestUtil;
+import com.intellij.util.containers.MultiMap;
+
+/**
+ * Provides SDK compatibility shims for base plugin API classes, available to all IDEs during
+ * test-time.
+ */
+public final class JavaSdkCompat {
+  private JavaSdkCompat() {}
+  /** #api233 to inline */
+  public static Sdk getUniqueMockJdk(LanguageLevel languageLevel) {
+    MockSdk jdk = (MockSdk) IdeaTestUtil.getMockJdk(languageLevel.toJavaVersion());
+    jdk.setName(jdk.getName() + "." + jdk.hashCode());
+    jdk.setHomePath(jdk.getHomePath() + "." + jdk.hashCode());
+    return jdk;
+  }
+
+  /** #api233 to remove */
+  public static Sdk getNonJavaMockSdk() {
+    return new MockSdk(
+            /* name= */ "",
+            /* homePath= */ "",
+            /* versionString= */ "",
+            /* roots= */ MultiMap.empty(),
+            UnknownSdkType.getInstance(""));
+  }
+}


### PR DESCRIPTION
There are two breaking changes related to MockSdk that come in 2024.1:
1. It is impossible to add a non-JDK SDK to the JdkTable, so the test testChooseDifferentSdkIfCurrentNotJdk becomes useless and even more impossible to run, because it just fails at preparation phase. The related IntelliJ change is here:
https://github.com/JetBrains/intellij-community/commit/e8e8cf58cf35c1985ef075f6bdfb4778a1926966#diff-76a3bd6e3df59635af359a63c0936b224dda2f0a80b42ba36236ee4fa85bc09bR55

2. The IdeaTestUtil.getMockJdk no longer returns an instance of MockJdk. It returns a regular JavaSdk instead. Even more, the MockSdk is officially deprecated. Hence, in 2024.1 and newer we need to Use the regular SDKs in tests and modify them with SdkModificator

https://github.com/JetBrains/intellij-community/commit/7f05dd0629c0d6da3a19f8a800c32c4eb8275bd0#diff-5fb6bb2bf3104221b2ee04a10cdcf4424ea108b3f541e6b7eb828c721ea8817fL183

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

