### PR TITLE
Followup for Pass path associations as special compiler flags

### DIFF
--- a/base/src/com/google/idea/blaze/base/model/primitives/Label.java
+++ b/base/src/com/google/idea/blaze/base/model/primitives/Label.java
@@ -107,7 +107,7 @@ public final class Label extends TargetExpression {
     }
     int slashesIndex = label.indexOf("//");
     logger.assertTrue(slashesIndex >= 0);
-    return label.substring(0, slashesIndex).replaceFirst("^@+", "");
+    return label.substring(1, slashesIndex);
   }
 
   /**

--- a/base/src/com/google/idea/blaze/base/model/primitives/Label.java
+++ b/base/src/com/google/idea/blaze/base/model/primitives/Label.java
@@ -107,7 +107,7 @@ public final class Label extends TargetExpression {
     }
     int slashesIndex = label.indexOf("//");
     logger.assertTrue(slashesIndex >= 0);
-    return label.substring(1, slashesIndex);
+    return label.substring(0, slashesIndex).replaceFirst("^@+", "");
   }
 
   /**

--- a/base/src/com/google/idea/blaze/base/sync/workspace/ExecutionRootPathResolver.java
+++ b/base/src/com/google/idea/blaze/base/sync/workspace/ExecutionRootPathResolver.java
@@ -26,7 +26,6 @@ import com.google.idea.blaze.base.settings.Blaze;
 import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.util.registry.Registry;
 import java.io.File;
 import java.io.IOException;
 import javax.annotation.Nullable;
@@ -48,20 +47,17 @@ public class ExecutionRootPathResolver {
   private final File executionRoot;
   private final File outputBase;
   private final WorkspacePathResolver workspacePathResolver;
-  private final TargetMap targetMap;
 
   public ExecutionRootPathResolver(
       BuildSystemProvider buildSystemProvider,
       WorkspaceRoot workspaceRoot,
       File executionRoot,
       File outputBase,
-      WorkspacePathResolver workspacePathResolver,
-      TargetMap targetMap) {
+      WorkspacePathResolver workspacePathResolver) {
     this.buildArtifactDirectories = buildArtifactDirectories(buildSystemProvider, workspaceRoot);
     this.executionRoot = executionRoot;
     this.outputBase = outputBase;
     this.workspacePathResolver = workspacePathResolver;
-    this.targetMap = targetMap;
   }
 
   @Nullable
@@ -76,8 +72,7 @@ public class ExecutionRootPathResolver {
         WorkspaceRoot.fromProject(project),
         projectData.getBlazeInfo().getExecutionRoot(),
         projectData.getBlazeInfo().getOutputBase(),
-        projectData.getWorkspacePathResolver(),
-        projectData.getTargetMap());
+        projectData.getWorkspacePathResolver());
   }
 
   private static ImmutableList<String> buildArtifactDirectories(
@@ -114,25 +109,7 @@ public class ExecutionRootPathResolver {
     }
     String firstPathComponent = getFirstPathComponent(path.getAbsoluteOrRelativeFile().getPath());
     if (buildArtifactDirectories.contains(firstPathComponent)) {
-      // Build artifacts accumulate under the execution root, independent of symlink settings
-
-      if(Registry.is("bazel.sync.resolve.virtual.includes") &&
-          VirtualIncludesHandler.containsVirtualInclude(path)) {
-        // Resolve virtual_include from execution root either to local or external workspace for correct code insight
-        ImmutableList<File> resolved = ImmutableList.of();
-        try {
-          resolved = VirtualIncludesHandler.resolveVirtualInclude(path, outputBase,
-              workspacePathResolver, targetMap);
-        } catch (Throwable throwable) {
-          LOG.error("Failed to resolve virtual includes for " + path, throwable);
-        }
-
-        return resolved.isEmpty()
-            ? ImmutableList.of(path.getFileRootedAt(executionRoot))
-            : resolved;
-      } else {
-        return ImmutableList.of(path.getFileRootedAt(executionRoot));
-      }
+      return ImmutableList.of(path.getFileRootedAt(executionRoot));
     }
     if (firstPathComponent.equals(externalPrefix)) { // In external workspace
       // External workspaces accumulate under the output base.

--- a/base/src/com/google/idea/blaze/base/sync/workspace/ExecutionRootPathResolver.java
+++ b/base/src/com/google/idea/blaze/base/sync/workspace/ExecutionRootPathResolver.java
@@ -154,7 +154,7 @@ public class ExecutionRootPathResolver {
    * workspace is a link to workspace root then follows it and returns a path to workspace root
    */
   @NotNull
