### PR TITLE
Added external_include paths to system includes switch

### DIFF
--- a/aspect/intellij_info_impl.bzl
+++ b/aspect/intellij_info_impl.bzl
@@ -472,6 +472,7 @@ def collect_cpp_info(target, ctx, semantics, ide_info, ide_info_file, output_gro
         transitive_system_include_directory = compilation_context.system_includes.to_list(),
         include_prefix = getattr(ctx.rule.attr, "include_prefix", None),
         strip_include_prefix = getattr(ctx.rule.attr, "strip_include_prefix", None),
+        external_includes = getattr(compilation_context, "external_includes", depset()).to_list(),
     )
     ide_info["c_ide_info"] = c_info
     resolve_files = compilation_context.headers

--- a/base/src/com/google/idea/blaze/base/ideinfo/CIdeInfo.java
+++ b/base/src/com/google/idea/blaze/base/ideinfo/CIdeInfo.java
@@ -38,6 +38,8 @@ public final class CIdeInfo implements ProtoWrapper<IntellijIdeInfo.CIdeInfo> {
   private final String includePrefix;
   private final String stripIncludePrefix;
 
+  private final ImmutableList<ExecutionRootPath> externalIncludes;
+
   private CIdeInfo(
       ImmutableList<ArtifactLocation> sources,
       ImmutableList<ArtifactLocation> headers,
@@ -48,7 +50,8 @@ public final class CIdeInfo implements ProtoWrapper<IntellijIdeInfo.CIdeInfo> {
       ImmutableList<String> transitiveDefines,
       ImmutableList<ExecutionRootPath> transitiveSystemIncludeDirectories,
       String includePrefix,
-      String stripIncludePrefix) {
+      String stripIncludePrefix,
+      ImmutableList<ExecutionRootPath> externalIncludes) {
     this.sources = sources;
     this.headers = headers;
     this.textualHeaders = textualHeaders;
@@ -59,6 +62,7 @@ public final class CIdeInfo implements ProtoWrapper<IntellijIdeInfo.CIdeInfo> {
     this.transitiveSystemIncludeDirectories = transitiveSystemIncludeDirectories;
     this.includePrefix = includePrefix;
     this.stripIncludePrefix = stripIncludePrefix;
+    this.externalIncludes = externalIncludes;
   }
 
   static CIdeInfo fromProto(IntellijIdeInfo.CIdeInfo proto) {
@@ -74,7 +78,9 @@ public final class CIdeInfo implements ProtoWrapper<IntellijIdeInfo.CIdeInfo> {
         ProtoWrapper.map(
             proto.getTransitiveSystemIncludeDirectoryList(), ExecutionRootPath::fromProto),
         proto.getIncludePrefix(),
-        proto.getStripIncludePrefix());
+        proto.getStripIncludePrefix(),
+        ProtoWrapper.map(proto.getExternalIncludesList(), ExecutionRootPath::fromProto)
+    );
   }
 
   @Override
@@ -90,6 +96,7 @@ public final class CIdeInfo implements ProtoWrapper<IntellijIdeInfo.CIdeInfo> {
         .addAllTransitiveDefine(transitiveDefines)
         .addAllTransitiveSystemIncludeDirectory(
             ProtoWrapper.mapToProtos(transitiveSystemIncludeDirectories))
+        .addAllExternalIncludes(ProtoWrapper.mapToProtos(externalIncludes))
         .build();
   }
 
@@ -133,6 +140,10 @@ public final class CIdeInfo implements ProtoWrapper<IntellijIdeInfo.CIdeInfo> {
     return stripIncludePrefix;
   }
 
+  public ImmutableList<ExecutionRootPath> getExternalIncludes() {
+    return externalIncludes;
+  }
+
   public static Builder builder() {
     return new Builder();
   }
@@ -154,6 +165,8 @@ public final class CIdeInfo implements ProtoWrapper<IntellijIdeInfo.CIdeInfo> {
 
     private String includePrefix = "";
     private String stripIncludePrefix = "";
+
+    private final ImmutableList.Builder<ExecutionRootPath> externalIncludes = ImmutableList.builder();
 
     @CanIgnoreReturnValue
     public Builder addSources(Iterable<ArtifactLocation> sources) {
@@ -236,6 +249,12 @@ public final class CIdeInfo implements ProtoWrapper<IntellijIdeInfo.CIdeInfo> {
       return this;
     }
 
+    @CanIgnoreReturnValue
+    public Builder setExternalIncludes(Iterable<ExecutionRootPath> externalIncludes) {
+      this.externalIncludes.addAll(externalIncludes);
+      return this;
+    }
+
     public CIdeInfo build() {
       return new CIdeInfo(
           sources.build(),
@@ -247,7 +266,8 @@ public final class CIdeInfo implements ProtoWrapper<IntellijIdeInfo.CIdeInfo> {
           transitiveDefines.build(),
           transitiveSystemIncludeDirectories.build(),
           includePrefix,
-          stripIncludePrefix);
+          stripIncludePrefix,
+          externalIncludes.build());
     }
   }
 
@@ -279,6 +299,9 @@ public final class CIdeInfo implements ProtoWrapper<IntellijIdeInfo.CIdeInfo> {
         + "  transitiveSystemIncludeDirectories="
         + getTransitiveSystemIncludeDirectories()
         + "\n"
+        + "  externalIncludes"
+        + getExternalIncludes()
+        + "\n"
         + '}';
   }
 
@@ -300,7 +323,8 @@ public final class CIdeInfo implements ProtoWrapper<IntellijIdeInfo.CIdeInfo> {
             transitiveQuoteIncludeDirectories, cIdeInfo.transitiveQuoteIncludeDirectories)
         && Objects.equals(transitiveDefines, cIdeInfo.transitiveDefines)
         && Objects.equals(
-            transitiveSystemIncludeDirectories, cIdeInfo.transitiveSystemIncludeDirectories);
+            transitiveSystemIncludeDirectories, cIdeInfo.transitiveSystemIncludeDirectories)
+        && Objects.equals(externalIncludes, cIdeInfo.externalIncludes);
   }
 
   @Override
@@ -313,6 +337,7 @@ public final class CIdeInfo implements ProtoWrapper<IntellijIdeInfo.CIdeInfo> {
         transitiveIncludeDirectories,
         transitiveQuoteIncludeDirectories,
         transitiveDefines,
-        transitiveSystemIncludeDirectories);
+        transitiveSystemIncludeDirectories,
+        externalIncludes);
   }
 }

