### PR TITLE
Fix imports for go modules named "external"

### DIFF
--- a/examples/go/with_proto/MODULE.bazel
+++ b/examples/go/with_proto/MODULE.bazel
@@ -1,0 +1,6 @@
+###############################################################################
+# Bazel now uses Bzlmod by default to manage external dependencies.
+# Please consider migrating your external dependencies from WORKSPACE to MODULE.bazel.
+#
+# For more details, please check https://github.com/bazelbuild/bazel/issues/18958
+###############################################################################

--- a/examples/go/with_proto/go/external/BUILD.bazel
+++ b/examples/go/with_proto/go/external/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "external",
+    srcs = ["external.go"],
+    importpath = "github.com/bazelbuild/intellij/examples/go/with_proto/go/external",
+    visibility = ["//visibility:public"],
+)

--- a/examples/go/with_proto/go/external/README.md
+++ b/examples/go/with_proto/go/external/README.md
@@ -1,0 +1,4 @@
+# Packages named `external`
+
+This directory exists to make sure that packages named `external` are imported correctly, as per https://github.com/bazelbuild/intellij/issues/6324.
+Targets depending on this package (such as `//lib:lib.go`) should resolve without red squigglies.

--- a/examples/go/with_proto/go/external/external.go
+++ b/examples/go/with_proto/go/external/external.go
@@ -1,0 +1,5 @@
+package external
+
+func ExternalCats() []string {
+	return []string{"Ember", "Cinder"}
+}

--- a/examples/go/with_proto/go/main.go
+++ b/examples/go/with_proto/go/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/bazelbuild/intellij/examples/go/with_proto/go/external"
 	"github.com/bazelbuild/intellij/examples/go/with_proto/go/lib"
 	"github.com/bazelbuild/intellij/examples/go/with_proto/proto"
 	"google.golang.org/grpc"
@@ -12,7 +13,7 @@ func main() {
 	fmt.Printf("AddToTwo(%d) = %d", num, lib.AddToTwo(num))
 }
 
-// This function exists to check that:
+// serv exists to check that:
 // - Third party symbols (`grpc.Server`) resolve.
 // - Code generated from protobuf resolves (symbols in the `proto` package).
 //   - We should be able to "go to definition" in `proto.FooServiceServer`.
@@ -21,4 +22,11 @@ func serv(grpcSrv *grpc.Server, protoSrv *proto.FooServiceServer) {
 	name := "World"
 	req := proto.HelloRequest{Name: &name}
 	req.GetName()
+}
+
+// CountExternalCats function exists to check that packages that are named `external` resolve:
+//
+//	We should be able to "go to definition" in `external.ExternalCats()`.
+func CountExternalCats() int {
+	return len(external.ExternalCats())
 }

--- a/examples/go/with_proto/go/main_test.go
+++ b/examples/go/with_proto/go/main_test.go
@@ -54,3 +54,24 @@ func TestEnvVars(t *testing.T) {
 		}
 	}
 }
+
+func TestCountExternalCats(t *testing.T) {
+	testCases := []struct {
+		name          string
+		expectedCount int
+	}{
+		{
+			name:          "Cats",
+			expectedCount: 2,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			count := CountExternalCats()
+			if count != tc.expectedCount {
+				t.Errorf("Expected to have %d cats, got %d cats", tc.expectedCount, count)
+			}
+		})
+	}
+
+}

--- a/golang/src/com/google/idea/blaze/golang/resolve/BlazeGoPackage.java
+++ b/golang/src/com/google/idea/blaze/golang/resolve/BlazeGoPackage.java
@@ -185,7 +185,7 @@ public class BlazeGoPackage extends GoPackage {
     if (externalString.contains("/external/")
         && !externalString.contains("/bazel-out/")
         && !externalString.contains("/blaze-out/")) {
-      return new File(externalString.replaceAll("/execroot.*/external/", "/external/"));
+      return new File(externalString.replaceAll("/execroot.*?/external/", "/external/"));
     }
     return maybeExternal;
   }


### PR DESCRIPTION
Fixes #6324

# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #6324

# Description of this change
If the package is literally named "external", the transformation was incorrect. Example:

String from real logs: `/private/var/tmp/_bazel_muldrik/79e0cc1117c2f3c124d7043e835ad8a1/execroot/_main/external/gazelle~~go_deps~io_k8s_sigs_cluster_api/controllers/external/doc.go`

Actual resulting transformation (breaks intellij imports):
`/private/var/tmp/_bazel_muldrik/79e0cc1117c2f3c124d7043e835ad8a1/external/doc.go`

Expected:
`/private/var/tmp/_bazel_muldrik/79e0cc1117c2f3c124d7043e835ad8a1/external/gazelle~~go_deps~io_k8s_sigs_cluster_api/controllers/external/doc.go`