### PR TITLE
Support for @@ syntax in label

### DIFF
--- a/base/src/com/google/idea/blaze/base/model/primitives/Label.java
+++ b/base/src/com/google/idea/blaze/base/model/primitives/Label.java
@@ -20,7 +20,12 @@ import com.intellij.openapi.diagnostic.Logger;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
-/** Wrapper around a string for a blaze label ([@external_workspace]//package:rule). */
+/**
+ * Wrapper around a string for a blaze label ([@@?external_workspace]//package:rule).
+ *
+ * <p>Unlike {@link com.google.idea.blaze.common.Label} this implementation does not normalize from
+ * a single @ to @@ for external workspaces. Since the expression could be serialized.
+ */
 @Immutable
 public final class Label extends TargetExpression {
   private static final Logger logger = Logger.getInstance(Label.class);
@@ -107,7 +112,7 @@ public final class Label extends TargetExpression {
     }
     int slashesIndex = label.indexOf("//");
     logger.assertTrue(slashesIndex >= 0);
-    return label.substring(1, slashesIndex);
+    return label.substring(0, slashesIndex).replaceFirst("@@?", "");
   }
 
   /**

--- a/base/src/com/google/idea/blaze/base/model/primitives/TargetExpression.java
+++ b/base/src/com/google/idea/blaze/base/model/primitives/TargetExpression.java
@@ -32,7 +32,7 @@ public class TargetExpression
   // still Serializable as part of ProjectViewSet
   public static final long serialVersionUID = 1L;
 
-  protected static final Pattern VALID_REPO_NAME = Pattern.compile("@[\\w\\-.]*");
+  protected static final Pattern VALID_REPO_NAME = Pattern.compile("@@?[\\w\\-.]*");
 
   private final String expression;
 

--- a/base/tests/unittests/com/google/idea/blaze/base/model/primitives/LabelTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/model/primitives/LabelTest.java
@@ -111,4 +111,12 @@ public class LabelTest extends BlazeTestCase {
     assertThat(label.blazePackage()).isEqualTo(packagePath);
     assertThat(label.targetName()).isEqualTo(targetName);
   }
+
+  @Test
+  public void testCanonicalExternalWorkspace() {
+    Label label = Label.create("@@workspace//path:target");
+
+    assertThat(label.isExternal()).isTrue();
+    assertThat(label.externalWorkspaceName()).isEqualTo("workspace");
+  }
 }


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #6234

# Description of this change
Adds support for the `@@` syntax for external dependencies used in labels since bazel 7. Fixes #6234.