-  private ImmutableList<File> resolveToExternalWorkspaceWithSymbolicLinkResolution(
+  public ImmutableList<File> resolveToExternalWorkspaceWithSymbolicLinkResolution(
       ExecutionRootPath path) {
     File fileInExecutionRoot = path.getFileRootedAt(outputBase);
 

--- a/base/src/com/google/idea/blaze/base/sync/workspace/VirtualIncludesHandler.java
+++ b/base/src/com/google/idea/blaze/base/sync/workspace/VirtualIncludesHandler.java
@@ -1,24 +1,34 @@
 package com.google.idea.blaze.base.sync.workspace;
 
+import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import com.google.idea.blaze.base.ideinfo.ArtifactLocation;
 import com.google.idea.blaze.base.ideinfo.CIdeInfo;
+import com.google.idea.blaze.base.ideinfo.Dependency;
 import com.google.idea.blaze.base.ideinfo.TargetIdeInfo;
 import com.google.idea.blaze.base.ideinfo.TargetKey;
 import com.google.idea.blaze.base.ideinfo.TargetMap;
+import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.primitives.ExecutionRootPath;
 import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.model.primitives.TargetName;
 import com.google.idea.blaze.base.model.primitives.WorkspacePath;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.util.io.FileUtil;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
+import com.intellij.openapi.util.registry.Registry;
 import java.io.File;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.Stack;
+import java.util.concurrent.TimeUnit;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Utility class designed to convert execroot {@code _virtual_includes} references to
@@ -33,7 +43,7 @@ import java.util.List;
  * <p>
  * {@code bazel-out/.../bin/.../_virtual_includes/...}
  */
-class VirtualIncludesHandler {
+public class VirtualIncludesHandler {
     private static final Logger LOG = Logger.getInstance(VirtualIncludesHandler.class);
     final static Path VIRTUAL_INCLUDES_DIRECTORY = Path.of("_virtual_includes");
     private static final int EXTERNAL_DIRECTORY_IDX = 3;
@@ -159,4 +169,156 @@ class VirtualIncludesHandler {
             return null;
         }
     }
+
+  private static Path trimStart(Path value, @Nullable Path prefix) {
+    if (prefix == null || !value.startsWith(prefix)) {
+      return value;
+    }
+
+    return value.subpath(prefix.getNameCount(), value.getNameCount());
+  }
+
+  @Nullable
+  private static Path pathOf(@Nullable String value) {
+    if (value == null || value.isEmpty()) {
+      return null;
+    }
+
+    // turns a windows absolut path into a normal absolut path
+    if (value.startsWith(ABSOLUTE_LABEL_PREFIX)) {
+      value = value.substring(1);
+    }
+
+    try {
+      return Path.of(value);
+    } catch (InvalidPathException e) {
+      LOG.warn("invalid path: " + value);
+      return null;
+    }
+  }
+
+  private static void collectTargetIncludeHints(
+      Path root,
+      TargetKey targetKey,
+      TargetIdeInfo targetIdeInfo,
+      ExecutionRootPathResolver resolver,
+      ProgressIndicator indicator,
+      ImmutableList.Builder<String> includes) {
+    CIdeInfo cIdeInfo = targetIdeInfo.getcIdeInfo();
+    if (cIdeInfo == null) {
+      return;
+    }
+
+    Path includePrefix = pathOf(cIdeInfo.getIncludePrefix());
+    Path stripPrefix = pathOf(cIdeInfo.getStripIncludePrefix());
+    Path packagePath = targetKey.getLabel().blazePackage().asPath();
+
+    String externalWorkspaceName = targetKey.getLabel().externalWorkspaceName();
+
+    for (ArtifactLocation header : cIdeInfo.getHeaders()) {
+      indicator.checkCanceled();
+
+      Path realPath;
+      if (externalWorkspaceName != null) {
+        Path externalWorkspace = ExecutionRootPathResolver.externalPath.toPath()
+            .resolve(externalWorkspaceName);
+
+        Path resolvedPath = resolver.resolveToExternalWorkspaceWithSymbolicLinkResolution(
+            new ExecutionRootPath(externalWorkspace.toString())).get(0).toPath();
+
+        realPath = resolvedPath.resolve(header.getRelativePath());
+      } else {
+        realPath = root.resolve(header.getExecutionRootRelativePath());
+      }
+
+      Path codePath = pathOf(header.getRelativePath());
+      if (codePath == null) {
+        continue;
+      }
+
+      // if the path is absolut, strip prefix is a repository-relative path
+      if (stripPrefix != null && stripPrefix.isAbsolute()) {
+        codePath = trimStart(codePath, stripPrefix.subpath(0, stripPrefix.getNameCount()));
+      }
+
+      codePath = trimStart(codePath, packagePath);
+
+      // if the path is not absolut, strip prefix is a package-relative path
+      if (stripPrefix != null && !stripPrefix.isAbsolute()) {
+        codePath = trimStart(codePath, stripPrefix);
+      }
+
+      if (includePrefix != null) {
+        codePath = includePrefix.resolve(codePath);
+      }
+
+      includes.add(String.format("-ibazel%s=%s", codePath, realPath));
+    }
+  }
+
+  private static ImmutableList<String> doCollectIncludeHints(
+      Path root,
+      TargetKey targetKey,
+      BlazeProjectData projectData,
+      ExecutionRootPathResolver resolver,
+      ProgressIndicator indicator) {
+    Stack<TargetKey> frontier = new Stack<>();
+    frontier.push(targetKey);
+
+    Set<TargetKey> explored = new HashSet<>();
+
+    ImmutableList.Builder<String> includes = ImmutableList.builder();
+    while (!frontier.isEmpty()) {
+      indicator.checkCanceled();
+
+      TargetKey currentKey = frontier.pop();
+      if (!explored.add(currentKey)) {
+        continue;
+      }
+
+      TargetIdeInfo currentIdeInfo = projectData.getTargetMap().get(currentKey);
+      if (currentIdeInfo == null) {
+        continue;
+      }
+
+      collectTargetIncludeHints(root, currentKey, currentIdeInfo, resolver, indicator, includes);
+
+      for (Dependency dep : currentIdeInfo.getDependencies()) {
+        frontier.push(dep.getTargetKey());
+      }
+    }
+
+    return includes.build();
+  }
+
+  /**
+   * Collects all header files form the targetKey and its dependencies to create the '-ibazel'
+   * mappings. The mappings are used to resolve headers which use an 'include_prefix' or a
+   * 'strip_include_prefix'.
+   */
+  public static ImmutableList<String> collectIncludeHints(
+      Path projectRoot,
+      TargetKey targetKey,
+      BlazeProjectData projectData,
+      ExecutionRootPathResolver resolver,
+      ProgressIndicator indicator) {
+    if (Registry.is("bazel.cpp.sync.workspace.collect.include.prefix.hints.disabled")) {
+      return ImmutableList.of();
+    }
+
+    indicator.pushState();
+    indicator.setIndeterminate(true);
+    indicator.setText2("Collecting include hints...");
+
+    Stopwatch stopwatch = Stopwatch.createStarted();
+    ImmutableList<String> result = doCollectIncludeHints(projectRoot, targetKey, projectData,
+        resolver, indicator);
+
+    long elapsed = stopwatch.elapsed(TimeUnit.MILLISECONDS);
+    LOG.info(String.format("Collecting include hints took %dms", elapsed));
+
+    indicator.popState();
+
+    return result;
+  }
 }

--- a/base/src/com/google/idea/blaze/base/sync/workspace/VirtualIncludesHandler.java
+++ b/base/src/com/google/idea/blaze/base/sync/workspace/VirtualIncludesHandler.java
@@ -2,32 +2,22 @@ package com.google.idea.blaze.base.sync.workspace;
 
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 import com.google.idea.blaze.base.ideinfo.ArtifactLocation;
 import com.google.idea.blaze.base.ideinfo.CIdeInfo;
 import com.google.idea.blaze.base.ideinfo.Dependency;
 import com.google.idea.blaze.base.ideinfo.TargetIdeInfo;
 import com.google.idea.blaze.base.ideinfo.TargetKey;
-import com.google.idea.blaze.base.ideinfo.TargetMap;
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.primitives.ExecutionRootPath;
-import com.google.idea.blaze.base.model.primitives.Label;
-import com.google.idea.blaze.base.model.primitives.TargetName;
-import com.google.idea.blaze.base.model.primitives.WorkspacePath;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.progress.ProgressIndicator;
-import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.registry.Registry;
-import java.io.File;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.Stack;
 import java.util.concurrent.TimeUnit;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -44,131 +34,8 @@ import org.jetbrains.annotations.Nullable;
  * {@code bazel-out/.../bin/.../_virtual_includes/...}
  */
 public class VirtualIncludesHandler {
-    private static final Logger LOG = Logger.getInstance(VirtualIncludesHandler.class);
-    final static Path VIRTUAL_INCLUDES_DIRECTORY = Path.of("_virtual_includes");
-    private static final int EXTERNAL_DIRECTORY_IDX = 3;
-    private static final int EXTERNAL_WORKSPACE_NAME_IDX = 4;
-    private static final int WORKSPACE_PATH_START_FOR_EXTERNAL_WORKSPACE = 5;
-    private static final int WORKSPACE_PATH_START_FOR_LOCAL_WORKSPACE = 3;
-    private static final String ABSOLUTE_LABEL_PREFIX = "//";
-    private static final int ABSOLUTE_LABEL_PREFIX_LENGTH = ABSOLUTE_LABEL_PREFIX.length();
-
-    private static List<Path> splitExecutionPath(ExecutionRootPath executionRootPath) {
-        return Lists.newArrayList(executionRootPath.getAbsoluteOrRelativeFile().toPath().iterator());
-    }
-
-    static boolean containsVirtualInclude(ExecutionRootPath executionRootPath) {
-        return splitExecutionPath(executionRootPath).contains(VIRTUAL_INCLUDES_DIRECTORY);
-    }
-
-    /**
-     * Resolves execution root path to {@code _virtual_includes} directory to the matching workspace location
-     *
-     * @return list of resolved paths if required information is obtained from execution root path and target data
-     * or empty list if resolution has failed
-     */
-    @NotNull
-    static ImmutableList<File> resolveVirtualInclude(ExecutionRootPath executionRootPath,
-        File externalWorkspacePath,
-        WorkspacePathResolver workspacePathResolver,
-        TargetMap targetMap)
-    {
-        TargetKey key = null;
-        try {
-            key = guessTargetKey(executionRootPath);
-        } catch (IndexOutOfBoundsException exception) {
-            // report to intellij EA
-            LOG.error(
-                "Failed to detect target from execution root path: " + executionRootPath,
-                exception);
-        }
-
-        if (key == null) {
-            return ImmutableList.of();
-        }
-
-        TargetIdeInfo info = targetMap.get(key);
-        if (info == null) {
-            return ImmutableList.of();
-        }
-
-        CIdeInfo cIdeInfo = info.getcIdeInfo();
-        if (cIdeInfo == null) {
-            return ImmutableList.of();
-        }
-
-        if (!info.getcIdeInfo().getIncludePrefix().isEmpty()) {
-            LOG.debug(
-                "_virtual_includes cannot be handled for targets with include_prefix attribute");
-            return ImmutableList.of();
-        }
-
-        String stripPrefix = info.getcIdeInfo().getStripIncludePrefix();
-        if (!stripPrefix.isEmpty()) {
-            if (stripPrefix.endsWith("/")) {
-                stripPrefix = stripPrefix.substring(0, stripPrefix.length() - 1);
-            }
-            String externalWorkspaceName = key.getLabel().externalWorkspaceName();
-            WorkspacePath stripPrefixWorkspacePath = stripPrefix.startsWith(ABSOLUTE_LABEL_PREFIX) ?
-              new WorkspacePath(stripPrefix.substring(ABSOLUTE_LABEL_PREFIX_LENGTH)) :
-              new WorkspacePath(key.getLabel().blazePackage(), stripPrefix);
-            if (key.getLabel().externalWorkspaceName() != null) {
-                ExecutionRootPath external = new ExecutionRootPath(
-                    ExecutionRootPathResolver.externalPath.toPath()
-                        .resolve(externalWorkspaceName)
-                        .resolve(stripPrefixWorkspacePath.toString()).toString());
-
-                return ImmutableList.of(external.getFileRootedAt(externalWorkspacePath));
-            } else {
-                return workspacePathResolver.resolveToIncludeDirectories(
-                    stripPrefixWorkspacePath);
-            }
-        } else {
-            return ImmutableList.of();
-        }
-
-    }
-
-    /**
-     * @throws IndexOutOfBoundsException if executionRootPath has _virtual_includes but
-     * its content is unexpected
-     */
-    @Nullable
-    private static TargetKey guessTargetKey(ExecutionRootPath executionRootPath) {
-        List<Path> split = splitExecutionPath(executionRootPath);
-        int virtualIncludesIdx = split.indexOf(VIRTUAL_INCLUDES_DIRECTORY);
-
-        if (virtualIncludesIdx > -1) {
-            String externalWorkspaceName =
-                split.get(EXTERNAL_DIRECTORY_IDX)
-                    .equals(ExecutionRootPathResolver.externalPath.toPath())
-                    ? split.get(EXTERNAL_WORKSPACE_NAME_IDX).toString()
-                    : null;
-
-            int workspacePathStart = externalWorkspaceName != null
-                ? WORKSPACE_PATH_START_FOR_EXTERNAL_WORKSPACE
-                : WORKSPACE_PATH_START_FOR_LOCAL_WORKSPACE;
-
-            List<Path> workspacePaths = (workspacePathStart <= virtualIncludesIdx)
-                ? split.subList(workspacePathStart, virtualIncludesIdx)
-                : Collections.emptyList();
-
-            String workspacePathString =
-                FileUtil.toSystemIndependentName(
-                    workspacePaths.stream().reduce(Path.of(""), Path::resolve).toString());
-
-            TargetName target = TargetName.create(split.get(virtualIncludesIdx + 1).toString());
-            WorkspacePath workspacePath = WorkspacePath.createIfValid(workspacePathString);
-            if (workspacePath == null) {
-                return null;
-            }
-
-            return TargetKey.forPlainTarget(
-                Label.create(externalWorkspaceName, workspacePath, target));
-        } else {
-            return null;
-        }
-    }
+  private static final Logger LOG = Logger.getInstance(VirtualIncludesHandler.class);
+  private static final String ABSOLUTE_LABEL_PREFIX = "//";
 
   private static Path trimStart(Path value, @Nullable Path prefix) {
     if (prefix == null || !value.startsWith(prefix)) {

--- a/base/tests/unittests/com/google/idea/blaze/base/sync/workspace/ExecutionRootPathResolverTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/sync/workspace/ExecutionRootPathResolverTest.java
@@ -108,33 +108,6 @@ public class ExecutionRootPathResolverTest extends BlazeTestCase {
         .build();
   }
 
-  @NotNull
-  private static TargetMap getTargetMap() {
-    ImmutableMap.Builder<TargetKey, TargetIdeInfo> builder = new ImmutableMap.Builder<>();
-
-    for (String workspaceName : WORKSPACES) {
-      for (WorkspacePath workspacePath : WORKSPACE_PATHS) {
-        for (TargetName targetName : TARGET_NAMES) {
-          builder.put(
-              TargetKey.forPlainTarget(Label.create(workspaceName, workspacePath, targetName)),
-              getTargetIdeInfo(targetName));
-        }
-      }
-
-      builder.put(
-        TargetKey.forPlainTarget(
-          Label.create(workspaceName, ABSOLUTE_STRIP_PREFIX_WORKSPACE_PATH, TARGET_WITH_ABSOLUTE_STRIP_PREFIX)),
-        getTargetIdeInfo(TARGET_WITH_ABSOLUTE_STRIP_PREFIX));
-    }
-
-    builder.put(
-        TargetKey.forPlainTarget(
-            Label.create(WORKSPACES.get(0), WORKSPACE_PATHS.get(0), TARGET_WITH_INCLUDE_PREFIX)),
-        getTargetIdeInfo(TARGET_WITH_INCLUDE_PREFIX));
-
-    return new TargetMap(builder.build());
-  }
-
   @Override
   protected void initTest(Container applicationServices, Container projectServices) {
     Registry.get("bazel.sync.resolve.virtual.includes").setValue(true);
@@ -145,8 +118,7 @@ public class ExecutionRootPathResolverTest extends BlazeTestCase {
             WORKSPACE_ROOT,
             new File(EXECUTION_ROOT),
             new File(OUTPUT_BASE),
-            new WorkspacePathResolverImpl(WORKSPACE_ROOT),
-            getTargetMap());
+            new WorkspacePathResolverImpl(WORKSPACE_ROOT));
   }
 
   @Test
@@ -187,98 +159,6 @@ public class ExecutionRootPathResolverTest extends BlazeTestCase {
     ImmutableList<File> files =
         pathResolver.resolveToIncludeDirectories(new ExecutionRootPath("tools/fast/:include"));
     assertThat(files).isEmpty();
-  }
-
-  @Test
-  public void testVirtualIncludes() {
-    for (String workspaceName : WORKSPACES) {
-      for (WorkspacePath workspacePath : WORKSPACE_PATHS) {
-        for (TargetName targetName : TARGET_NAMES) {
-          String workspaceNameString = workspaceName != null ? workspaceName : "";
-
-          ExecutionRootPath generatedPath = new ExecutionRootPath(Path.of(
-              "bazel-out/k8-fastbuild/bin",
-              (workspaceName == null ? "" : ExecutionRootPathResolver.externalPath.getPath()),
-              workspaceNameString,
-              workspacePath.toString(),
-              VirtualIncludesHandler.VIRTUAL_INCLUDES_DIRECTORY.toString(),
-              targetName.toString()).toFile());
-
-          ImmutableList<File> files =
-              pathResolver.resolveToIncludeDirectories(generatedPath);
-
-          String stripPrefix = getStripPrefix(targetName);
-          if (stripPrefix.endsWith("/")) {
-            stripPrefix = stripPrefix.substring(0, stripPrefix.length() - 1);
-          }
-          String expectedPath = Path.of(workspaceNameString,
-              workspacePath.toString(),
-              stripPrefix).toString();
-
-          if (workspaceName != null) {
-            // check external workspace
-            assertThat(files).containsExactly(
-                Path.of(OUTPUT_BASE, ExecutionRootPathResolver.externalPath.getPath(), expectedPath)
-                    .toFile());
-          } else {
-            // check local
-            assertThat(files).containsExactly(
-                WORKSPACE_ROOT.fileForPath(new WorkspacePath(expectedPath)));
-          }
-        }
-      }
-    }
-  }
-
-  @Test
-  public void testVirtualIncludesWithAbsoluteStripPrefix() {
-    for (String workspaceName : WORKSPACES) {
-        String workspaceNameString = workspaceName != null ? workspaceName : "";
-
-        ExecutionRootPath generatedPath = new ExecutionRootPath(Path.of(
-          "bazel-out/k8-fastbuild/bin",
-          (workspaceName == null ? "" : ExecutionRootPathResolver.externalPath.getPath()),
-          workspaceNameString,
-          ABSOLUTE_STRIP_PREFIX_WORKSPACE_PATH.toString(),
-          VirtualIncludesHandler.VIRTUAL_INCLUDES_DIRECTORY.toString(),
-          TARGET_WITH_ABSOLUTE_STRIP_PREFIX.toString()).toFile());
-
-        ImmutableList<File> files =
-          pathResolver.resolveToIncludeDirectories(generatedPath);
-
-        String expectedPath = Path.of(workspaceNameString,
-          ABSOLUTE_STRIP_PREFIX_PATH).toString();
-
-        if (workspaceName != null) {
-          // check external workspace
-          assertThat(files).containsExactly(
-            Path.of(OUTPUT_BASE, ExecutionRootPathResolver.externalPath.getPath(), expectedPath)
-              .toFile());
-        } else {
-          // check local
-          assertThat(files).containsExactly(
-            WORKSPACE_ROOT.fileForPath(new WorkspacePath(expectedPath)));
-        }
-    }
-  }
-
-  @Test
-  public void testVirtualIncludesWithIncludePrefix() {
-    File fileToBeResolved = Path.of(
-        "bazel-out/k8-fastbuild/bin",
-        WORKSPACE_PATHS.get(0).toString(),
-        VirtualIncludesHandler.VIRTUAL_INCLUDES_DIRECTORY.toString(),
-        TARGET_WITH_INCLUDE_PREFIX.toString(),
-        INCLUDE_PREFIX).toFile();
-
-    ExecutionRootPath generatedPath = new ExecutionRootPath(fileToBeResolved);
-
-    ImmutableList<File> files =
-        pathResolver.resolveToIncludeDirectories(generatedPath);
-
-    // check that include path for target with "include_prefix" attribute is resolved to execution root
-    assertThat(files).containsExactly(
-        new File(EXECUTION_ROOT, fileToBeResolved.toString()));
   }
 
   @Test

--- a/cpp/src/META-INF/blaze-cpp.xml
+++ b/cpp/src/META-INF/blaze-cpp.xml
@@ -59,6 +59,7 @@
     <registryKey defaultValue="false" description="Disable absolute path trimming in debug clang builds" key="bazel.trim.absolute.path.disabled"/>
     <registryKey defaultValue="true" description="Allow external targets from source directories be imported in" key="bazel.cpp.sync.external.targets.from.directories"/>
     <registryKey defaultValue="false" description="Filter out some incompatible compiler flags (-include)" key="bazel.cpp.sync.workspace.filter.out.incompatible.flags"/>
+    <registryKey defaultValue="false" description="Disable collection of includes during sync" key="bazel.cpp.sync.workspace.collect.includes.disabled"/>
     <applicationService serviceInterface="com.google.idea.blaze.cpp.CompilerVersionChecker"
                         serviceImplementation="com.google.idea.blaze.cpp.CompilerVersionCheckerImpl"/>
     <applicationService serviceInterface="com.google.idea.blaze.cpp.CompilerWrapperProvider"

--- a/cpp/src/META-INF/blaze-cpp.xml
+++ b/cpp/src/META-INF/blaze-cpp.xml
@@ -59,7 +59,7 @@
     <registryKey defaultValue="false" description="Disable absolute path trimming in debug clang builds" key="bazel.trim.absolute.path.disabled"/>
     <registryKey defaultValue="true" description="Allow external targets from source directories be imported in" key="bazel.cpp.sync.external.targets.from.directories"/>
     <registryKey defaultValue="false" description="Filter out some incompatible compiler flags (-include)" key="bazel.cpp.sync.workspace.filter.out.incompatible.flags"/>
-    <registryKey defaultValue="false" description="Disable collection of includes during sync" key="bazel.cpp.sync.workspace.collect.includes.disabled"/>
+    <registryKey defaultValue="false" description="Disable collection of include prefix hints during sync" key="bazel.cpp.sync.workspace.collect.include.prefix.hints.disabled"/>
     <applicationService serviceInterface="com.google.idea.blaze.cpp.CompilerVersionChecker"
                         serviceImplementation="com.google.idea.blaze.cpp.CompilerVersionCheckerImpl"/>
     <applicationService serviceInterface="com.google.idea.blaze.cpp.CompilerWrapperProvider"

--- a/cpp/src/com/google/idea/blaze/cpp/BlazeCWorkspace.java
+++ b/cpp/src/com/google/idea/blaze/cpp/BlazeCWorkspace.java
@@ -22,7 +22,11 @@ import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.errorprone.annotations.Keep;
-import com.google.idea.blaze.base.ideinfo.*;
+import com.google.idea.blaze.base.ideinfo.ArtifactLocation;
+import com.google.idea.blaze.base.ideinfo.CIdeInfo;
+import com.google.idea.blaze.base.ideinfo.Dependency;
+import com.google.idea.blaze.base.ideinfo.TargetIdeInfo;
+import com.google.idea.blaze.base.ideinfo.TargetKey;
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.primitives.ExecutionRootPath;
 import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
@@ -70,7 +74,13 @@ import com.jetbrains.cidr.lang.workspace.compiler.TempFilesPool;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -172,16 +182,24 @@ public final class BlazeCWorkspace implements ProjectComponent {
     String stripPrefix = cIdeInfo.getStripIncludePrefix();
     for (ArtifactLocation header : cIdeInfo.getHeaders()) {
       String realPath = rootPath + "/" + header.getExecutionRootRelativePath();
+      String libPath = targetKey.getLabel().blazePackage().asPath().toString();
       String pathUsedInSourceCode = header.getRelativePath();
-      if (stripPrefix != null && !stripPrefix.isEmpty() && pathUsedInSourceCode.startsWith(stripPrefix)) {
-        pathUsedInSourceCode = pathUsedInSourceCode.substring(stripPrefix.length() +
-                (stripPrefix.endsWith("/") ? 0 : 1));
-      }
-      if (includePrefix != null && !includePrefix.isEmpty()) {
-        pathUsedInSourceCode = includePrefix + "/" + pathUsedInSourceCode;
-      }
+      if (pathUsedInSourceCode != null) {
+        if (libPath != null && !libPath.isEmpty() && pathUsedInSourceCode.startsWith(libPath)) {
+          pathUsedInSourceCode = pathUsedInSourceCode.substring(libPath.length() + 1);
+        }
+        if (stripPrefix != null && !stripPrefix.isEmpty() && pathUsedInSourceCode.startsWith(stripPrefix)) {
+          pathUsedInSourceCode = pathUsedInSourceCode.substring(stripPrefix.length() +
+                  (stripPrefix.endsWith("/") ? 0 : 1));
+          System.out.println("updated path = " + pathUsedInSourceCode);
+        }
+        if (includePrefix != null && !includePrefix.isEmpty()) {
+          pathUsedInSourceCode = includePrefix + "/" + pathUsedInSourceCode;
+          System.out.println("updated path 2 = " + pathUsedInSourceCode);
+        }
 
-      includes.add("-ibazel" + pathUsedInSourceCode + "=" + realPath);
+        includes.add("-ibazel" + pathUsedInSourceCode + "=" + realPath);
+      }
     }
 
     for (Dependency dep : targetIdeInfo.getDependencies()) {
@@ -225,18 +243,18 @@ public final class BlazeCWorkspace implements ProjectComponent {
           continue;
         }
 
-        @NotNull CIdeInfo cIdeInfo = targetIdeInfo.getcIdeInfo();
         // defines and include directories are the same for all sources in a given target, so lets
         // collect them once and reuse for each source file's options
 
         UnfilteredCompilerOptions coptsExtractor =
             UnfilteredCompilerOptions.builder()
                 .registerSingleOrSplitOption("-I")
-                .build(cIdeInfo.getLocalCopts());
+                .build(targetIdeInfo.getcIdeInfo().getLocalCopts());
         List<String> plainLocalCopts = coptsExtractor.getUninterpretedOptions();
         if (Registry.is("bazel.cpp.sync.workspace.filter.out.incompatible.flags")) {
           plainLocalCopts = filterIncompatibleFlags(plainLocalCopts);
         }
+
         ImmutableList<ExecutionRootPath> localIncludes =
             coptsExtractor.getExtractedOptionValues("-I").stream()
                 .map(ExecutionRootPath::new)
@@ -244,7 +262,7 @@ public final class BlazeCWorkspace implements ProjectComponent {
 
         // transitiveDefines are sourced from a target's (and transitive deps) "defines" attribute
         ImmutableList<String> transitiveDefineOptions =
-                cIdeInfo.getTransitiveDefines().stream()
+                targetIdeInfo.getcIdeInfo().getTransitiveDefines().stream()
                 .map(s -> "-D" + s)
                 .collect(toImmutableList());
 
@@ -258,7 +276,7 @@ public final class BlazeCWorkspace implements ProjectComponent {
         ImmutableList<String> iOptionIncludeDirectories =
             Stream.concat(
                     localIncludes.stream().flatMap(resolver),
-                    cIdeInfo.getTransitiveIncludeDirectories().stream()
+                    targetIdeInfo.getcIdeInfo().getTransitiveIncludeDirectories().stream()
                         .flatMap(resolver)
                         .filter(configResolveData::isValidHeaderRoot))
                 .map(file -> "-I" + file.getAbsolutePath())
@@ -267,7 +285,7 @@ public final class BlazeCWorkspace implements ProjectComponent {
         // transitiveQuoteIncludeDirectories are sourced from
         // CcSkylarkApiProvider.quote_include_directories
         ImmutableList<String> iquoteOptionIncludeDirectories =
-                cIdeInfo.getTransitiveQuoteIncludeDirectories().stream()
+            targetIdeInfo.getcIdeInfo().getTransitiveQuoteIncludeDirectories().stream()
                 .flatMap(resolver)
                 .filter(configResolveData::isValidHeaderRoot)
                 .map(file -> "-iquote" + file.getAbsolutePath())
@@ -277,7 +295,7 @@ public final class BlazeCWorkspace implements ProjectComponent {
         // Note: We would ideally use -isystem here, but it interacts badly with the switches
         // that get built by ClangUtils::addIncludeDirectories (it uses -I for system libraries).
         ImmutableList<String> isystemOptionIncludeDirectories =
-            cIdeInfo.getTransitiveSystemIncludeDirectories().stream()
+            targetIdeInfo.getcIdeInfo().getTransitiveSystemIncludeDirectories().stream()
                 .flatMap(resolver)
                 .filter(configResolveData::isValidHeaderRoot)
                 .map(file -> "-I" + file.getAbsolutePath())

--- a/cpp/src/com/google/idea/blaze/cpp/BlazeCWorkspace.java
+++ b/cpp/src/com/google/idea/blaze/cpp/BlazeCWorkspace.java
@@ -183,8 +183,7 @@ public final class BlazeCWorkspace implements ProjectComponent {
             workspaceRoot,
             blazeProjectData.getBlazeInfo().getExecutionRoot(),
             blazeProjectData.getBlazeInfo().getOutputBase(),
-            blazeProjectData.getWorkspacePathResolver(),
-            blazeProjectData.getTargetMap());
+            blazeProjectData.getWorkspacePathResolver());
 
     int progress = 0;
 

--- a/cpp/src/com/google/idea/blaze/cpp/BlazeCWorkspace.java
+++ b/cpp/src/com/google/idea/blaze/cpp/BlazeCWorkspace.java
@@ -22,8 +22,7 @@ import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.errorprone.annotations.Keep;
-import com.google.idea.blaze.base.ideinfo.TargetIdeInfo;
-import com.google.idea.blaze.base.ideinfo.TargetKey;
+import com.google.idea.blaze.base.ideinfo.*;
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.primitives.ExecutionRootPath;
 import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
@@ -68,14 +67,10 @@ import com.jetbrains.cidr.lang.workspace.compiler.CompilerInfoCache.Message;
 import com.jetbrains.cidr.lang.workspace.compiler.CompilerInfoCache.Session;
 import com.jetbrains.cidr.lang.workspace.compiler.OCCompilerKind;
 import com.jetbrains.cidr.lang.workspace.compiler.TempFilesPool;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -165,6 +160,37 @@ public final class BlazeCWorkspace implements ProjectComponent {
             });
   }
 
+  private List<String> collectIncludes(String rootPath, TargetKey targetKey, BlazeProjectData blazeProjectData) {
+    TargetIdeInfo targetIdeInfo = blazeProjectData.getTargetMap().get(targetKey);
+    if (targetIdeInfo == null || targetIdeInfo.getcIdeInfo() == null) {
+      return Collections.emptyList();
+    }
+
+    ArrayList<String> includes = new ArrayList<>();
+    CIdeInfo cIdeInfo = targetIdeInfo.getcIdeInfo();
+    String includePrefix = cIdeInfo.getIncludePrefix();
+    String stripPrefix = cIdeInfo.getStripIncludePrefix();
+    for (ArtifactLocation header : cIdeInfo.getHeaders()) {
+      String realPath = rootPath + "/" + header.getExecutionRootRelativePath();
+      String pathUsedInSourceCode = header.getRelativePath();
+      if (stripPrefix != null && !stripPrefix.isEmpty() && pathUsedInSourceCode.startsWith(stripPrefix)) {
+        pathUsedInSourceCode = pathUsedInSourceCode.substring(stripPrefix.length() +
+                (stripPrefix.endsWith("/") ? 0 : 1));
+      }
+      if (includePrefix != null && !includePrefix.isEmpty()) {
+        pathUsedInSourceCode = includePrefix + "/" + pathUsedInSourceCode;
+      }
+
+      includes.add("-ibazel" + pathUsedInSourceCode + "=" + realPath);
+    }
+
+    for (Dependency dep : targetIdeInfo.getDependencies()) {
+      includes.addAll(collectIncludes(rootPath, dep.getTargetKey(), blazeProjectData));
+    }
+
+    return includes;
+  }
+
   private OCWorkspaceImpl.ModifiableModel calculateConfigurations(
       BlazeProjectData blazeProjectData,
       WorkspaceRoot workspaceRoot,
@@ -199,18 +225,18 @@ public final class BlazeCWorkspace implements ProjectComponent {
           continue;
         }
 
+        @NotNull CIdeInfo cIdeInfo = targetIdeInfo.getcIdeInfo();
         // defines and include directories are the same for all sources in a given target, so lets
         // collect them once and reuse for each source file's options
 
         UnfilteredCompilerOptions coptsExtractor =
             UnfilteredCompilerOptions.builder()
                 .registerSingleOrSplitOption("-I")
-                .build(targetIdeInfo.getcIdeInfo().getLocalCopts());
+                .build(cIdeInfo.getLocalCopts());
         List<String> plainLocalCopts = coptsExtractor.getUninterpretedOptions();
         if (Registry.is("bazel.cpp.sync.workspace.filter.out.incompatible.flags")) {
           plainLocalCopts = filterIncompatibleFlags(plainLocalCopts);
         }
-
         ImmutableList<ExecutionRootPath> localIncludes =
             coptsExtractor.getExtractedOptionValues("-I").stream()
                 .map(ExecutionRootPath::new)
@@ -218,7 +244,7 @@ public final class BlazeCWorkspace implements ProjectComponent {
 
         // transitiveDefines are sourced from a target's (and transitive deps) "defines" attribute
         ImmutableList<String> transitiveDefineOptions =
-            targetIdeInfo.getcIdeInfo().getTransitiveDefines().stream()
+                cIdeInfo.getTransitiveDefines().stream()
                 .map(s -> "-D" + s)
                 .collect(toImmutableList());
 
@@ -232,7 +258,7 @@ public final class BlazeCWorkspace implements ProjectComponent {
         ImmutableList<String> iOptionIncludeDirectories =
             Stream.concat(
                     localIncludes.stream().flatMap(resolver),
-                    targetIdeInfo.getcIdeInfo().getTransitiveIncludeDirectories().stream()
+                    cIdeInfo.getTransitiveIncludeDirectories().stream()
                         .flatMap(resolver)
                         .filter(configResolveData::isValidHeaderRoot))
                 .map(file -> "-I" + file.getAbsolutePath())
@@ -241,7 +267,7 @@ public final class BlazeCWorkspace implements ProjectComponent {
         // transitiveQuoteIncludeDirectories are sourced from
         // CcSkylarkApiProvider.quote_include_directories
         ImmutableList<String> iquoteOptionIncludeDirectories =
-            targetIdeInfo.getcIdeInfo().getTransitiveQuoteIncludeDirectories().stream()
+                cIdeInfo.getTransitiveQuoteIncludeDirectories().stream()
                 .flatMap(resolver)
                 .filter(configResolveData::isValidHeaderRoot)
                 .map(file -> "-iquote" + file.getAbsolutePath())
@@ -251,11 +277,14 @@ public final class BlazeCWorkspace implements ProjectComponent {
         // Note: We would ideally use -isystem here, but it interacts badly with the switches
         // that get built by ClangUtils::addIncludeDirectories (it uses -I for system libraries).
         ImmutableList<String> isystemOptionIncludeDirectories =
-            targetIdeInfo.getcIdeInfo().getTransitiveSystemIncludeDirectories().stream()
+            cIdeInfo.getTransitiveSystemIncludeDirectories().stream()
                 .flatMap(resolver)
                 .filter(configResolveData::isValidHeaderRoot)
                 .map(file -> "-I" + file.getAbsolutePath())
                 .collect(toImmutableList());
+
+        String rootPath = workspaceRoot.directory().getAbsolutePath();
+        ImmutableList<String> includes = ImmutableList.copyOf(collectIncludes(rootPath, targetKey, blazeProjectData));
 
         for (VirtualFile vf : resolveConfiguration.getSources(targetKey)) {
           OCLanguageKind kind = resolveConfiguration.getDeclaredLanguageKind(vf);
@@ -272,6 +301,7 @@ public final class BlazeCWorkspace implements ProjectComponent {
           fileSpecificSwitchBuilder.addAllRaw(iOptionIncludeDirectories);
           fileSpecificSwitchBuilder.addAllRaw(isystemOptionIncludeDirectories);
           fileSpecificSwitchBuilder.addAllRaw(plainLocalCopts);
+          fileSpecificSwitchBuilder.addAllRaw(includes);
 
           PerFileCompilerOpts perFileCompilerOpts =
               new PerFileCompilerOpts(kind, fileSpecificSwitchBuilder.build());

--- a/cpp/src/com/google/idea/blaze/cpp/BlazeConfigurationResolver.java
+++ b/cpp/src/com/google/idea/blaze/cpp/BlazeConfigurationResolver.java
@@ -89,8 +89,7 @@ final class BlazeConfigurationResolver {
             WorkspaceRoot.fromProject(project),
             blazeProjectData.getBlazeInfo().getExecutionRoot(),
             blazeProjectData.getBlazeInfo().getOutputBase(),
-            blazeProjectData.getWorkspacePathResolver(),
-            blazeProjectData.getTargetMap());
+            blazeProjectData.getWorkspacePathResolver());
     ImmutableMap<TargetKey, CToolchainIdeInfo> toolchainLookupMap =
         BlazeConfigurationToolchainResolver.buildToolchainLookupMap(
             context, blazeProjectData.getTargetMap());

--- a/cpp/src/com/google/idea/blaze/cpp/IncludeRootFlagsProcessor.java
+++ b/cpp/src/com/google/idea/blaze/cpp/IncludeRootFlagsProcessor.java
@@ -48,8 +48,7 @@ public class IncludeRootFlagsProcessor implements BlazeCompilerFlagsProcessor {
               workspaceRoot,
               projectData.getBlazeInfo().getExecutionRoot(),
               projectData.getBlazeInfo().getOutputBase(),
-              projectData.getWorkspacePathResolver(),
-              projectData.getTargetMap());
+              projectData.getWorkspacePathResolver());
       return Optional.of(new IncludeRootFlagsProcessor(executionRootPathResolver));
     }
   }

--- a/cpp/tests/integrationtests/com/google/idea/blaze/cpp/BlazeCppResolvingTestCase.java
+++ b/cpp/tests/integrationtests/com/google/idea/blaze/cpp/BlazeCppResolvingTestCase.java
@@ -102,8 +102,7 @@ public class BlazeCppResolvingTestCase extends BlazeCppIntegrationTestCase {
         workspaceRoot,
         projectData.getBlazeInfo().getExecutionRoot(),
         projectData.getBlazeInfo().getOutputBase(),
-        projectData.getWorkspacePathResolver(),
-        projectData.getTargetMap());
+        projectData.getWorkspacePathResolver());
   }
 
   private HeadersSearchRoot searchRootFromExecRoot(


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #5300

# Description of this change
Followup for #5301. Pass all headers in targets with `include_prefix` with special "-ibazel" flag like that they can be handled by CLion. Also I tried to address all open comments in the pull request.
