### PR TITLE
Compose Preview Support

### DIFF
--- a/aswb/sdkcompat/as232/com/google/idea/blaze/android/projectsystem/BinaryTargetClassFileFinder.java
+++ b/aswb/sdkcompat/as232/com/google/idea/blaze/android/projectsystem/BinaryTargetClassFileFinder.java
@@ -1,0 +1,346 @@
+/*
+ * Copyright 2024 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.android.projectsystem;
+
+import com.android.tools.idea.projectsystem.ClassContent;
+import com.android.tools.idea.projectsystem.ClassFileFinder;
+import com.android.tools.idea.projectsystem.ClassFileFinderUtil;
+import com.android.tools.idea.rendering.classloading.loaders.JarManager;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableSet;
+import com.google.idea.blaze.android.sync.model.AndroidResourceModule;
+import com.google.idea.blaze.android.sync.model.AndroidResourceModuleRegistry;
+import com.google.idea.blaze.android.targetmaps.TargetToBinaryMap;
+import com.google.idea.blaze.base.command.buildresult.OutputArtifactResolver;
+import com.google.idea.blaze.base.ideinfo.TargetIdeInfo;
+import com.google.idea.blaze.base.ideinfo.TargetKey;
+import com.google.idea.blaze.base.model.BlazeProjectData;
+import com.google.idea.blaze.base.settings.Blaze;
+import com.google.idea.blaze.base.settings.BlazeImportSettings.ProjectType;
+import com.google.idea.blaze.base.sync.BlazeSyncModificationTracker;
+import com.google.idea.blaze.base.sync.data.BlazeDataStorage;
+import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
+import com.google.idea.blaze.base.sync.workspace.ArtifactLocationDecoder;
+import com.google.idea.blaze.base.targetmaps.TransitiveDependencyMap;
+import com.google.idea.common.experiments.BoolExperiment;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.text.StringUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.joining;
+
+/**
+ * A {@link ClassFileFinder} inspired by {@link RenderJarClassFileFinder}.
+ * This finder uses binary target dependencies to locate the class file.
+ *
+ * <br><p>When a class is being loaded, this finder prioritizes binary targets and their transitive dependencies.
+ * This finder is optimized for large projects in the following ways:
+ * <ul>
+ *   <li>It utilizes {@link ClassContentCache} for recurring lookups, which improves performance by avoiding redundant searches.</li>
+ *   <li>It maintains a local cache that maps package names to their corresponding target keys, which accelerates the lookup process.</li>
+ *   <li>It employs the Jaccard index as a heuristic for initial lookups to cover cache misses. This heuristic helps in identifying the most relevant targets for a given class.</li>
+ * </ul>
+ */
+public class BinaryTargetClassFileFinder implements ClassFileFinder {
+  /** Experiment to control whether class file finding from render jars should be enabled. */
+  @VisibleForTesting
+  static final BoolExperiment enabled =
+      new BoolExperiment("aswb.lookup.binary.deps.render.jar", true);
+
+  private static final String REGEX_WORDS = "[^a-zA-Z0-9]+";
+
+  private static final Logger log = Logger.getInstance(BinaryTargetClassFileFinder.class);
+
+  // create a ignored packages collection and add kotlinx.coroutines.test.internal.TestMainDispatcherFactory
+  private static final Set<String> IGNORED_FQCN = Set.of("kotlinx.coroutines.test.internal.TestMainDispatcherFactory");
+
+  private static final String INTERNAL_PACKAGE = "_layoutlib_._internal_.";
+
+  // matches foo.bar.R or foo.bar.R$baz
+  private static final Pattern RESOURCE_CLASS_NAME = Pattern.compile(".+\\.R(\\$[^.]+)?$");
+  public static final int MAX_SORTED_TARGET_KEY_SIZE = 100;
+
+  // create a map to store package names and their corresponding target keys to improve performance
+  private final Map<String, TargetKey> packageToTargetKeyMap = new HashMap<>();
+  private final Module module;
+  private final Project project;
+  private final JarManager jarManager;
+
+  // tracks the binary targets that depend resource targets
+  // will be recalculated after every sync
+  private ImmutableSet<TargetKey> binaryTargets = ImmutableSet.of();
+
+  // tracks the value of {@link BlazeSyncModificationTracker} when binaryTargets is calculated
+  // binaryTargets is calculated when the value of {@link BlazeSyncModificationTracker} does not
+  // equal lastSyncCount
+  long lastSyncCount = -1;
+
+  // true if the current module is the .workspace Module
+  private final boolean isWorkspaceModule;
+
+  public BinaryTargetClassFileFinder(Module module) {
+    this.module = module;
+    this.project = module.getProject();
+    this.isWorkspaceModule = BlazeDataStorage.WORKSPACE_MODULE_NAME.equals(module.getName());
+    this.jarManager = JarManager.getInstance(project);
+  }
+
+  @Nullable
+  @Override
+  public ClassContent findClassFile(@NotNull String fqcn) {
+    if (!isEnabled()) {
+      return null;
+    }
+
+    try {
+      return findClassContent(fqcn);
+    } catch (Error e) {
+      log.warn(
+          String.format(
+              "Unexpected error while finding the class file for `%1$s`: %2$s",
+              fqcn, Throwables.getRootCause(e).getMessage()));
+      return null;
+    }
+  }
+
+  @Nullable
+  public ClassContent findClassContent(String fqcn) {
+    if (isResourceClass(fqcn)) {
+      log.warn(String.format("Skipping resource class loading: %s", fqcn));
+      return null;
+    }
+
+    if(IGNORED_FQCN.contains(fqcn)) {
+      log.debug(String.format("Skipping ignored class loading: %s", fqcn));
+      return null;
+    }
+
+    if (Blaze.getProjectType(project).equals(ProjectType.QUERY_SYNC)) {
+      //TODO: add support for QuerySync
+      return null;
+    }
+    return findClass(fqcn);
+  }
+
+  private ClassContent findClass(String fqcn) {
+    BlazeProjectData projectData =
+        BlazeProjectDataManager.getInstance(project).getBlazeProjectData();
+    if (projectData == null) {
+      log.warn("Could not find BlazeProjectData for project " + project.getName());
+      return null;
+    }
+
+    ImmutableSet<TargetKey> binaryTargets = getBinaryTargets();
+    if (binaryTargets.isEmpty()) {
+      log.warn(
+          String.format(
+              "No binaries for module %s. Adding a binary target is the best practice when using Compose/Layout preview.",
+              module.getName()));
+    }
+
+    // Remove internal package prefix if present
+    fqcn = StringUtil.trimStart(fqcn, INTERNAL_PACKAGE);
+
+    ClassContentCache classContentCache = ClassContentCache.getInstance(project);
+    String packageName = StringUtil.getPackageName(fqcn);
+    Set<TargetKey> visitedTargets = new HashSet<>();
+    for (TargetKey binaryTarget : binaryTargets) {
+        // 1st attempt from cache
+        ClassContent classContent = classContentCache.getClassContent(fqcn);
+        if (classContent != null) {
+          return classContent;
+        }
+
+        if(packageToTargetKeyMap.containsKey(packageName)) {
+          // 2nd attempt from the target key that contains the package
+          TargetKey targetKey = packageToTargetKeyMap.get(packageName);
+          classContent = getClassFromClassJar(projectData, fqcn, targetKey);
+          if (classContent != null) {
+            classContentCache.putEntry(fqcn, classContent);
+            return classContent;
+          }
+        }
+
+        // 3rd attempt from the binary target transitive dependencies
+       classContent = getClassFromTransitiveDeps(projectData, fqcn, visitedTargets, binaryTarget);
+        if (classContent != null) {
+          classContentCache.putEntry(fqcn, classContent);
+          return classContent;
+      }
+    }
+
+    // 4th attempt from non visited targets in the entire target map
+    for (TargetIdeInfo targetIdeInfo : projectData.getTargetMap().targets()) {
+      if(visitedTargets.contains(targetIdeInfo.getKey())) {
+        continue;
+      }
+      ClassContent classContent = getClassFromClassJar(projectData, fqcn, targetIdeInfo.getKey());
+      if (classContent != null) {
+        packageToTargetKeyMap.put(packageName, targetIdeInfo.getKey());
+        classContentCache.putEntry(fqcn, classContent);
+        return classContent;
+      }
+    }
+
+    log.warn(String.format("Could not find class `%1$s` (module: `%2$s`)", fqcn, module.getName()));
+    return null;
+  }
+
+  @Nullable
+  private ClassContent getClassFromTransitiveDeps(BlazeProjectData projectData, String fqcn,Set<TargetKey> visitedTargets, TargetKey binaryTarget) {
+    String packageName  = StringUtil.getPackageName(fqcn);
+    List<TargetKey> targetKeysSorted = sortTargetKeysWithPackageName(TransitiveDependencyMap.getInstance(project).getTransitiveDependencies(binaryTarget), packageName);
+    for (TargetKey dependencyTargetKey : targetKeysSorted) {
+      if(visitedTargets.contains(dependencyTargetKey)) {
+        continue;
+      }
+      ClassContent classFile = getClassFromClassJar(projectData, fqcn, dependencyTargetKey);
+      visitedTargets.add(dependencyTargetKey);
+      if (classFile != null) {
+        packageToTargetKeyMap.put(packageName, dependencyTargetKey);
+        return classFile;
+      }
+    }
+    return null;
+  }
+
+
+  @VisibleForTesting
+  static boolean isResourceClass(String fqcn) {
+    return RESOURCE_CLASS_NAME.matcher(fqcn).matches();
+  }
+
+  private ImmutableSet<TargetKey> getBinaryTargets() {
+    long currentSyncCount =
+        BlazeSyncModificationTracker.getInstance(project).getModificationCount();
+    if (currentSyncCount == lastSyncCount) {
+      // Return the cached set if there hasn't been a sync since last calculation
+      return binaryTargets;
+    }
+    lastSyncCount = currentSyncCount;
+
+    AndroidResourceModule androidResourceModule =
+        AndroidResourceModuleRegistry.getInstance(project).get(module);
+    if (androidResourceModule != null) {
+      binaryTargets =
+          TargetToBinaryMap.getInstance(project)
+              .getBinariesDependingOn(androidResourceModule.sourceTargetKeys);
+    } else if (isWorkspaceModule) {
+      binaryTargets = TargetToBinaryMap.getInstance(project).getSourceBinaryTargets();
+    } else {
+      binaryTargets = ImmutableSet.of();
+      log.warn("Could not find AndroidResourceModule for " + module.getName());
+    }
+    log.info(
+        String.format(
+            "Binary targets for module `%1$s`: %2$s",
+            module.getName(),
+            binaryTargets.stream()
+                .limit(5)
+                .map(t -> t.getLabel().toString())
+                .collect(joining(", "))));
+    return binaryTargets;
+  }
+
+  private ClassContent findClassInJar(File renderResolveJarFile, String fqcn) {
+    String relativePath = ClassFileFinderUtil.getPathFromFqcn(fqcn);
+    final byte[] bytes;
+    if (ApplicationManager.getApplication().isUnitTestMode()) {
+      try {
+        Path targetPath = renderResolveJarFile.toPath().resolve("!" + relativePath);
+        bytes = Files.isRegularFile(targetPath) ? Files.readAllBytes(targetPath) : new byte[0];
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    } else {
+      bytes =
+          jarManager.loadFileFromJar(
+              renderResolveJarFile.toPath(), ClassFileFinderUtil.getPathFromFqcn(fqcn));
+    }
+    if (bytes == null) {
+      return null;
+    }
+
+    return ClassContent.fromJarEntryContent(renderResolveJarFile, bytes);
+  }
+
+  @Nullable
+  private ClassContent getClassFromClassJar(
+      BlazeProjectData projectData, String fqcn, TargetKey targetKey) {
+    log.debug("Reading class from jar. Class name: " + fqcn + ", Target key label: " + targetKey.getLabel());
+
+    ArtifactLocationDecoder decoder = projectData.getArtifactLocationDecoder();
+    TargetIdeInfo ideInfo = projectData.getTargetMap().get(targetKey);
+    if (ideInfo == null
+        || ideInfo.getJavaIdeInfo() == null
+        || ideInfo.getJavaIdeInfo().getJars().isEmpty()
+        || decoder == null) {
+      return null;
+    }
+
+    File classJar = OutputArtifactResolver.resolve(project, decoder, ideInfo.getJavaIdeInfo().getJars().get(0).getClassJar());
+    if (classJar == null || !classJar.exists()) {
+      return null;
+    }
+
+
+    return findClassInJar(classJar, fqcn);
+  }
+
+  public static boolean isEnabled() {
+    return enabled.getValue();
+  }
+
+  private static double jaccardIndex(String key, Collection<String> packageWords) {
+    String[] keyWords = key.split(REGEX_WORDS);
+
+    long intersectionCount = Arrays.stream(keyWords)
+        .filter(packageWords::contains)
+        .count();
+
+    long unionCount = Arrays.stream(keyWords).distinct().count()
+        + packageWords.size()
+        - intersectionCount;
+
+    return (double) intersectionCount / unionCount;
+  }
+
+  public static List<TargetKey> sortTargetKeysWithPackageName(Collection<TargetKey> targetKeys, String packageName) {
+    Set<String> packageWords = Set.of(packageName.split(REGEX_WORDS));
+    Map<TargetKey, Double> jaccardIndexes = targetKeys.stream()
+        .collect(Collectors.toMap(Function.identity(), tk -> jaccardIndex(tk.toString(), packageWords)));
+
+    return targetKeys.stream()
+        .sorted(Comparator.comparing(jaccardIndexes::get).reversed())
+        .limit(MAX_SORTED_TARGET_KEY_SIZE)
+        .collect(Collectors.toList());
+  }
+}

--- a/aswb/src/META-INF/aswb.xml
+++ b/aswb/src/META-INF/aswb.xml
@@ -70,6 +70,7 @@
   </extensionPoints>
 
   <extensions defaultExtensionNs="com.google.idea.blaze">
+    <MavenArtifactLocator implementation="com.google.idea.blaze.android.projectsystem.DefaultMavenArtifactLocator"/>
     <LintCollector implementation="com.google.idea.blaze.android.libraries.AndroidLintCollector"/>
     <SyncPlugin implementation="com.google.idea.blaze.android.sync.BlazeAndroidSyncPlugin"/>
     <QuerySyncPlugin implementation="com.google.idea.blaze.android.qsync.BlazeAndroidQuerySyncPlugin"/>

--- a/aswb/src/META-INF/aswb.xml
+++ b/aswb/src/META-INF/aswb.xml
@@ -20,7 +20,7 @@
   <depends>org.jetbrains.android</depends>
   <depends>com.google.gct.test.recorder</depends>
   <depends>com.intellij.modules.java</depends>
-
+  <depends optional="true">com.android.tools.design</depends>
   <extensions defaultExtensionNs="com.intellij">
     <programRunner implementation="com.google.idea.blaze.android.run.binary.BlazeAndroidBinaryProgramRunner" order="first"/>
     <programRunner implementation="com.google.idea.blaze.android.run.test.BlazeAndroidTestProgramRunner" order="first"/>

--- a/aswb/src/META-INF/aswb.xml
+++ b/aswb/src/META-INF/aswb.xml
@@ -93,6 +93,7 @@
     <BlazeHighlightStatsCollector implementation="com.google.idea.blaze.android.editor.UnresolvedResourceStatsCollector"/>
     <SyncListener implementation="com.google.idea.blaze.android.editor.ProjectUnresolvedResourceStatsCollector$CollectorSyncListener"/>
     <SyncListener implementation="com.google.idea.blaze.android.targetmaps.TargetToBinaryMapImpl$Adapter"/>
+    <SyncListener implementation="com.google.idea.blaze.android.projectsystem.ClassContentCache$Listener"/>
     <OutputGroupsProvider implementation="com.google.idea.blaze.android.sync.aspects.strategy.RenderResolveOutputGroupProvider"/>
     <ComposeStatusProvider implementation="com.google.idea.blaze.android.compose.ExperimentComposeStatusProvider"/>
     <BlazeBuildListener implementation="com.google.idea.blaze.android.projectsystem.BlazeProjectSystemBuildManager$BuildCallbackPublisher"/>

--- a/aswb/src/com/google/idea/blaze/android/compose/ExperimentComposeStatusProvider.java
+++ b/aswb/src/com/google/idea/blaze/android/compose/ExperimentComposeStatusProvider.java
@@ -24,7 +24,7 @@ import com.intellij.openapi.project.Project;
  */
 public class ExperimentComposeStatusProvider implements ComposeStatusProvider {
   private static final BoolExperiment composeEnabled =
-      new BoolExperiment("aswb.force.enable.compose", false);
+      new BoolExperiment("aswb.force.enable.compose", true);
 
   @Override
   public boolean composeEnabled(Project project) {

--- a/aswb/src/com/google/idea/blaze/android/projectsystem/BlazeModuleSystemBase.java
+++ b/aswb/src/com/google/idea/blaze/android/projectsystem/BlazeModuleSystemBase.java
@@ -129,7 +129,7 @@ abstract class BlazeModuleSystemBase implements AndroidModuleSystem {
   protected final Project project;
   private final ProjectPath.Resolver pathResolver;
   SampleDataDirectoryProvider sampleDataDirectoryProvider;
-  RenderJarClassFileFinder classFileFinder;
+  ClassFileFinder classFileFinder;
   final boolean isWorkspaceModule;
   private AndroidExternalLibraryManager androidExternalLibraryManager = null;
 
@@ -143,7 +143,8 @@ abstract class BlazeModuleSystemBase implements AndroidModuleSystem {
                 BlazeImportSettingsManager.getInstance(project)
                     .getImportSettings()
                     .getProjectDataDirectory()));
-    classFileFinder = new RenderJarClassFileFinder(module);
+    classFileFinder = BinaryTargetClassFileFinder.isEnabled() ?
+        new BinaryTargetClassFileFinder(module) : new RenderJarClassFileFinder(module);
     sampleDataDirectoryProvider = new BlazeSampleDataDirectoryProvider(module);
     isWorkspaceModule = module.getName().equals(BlazeDataStorage.WORKSPACE_MODULE_NAME);
     if (Blaze.getProjectType(project) == ProjectType.QUERY_SYNC

--- a/aswb/src/com/google/idea/blaze/android/projectsystem/BlazeModuleSystemBase.java
+++ b/aswb/src/com/google/idea/blaze/android/projectsystem/BlazeModuleSystemBase.java
@@ -726,7 +726,9 @@ abstract class BlazeModuleSystemBase implements AndroidModuleSystem {
             resFolderPathString == null
                 ? null
                 : resFolderPathString.getParentOrRoot().resolve("R.txt"))
-        .withPackageName(library.resourcePackage);
+        .withPackageName(library.resourcePackage != null && !library.resourcePackage.isEmpty()
+            ? library.resourcePackage
+            : null);
   }
 
   @Override

--- a/aswb/src/com/google/idea/blaze/android/projectsystem/ClassContentCache.java
+++ b/aswb/src/com/google/idea/blaze/android/projectsystem/ClassContentCache.java
@@ -1,0 +1,33 @@
+package com.google.idea.blaze.android.projectsystem;
+
+import com.android.tools.idea.projectsystem.ClassContent;
+import com.google.idea.blaze.base.scope.BlazeContext;
+import com.google.idea.blaze.base.sync.SyncListener;
+import com.google.idea.blaze.base.sync.SyncMode;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * A cache for {@link ClassContent} objects mapped by fully qualified class name.
+ */
+public interface ClassContentCache {
+  @Nullable ClassContent getClassContent(String fqcn);
+
+  void putEntry(String fqcn, ClassContent classContent);
+
+  void invalidate();
+
+  static ClassContentCache getInstance(Project project) {
+    return project.getService(ClassContentCacheImpl.class);
+  }
+
+  class Listener implements SyncListener {
+    @Override
+    public void onSyncStart(Project project, BlazeContext context, SyncMode syncMode) {
+      //TODO: there may be more scenarios to invalidate the cache
+      if (syncMode == SyncMode.FULL) {
+        ClassContentCache.getInstance(project).invalidate();
+      }
+    }
+  }
+}

--- a/aswb/src/com/google/idea/blaze/android/projectsystem/ClassContentCacheImpl.java
+++ b/aswb/src/com/google/idea/blaze/android/projectsystem/ClassContentCacheImpl.java
@@ -1,0 +1,40 @@
+package com.google.idea.blaze.android.projectsystem;
+
+import com.android.tools.idea.projectsystem.ClassContent;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.intellij.openapi.components.Service;
+import org.jetbrains.annotations.Nullable;
+
+@Service(Service.Level.PROJECT)
+public final class ClassContentCacheImpl implements ClassContentCache {
+  private final Cache<String, ClassContent> cache;
+
+
+  public ClassContentCacheImpl() {
+    cache = CacheBuilder.newBuilder()
+        .softValues()
+        .maximumSize(2500)
+        .build();
+  }
+
+  @Override
+  @Nullable
+  public ClassContent getClassContent(String fqcn) {
+    ClassContent content = cache.getIfPresent(fqcn);
+    if (content != null && content.isUpToDate()) {
+      return content;
+    }
+    return null;
+  }
+
+  @Override
+  public void putEntry(String fqcn, ClassContent classContent) {
+    cache.put(fqcn, classContent);
+  }
+
+  @Override
+  public void invalidate() {
+    cache.invalidateAll();
+  }
+}

--- a/aswb/src/com/google/idea/blaze/android/projectsystem/DefaultMavenArtifactLocator.java
+++ b/aswb/src/com/google/idea/blaze/android/projectsystem/DefaultMavenArtifactLocator.java
@@ -1,0 +1,23 @@
+package com.google.idea.blaze.android.projectsystem;
+
+import com.android.ide.common.repository.GradleCoordinate;
+import com.google.common.collect.ImmutableList;
+import com.google.idea.blaze.base.model.primitives.Label;
+import com.google.idea.blaze.base.settings.BuildSystemName;
+import com.intellij.openapi.extensions.ExtensionPointName;
+
+
+public class DefaultMavenArtifactLocator implements MavenArtifactLocator {
+
+    public Label labelFor(GradleCoordinate coordinate) {
+        return Label.create(String.format("@maven//:%s_%s",
+                        coordinate.getGroupId().replaceAll("[.-]", "_"),
+                        coordinate.getArtifactId().replaceAll("[.-]", "_")
+                )
+        );
+    }
+
+    public BuildSystemName buildSystem() {
+        return BuildSystemName.Bazel;
+    }
+}

--- a/aswb/src/com/google/idea/blaze/android/projectsystem/DefaultMavenArtifactLocator.java
+++ b/aswb/src/com/google/idea/blaze/android/projectsystem/DefaultMavenArtifactLocator.java
@@ -1,23 +1,31 @@
 package com.google.idea.blaze.android.projectsystem;
 
 import com.android.ide.common.repository.GradleCoordinate;
-import com.google.common.collect.ImmutableList;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.settings.BuildSystemName;
-import com.intellij.openapi.extensions.ExtensionPointName;
-
 
 public class DefaultMavenArtifactLocator implements MavenArtifactLocator {
+  private final BuildSystemName buildSystemName;
 
-    public Label labelFor(GradleCoordinate coordinate) {
-        return Label.create(String.format("@maven//:%s_%s",
-                        coordinate.getGroupId().replaceAll("[.-]", "_"),
-                        coordinate.getArtifactId().replaceAll("[.-]", "_")
-                )
-        );
-    }
+  public DefaultMavenArtifactLocator() {
+    this.buildSystemName = BuildSystemName.Bazel;
+  }
 
-    public BuildSystemName buildSystem() {
-        return BuildSystemName.Bazel;
-    }
+  @VisibleForTesting
+  public DefaultMavenArtifactLocator(BuildSystemName buildSystemName) {
+    this.buildSystemName = buildSystemName;
+  }
+
+  public Label labelFor(GradleCoordinate coordinate) {
+    return Label.create(String.format("@maven//:%s_%s",
+            coordinate.getGroupId().replaceAll("[.-]", "_"),
+            coordinate.getArtifactId().replaceAll("[.-]", "_")
+        )
+    );
+  }
+
+  public BuildSystemName buildSystem() {
+    return buildSystemName;
+  }
 }

--- a/aswb/src/com/google/idea/blaze/android/sync/importer/BlazeAndroidWorkspaceImporter.java
+++ b/aswb/src/com/google/idea/blaze/android/sync/importer/BlazeAndroidWorkspaceImporter.java
@@ -195,6 +195,8 @@ public class BlazeAndroidWorkspaceImporter {
           depTargetResourceModule.getTransitiveResourceDependencies().stream()
               .filter(key -> !targetKey.equals(key))
               .collect(Collectors.toList()));
+      targetResourceModule.addTransitiveAssetsFolders(
+          depTargetResourceModule.getTransitiveAssetsFolders());
       if (containsProjectRelevantResources(depIdeInfo.getAndroidIdeInfo())
           && !depKey.equals(targetKey)) {
         targetResourceModule.addTransitiveResourceDependency(depKey);
@@ -266,6 +268,13 @@ public class BlazeAndroidWorkspaceImporter {
           }
           androidResourceModule.addTransitiveResource(artifactLocation);
         }
+      }
+    }
+
+    for (ArtifactLocation asset : androidIdeInfo.getAssetsFolders()) {
+      if (isSourceOrAllowedGenPath(asset, allowlistFilter) && isOutsideProjectViewFilter.test(asset)) {
+          androidResourceModule.addAssetsFolder(asset);
+          androidResourceModule.addTransitiveAssetsFolder(asset);
       }
     }
     return androidResourceModule;
@@ -437,7 +446,9 @@ public class BlazeAndroidWorkspaceImporter {
                 .addResources(m.resources)
                 .addTransitiveResources(m.transitiveResources)
                 .addResourceLibraryKeys(m.resourceLibraryKeys)
-                .addTransitiveResourceDependencies(m.transitiveResourceDependencies));
+                .addTransitiveResourceDependencies(m.transitiveResourceDependencies)
+                .addAssetsFolders(m.assetsFolders)
+                .addTransitiveAssetsFolders(m.transitiveAssetsFolders));
     return moduleBuilder.build();
   }
 

