### PR TITLE
Remove aspect-tools dependency on the platform.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -750,8 +750,8 @@ jvm_maven_import_external(
 
 jvm_maven_import_external(
     name = "com_google_guava_guava",
-    artifact = "com.google.guava:guava:31.1-jre",
-    artifact_sha256 = "a42edc9cab792e39fe39bb94f3fca655ed157ff87a8af78e1d6ba5b07c4a00ab",
+    artifact = "com.google.guava:guava:33.0.0-jre",
+    artifact_sha256 = "f4d85c3e4d411694337cb873abea09b242b664bb013320be6105327c45991537",
     server_urls = [
         "https://repo1.maven.org/maven2",
     ],

--- a/aspect/tools/BUILD
+++ b/aspect/tools/BUILD
@@ -7,20 +7,12 @@ package(default_visibility = ["//aspect:__pkg__"])
 
 licenses(["notice"])
 
-# To prevent versioning conflicts when developing internally, we always use the same
-# guava version bundled with the IntelliJ plugin API.
-java_library(
-    name = "guava",
-    visibility = ["//visibility:private"],
-    exports = ["//intellij_platform_sdk:guava_for_external_binaries"],
-)
-
 java_library(
     name = "lib",
     srcs = glob(["src/**/*.java"]),
     javacopts = ["-source 8 -target 8"],
     deps = [
-        ":guava",
+        "@com_google_guava_guava//jar",
         "//proto:proto_deps",
         "@jsr305_annotations//jar",
         "//third_party/bazel/src/main/protobuf:worker_protocol_java_proto",

--- a/build-visibility.bzl
+++ b/build-visibility.bzl
@@ -47,8 +47,6 @@ ASPECT_TEST_RULES_VISIBILITY_TO_ALL = [
 
 SERVICES_EXPERIMENT_SUBPACKAGES = None
 
-ASPECT_TOOLS_PACKAGE = ["//aspect/tools:__pkg__"]
-
 def create_plugin_packages_group(name = None):
     # This group is not needed externally
     pass

--- a/intellij_platform_sdk/BUILD
+++ b/intellij_platform_sdk/BUILD
@@ -7,7 +7,6 @@
 
 load(
     "//:build-visibility.bzl",
-    "ASPECT_TOOLS_PACKAGE",
     "INTELLIJ_PLUGINS_VISIBILITY",
     "create_test_libs_visibility_package",
 )
@@ -774,16 +773,6 @@ java_library(
 java_library(
     name = "guava",
     testonly = True,
-    exports = select_from_plugin_api_directory(
-        android_studio = [":guava"],
-        clion = [":guava"],
-        intellij = [":guava"],
-    ),
-)
-
-java_library(
-    name = "guava_for_external_binaries",
-    visibility = ASPECT_TOOLS_PACKAGE,
     exports = select_from_plugin_api_directory(
         android_studio = [":guava"],
         clion = [":guava"],


### PR DESCRIPTION
It's hard to reason what is included in *_deploy.jar files and what is not

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