--- a/cpp/src/com/google/idea/blaze/cpp/BlazeCWorkspace.java
+++ b/cpp/src/com/google/idea/blaze/cpp/BlazeCWorkspace.java
@@ -69,7 +69,6 @@ import com.jetbrains.cidr.lang.workspace.compiler.CompilerInfoCache.Message;
 import com.jetbrains.cidr.lang.workspace.compiler.CompilerInfoCache.Session;
 import com.jetbrains.cidr.lang.workspace.compiler.OCCompilerKind;
 import com.jetbrains.cidr.lang.workspace.compiler.TempFilesPool;
-
 import java.io.File;
 import java.nio.file.Path;
 import java.util.Collection;
@@ -251,7 +250,10 @@ public final class BlazeCWorkspace implements ProjectComponent {
         // Note: We would ideally use -isystem here, but it interacts badly with the switches
         // that get built by ClangUtils::addIncludeDirectories (it uses -I for system libraries).
         ImmutableList<String> isystemOptionIncludeDirectories =
-            targetIdeInfo.getcIdeInfo().getTransitiveSystemIncludeDirectories().stream()
+            Stream.concat(
+                    targetIdeInfo.getcIdeInfo().getTransitiveSystemIncludeDirectories().stream(),
+                    targetIdeInfo.getcIdeInfo().getExternalIncludes().stream()
+                )
                 .flatMap(resolver)
                 .filter(configResolveData::isValidHeaderRoot)
                 .map(file -> "-I" + file.getAbsolutePath())

--- a/cpp/src/com/google/idea/blaze/cpp/HeaderRootTrimmer.java
+++ b/cpp/src/com/google/idea/blaze/cpp/HeaderRootTrimmer.java
@@ -192,6 +192,7 @@ final class HeaderRootTrimmer {
         paths.addAll(target.getcIdeInfo().getTransitiveSystemIncludeDirectories());
         paths.addAll(target.getcIdeInfo().getTransitiveIncludeDirectories());
         paths.addAll(target.getcIdeInfo().getTransitiveQuoteIncludeDirectories());
+        paths.addAll(target.getcIdeInfo().getExternalIncludes());
       }
     }
     Set<CToolchainIdeInfo> toolchains = new LinkedHashSet<>(toolchainLookupMap.values());

--- a/examples/cpp/external_includes/external/BUILD
+++ b/examples/cpp/external_includes/external/BUILD
@@ -1,0 +1,6 @@
+cc_library(
+    name = "simple",
+    srcs = ["simple.cc"],
+    hdrs = ["simple.h"],
+    visibility = ["//visibility:public"],
+)

--- a/examples/cpp/external_includes/external/simple.cc
+++ b/examples/cpp/external_includes/external/simple.cc
@@ -1,0 +1,7 @@
+#include "simple.h"
+
+#include <stdio.h>
+
+void simple_header_fun() {
+	printf("Hello there!\n");
+}

--- a/examples/cpp/external_includes/external/simple.h
+++ b/examples/cpp/external_includes/external/simple.h
@@ -1,0 +1,6 @@
+#ifndef SIMPLE_H
+#define SIMPLE_H
+
+void simple_header_fun();
+
+#endif

--- a/examples/cpp/external_includes/project/.bazelrc
+++ b/examples/cpp/external_includes/project/.bazelrc
@@ -1,0 +1,1 @@
+build --features=external_include_paths

--- a/examples/cpp/external_includes/project/BUILD
+++ b/examples/cpp/external_includes/project/BUILD
@@ -1,0 +1,5 @@
+cc_binary(
+    name = "simple",
+    srcs = ["simple.cc"],
+	deps = ["@lib//:simple"],
+)

--- a/examples/cpp/external_includes/project/WORKSPACE
+++ b/examples/cpp/external_includes/project/WORKSPACE
@@ -1,0 +1,4 @@
+local_repository(
+	name = "lib",
+	path = "../external",
+)

--- a/examples/cpp/external_includes/project/simple.cc
+++ b/examples/cpp/external_includes/project/simple.cc
@@ -1,0 +1,6 @@
+#include <simple.h>
+
+int main() {
+	simple_header_fun();
+	return 0;
+}

--- a/proto/intellij_ide_info.proto
+++ b/proto/intellij_ide_info.proto
@@ -66,6 +66,8 @@ message CIdeInfo {
 
   string include_prefix = 10;
   string strip_include_prefix = 11;
+
+  repeated string external_includes = 12;
 }
 
 message AndroidIdeInfo {


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #4980

# Description of this change
Support for external_includes. Fixes #4980. When `--features=external_include_paths` is specified includes are added to `compilation_context.external_includes` and no longer to `compilation_context.includes`.