--- a/aswb/src/com/google/idea/blaze/android/sync/model/AndroidResourceModule.java
+++ b/aswb/src/com/google/idea/blaze/android/sync/model/AndroidResourceModule.java
@@ -45,6 +45,8 @@ public final class AndroidResourceModule
   // If merging AndroidResourceModules is off, then this only contains `targetKey`. Otherwise
   // contains the list of targets merged to make this module.
   public final ImmutableList<TargetKey> sourceTargetKeys;
+  public final ImmutableList<ArtifactLocation> assetsFolders;
+  public final ImmutableList<ArtifactLocation> transitiveAssetsFolders;
 
   private AndroidResourceModule(
       TargetKey targetKey,
@@ -52,13 +54,17 @@ public final class AndroidResourceModule
       ImmutableList<ArtifactLocation> transitiveResources,
       ImmutableList<String> resourceLibraryKeys,
       ImmutableList<TargetKey> transitiveResourceDependencies,
-      ImmutableList<TargetKey> sourceTargetKeys) {
+      ImmutableList<TargetKey> sourceTargetKeys,
+      ImmutableList<ArtifactLocation> assetsFolders,
+      ImmutableList<ArtifactLocation> transitiveAssetsFolders) {
     this.targetKey = targetKey;
     this.resources = resources;
     this.transitiveResources = transitiveResources;
     this.resourceLibraryKeys = resourceLibraryKeys;
     this.transitiveResourceDependencies = transitiveResourceDependencies;
     this.sourceTargetKeys = sourceTargetKeys;
+    this.assetsFolders = assetsFolders;
+    this.transitiveAssetsFolders = transitiveAssetsFolders;
   }
 
   static AndroidResourceModule fromProto(ProjectData.AndroidResourceModule proto) {
@@ -68,7 +74,10 @@ public final class AndroidResourceModule
         ProtoWrapper.map(proto.getTransitiveResourcesList(), ArtifactLocation::fromProto),
         ImmutableList.copyOf(proto.getResourceLibraryKeysList()),
         ProtoWrapper.map(proto.getTransitiveResourceDependenciesList(), TargetKey::fromProto),
-        ProtoWrapper.map(proto.getSourceTargetKeysList(), TargetKey::fromProto));
+        ProtoWrapper.map(proto.getSourceTargetKeysList(), TargetKey::fromProto),
+        ProtoWrapper.map(proto.getAssetsFoldersList(), ArtifactLocation::fromProto),
+        ProtoWrapper.map(proto.getTransitiveAssetsFoldersList(), ArtifactLocation::fromProto)
+    );
   }
 
   @Override
