### PR TITLE
Added registry key to disable fission flag

### DIFF
--- a/clwb/src/META-INF/clwb.xml
+++ b/clwb/src/META-INF/clwb.xml
@@ -33,6 +33,7 @@
     <postStartupActivity implementation="com.google.idea.blaze.clwb.run.producers.NonBlazeProducerSuppressor"/>
     <actionConfigurationCustomizer implementation="com.google.idea.blaze.plugin.ClwbHideMakeActions"/>
     <registryKey defaultValue="false" description="Disable the extra debug flags in debug C/C++ builds" key="bazel.clwb.debug.extraflags.disabled"/>
+    <registryKey defaultValue="false" description="Disable the fission flag in debug C/C++ builds" key="bazel.clwb.debug.fission.disabled"/>
   </extensions>
 
   <extensions defaultExtensionNs="com.google.idea.blaze">

--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrRunConfigurationRunner.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrRunConfigurationRunner.java
@@ -130,7 +130,7 @@ public class BlazeCidrRunConfigurationRunner implements BlazeCommandRunConfigura
                       "--copt=-g",
                       "--strip=never",
                       "--dynamic_mode=off"),
-                      BlazeGDBServerProvider.fissionFlag().stream(),
+                      BlazeGDBServerProvider.getOptionalFissionArguments().stream(),
                       extraClangFlags.stream()).collect(Collectors.toList());
         } else {
           extraDebugFlags =

--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrRunConfigurationRunner.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrRunConfigurationRunner.java
@@ -129,8 +129,9 @@ public class BlazeCidrRunConfigurationRunner implements BlazeCommandRunConfigura
                       "--copt=-O0",
                       "--copt=-g",
                       "--strip=never",
-                      "--dynamic_mode=off",
-                      "--fission=yes"), extraClangFlags.stream()).collect(Collectors.toList());
+                      "--dynamic_mode=off"),
+                      BlazeGDBServerProvider.fissionFlag().stream(),
+                      extraClangFlags.stream()).collect(Collectors.toList());
         } else {
           extraDebugFlags =
               BlazeGDBServerProvider.getFlagsForDebugging(configuration.getHandler().getState());

--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeGDBServerProvider.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeGDBServerProvider.java
@@ -77,7 +77,7 @@ public class BlazeGDBServerProvider {
 
   // Allows the fission flag to be disabled as workaround for
   // https://github.com/bazelbuild/intellij/issues/5604
-  static ImmutableList<String> fissionFlag() {
+  static ImmutableList<String> getOptionalFissionArguments() {
     if(Registry.is("bazel.clwb.debug.fission.disabled")) {
       return ImmutableList.of();
     } else {
@@ -128,12 +128,12 @@ public class BlazeGDBServerProvider {
     }
     if (BlazeCommandName.RUN.equals(commandName)) {
       builder.addAll(EXTRA_FLAGS_FOR_DEBUG_RUN);
-      builder.addAll(fissionFlag());
+      builder.addAll(getOptionalFissionArguments());
       return builder.build();
     }
     if (BlazeCommandName.TEST.equals(commandName)) {
       builder.addAll(EXTRA_FLAGS_FOR_DEBUG_TEST);
-      builder.addAll(fissionFlag());
+      builder.addAll(getOptionalFissionArguments());
       return builder.build();
     }
     return ImmutableList.of();


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #5604 

# Description of this change
Adds a new registry key `bazel.clwb.debug.fission.disabled` which can be used to prevent CLion from adding the `--fission=yes` flag automatically. This was mentioned as a workaround in the discussion of the issue.
