### PR TITLE
fix: Move BlazeProjectAction.update() to the BGT

### DIFF
--- a/base/src/com/google/idea/blaze/base/actions/BackgroundUpdatingBlazeProjectAction.java
+++ b/base/src/com/google/idea/blaze/base/actions/BackgroundUpdatingBlazeProjectAction.java
@@ -1,0 +1,22 @@
+package com.google.idea.blaze.base.actions;
+
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * {@BackgroundUpdatingBlazeProjectAction} is a mixin for {@BlazeProjectAction}s that need
+ * to access project data in their update() functions.
+ * Actions can choose whether they run their update() methods on the
+ * BackGround Thread or the Event Dispatcher Thread.
+ * Implement this if the action requires access to the PSI, VFS, or project data,
+ * but _not_ access to UI elements.
+ * <p>
+ * Ref: <a href="https://plugins.jetbrains.com/docs/intellij/basic-action-system.html#principal-implementation-overrides">...</a>
+ */
+public abstract class BackgroundUpdatingBlazeProjectAction extends BlazeProjectAction {
+  @Override
+  @NotNull
+  public ActionUpdateThread getActionUpdateThread() {
+    return ActionUpdateThread.BGT;
+  }
+}

--- a/base/src/com/google/idea/blaze/base/actions/BlazeProjectAction.java
+++ b/base/src/com/google/idea/blaze/base/actions/BlazeProjectAction.java
@@ -24,6 +24,8 @@ import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
+
 import javax.annotation.Nullable;
 import javax.swing.Icon;
 import org.jetbrains.annotations.NotNull;

--- a/base/src/com/google/idea/blaze/base/actions/CopyBlazeTargetPathAction.java
+++ b/base/src/com/google/idea/blaze/base/actions/CopyBlazeTargetPathAction.java
@@ -30,7 +30,7 @@ import java.io.File;
 import javax.annotation.Nullable;
 
 /** Copies a blaze target path into the clipboard */
