### PR TITLE
#6265 Target Management

### DIFF
--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -375,6 +375,10 @@
     <codeInsight.lineMarkerProvider
         language="BUILD"
         implementationClass="com.google.idea.blaze.base.query.MacroLineMarkerProvider"/>
+    <codeInsight.lineMarkerProvider
+            language="projectview"
+            implementationClass="com.google.idea.blaze.base.projectview.section.sections.DirectoryLineMarkerProvider"/>
+
     <runLineMarkerContributor
         language="BUILD"
         implementationClass="com.google.idea.blaze.base.run.producers.BuildFileRunLineMarkerContributor"/>

--- a/base/src/com/google/idea/blaze/base/projectview/section/ListSection.java
+++ b/base/src/com/google/idea/blaze/base/projectview/section/ListSection.java
@@ -127,6 +127,19 @@ public final class ListSection<T> extends Section<T> {
       return this;
     }
 
+    @CanIgnoreReturnValue
+    public final Builder<T> replaceDirectory(T what, T with) {
+      for (int i =0; i < items.size(); i++) {
+        var cur = items.get(i);
+        if (cur.item != null && cur.item.equals(what)){
+          items.set(i, new ItemOrTextBlock<>(with));
+          break;
+        }
+      }
+
+      return this;
+    }
+
     @Override
     public final ListSection<T> build() {
       return new ListSection<>(getSectionKey(), ImmutableList.copyOf(items));

--- a/base/src/com/google/idea/blaze/base/projectview/section/ListSection.java
+++ b/base/src/com/google/idea/blaze/base/projectview/section/ListSection.java
@@ -128,7 +128,7 @@ public final class ListSection<T> extends Section<T> {
     }
 
     @CanIgnoreReturnValue
-    public final Builder<T> replaceDirectory(T what, T with) {
+    public final Builder<T> replaceElement(T what, T with) {
       for (int i =0; i < items.size(); i++) {
         var cur = items.get(i);
         if (cur.item != null && cur.item.equals(what)){

--- a/base/src/com/google/idea/blaze/base/projectview/section/sections/DirectoryLineMarkerProvider.java
+++ b/base/src/com/google/idea/blaze/base/projectview/section/sections/DirectoryLineMarkerProvider.java
@@ -15,10 +15,11 @@
  */
 package com.google.idea.blaze.base.projectview.section.sections;
 
-import com.google.common.collect.ImmutableList;
 import com.google.idea.blaze.base.lang.projectview.psi.ProjectViewPsiListItem;
 import com.google.idea.blaze.base.lang.projectview.psi.ProjectViewPsiListSection;
+import com.google.idea.blaze.base.model.primitives.TargetExpression;
 import com.google.idea.blaze.base.model.primitives.WorkspacePath;
+import com.google.idea.blaze.base.projectview.ProjectView;
 import com.google.idea.blaze.base.projectview.ProjectViewEdit;
 import com.google.idea.blaze.base.projectview.section.ListSection;
 import com.google.idea.blaze.base.settings.ui.AddDirectoryToProjectAction;
@@ -58,21 +59,23 @@ public class DirectoryLineMarkerProvider implements LineMarkerProvider {
                         (e, elt) -> AddDirectoryToProjectAction.runAction(element.getProject(), null),
                         GutterIconRenderer.Alignment.RIGHT,
                         () -> "Add Directory to Project");
-            } else if (element.getParent() instanceof ProjectViewPsiListItem parent &&
-                    parent.getParent().getFirstChild().getText().equals("directories")
-            ) {
-                var disabled = element.getText().startsWith("-");
-                var txt = disabled ? "Enable" : "Disable";
-                var icon = disabled ? AllIcons.Diff.GutterCheckBox : AllIcons.Diff.GutterCheckBoxSelected;
+            } else if (element.getParent() instanceof ProjectViewPsiListItem parent) {
+                var parentTag = parent.getParent().getFirstChild().getText();
 
-                return new LineMarkerInfo<>(
-                        element,
-                        element.getTextRange(),
-                        icon,
-                        psi -> txt,
-                        (e, elt) -> toggleTarget(elt, disabled),
-                        GutterIconRenderer.Alignment.RIGHT,
-                        () -> txt);
+                if (parentTag.equals("directories") || parentTag.equals("targets")) {
+                    var disabled = element.getText().startsWith("-");
+                    var txt = disabled ? "Enable" : "Disable";
+                    var icon = disabled ? AllIcons.Diff.GutterCheckBox : AllIcons.Diff.GutterCheckBoxSelected;
+
+                    return new LineMarkerInfo<>(
+                            element,
+                            element.getTextRange(),
+                            icon,
+                            psi -> txt,
+                            (e, elt) -> toggleTarget(elt, disabled, parentTag),
+                            GutterIconRenderer.Alignment.RIGHT,
+                            () -> txt);
+                }
             }
         }
 
@@ -80,33 +83,24 @@ public class DirectoryLineMarkerProvider implements LineMarkerProvider {
     }
 
     @Override
-    public void collectSlowLineMarkers(@NotNull List<? extends PsiElement> elements, Collection<? super LineMarkerInfo<?>> result) {
+    public void collectSlowLineMarkers(@NotNull List<? extends PsiElement> elements, @NotNull Collection<? super LineMarkerInfo<?>> result) {
     }
 
-    private void toggleTarget(PsiElement elt, boolean disabled) {
-        var edit =
-                ProjectViewEdit.editLocalProjectView(
-                        elt.getProject(),
-                        builder -> {
-                            var directories = builder.getLast(DirectorySection.KEY);
-                            var directoriesUpdater = ListSection.update(DirectorySection.KEY, directories);
+    private void toggleTarget(PsiElement elt, boolean disabled, String parentTag) {
+        ProjectViewEdit.ProjectViewEditor action = switch (parentTag) {
+            case "directories" -> (builder) -> toggleDirectory(builder, elt, disabled);
+            case "targets" -> (builder) -> toggleTarget(builder, elt, disabled);
+            default -> null;
+        };
 
-                            var directoryStr = elt.getText().substring(disabled ? 1 : 0);
+        if (action == null) {
+            Messages.showErrorDialog(
+                    "Could not modify project view: invalid tag %s.".formatted(parentTag),
+                    "Error");
+            return;
+        }
 
-                            directoriesUpdater.replaceDirectory(
-                                    disabled ?
-                                            DirectoryEntry.exclude(new WorkspacePath(directoryStr)) :
-                                            DirectoryEntry.include(new WorkspacePath(directoryStr)),
-                                    disabled ?
-                                            DirectoryEntry.include(new WorkspacePath(directoryStr)) :
-                                            DirectoryEntry.exclude(new WorkspacePath(directoryStr))
-                            );
-
-                            builder.replace(directories, directoriesUpdater);
-
-                            return true;
-                        }
-                );
+        var edit = ProjectViewEdit.editLocalProjectView(elt.getProject(), action);
 
         if (edit == null) {
             Messages.showErrorDialog(
@@ -116,5 +110,43 @@ public class DirectoryLineMarkerProvider implements LineMarkerProvider {
         }
 
         edit.apply();
+    }
+
+    private static boolean toggleDirectory(ProjectView.Builder builder, PsiElement elt, boolean disabled) {
+        var directories = builder.getLast(DirectorySection.KEY);
+        var directoriesUpdater = ListSection.update(DirectorySection.KEY, directories);
+
+        var directoryStr = elt.getText().substring(disabled ? 1 : 0);
+
+        directoriesUpdater.replaceElement(
+                disabled ?
+                        DirectoryEntry.exclude(new WorkspacePath(directoryStr)) :
+                        DirectoryEntry.include(new WorkspacePath(directoryStr)),
+                disabled ?
+                        DirectoryEntry.include(new WorkspacePath(directoryStr)) :
+                        DirectoryEntry.exclude(new WorkspacePath(directoryStr))
+        );
+
+        builder.replace(directories, directoriesUpdater);
+
+        return true;
+    }
+
+    private static boolean toggleTarget(ProjectView.Builder builder, PsiElement elt, boolean disabled) {
+        var targets = builder.getLast(TargetSection.KEY);
+        var targetsUpdater = ListSection.update(TargetSection.KEY, targets);
+
+        var targetStr = elt.getText();
+
+        targetsUpdater.replaceElement(
+                TargetExpression.fromStringSafe(targetStr),
+                disabled ?
+                        TargetExpression.fromStringSafe(targetStr.substring(1)) :
+                        TargetExpression.fromStringSafe('-' + targetStr)
+        );
+
+        builder.replace(targets, targetsUpdater);
+
+        return true;
     }
 }

--- a/base/src/com/google/idea/blaze/base/projectview/section/sections/DirectoryLineMarkerProvider.java
+++ b/base/src/com/google/idea/blaze/base/projectview/section/sections/DirectoryLineMarkerProvider.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2019 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.projectview.section.sections;
+
+import com.google.common.collect.ImmutableList;
+import com.google.idea.blaze.base.lang.projectview.psi.ProjectViewPsiListItem;
+import com.google.idea.blaze.base.lang.projectview.psi.ProjectViewPsiListSection;
+import com.google.idea.blaze.base.model.primitives.WorkspacePath;
+import com.google.idea.blaze.base.projectview.ProjectViewEdit;
+import com.google.idea.blaze.base.projectview.section.ListSection;
+import com.google.idea.blaze.base.settings.ui.AddDirectoryToProjectAction;
+import com.google.idea.common.experiments.BoolExperiment;
+import com.intellij.codeInsight.daemon.LineMarkerInfo;
+import com.intellij.codeInsight.daemon.LineMarkerProvider;
+import com.intellij.icons.AllIcons;
+import com.intellij.openapi.editor.markup.GutterIconRenderer;
+import com.intellij.openapi.ui.Messages;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.impl.source.tree.LeafPsiElement;
+import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * A line marker provider for project view files, showing a plus icon for adding new directories.
+ */
+public class DirectoryLineMarkerProvider implements LineMarkerProvider {
+
+    private static final BoolExperiment enabled = new BoolExperiment("projectview.directory.section.gutter.icons.enabled", true);
+
+    @Nullable
+    @Override
+    @SuppressWarnings("rawtypes")
+    public LineMarkerInfo getLineMarkerInfo(@NotNull PsiElement element) {
+        if (enabled.getValue() && element instanceof LeafPsiElement leafPsiElement) {
+            if (element.getText().equals("directories") &&
+                    leafPsiElement.getParent() instanceof ProjectViewPsiListSection) {
+                return new LineMarkerInfo<>(
+                        element,
+                        element.getTextRange(),
+                        AllIcons.Actions.AddFile,
+                        psi -> "Add Directory to Project",
+                        (e, elt) -> AddDirectoryToProjectAction.runAction(element.getProject(), null),
+                        GutterIconRenderer.Alignment.RIGHT,
+                        () -> "Add Directory to Project");
+            } else if (element.getParent() instanceof ProjectViewPsiListItem parent &&
+                    parent.getParent().getFirstChild().getText().equals("directories")
+            ) {
+                var disabled = element.getText().startsWith("-");
+                var txt = disabled ? "Enable" : "Disable";
+                var icon = disabled ? AllIcons.Diff.GutterCheckBox : AllIcons.Diff.GutterCheckBoxSelected;
+
+                return new LineMarkerInfo<>(
+                        element,
+                        element.getTextRange(),
+                        icon,
+                        psi -> txt,
+                        (e, elt) -> toggleTarget(elt, disabled),
+                        GutterIconRenderer.Alignment.RIGHT,
+                        () -> txt);
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public void collectSlowLineMarkers(@NotNull List<? extends PsiElement> elements, Collection<? super LineMarkerInfo<?>> result) {
+    }
+
+    private void toggleTarget(PsiElement elt, boolean disabled) {
+        var edit =
+                ProjectViewEdit.editLocalProjectView(
+                        elt.getProject(),
+                        builder -> {
+                            var directories = builder.getLast(DirectorySection.KEY);
+                            var directoriesUpdater = ListSection.update(DirectorySection.KEY, directories);
+
+                            var directoryStr = elt.getText().substring(disabled ? 1 : 0);
+
+                            directoriesUpdater.replaceDirectory(
+                                    disabled ?
+                                            DirectoryEntry.exclude(new WorkspacePath(directoryStr)) :
+                                            DirectoryEntry.include(new WorkspacePath(directoryStr)),
+                                    disabled ?
+                                            DirectoryEntry.include(new WorkspacePath(directoryStr)) :
+                                            DirectoryEntry.exclude(new WorkspacePath(directoryStr))
+                            );
+
+                            builder.replace(directories, directoriesUpdater);
+
+                            return true;
+                        }
+                );
+
+        if (edit == null) {
+            Messages.showErrorDialog(
+                    "Could not modify project view. Check for errors in your project view and try again",
+                    "Error");
+            return;
+        }
+
+        edit.apply();
+    }
+}


### PR DESCRIPTION
Add "Add Directory" button to the project view
Add directory toggle checkboxes to the project view

# Checklist

- [X] I have filed an issue about this change and discussed potential changes with the maintainers.
- [X] I have received the approval from the maintainers to make this change.
- [X] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `6265`

# Description of this change
![Untitled Project](https://github.com/bazelbuild/intellij/assets/15722184/209eefb0-b3c0-4cdf-af38-f0d33150fc19)

Add directory and management buttons to the project-view file. Note that this is the first part of a series of features and enhancements that target the hardships of navigating large repos using Bazel.
