### PR TITLE
Path translations for the Python debugger command line

### DIFF
--- a/python/src/META-INF/blaze-python.xml
+++ b/python/src/META-INF/blaze-python.xml
@@ -19,4 +19,7 @@
     <TargetKindProvider implementation="com.google.idea.blaze.python.PythonBlazeRules"/>
     <BlazePyExecutableOutputFinder implementation="com.google.idea.blaze.python.run.BlazePyExecutableOutputFinderImpl"/>
   </extensions>
+  <extensions defaultExtensionNs="com.google.idea.blaze">
+    <BlazePyDebugFlagsProvider implementation="com.google.idea.blaze.python.run.BlazePyDebugHelperImpl"/>
+  </extensions>
 </idea-plugin>

--- a/python/src/com/google/idea/blaze/python/run/BlazePyDebugHelperImpl.java
+++ b/python/src/com/google/idea/blaze/python/run/BlazePyDebugHelperImpl.java
@@ -1,0 +1,60 @@
+package com.google.idea.blaze.python.run;
+
+import com.google.idea.blaze.base.model.primitives.Label;
+import com.google.idea.blaze.base.model.primitives.TargetExpression;
+import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
+import com.google.idea.blaze.base.sync.workspace.WorkspaceHelper;
+import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class BlazePyDebugHelperImpl implements BlazePyDebugHelper {
+    private static final Logger logger = Logger.getInstance(BlazePyDebugHelperImpl.class);
+
+    public static final Map<TargetExpression, Path> knownExecRoots = new HashMap<>();
+
+
+    @Override
+    public void patchBlazeDebugCommandline(Project project, TargetExpression target, GeneralCommandLine commandLine) {
+        logger.info(String.format("The target executable map contains %d keys", knownExecRoots.size()));
+        if(!knownExecRoots.containsKey(target)) {
+            logger.warn("No cached executable path for " + target);
+            return;
+        }
+        try {
+            Label label = Label.create(target.toString());
+            WorkspaceRoot workspaceRoot = WorkspaceRoot.fromProject(project);
+            Path bazelBin = workspaceRoot.absolutePathFor("bazel-bin");
+            File sourcePackageRoot = WorkspaceHelper.resolveBlazePackage(project, label);
+            Objects.requireNonNull(sourcePackageRoot, "Could not resolve the package root for " + target);
+            Path relativePkg = workspaceRoot.workspacePathFor(sourcePackageRoot).asPath();
+            String workspaceName = parseWorkspaceName(knownExecRoots.get(target));
+            Path actualBinPath = bazelBin.resolve(relativePkg)
+                    .resolve(label.targetName() + ".runfiles")
+                    .resolve(workspaceName).resolve(relativePkg);
+            logger.info(String.format("Target %s: mapping %s to %s", target, sourcePackageRoot, actualBinPath));
+            commandLine.withEnvironment("PATHS_FROM_ECLIPSE_TO_PYTHON", String.format("[[\"%s\", \"%s\"]]", sourcePackageRoot, actualBinPath));
+        } catch (RuntimeException e) {
+            logger.error("Failed to calculate the debugger path mapping for " + target, e);
+        }
+    }
+
+    private String parseWorkspaceName(Path executableFile) {
+        logger.info("Attempting to parse path: " + executableFile);
+        Pattern p = Pattern.compile("^/(?:[\\w-.]+/)+execroot/([\\w-]+)/bazel-out/[\\w-]+/bin/([\\w-]+(?:/[\\w-]+)*)/[\\w-]+$");
+        Matcher m = p.matcher(executableFile.toString());
+        if(m.matches()) {
+            return m.group(1);
+        }
+        throw new IllegalStateException("Could not parse the executable path: " + executableFile);
+    }
+
+}

--- a/python/src/com/google/idea/blaze/python/run/BlazePyRunConfigurationRunner.java
+++ b/python/src/com/google/idea/blaze/python/run/BlazePyRunConfigurationRunner.java
@@ -357,6 +357,7 @@ public class BlazePyRunConfigurationRunner implements BlazeCommandRunConfigurati
                 target));
       }
       LocalFileSystem.getInstance().refreshIoFiles(ImmutableList.of(file));
+      BlazePyDebugHelperImpl.knownExecRoots.put(configuration.getSingleTarget(), file.toPath());
       return new PyExecutionInfo(file, args);
     } catch (CancellationException e) {
       streamProviderFuture.cancel(true);


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #6260 

# Description of this change

When there is some Python code to be debugged, the plugin first builds the corresponding target, which (as far as I understand) involves copying some Python source files into some directory inside `bazel-bin`. The plugin also creates a script which invokes those files, and passes that script to pydevd (which is bundled with the python-ce plugin). 

The problem is, pydevd knows nothing about the Bazel workspace and its source root; from its point of view, the source root is somewhere in the Bazel output directory. When asked to stop at a breakpoint inside some source file, pydevd accepts its _relative_ path within the source root, and thus the breakpoint is places in the right location; however, when reporting back to IntelliJ, pydevd uses the _absolute_ path of the file, which of course doesn't match the path to the original source file.

Fortunately, pydevd allows to define path translations by setting the environment variable called `PATHS_FROM_ECLIPSE_TO_PYTHON`. When the environment is like `PATHS_FROM_ECLIPSE_TO_PYTHON=[["X", "Y"]]`, pydevd will report stopping at X whenever it actually stops at Y. (This feature is actually intended for debugging code that runs on a remote computer, but is is also suitable for our purposes).

This is an attempt to set up the right path mapping for the particular target that's being debugged. The logic can be summarised as follows:

1. Find the executable script which has been generated for our Bazel target.
2. Parse the path to the executable script in order to determine the workspace name.
3. Find the relative path from the workspace root to the package that contains our target.
4. Use the workspace name, the package's relative path, and the target name to guess the actual source root of the files that are processed by the debugger. 

In this PR, I have attempted to minimise the changes on the existing codebase of the plugin. I realise that this PR needs work before it can be merged into master, but I hope to get some early feedback, especially from people which are more familiar with the Python debugger.

I have tested my code manually on some Python tests, and it worked.