### PR TITLE
fix: exception when trying to import java project

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -758,6 +758,15 @@ jvm_maven_import_external(
 )
 
 jvm_maven_import_external(
+    name = "com_google_guava_failureaccess",
+    artifact = "com.google.guava:failureaccess:1.0.2",
+    artifact_sha256 = "8a8f81cf9b359e3f6dfa691a1e776985c061ef2f223c9b2c80753e1b458e8064",
+    server_urls = [
+        "https://repo1.maven.org/maven2",
+    ],
+)
+
+jvm_maven_import_external(
     name = "gson",
     artifact = "com.google.code.gson:gson:2.9.1",
     artifact_sha256 = "378534e339e6e6d50b1736fb3abb76f1c15d1be3f4c13cec6d536412e23da603",

--- a/aspect/tools/BUILD
+++ b/aspect/tools/BUILD
@@ -12,10 +12,11 @@ java_library(
     srcs = glob(["src/**/*.java"]),
     javacopts = ["-source 8 -target 8"],
     deps = [
-        "@com_google_guava_guava//jar",
         "//proto:proto_deps",
-        "@jsr305_annotations//jar",
         "//third_party/bazel/src/main/protobuf:worker_protocol_java_proto",
+        "@com_google_guava_failureaccess//jar",
+        "@com_google_guava_guava//jar",
+        "@jsr305_annotations//jar",
     ],
 )
 


### PR DESCRIPTION
For the reference:
https://github.com/google/guava/blob/37ce42927192b4fbd7b1d0cf946485f88fa25130/README.md#important-warnings

"Guava has one dependency that is needed for linkage at runtime: com.google.guava:failureaccess:1.0.2."

closes #6139

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

