### PR TITLE
Suppress errors from DirectoryToTargetProvider.expandDirectoryTargets

### DIFF
--- a/base/src/com/google/idea/blaze/base/command/BlazeCommand.java
+++ b/base/src/com/google/idea/blaze/base/command/BlazeCommand.java
@@ -96,6 +96,7 @@ public final class BlazeCommand {
     private final String binaryPath;
     private final BlazeCommandName name;
     private boolean invokeParallel;
+    private boolean suppressErrors;
     private Path effectiveWorkspaceRoot;
     private final ImmutableList.Builder<String> blazeStartupFlags = ImmutableList.builder();
     private final ImmutableList.Builder<TargetExpression> targets = ImmutableList.builder();
@@ -142,6 +143,16 @@ public final class BlazeCommand {
     @CanIgnoreReturnValue
     public Builder setInvokeParallel(boolean invokeParallel) {
       this.invokeParallel = invokeParallel;
+      return this;
+    }
+
+    public boolean isSuppressErrors() {
+      return suppressErrors;
+    }
+
+    @CanIgnoreReturnValue
+    public Builder setSuppressErrors(boolean suppressErrors) {
+      this.suppressErrors = suppressErrors;
       return this;
     }
 

--- a/base/src/com/google/idea/blaze/base/command/CommandLineBlazeCommandRunner.java
+++ b/base/src/com/google/idea/blaze/base/command/CommandLineBlazeCommandRunner.java
@@ -152,7 +152,9 @@ public class CommandLineBlazeCommandRunner implements BlazeCommandRunner {
                         line = rootReplacement.apply(line);
                         // errors are expected, so limit logging to info level
                         Logger.getInstance(this.getClass()).info(line.stripTrailing());
-                        context.output(PrintOutput.output(line.stripTrailing()));
+                        if (!blazeCommandBuilder.isSuppressErrors()) {
+                          context.output(PrintOutput.output(line.stripTrailing()));
+                        }
                         return true;
                       }))
               .ignoreExitCode(true)

--- a/base/src/com/google/idea/blaze/base/dependencies/BlazeQueryDirectoryToTargetProvider.java
+++ b/base/src/com/google/idea/blaze/base/dependencies/BlazeQueryDirectoryToTargetProvider.java
@@ -100,7 +100,8 @@ public class BlazeQueryDirectoryToTargetProvider implements DirectoryToTargetPro
                 buildSystem.getDefaultInvoker(project, context), BlazeCommandName.QUERY)
             .addBlazeFlags("--output=label_kind")
             .addBlazeFlags("--keep_going")
-            .addBlazeFlags(query);
+            .addBlazeFlags(query)
+            .setSuppressErrors(true);
     BuildInvoker invoker = buildSystem.getDefaultInvoker(project, context);
     BlazeQueryLabelKindParser outputProcessor = new BlazeQueryLabelKindParser(t -> true);
     try (BuildResultHelper helper = invoker.createBuildResultHelper();


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #5209

# Description of this change
Suppresses errors from `DirectoryToTargetProvider.expandDirectoryTargets`. Since this is only used with `childContext.setPropagatesErrors(false)` I figured it should be safe to suppress all messages which are published to `stderr`. This prevents the error messages, which are described in the issue, from being shown to the user.