### PR TITLE
Add missing kt library kind when collecting android ide info

### DIFF
--- a/aspect/intellij_info_impl.bzl
+++ b/aspect/intellij_info_impl.bzl
@@ -807,7 +807,7 @@ def _collect_android_ide_info(target, ctx, semantics, ide_info, ide_info_file, o
     consistent functionality with the previous condition of the presence of the .android legacy
     provider.
     """
-    if ctx.rule.kind not in ["android_library", "android_binary"]:
+    if ctx.rule.kind not in ["android_library", "android_binary", "kt_android_library"]:
         return False
 
     android_semantics = semantics.android if hasattr(semantics, "android") else None


### PR DESCRIPTION
https://github.com/bazelbuild/intellij/commit/eeb20cd4dd7c7e1fd28c5a6bd9109130f5eeae43#diff-7e834e0a725805ad4dfd127ba905e50964c78307ddb756da99d15a0a1ea28a46R813

Added a filtering based on the rule kind, for kotlin users who don't use the sandwich solution the `kt_android_library` kind is needed.

Also see: https://github.com/bazelbuild/intellij/pull/5789

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