@@ -81,6 +90,8 @@ public final class AndroidResourceModule
         .addAllTransitiveResourceDependencies(
             ProtoWrapper.mapToProtos(transitiveResourceDependencies))
         .addAllSourceTargetKeys(ProtoWrapper.mapToProtos(sourceTargetKeys))
+        .addAllAssetsFolders(ProtoWrapper.mapToProtos(assetsFolders))
+        .addAllTransitiveAssetsFolders(ProtoWrapper.mapToProtos(transitiveAssetsFolders))
         .build();
   }
 
@@ -93,7 +104,9 @@ public final class AndroidResourceModule
           && Objects.equal(this.transitiveResources, that.transitiveResources)
           && Objects.equal(this.resourceLibraryKeys, that.resourceLibraryKeys)
           && Objects.equal(this.transitiveResourceDependencies, that.transitiveResourceDependencies)
-          && Objects.equal(this.sourceTargetKeys, that.sourceTargetKeys);
+          && Objects.equal(this.sourceTargetKeys, that.sourceTargetKeys)
+          && Objects.equal(this.assetsFolders, that.assetsFolders)
+          && Objects.equal(this.transitiveAssetsFolders, that.transitiveAssetsFolders);
     }
     return false;
   }
@@ -106,7 +119,9 @@ public final class AndroidResourceModule
         this.transitiveResources,
         this.resourceLibraryKeys,
         this.transitiveResourceDependencies,
