### PR TITLE
Fix: Silence false positive "No such target" errors for files in the project root

### DIFF
--- a/base/src/com/google/idea/blaze/base/issueparser/BlazeIssueParser.java
+++ b/base/src/com/google/idea/blaze/base/issueparser/BlazeIssueParser.java
@@ -471,7 +471,7 @@ public class BlazeIssueParser {
             "(" + BAZEL_BUILD_FILES_PATTERN + ":[0-9]+:[0-9]+: Couldn't build file .*)");
 
     private static final ImmutableList<String> QUERY_PATTERNS = ImmutableList.of(
-            "(Skipping '//.+': no such target '//.+': target '.*' not declared in package '.+' defined by .+)",
+            "(Skipping '//.+': no such target '//.+': target '.*' not declared in package '.*' defined by .+)",
             "(Skipping '//.+': no targets found beneath '.+')"
     );
 


### PR DESCRIPTION
In these cases, bazel reports an error with empty (`''`) package

Follow up of #6262

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