-public class CopyBlazeTargetPathAction extends BlazeProjectAction {
+public class CopyBlazeTargetPathAction extends BackgroundUpdatingBlazeProjectAction {
 
   @Override
   protected QuerySyncStatus querySyncSupport() {

--- a/base/src/com/google/idea/blaze/base/actions/OpenCorrespondingBuildFile.java
+++ b/base/src/com/google/idea/blaze/base/actions/OpenCorrespondingBuildFile.java
@@ -28,7 +28,7 @@ import com.intellij.psi.NavigatablePsiElement;
 import com.intellij.psi.PsiElement;
 import java.io.File;
 
-class OpenCorrespondingBuildFile extends BlazeProjectAction {
+class OpenCorrespondingBuildFile extends BackgroundUpdatingBlazeProjectAction {
 
   @Override
   protected QuerySyncStatus querySyncSupport() {

--- a/base/src/com/google/idea/blaze/base/dependencies/AddSourceToProjectAction.java
+++ b/base/src/com/google/idea/blaze/base/dependencies/AddSourceToProjectAction.java
@@ -18,7 +18,7 @@ package com.google.idea.blaze.base.dependencies;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
-import com.google.idea.blaze.base.actions.BlazeProjectAction;
+import com.google.idea.blaze.base.actions.BackgroundUpdatingBlazeProjectAction;
 import com.google.idea.blaze.base.dependencies.AddSourceToProjectHelper.LocationContext;
 import com.google.idea.blaze.base.lang.buildfile.psi.BuildFile;
 import com.google.idea.blaze.base.lang.buildfile.psi.BuildFile.BlazeFileType;
@@ -45,7 +45,7 @@ import javax.annotation.Nullable;
  * For files not covered by project directories / targets, finds the relevant BUILD target and
  * updates the .blazeproject 'targets' and 'directories' as required.
  */
-class AddSourceToProjectAction extends BlazeProjectAction {
+class AddSourceToProjectAction extends BackgroundUpdatingBlazeProjectAction {
 
   @Override
   protected QuerySyncStatus querySyncSupport() {

--- a/base/src/com/google/idea/blaze/base/qsync/action/BuildDependenciesAction.java
+++ b/base/src/com/google/idea/blaze/base/qsync/action/BuildDependenciesAction.java
@@ -15,7 +15,7 @@
  */
 package com.google.idea.blaze.base.qsync.action;
 
-import com.google.idea.blaze.base.actions.BlazeProjectAction;
+import com.google.idea.blaze.base.actions.BackgroundUpdatingBlazeProjectAction;
 import com.google.idea.blaze.base.qsync.action.BuildDependenciesHelper.DepsBuildType;
 import com.google.idea.blaze.common.Context;
 import com.intellij.icons.AllIcons.Actions;
@@ -36,7 +36,7 @@ import org.jetbrains.annotations.NotNull;
  * com.google.idea.blaze.qsync.project.BuildGraphData#getProjectTargets(Context, Path)} for a
  * description of what targets dependencies aren built for in each case.
  */
-public class BuildDependenciesAction extends BlazeProjectAction {
+public class BuildDependenciesAction extends BackgroundUpdatingBlazeProjectAction {
 
   private static final String NAME = "Build dependencies";
 

--- a/base/src/com/google/idea/blaze/base/qsync/action/BuildDependenciesForWorkingSetAction.java
+++ b/base/src/com/google/idea/blaze/base/qsync/action/BuildDependenciesForWorkingSetAction.java
@@ -22,10 +22,10 @@ import com.google.idea.blaze.base.qsync.QuerySyncManager;
 import com.google.idea.blaze.base.qsync.action.BuildDependenciesHelper.DepsBuildType;
 import com.google.idea.blaze.common.Label;
 import com.google.idea.blaze.exception.BuildException;
-import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
+
 import java.nio.file.Path;
 
 /**
@@ -35,11 +35,6 @@ import java.nio.file.Path;
 public class BuildDependenciesForWorkingSetAction extends BlazeProjectAction {
   private static final Logger logger =
       Logger.getInstance(BuildDependenciesForWorkingSetAction.class);
-
-  @Override
-  public ActionUpdateThread getActionUpdateThread() {
-    return ActionUpdateThread.BGT;
-  }
 
   @Override
   protected QuerySyncStatus querySyncSupport() {

--- a/java/src/com/google/idea/blaze/java/libraries/AddLibraryTargetDirectoryToProjectViewAction.java
+++ b/java/src/com/google/idea/blaze/java/libraries/AddLibraryTargetDirectoryToProjectViewAction.java
@@ -20,7 +20,7 @@ import static java.util.stream.Collectors.toList;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
-import com.google.idea.blaze.base.actions.BlazeProjectAction;
+import com.google.idea.blaze.base.actions.BackgroundUpdatingBlazeProjectAction;
 import com.google.idea.blaze.base.ideinfo.JavaIdeInfo;
 import com.google.idea.blaze.base.ideinfo.TargetIdeInfo;
 import com.google.idea.blaze.base.ideinfo.TargetKey;
@@ -50,7 +50,7 @@ import java.util.List;
 import java.util.Set;
 import javax.annotation.Nullable;
 
-class AddLibraryTargetDirectoryToProjectViewAction extends BlazeProjectAction {
+class AddLibraryTargetDirectoryToProjectViewAction extends BackgroundUpdatingBlazeProjectAction {
 
   @Override
   protected QuerySyncStatus querySyncSupport() {

--- a/java/src/com/google/idea/blaze/java/libraries/AttachSourceJarAction.java
+++ b/java/src/com/google/idea/blaze/java/libraries/AttachSourceJarAction.java
@@ -15,7 +15,7 @@
  */
 package com.google.idea.blaze.java.libraries;
 
-import com.google.idea.blaze.base.actions.BlazeProjectAction;
+import com.google.idea.blaze.base.actions.BackgroundUpdatingBlazeProjectAction;
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
 import com.google.idea.blaze.base.sync.libraries.LibraryEditor;
@@ -27,7 +27,7 @@ import com.intellij.openapi.externalSystem.service.project.IdeModifiableModelsPr
 import com.intellij.openapi.externalSystem.service.project.IdeModifiableModelsProviderImpl;
 import com.intellij.openapi.project.Project;
 
-class AttachSourceJarAction extends BlazeProjectAction {
+class AttachSourceJarAction extends BackgroundUpdatingBlazeProjectAction {
 
   @Override
   protected QuerySyncStatus querySyncSupport() {

--- a/java/src/com/google/idea/blaze/java/libraries/DescribeLibraryAction.java
+++ b/java/src/com/google/idea/blaze/java/libraries/DescribeLibraryAction.java
@@ -15,7 +15,7 @@
  */
 package com.google.idea.blaze.java.libraries;
 
-import com.google.idea.blaze.base.actions.BlazeProjectAction;
+import com.google.idea.blaze.base.actions.BackgroundUpdatingBlazeProjectAction;
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
 import com.google.idea.blaze.java.sync.model.BlazeJarLibrary;
@@ -32,7 +32,7 @@ import com.intellij.openapi.ui.Messages;
  *
  * <p>Currently just the artifact location of the jars.
  */
-class DescribeLibraryAction extends BlazeProjectAction {
+class DescribeLibraryAction extends BackgroundUpdatingBlazeProjectAction {
 
   @Override
   protected QuerySyncStatus querySyncSupport() {

--- a/java/src/com/google/idea/blaze/java/libraries/ExcludeLibraryAction.java
+++ b/java/src/com/google/idea/blaze/java/libraries/ExcludeLibraryAction.java
@@ -15,7 +15,7 @@
  */
 package com.google.idea.blaze.java.libraries;
 
-import com.google.idea.blaze.base.actions.BlazeProjectAction;
+import com.google.idea.blaze.base.actions.BackgroundUpdatingBlazeProjectAction;
 import com.google.idea.blaze.base.ideinfo.LibraryArtifact;
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.projectview.ProjectViewEdit;
@@ -32,7 +32,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.libraries.Library;
 import com.intellij.openapi.ui.Messages;
 
-class ExcludeLibraryAction extends BlazeProjectAction {
+class ExcludeLibraryAction extends BackgroundUpdatingBlazeProjectAction {
 
   @Override
   protected QuerySyncStatus querySyncSupport() {


### PR DESCRIPTION

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

We were seeing many instances of action updates freezing the UI by
performing expensive operations in the Event Dispatch Thread.

## Solution:

Create a new base class that shoves an action into the BGT.
Go through the current BlazeProjectActions and add the mixing to the ones that are potentially expensive.

## Result:

Hopefully fewer UI freezes due to actions updating.