-        this.sourceTargetKeys);
+        this.sourceTargetKeys,
+        this.assetsFolders,
+        this.transitiveAssetsFolders);
   }
 
   @Override
@@ -128,8 +143,14 @@ public final class AndroidResourceModule
         + "  transitiveResourceDependencies: "
         + transitiveResourceDependencies
         + "\n"
-        + "sourceTargetKeys: "
+        + "  sourceTargetKeys: "
         + sourceTargetKeys
+        + "\n"
+        + "  assetsFolders: "
+        + assetsFolders
+        + "\n"
+        + "  transitiveAssetsFolders: "
+        + transitiveAssetsFolders
         + "\n"
         + '}';
   }
@@ -150,6 +171,8 @@ public final class AndroidResourceModule
     private final Set<String> resourceLibraryKeys = Sets.newHashSet();
     private final Set<TargetKey> transitiveResourceDependencies = Sets.newHashSet();
     private final Set<TargetKey> sourceTargetKeys = Sets.newHashSet();
+    private final Set<ArtifactLocation> assetsFolders = Sets.newHashSet();
+    private final Set<ArtifactLocation> transitiveAssetsFolders = Sets.newHashSet();
 
     public Builder(TargetKey targetKey) {
       this.targetKey = targetKey;
@@ -250,6 +273,39 @@ public final class AndroidResourceModule
       return this.transitiveResourceDependencies;
     }
 
