### PR TITLE
fix: Enviroment Variables are not correctly inherited from system on …

### DIFF
--- a/base/src/com/google/idea/blaze/base/run/confighandler/BlazeCommandGenericRunConfigurationRunner.java
+++ b/base/src/com/google/idea/blaze/base/run/confighandler/BlazeCommandGenericRunConfigurationRunner.java
@@ -199,7 +199,7 @@ public final class BlazeCommandGenericRunConfigurationRunner
       commandLine.withEnvironment(envVarState.getEnvs());
       commandLine.withParentEnvironmentType(
               envVarState.isPassParentEnvs()
-                      ? GeneralCommandLine.ParentEnvironmentType.SYSTEM
+                      ? GeneralCommandLine.ParentEnvironmentType.CONSOLE
                       : GeneralCommandLine.ParentEnvironmentType.NONE);
       return new ScopedBlazeProcessHandler(
           project,

--- a/java/src/com/google/idea/blaze/java/run/BlazeJavaRunProfileState.java
+++ b/java/src/com/google/idea/blaze/java/run/BlazeJavaRunProfileState.java
@@ -291,7 +291,7 @@ public final class BlazeJavaRunProfileState extends BlazeJavaDebuggableRunProfil
     commandLine.withEnvironment(envVarState.getEnvs());
     commandLine.withParentEnvironmentType(
             envVarState.isPassParentEnvs()
-                    ? GeneralCommandLine.ParentEnvironmentType.SYSTEM
+                    ? GeneralCommandLine.ParentEnvironmentType.CONSOLE
                     : GeneralCommandLine.ParentEnvironmentType.NONE);
     return new ScopedBlazeProcessHandler(
         project,


### PR DESCRIPTION
…MacOS

Use CONSOLE ParentEnvironmentType instead of SYSTEM

CONSOLE is the default value initialized in GeneralCommandLineso it was used before. Now, if we want to inherit the system envs we use SYSTEM, so in both cases it differs from what was there before. This PR just brings the old behavior in case a user wants to inherit enviroment from the system.

https://github.com/JetBrains/intellij-community/blob/9838665ba816fc8ce06e4071aa5a906a35fbb22e/platform/platform-util-io/src/com/intellij/execution/configurations/GeneralCommandLine.java#L85C1-L86C1

fixes #6163

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

