### PR TITLE
fix: Replace zip with default Bazel zipper

### DIFF
--- a/intellij_platform_sdk/build_defs.bzl
+++ b/intellij_platform_sdk/build_defs.bzl
@@ -592,8 +592,19 @@ def no_mockito_extensions(name, jars, **kwargs):
             cmd = """
             cp "$<" "$@"
             chmod u+w "$@"
-            zip -d "$@" mockito-extensions/*
+            tmpdir=$$(mktemp -d)
+            zipper="$$(pwd)/$(execpath @bazel_tools//tools/zip:zipper)"
+            "$$zipper" x "$@" -d ".out"
+            mv ".out" "$$tmpdir"
+
+            pushd "$$tmpdir"
+            rm -fr "mockito-extensions"
+            "$$zipper" c "out.jar" .
+            popd
+
+            cp "$$tmpdir/out.jar" "$@"
             """,
+            tools = ["@bazel_tools//tools/zip:zipper"],
         )
         output_jars.append(output_jar_name)
 


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

`zip` might not be available in all machines. Specifically, it might not be available in Remote Build Execution environments. Instead, we use Bazel's built-in zipper.