+    public Set<ArtifactLocation> getTransitiveAssetsFolders() {
+      return this.transitiveAssetsFolders;
+    }
+
+    public Set<ArtifactLocation> getAssetsFolders() {
+      return this.assetsFolders;
+    }
+
+
+    @CanIgnoreReturnValue
+    public Builder addAssetsFolder(ArtifactLocation assetFolder) {
+      this.assetsFolders.add(assetFolder);
+      return this;
+    }
+
+    @CanIgnoreReturnValue
+    public Builder addAssetsFolders(Collection<ArtifactLocation> assetFolders) {
+      this.assetsFolders.addAll(assetFolders);
+      return this;
+    }
+
+    @CanIgnoreReturnValue
+    public Builder addTransitiveAssetsFolder(ArtifactLocation assetFolder) {
+      this.transitiveAssetsFolders.add(assetFolder);
+      return this;
+    }
+
+    @CanIgnoreReturnValue
+    public Builder addTransitiveAssetsFolders(Collection<ArtifactLocation> assetFolders) {
+      this.transitiveAssetsFolders.addAll(assetFolders);
+      return this;
+    }
+
     @NotNull
     public AndroidResourceModule build() {
       return new AndroidResourceModule(
@@ -258,7 +314,9 @@ public final class AndroidResourceModule
           ImmutableList.sortedCopyOf(transitiveResources),
           ImmutableList.sortedCopyOf(resourceLibraryKeys),
           ImmutableList.sortedCopyOf(transitiveResourceDependencies),
-          ImmutableList.sortedCopyOf(sourceTargetKeys));
+          ImmutableList.sortedCopyOf(sourceTargetKeys),
+          ImmutableList.sortedCopyOf(assetsFolders),
+          ImmutableList.sortedCopyOf(transitiveAssetsFolders));
     }
   }
 }

