### PR TITLE
fix(sync): Disable query-sync by default

### DIFF
--- a/base/src/com/google/idea/blaze/base/qsync/QuerySync.java
+++ b/base/src/com/google/idea/blaze/base/qsync/QuerySync.java
@@ -54,10 +54,7 @@ public class QuerySync {
   private QuerySync() {}
 
   public static boolean useByDefault() {
-    // We disable query sync by default until the feature is stable the feature.
-    // Note that users can still enable the feature via their settings menu (Cmd+, -> Bazel -> Query Sync)
-    //    return ENABLED.isEnabled();
-    return false;
+    return ENABLED.isEnabled();
   }
 
   public static boolean isLegacyExperimentEnabled() {

--- a/base/src/com/google/idea/blaze/base/qsync/QuerySync.java
+++ b/base/src/com/google/idea/blaze/base/qsync/QuerySync.java
@@ -54,7 +54,10 @@ public class QuerySync {
   private QuerySync() {}
 
   public static boolean useByDefault() {
-    return ENABLED.isEnabled();
+    // We disable query sync by default until the feature is stable the feature.
+    // Note that users can still enable the feature via their settings menu (Cmd+, -> Bazel -> Query Sync)
+    //    return ENABLED.isEnabled();
+    return false;
   }
 
   public static boolean isLegacyExperimentEnabled() {

--- a/common/experiments/src/com/google/idea/common/experiments/experiment.properties
+++ b/common/experiments/src/com/google/idea/common/experiments/experiment.properties
@@ -12,3 +12,6 @@ aswb.use.studio.deployer.2=100
 
 # Show What's New pop-up at startup
 blaze.assistant.whatsnew.popup=1
+
+# Disable until the feature is stabilized
+query.sync=disabled


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

Recently, upstream has started rolling out a new way of syncing a project (https://github.com/bazelbuild/intellij/pull/5646). This is still in beta, and we've seen some issues reported internally.

We disable it for now, until they stabilize the feature. Users that want to try it can still do so, from their settings menu.