### PR TITLE
fix(build): Allow for targets outside of release channels

### DIFF
--- a/common/util/BUILD
+++ b/common/util/BUILD
@@ -81,11 +81,18 @@ genrule(
 )
 
 genrule(
+    name = "freeform",
+    outs = ["freeform.txt"],
+    cmd = "echo freeform > $@",
+)
+
+genrule(
     name = "channel_java",
     srcs = select_for_channel({
         "stable": [":stable"],
         "beta": [":beta"],
         "canary": [":canary"],
+        "freeform": [":freeform"],
     }),
     outs = ["com/google/idea/common/util/channel/Channel.java"],
     cmd = "\n".join([

--- a/cpp/sdkcompat/BUILD
+++ b/cpp/sdkcompat/BUILD
@@ -13,7 +13,7 @@ java_library(
         "clion-2023.1": ["//cpp/sdkcompat/v231"],
         "clion-2023.2": ["//cpp/sdkcompat/v232"],
         "clion-2023.3": ["//cpp/sdkcompat/v233"],
-        "clion-2024.1": ["//cpp/sdkcompat/v241"],	
+        "clion-2024.1": ["//cpp/sdkcompat/v241"],
     }),
     visibility = ["//cpp:__pkg__"],
     deps = ["//intellij_platform_sdk:plugin_api"],


### PR DESCRIPTION
# Checklist

- [X] I have filed an issue about this change and discussed potential changes with the maintainers.
- [X] I have received the approval from the maintainers to make this change.
- [X] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Description of this change

Some users would like to build the plugin for IJ versions outside of release channels. Since changes 5fdf7c36617912b877f288c3f71dc4bbd1dac7bc, one cannot build an IJ version that is not in a release channel (because we hardcode a release channel into a Java file for runtime access).

As a result, this stopped working:
```
bazel build --define=ij_product=intellij-2023.1 //ijwb:ijwb_bazel_zip
```

This PR adds a "freeform" release channel containing all the `DIRECT_IJ_PRODUCTS` that are not in a channel already.