--- a/aswb/src/com/google/idea/blaze/android/sync/projectstructure/BlazeAndroidProjectStructureSyncer.java
+++ b/aswb/src/com/google/idea/blaze/android/sync/projectstructure/BlazeAndroidProjectStructureSyncer.java
@@ -346,6 +346,9 @@ public class BlazeAndroidProjectStructureSyncer {
       List<File> resources =
           OutputArtifactResolver.resolveAll(
               project, artifactLocationDecoder, androidResourceModule.resources);
+      List<File> assets =
+          OutputArtifactResolver.resolveAll(
+              project, artifactLocationDecoder, androidResourceModule.transitiveAssetsFolders);
       updateModuleFacetInMemoryState(
           project,
           context,
@@ -355,7 +358,8 @@ public class BlazeAndroidProjectStructureSyncer {
           manifestFile,
           modulePackage,
           resources,
-          configAndroidJava8Libs);
+          configAndroidJava8Libs,
+          assets);
       rClassBuilder.addRClass(modulePackage, module);
       sourcePackages.remove(modulePackage);
     }
@@ -449,7 +453,8 @@ public class BlazeAndroidProjectStructureSyncer {
         null,
         resourceJavaPackage,
         ImmutableList.of(),
-        configAndroidJava8Libs);
+        configAndroidJava8Libs,
+        ImmutableList.of());
   }
 
   private static void updateModuleFacetInMemoryState(
@@ -461,7 +466,8 @@ public class BlazeAndroidProjectStructureSyncer {
       @Nullable File manifestFile,
       String resourceJavaPackage,
       Collection<File> resources,
-      boolean configAndroidJava8Libs) {
+      boolean configAndroidJava8Libs,
+      Collection<File> assets) {
     String name = module.getName();
     File manifest = manifestFile != null ? manifestFile : new File("MissingManifest.xml");
     NamedIdeaSourceProvider sourceProvider =
@@ -469,6 +475,8 @@ public class BlazeAndroidProjectStructureSyncer {
             .withScopeType(ScopeType.MAIN)
             .withResDirectoryUrls(
                 ContainerUtil.map(resources, it -> VfsUtilCore.fileToUrl(it.getAbsoluteFile())))
+            .withAssetsDirectoryUrls(
+                ContainerUtil.map(assets, it -> VfsUtilCore.fileToUrl(it.getAbsoluteFile())))
             .build();
 
     ListenableFuture<String> applicationId =

--- a/aswb/tests/unittests/sdkcompat/as223/com/google/idea/blaze/android/projectsystem/BlazeModuleSystemTest.java
+++ b/aswb/tests/unittests/sdkcompat/as223/com/google/idea/blaze/android/projectsystem/BlazeModuleSystemTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import com.android.tools.idea.rendering.classloading.loaders.JarManager;
 import com.google.common.collect.Maps;
 import com.google.idea.blaze.android.resources.BlazeLightResourceClassService;
 import com.google.idea.blaze.android.sync.model.AndroidResourceModule;
@@ -91,6 +92,7 @@ public class BlazeModuleSystemTest extends BlazeTestCase {
 
     // For the 'blaze.class.file.finder.name' experiment.
     applicationServices.register(ExperimentService.class, new MockExperimentService());
+    projectServices.register(JarManager.class, JarManager.Companion.forTesting());
 
     mockBlazeImportSettings(projectServices); // For Blaze.isBlazeProject.
     createMocksForAddDependency(applicationServices, projectServices);

--- a/aswb/tests/unittests/sdkcompat/as231/com/google/idea/blaze/android/projectsystem/BlazeModuleSystemTest.java
+++ b/aswb/tests/unittests/sdkcompat/as231/com/google/idea/blaze/android/projectsystem/BlazeModuleSystemTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import com.android.tools.idea.rendering.classloading.loaders.JarManager;
 import com.google.common.collect.Maps;
 import com.google.idea.blaze.android.resources.BlazeLightResourceClassService;
 import com.google.idea.blaze.android.sync.model.AndroidResourceModule;
@@ -91,6 +92,7 @@ public class BlazeModuleSystemTest extends BlazeTestCase {
 
     // For the 'blaze.class.file.finder.name' experiment.
     applicationServices.register(ExperimentService.class, new MockExperimentService());
+    projectServices.register(JarManager.class, JarManager.Companion.forTesting());
 
     mockBlazeImportSettings(projectServices); // For Blaze.isBlazeProject.
     createMocksForAddDependency(applicationServices, projectServices);

--- a/aswb/tests/unittests/sdkcompat/as232/com/google/idea/blaze/android/projectsystem/BlazeModuleSystemTest.java
+++ b/aswb/tests/unittests/sdkcompat/as232/com/google/idea/blaze/android/projectsystem/BlazeModuleSystemTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import com.android.tools.idea.rendering.classloading.loaders.JarManager;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.google.idea.blaze.android.resources.BlazeLightResourceClassService;
@@ -95,6 +96,7 @@ public class BlazeModuleSystemTest extends BlazeTestCase {
 
     // For the 'blaze.class.file.finder.name' experiment.
     applicationServices.register(ExperimentService.class, new MockExperimentService());
+    projectServices.register(JarManager.class, JarManager.Companion.forTesting());
 
     mockBlazeImportSettings(projectServices); // For Blaze.isBlazeProject.
     createMocksForAddDependency(applicationServices, projectServices);

--- a/aswb/tests/unittests/sdkcompat/as233/com/google/idea/blaze/android/projectsystem/BlazeModuleSystemTest.java
+++ b/aswb/tests/unittests/sdkcompat/as233/com/google/idea/blaze/android/projectsystem/BlazeModuleSystemTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import com.android.tools.idea.rendering.classloading.loaders.JarManager;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.google.idea.blaze.android.resources.BlazeLightResourceClassService;
@@ -95,6 +96,7 @@ public class BlazeModuleSystemTest extends BlazeTestCase {
 
     // For the 'blaze.class.file.finder.name' experiment.
     applicationServices.register(ExperimentService.class, new MockExperimentService());
+    projectServices.register(JarManager.class, JarManager.Companion.forTesting());
 
     mockBlazeImportSettings(projectServices); // For Blaze.isBlazeProject.
     createMocksForAddDependency(applicationServices, projectServices);

--- a/base/src/com/google/idea/blaze/base/ideinfo/AndroidIdeInfo.java
+++ b/base/src/com/google/idea/blaze/base/ideinfo/AndroidIdeInfo.java
@@ -46,6 +46,7 @@ public final class AndroidIdeInfo implements ProtoWrapper<IntellijIdeInfo.Androi
   @Nullable private final Label legacyResources;
   @Nullable private final Label instruments;
   @Nullable private final ArtifactLocation renderResolveJar;
+  private final ImmutableList<ArtifactLocation> assetsFolders;
 
   private AndroidIdeInfo(
       List<AndroidResFolder> resources,
@@ -58,7 +59,8 @@ public final class AndroidIdeInfo implements ProtoWrapper<IntellijIdeInfo.Androi
       boolean hasIdlSources,
       @Nullable Label legacyResources,
       @Nullable Label instruments,
-      @Nullable ArtifactLocation renderResolveJar) {
+      @Nullable ArtifactLocation renderResolveJar,
+      List<ArtifactLocation> assetsFolders) {
     this.resources = ImmutableList.copyOf(resources);
     this.resourceJavaPackage = resourceJavaPackage;
     this.generateResourceClass = generateResourceClass;
@@ -70,6 +72,7 @@ public final class AndroidIdeInfo implements ProtoWrapper<IntellijIdeInfo.Androi
     this.legacyResources = legacyResources;
     this.instruments = instruments;
     this.renderResolveJar = renderResolveJar;
+    this.assetsFolders = ImmutableList.copyOf(assetsFolders);
   }
 
   static AndroidIdeInfo fromProto(IntellijIdeInfo.AndroidIdeInfo proto) {
@@ -92,7 +95,8 @@ public final class AndroidIdeInfo implements ProtoWrapper<IntellijIdeInfo.Androi
             : null,
         proto.hasRenderResolveJar()
             ? ArtifactLocation.fromProto(proto.getRenderResolveJar())
-            : null);
+            : null,
+        ProtoWrapper.map(proto.getAssetsFoldersList(), ArtifactLocation::fromProto));
   }
 
   @Override
@@ -102,7 +106,8 @@ public final class AndroidIdeInfo implements ProtoWrapper<IntellijIdeInfo.Androi
             .putAllManifestValues(manifestValues)
             .addAllResFolders(ProtoWrapper.mapToProtos(resources))
             .setGenerateResourceClass(generateResourceClass)
-            .setHasIdlSources(hasIdlSources);
+            .setHasIdlSources(hasIdlSources)
+            .addAllAssetsFolders(ProtoWrapper.mapToProtos(assetsFolders));
     ProtoWrapper.setIfNotNull(builder::setJavaPackage, resourceJavaPackage);
     ProtoWrapper.unwrapAndSetIfNotNull(builder::setManifest, manifest);
     ProtoWrapper.unwrapAndSetIfNotNull(builder::setIdlJar, idlJar);
@@ -164,6 +169,10 @@ public final class AndroidIdeInfo implements ProtoWrapper<IntellijIdeInfo.Androi
     return renderResolveJar;
   }
 
+  public ImmutableList<ArtifactLocation> getAssetsFolders() {
+    return assetsFolders;
+  }
+
   public static Builder builder() {
     return new Builder();
   }
@@ -181,6 +190,7 @@ public final class AndroidIdeInfo implements ProtoWrapper<IntellijIdeInfo.Androi
     private Label legacyResources;
     private Label instruments;
     private ArtifactLocation renderResolveJar;
+    private List<ArtifactLocation> assetsFolders = Lists.newArrayList();
 
     @CanIgnoreReturnValue
     public Builder setManifestFile(ArtifactLocation artifactLocation) {
@@ -253,6 +263,12 @@ public final class AndroidIdeInfo implements ProtoWrapper<IntellijIdeInfo.Androi
       return this;
     }
 
+    @CanIgnoreReturnValue
+    public Builder addAssetsFolder(ArtifactLocation assetFolder) {
+      this.assetsFolders.add(assetFolder);
+      return this;
+    }
+
     public AndroidIdeInfo build() {
       if (!resources.isEmpty() || manifest != null) {
         if (!generateResourceClass) {
@@ -272,7 +288,9 @@ public final class AndroidIdeInfo implements ProtoWrapper<IntellijIdeInfo.Androi
           hasIdlSources,
           legacyResources,
           instruments,
-          renderResolveJar);
+          renderResolveJar,
+          ImmutableList.copyOf(assetsFolders)
+      );
     }
   }
 
@@ -294,7 +312,8 @@ public final class AndroidIdeInfo implements ProtoWrapper<IntellijIdeInfo.Androi
         && Objects.equals(resourceJar, that.resourceJar)
         && Objects.equals(resourceJavaPackage, that.resourceJavaPackage)
         && Objects.equals(legacyResources, that.legacyResources)
-        && Objects.equals(instruments, that.instruments);
+        && Objects.equals(instruments, that.instruments)
+        && Objects.equals(assetsFolders, that.assetsFolders);
   }
 
   @Override
@@ -309,6 +328,7 @@ public final class AndroidIdeInfo implements ProtoWrapper<IntellijIdeInfo.Androi
         resourceJavaPackage,
         generateResourceClass,
         legacyResources,
-        instruments);
+        instruments,
+        assetsFolders);
   }
 }

