### PR TITLE
Update stale bot messages

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -28,23 +28,17 @@ jobs:
         days-before-issue-close : 14
         days-before-pr-close: 14
         stale-issue-message: >
-          Thank you for contributing to the IntelliJ repository! 
+          Thank you for contributing to the IntelliJ repository!
           This issue has been marked as stale since it has not had any activity in the last 6 months. It will be closed in the next 14
-          days unless any other activity occurs or one of the following labels is added: "not stale", "awaiting-maintainer". Please reach out 
-          to the triage team (`@bazelbuild/triage`) if you think this issue is still relevant or you are interested in getting the 
-          issue resolved.
+          days unless any other activity occurs. If you think this issue is still relevant and should stay open, please post any comment here and the issue will no longer be marked as stale.
         close-issue-message: >
-          This issue has been automatically closed due to inactivity. If you're still interested in pursuing this, please reach out 
-          to the triage team (`@bazelbuild/triage`). Thanks!
+          This issue has been automatically closed due to inactivity. If you're still interested in pursuing this, please post `@bazelbuild/triage` in a comment here and we'll take a look. Thanks!
         stale-pr-message: >
           Thank you for contributing to the IntelliJ repository!
           This pull request has been marked as stale since it has not had any activity in the last 6 months. It will be closed in the next
-          14 days unless any other activity occurs or one of the following labels is added: "not stale", "awaiting-review".
-          Please reach out to the triage team (`@bazelbuild/triage`) if you think this PR is still relevant or you are interested in getting the 
-          PR merged.
+          14 days unless any other activity occurs. If you think this PR is still relevant and should stay open, please post any comment here and the PR will no longer be marked as stale.
         close-pr-message: >
-          This pull request has been automatically closed due to inactivity. If you're still interested in pursuing this, please reach out
-          to the triage team (`@bazelbuild/triage`). Thanks!
+          This pull request has been automatically closed due to inactivity. If you're still interested in pursuing this, please post `@bazelbuild/triage` in a comment here and we'll take a look. Thanks!
         stale-issue-label: 'stale'
         exempt-issue-labels: 'not stale,awaiting-maintainer,P0,P1'
         close-issue-reason: "not_planned"


### PR DESCRIPTION
Update stale bot messages to be more clear and match what's in the [Bazel repo](https://github.com/bazelbuild/bazel/blob/master/.github/workflows/stale.yml).