### PR TITLE
Reduced the logging level for the stack traces produced when resolving external artifacts.

### DIFF
--- a/base/src/com/google/idea/blaze/base/sync/workspace/ArtifactLocationDecoderImpl.java
+++ b/base/src/com/google/idea/blaze/base/sync/workspace/ArtifactLocationDecoderImpl.java
@@ -98,8 +98,9 @@ public final class ArtifactLocationDecoderImpl implements ArtifactLocationDecode
           return realFile;
         }
       } catch (IOException ioException) {
-        LOG.warn("Failed to resolve real path for " + artifactLocation.getExecutionRootRelativePath(),
-            ioException);
+        LOG.warn("Failed to resolve real path for " + artifactLocation.getExecutionRootRelativePath() +
+                "\n" + ioException.getClass().getSimpleName() + ": " + ioException.getMessage());
+        LOG.trace(ioException);
       }
     }
     return null;


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #6309

# Description of this change
In case of an IOException, only the message and the type of error is logged as a warning. The stack trace is logged only at the lowest level, so as to limit the amount of logs when there are many problematic artifacts.