--- a/proto/intellij_ide_info.proto
+++ b/proto/intellij_ide_info.proto
@@ -94,6 +94,7 @@ message AndroidIdeInfo {
   // dependencies of a binary without the desugared APIs. This field is not set
   // for non-binary targets
   ArtifactLocation render_resolve_jar = 15;
+  repeated ArtifactLocation assets_folders = 16;
 }
 
 // Details about an Android res folder

--- a/proto/project_data.proto
+++ b/proto/project_data.proto
@@ -170,6 +170,8 @@ message AndroidResourceModule {
   // targets that contribute resources to the AndroidResourceModule,
   // including target_key
   repeated TargetKey source_target_keys = 6;
+  repeated ArtifactLocation assets_folders = 7;
+  repeated ArtifactLocation transitive_assets_folders = 8;
 }
 
 message BlazeJarLibrary {


### PR DESCRIPTION
Resolves #2765

Add support for Compose Preview in Android Studio, main changes are:
- Introduce a new `ClassFileFinder`, optimized for faster class lookups 
- Support reading and routing Android assets, such as fonts from the plugin aspect and pass them to Android Studio to be used in the rendering

Tested with the latest stable version, Iguana (23.2), it scales well even for our larger apps, I also did a sanity test and got the preview working in the [compose sample](https://github.com/bazelbuild/rules_kotlin/tree/master/examples/jetpack_compose) in rules kotlin.

Known gaps:
- Missing tests
- No support for versions older than 23.2

Possible future improvements: 
- More optimizations  `BinaryTargetClassFileFinder`, perhaps storing a map of package name -> target keys during sync could help
- Fix additional functionalities, including preview run configurations



