### PR TITLE
Changes to BlazeTargetFilter regex to match more target names

### DIFF
--- a/base/src/com/google/idea/blaze/base/run/filter/BlazeTargetFilter.java
+++ b/base/src/com/google/idea/blaze/base/run/filter/BlazeTargetFilter.java
@@ -40,9 +40,9 @@ import javax.annotation.Nullable;
 /** Parse blaze targets in streamed output. */
 public class BlazeTargetFilter implements Filter {
 
-  // See Bazel's LabelValidator class. Whitespace character intentionally not included here.
-  private static final String PACKAGE_NAME_CHARS = "a-zA-Z0-9/\\-\\._$()";
-  private static final String TARGET_CHARS = "a-zA-Z0-9+,=~#()$_@\\-/";
+  // See Bazel's LabelValidator class. Whitespace character and ' intentionally not included here.
+  private static final String PACKAGE_NAME_CHARS = "a-zA-Z0-9/\\-\\._$()@";
+  private static final String TARGET_CHARS = "a-zA-Z0-9!%@^_\"#$&()*\\-+,;<=>?\\[\\]{|}~/\\.";
 
   // ignore '//' preceded by text (e.g. https://...)
   // format: ([@external_workspace]//package:rule)

--- a/base/tests/unittests/com/google/idea/blaze/base/run/filter/BlazeTargetFilterTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/run/filter/BlazeTargetFilterTest.java
@@ -48,8 +48,8 @@ public class BlazeTargetFilterTest {
 
   @Test
   public void testUnusualCharsInTarget() {
-    String line = "Something //Package-._$():T0+,=~#target_@name something else";
-    assertThat(findMatch(line)).isEqualTo("//Package-._$():T0+,=~#target_@name");
+    String line = "Something //Package-._$()@:T0!%^_\"#$&()*-+,;<=>?[]{|}~/.target_@name something else";
+    assertThat(findMatch(line)).isEqualTo("//Package-._$()@:T0!%^_\"#$&()*-+,;<=>?[]{|}~/.target_@name");
   }
 
   @Test


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #4431

# Description of this change
Changed the regex used by BlazeTargetFilter to include more valid target names. I used [this](https://bazel.build/concepts/labels#target-names) documentation page to lookup the valid characters.
