### PR TITLE
Feature flags for resolve virtual includes using heuristics or clangd

### DIFF
--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -393,7 +393,7 @@
     <registryKey
       key="bazel.sync.collect.virtual.includes.hints"
       description="Collect the actual location of includes during sync. Currently, only available with the legacy engine. (requires re-sync)"
-      defaultValue="false"
+      defaultValue="true"
     />
     <registryKey defaultValue="true"
                  description="Enables opening the project view file the first time the project is imported"

--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -387,8 +387,13 @@
     <registryKey defaultValue="false" description="Allow to have optional imports in project view" key="bazel.projectview.optional.imports"/>
     <registryKey
       key="bazel.sync.resolve.virtual.includes"
-      description="Apply heuristics to detect correct location of headers which are accessed from _virtual_includes during build"
+      description="Apply heuristics to detect correct location of headers which are accessed from _virtual_includes during build. (requires re-sync)"
       defaultValue="true"
+    />
+    <registryKey
+      key="bazel.sync.clangd.virtual.includes"
+      description="Use clangd to resolve virtual includes. Only available with legacy engine. (requires re-sync)"
+      defaultValue="false"
     />
     <registryKey defaultValue="true"
                  description="Enables opening the project view file the first time the project is imported"

--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -391,8 +391,8 @@
       defaultValue="true"
     />
     <registryKey
-      key="bazel.sync.clangd.virtual.includes"
-      description="Use clangd to resolve virtual includes. Only available with legacy engine. (requires re-sync)"
+      key="bazel.sync.collect.virtual.includes.hints"
+      description="Collect the actual location of includes during sync. Currently, only available with the legacy engine. (requires re-sync)"
       defaultValue="false"
     />
     <registryKey defaultValue="true"

--- a/base/src/com/google/idea/blaze/base/sync/workspace/VirtualIncludesHandler.java
+++ b/base/src/com/google/idea/blaze/base/sync/workspace/VirtualIncludesHandler.java
@@ -197,10 +197,6 @@ public class VirtualIncludesHandler {
       BlazeProjectData projectData,
       ExecutionRootPathResolver resolver,
       ProgressIndicator indicator) {
-    if (Registry.is("bazel.cpp.sync.workspace.collect.include.prefix.hints.disabled")) {
-      return ImmutableList.of();
-    }
-
     indicator.pushState();
     indicator.setIndeterminate(true);
     indicator.setText2("Collecting include hints...");

--- a/base/src/com/google/idea/blaze/base/sync/workspace/VirtualIncludesHandler.java
+++ b/base/src/com/google/idea/blaze/base/sync/workspace/VirtualIncludesHandler.java
@@ -57,11 +57,11 @@ public class VirtualIncludesHandler {
   private static final int ABSOLUTE_LABEL_PREFIX_LENGTH = ABSOLUTE_LABEL_PREFIX.length();
 
   public static boolean useHeuristic() {
-    return Registry.is("bazel.sync.resolve.virtual.includes") && !useClangd();
+    return Registry.is("bazel.sync.resolve.virtual.includes") && !useHints();
   }
 
-  public static boolean useClangd() {
-    return Registry.is("bazel.sync.clangd.virtual.includes");
+  public static boolean useHints() {
+    return Registry.is("bazel.sync.collect.virtual.includes.hints");
   }
 
   private static Path trimStart(Path value, @Nullable Path prefix) {
@@ -91,7 +91,7 @@ public class VirtualIncludesHandler {
     }
   }
 
-  private static void collectClangdTargetIncludeHints(
+  private static void collectTargetIncludeHints(
       Path root,
       TargetKey targetKey,
       TargetIdeInfo targetIdeInfo,
@@ -150,7 +150,7 @@ public class VirtualIncludesHandler {
     }
   }
 
-  private static ImmutableList<String> doCollectClangdIncludeHints(
+  private static ImmutableList<String> doCollectIncludeHints(
       Path root,
       TargetKey targetKey,
       BlazeProjectData projectData,
@@ -175,7 +175,7 @@ public class VirtualIncludesHandler {
         continue;
       }
 
-      collectClangdTargetIncludeHints(root, currentKey, currentIdeInfo, resolver, indicator,
+      collectTargetIncludeHints(root, currentKey, currentIdeInfo, resolver, indicator,
           includes);
 
       for (Dependency dep : currentIdeInfo.getDependencies()) {
@@ -191,7 +191,7 @@ public class VirtualIncludesHandler {
    * mappings. The mappings are used to resolve headers which use an 'include_prefix' or a
    * 'strip_include_prefix'.
    */
-  public static ImmutableList<String> collectClangdIncludeHints(
+  public static ImmutableList<String> collectIncludeHints(
       Path projectRoot,
       TargetKey targetKey,
       BlazeProjectData projectData,
@@ -206,7 +206,7 @@ public class VirtualIncludesHandler {
     indicator.setText2("Collecting include hints...");
 
     Stopwatch stopwatch = Stopwatch.createStarted();
-    ImmutableList<String> result = doCollectClangdIncludeHints(projectRoot, targetKey, projectData,
+    ImmutableList<String> result = doCollectIncludeHints(projectRoot, targetKey, projectData,
         resolver, indicator);
 
     long elapsed = stopwatch.elapsed(TimeUnit.MILLISECONDS);

--- a/base/src/com/google/idea/blaze/base/sync/workspace/VirtualIncludesHandler.java
+++ b/base/src/com/google/idea/blaze/base/sync/workspace/VirtualIncludesHandler.java
@@ -2,22 +2,34 @@ package com.google.idea.blaze.base.sync.workspace;
 
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import com.google.idea.blaze.base.ideinfo.ArtifactLocation;
 import com.google.idea.blaze.base.ideinfo.CIdeInfo;
 import com.google.idea.blaze.base.ideinfo.Dependency;
 import com.google.idea.blaze.base.ideinfo.TargetIdeInfo;
 import com.google.idea.blaze.base.ideinfo.TargetKey;
+import com.google.idea.blaze.base.ideinfo.TargetMap;
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.primitives.ExecutionRootPath;
+import com.google.idea.blaze.base.model.primitives.Label;
+import com.google.idea.blaze.base.model.primitives.TargetName;
+import com.google.idea.blaze.base.model.primitives.WorkspacePath;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.registry.Registry;
+
+import java.io.File;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.Stack;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
+
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -34,8 +46,23 @@ import org.jetbrains.annotations.Nullable;
  * {@code bazel-out/.../bin/.../_virtual_includes/...}
  */
 public class VirtualIncludesHandler {
+  static final Path VIRTUAL_INCLUDES_DIRECTORY = Path.of("_virtual_includes");
+
   private static final Logger LOG = Logger.getInstance(VirtualIncludesHandler.class);
   private static final String ABSOLUTE_LABEL_PREFIX = "//";
+  private static final int EXTERNAL_DIRECTORY_IDX = 3;
+  private static final int EXTERNAL_WORKSPACE_NAME_IDX = 4;
+  private static final int WORKSPACE_PATH_START_FOR_EXTERNAL_WORKSPACE = 5;
+  private static final int WORKSPACE_PATH_START_FOR_LOCAL_WORKSPACE = 3;
+  private static final int ABSOLUTE_LABEL_PREFIX_LENGTH = ABSOLUTE_LABEL_PREFIX.length();
+
+  public static boolean useHeuristic() {
+    return Registry.is("bazel.sync.resolve.virtual.includes") && !useClangd();
+  }
+
+  public static boolean useClangd() {
+    return Registry.is("bazel.sync.clangd.virtual.includes");
+  }
 
   private static Path trimStart(Path value, @Nullable Path prefix) {
     if (prefix == null || !value.startsWith(prefix)) {
@@ -64,7 +91,7 @@ public class VirtualIncludesHandler {
     }
   }
 
-  private static void collectTargetIncludeHints(
+  private static void collectClangdTargetIncludeHints(
       Path root,
       TargetKey targetKey,
       TargetIdeInfo targetIdeInfo,
@@ -123,7 +150,7 @@ public class VirtualIncludesHandler {
     }
   }
 
-  private static ImmutableList<String> doCollectIncludeHints(
+  private static ImmutableList<String> doCollectClangdIncludeHints(
       Path root,
       TargetKey targetKey,
       BlazeProjectData projectData,
@@ -148,7 +175,8 @@ public class VirtualIncludesHandler {
         continue;
       }
 
-      collectTargetIncludeHints(root, currentKey, currentIdeInfo, resolver, indicator, includes);
+      collectClangdTargetIncludeHints(root, currentKey, currentIdeInfo, resolver, indicator,
+          includes);
 
       for (Dependency dep : currentIdeInfo.getDependencies()) {
         frontier.push(dep.getTargetKey());
@@ -163,7 +191,7 @@ public class VirtualIncludesHandler {
    * mappings. The mappings are used to resolve headers which use an 'include_prefix' or a
    * 'strip_include_prefix'.
    */
-  public static ImmutableList<String> collectIncludeHints(
+  public static ImmutableList<String> collectClangdIncludeHints(
       Path projectRoot,
       TargetKey targetKey,
       BlazeProjectData projectData,
@@ -178,7 +206,7 @@ public class VirtualIncludesHandler {
     indicator.setText2("Collecting include hints...");
 
     Stopwatch stopwatch = Stopwatch.createStarted();
-    ImmutableList<String> result = doCollectIncludeHints(projectRoot, targetKey, projectData,
+    ImmutableList<String> result = doCollectClangdIncludeHints(projectRoot, targetKey, projectData,
         resolver, indicator);
 
     long elapsed = stopwatch.elapsed(TimeUnit.MILLISECONDS);
@@ -187,5 +215,122 @@ public class VirtualIncludesHandler {
     indicator.popState();
 
     return result;
+  }
+
+  private static List<Path> splitExecutionPath(ExecutionRootPath executionRootPath) {
+    return Lists.newArrayList(executionRootPath.getAbsoluteOrRelativeFile().toPath().iterator());
+  }
+
+  static boolean containsVirtualInclude(ExecutionRootPath executionRootPath) {
+    return splitExecutionPath(executionRootPath).contains(VIRTUAL_INCLUDES_DIRECTORY);
+  }
+
+  /**
+   * Resolves execution root path to {@code _virtual_includes} directory to the matching workspace
+   * location
+   *
+   * @return list of resolved paths if required information is obtained from execution root path and
+   * target data or empty list if resolution has failed
+   */
+  @NotNull
+  static ImmutableList<File> resolveVirtualInclude(ExecutionRootPath executionRootPath,
+      File externalWorkspacePath,
+      WorkspacePathResolver workspacePathResolver,
+      TargetMap targetMap) {
+    TargetKey key = null;
+    try {
+      key = guessTargetKey(executionRootPath);
+    } catch (IndexOutOfBoundsException exception) {
+      // report to intellij EA
+      LOG.error(
+          "Failed to detect target from execution root path: " + executionRootPath,
+          exception);
+    }
+
+    if (key == null) {
+      return ImmutableList.of();
+    }
+
+    TargetIdeInfo info = targetMap.get(key);
+    if (info == null) {
+      return ImmutableList.of();
+    }
+
+    CIdeInfo cIdeInfo = info.getcIdeInfo();
+    if (cIdeInfo == null) {
+      return ImmutableList.of();
+    }
+
+    if (!info.getcIdeInfo().getIncludePrefix().isEmpty()) {
+      LOG.debug(
+          "_virtual_includes cannot be handled for targets with include_prefix attribute");
+      return ImmutableList.of();
+    }
+
+    String stripPrefix = info.getcIdeInfo().getStripIncludePrefix();
+    if (!stripPrefix.isEmpty()) {
+      if (stripPrefix.endsWith("/")) {
+        stripPrefix = stripPrefix.substring(0, stripPrefix.length() - 1);
+      }
+      String externalWorkspaceName = key.getLabel().externalWorkspaceName();
+      WorkspacePath stripPrefixWorkspacePath = stripPrefix.startsWith(ABSOLUTE_LABEL_PREFIX) ?
+          new WorkspacePath(stripPrefix.substring(ABSOLUTE_LABEL_PREFIX_LENGTH)) :
+          new WorkspacePath(key.getLabel().blazePackage(), stripPrefix);
+      if (key.getLabel().externalWorkspaceName() != null) {
+        ExecutionRootPath external = new ExecutionRootPath(
+            ExecutionRootPathResolver.externalPath.toPath()
+                .resolve(externalWorkspaceName)
+                .resolve(stripPrefixWorkspacePath.toString()).toString());
+
+        return ImmutableList.of(external.getFileRootedAt(externalWorkspacePath));
+      } else {
+        return workspacePathResolver.resolveToIncludeDirectories(
+            stripPrefixWorkspacePath);
+      }
+    } else {
+      return ImmutableList.of();
+    }
+
+  }
+
+  /**
+   * @throws IndexOutOfBoundsException if executionRootPath has _virtual_includes but its content is
+   *                                   unexpected
+   */
+  @Nullable
+  private static TargetKey guessTargetKey(ExecutionRootPath executionRootPath) {
+    List<Path> split = splitExecutionPath(executionRootPath);
+    int virtualIncludesIdx = split.indexOf(VIRTUAL_INCLUDES_DIRECTORY);
+
+    if (virtualIncludesIdx > -1) {
+      String externalWorkspaceName =
+          split.get(EXTERNAL_DIRECTORY_IDX)
+              .equals(ExecutionRootPathResolver.externalPath.toPath())
+              ? split.get(EXTERNAL_WORKSPACE_NAME_IDX).toString()
+              : null;
+
+      int workspacePathStart = externalWorkspaceName != null
+          ? WORKSPACE_PATH_START_FOR_EXTERNAL_WORKSPACE
+          : WORKSPACE_PATH_START_FOR_LOCAL_WORKSPACE;
+
+      List<Path> workspacePaths = (workspacePathStart <= virtualIncludesIdx)
+          ? split.subList(workspacePathStart, virtualIncludesIdx)
+          : Collections.emptyList();
+
+      String workspacePathString =
+          FileUtil.toSystemIndependentName(
+              workspacePaths.stream().reduce(Path.of(""), Path::resolve).toString());
+
+      TargetName target = TargetName.create(split.get(virtualIncludesIdx + 1).toString());
+      WorkspacePath workspacePath = WorkspacePath.createIfValid(workspacePathString);
+      if (workspacePath == null) {
+        return null;
+      }
+
+      return TargetKey.forPlainTarget(
+          Label.create(externalWorkspaceName, workspacePath, target));
+    } else {
+      return null;
+    }
   }
 }

--- a/base/src/com/google/idea/blaze/base/sync/workspace/VirtualIncludesHandler.java
+++ b/base/src/com/google/idea/blaze/base/sync/workspace/VirtualIncludesHandler.java
@@ -272,7 +272,7 @@ public class VirtualIncludesHandler {
       WorkspacePath stripPrefixWorkspacePath = stripPrefix.startsWith(ABSOLUTE_LABEL_PREFIX) ?
           new WorkspacePath(stripPrefix.substring(ABSOLUTE_LABEL_PREFIX_LENGTH)) :
           new WorkspacePath(key.getLabel().blazePackage(), stripPrefix);
-      if (key.getLabel().externalWorkspaceName() != null) {
+      if (externalWorkspaceName != null) {
         ExecutionRootPath external = new ExecutionRootPath(
             ExecutionRootPathResolver.externalPath.toPath()
                 .resolve(externalWorkspaceName)

--- a/base/tests/unittests/com/google/idea/blaze/base/sync/workspace/ExecutionRootPathResolverTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/sync/workspace/ExecutionRootPathResolverTest.java
@@ -138,7 +138,7 @@ public class ExecutionRootPathResolverTest extends BlazeTestCase {
   @Override
   protected void initTest(Container applicationServices, Container projectServices) {
     Registry.get("bazel.sync.resolve.virtual.includes").setValue(true);
-    Registry.get("bazel.sync.clangd.virtual.includes").setValue(false);
+    Registry.get("bazel.sync.collect.virtual.includes.hints").setValue(false);
 
     pathResolver =
         new ExecutionRootPathResolver(

--- a/cpp/src/META-INF/blaze-cpp.xml
+++ b/cpp/src/META-INF/blaze-cpp.xml
@@ -60,7 +60,6 @@
     <registryKey defaultValue="false" description="Disable absolute path trimming in debug clang builds" key="bazel.trim.absolute.path.disabled"/>
     <registryKey defaultValue="true" description="Allow external targets from source directories be imported in" key="bazel.cpp.sync.external.targets.from.directories"/>
     <registryKey defaultValue="false" description="Filter out some incompatible compiler flags (-include)" key="bazel.cpp.sync.workspace.filter.out.incompatible.flags"/>
-    <registryKey defaultValue="false" description="Disable collection of include prefix hints during sync" key="bazel.cpp.sync.workspace.collect.include.prefix.hints.disabled"/>
     <applicationService serviceInterface="com.google.idea.blaze.cpp.CompilerVersionChecker"
                         serviceImplementation="com.google.idea.blaze.cpp.CompilerVersionCheckerImpl"/>
     <applicationService serviceInterface="com.google.idea.blaze.cpp.CompilerWrapperProvider"

--- a/cpp/src/com/google/idea/blaze/cpp/BlazeCWorkspace.java
+++ b/cpp/src/com/google/idea/blaze/cpp/BlazeCWorkspace.java
@@ -183,7 +183,8 @@ public final class BlazeCWorkspace implements ProjectComponent {
             workspaceRoot,
             blazeProjectData.getBlazeInfo().getExecutionRoot(),
             blazeProjectData.getBlazeInfo().getOutputBase(),
-            blazeProjectData.getWorkspacePathResolver());
+            blazeProjectData.getWorkspacePathResolver(),
+            blazeProjectData.getTargetMap());
 
     int progress = 0;
 
@@ -257,9 +258,12 @@ public final class BlazeCWorkspace implements ProjectComponent {
                 .map(file -> "-I" + file.getAbsolutePath())
                 .collect(toImmutableList());
 
-        Path rootPath = workspaceRoot.directory().toPath();
-        ImmutableList<String> includePrefixHints = VirtualIncludesHandler.collectIncludeHints(rootPath,
-            targetKey, blazeProjectData, executionRootPathResolver, indicator);
+        ImmutableList<String> includePrefixHints = ImmutableList.of();
+        if (VirtualIncludesHandler.useClangd()) {
+          Path rootPath = workspaceRoot.directory().toPath();
+          includePrefixHints = VirtualIncludesHandler.collectClangdIncludeHints(rootPath, targetKey, blazeProjectData,
+              executionRootPathResolver, indicator);
+        }
 
         for (VirtualFile vf : resolveConfiguration.getSources(targetKey)) {
           OCLanguageKind kind = resolveConfiguration.getDeclaredLanguageKind(vf);

--- a/cpp/src/com/google/idea/blaze/cpp/BlazeCWorkspace.java
+++ b/cpp/src/com/google/idea/blaze/cpp/BlazeCWorkspace.java
@@ -259,9 +259,9 @@ public final class BlazeCWorkspace implements ProjectComponent {
                 .collect(toImmutableList());
 
         ImmutableList<String> includePrefixHints = ImmutableList.of();
-        if (VirtualIncludesHandler.useClangd()) {
+        if (VirtualIncludesHandler.useHints()) {
           Path rootPath = workspaceRoot.directory().toPath();
-          includePrefixHints = VirtualIncludesHandler.collectClangdIncludeHints(rootPath, targetKey, blazeProjectData,
+          includePrefixHints = VirtualIncludesHandler.collectIncludeHints(rootPath, targetKey, blazeProjectData,
               executionRootPathResolver, indicator);
         }
 

--- a/cpp/src/com/google/idea/blaze/cpp/BlazeConfigurationResolver.java
+++ b/cpp/src/com/google/idea/blaze/cpp/BlazeConfigurationResolver.java
@@ -89,7 +89,8 @@ final class BlazeConfigurationResolver {
             WorkspaceRoot.fromProject(project),
             blazeProjectData.getBlazeInfo().getExecutionRoot(),
             blazeProjectData.getBlazeInfo().getOutputBase(),
-            blazeProjectData.getWorkspacePathResolver());
+            blazeProjectData.getWorkspacePathResolver(),
+            blazeProjectData.getTargetMap());
     ImmutableMap<TargetKey, CToolchainIdeInfo> toolchainLookupMap =
         BlazeConfigurationToolchainResolver.buildToolchainLookupMap(
             context, blazeProjectData.getTargetMap());

--- a/cpp/src/com/google/idea/blaze/cpp/IncludeRootFlagsProcessor.java
+++ b/cpp/src/com/google/idea/blaze/cpp/IncludeRootFlagsProcessor.java
@@ -48,7 +48,8 @@ public class IncludeRootFlagsProcessor implements BlazeCompilerFlagsProcessor {
               workspaceRoot,
               projectData.getBlazeInfo().getExecutionRoot(),
               projectData.getBlazeInfo().getOutputBase(),
-              projectData.getWorkspacePathResolver());
+              projectData.getWorkspacePathResolver(),
+              projectData.getTargetMap());
       return Optional.of(new IncludeRootFlagsProcessor(executionRootPathResolver));
     }
   }

--- a/cpp/tests/integrationtests/com/google/idea/blaze/cpp/BlazeCppResolvingTestCase.java
+++ b/cpp/tests/integrationtests/com/google/idea/blaze/cpp/BlazeCppResolvingTestCase.java
@@ -102,7 +102,8 @@ public class BlazeCppResolvingTestCase extends BlazeCppIntegrationTestCase {
         workspaceRoot,
         projectData.getBlazeInfo().getExecutionRoot(),
         projectData.getBlazeInfo().getOutputBase(),
-        projectData.getWorkspacePathResolver());
+        projectData.getWorkspacePathResolver(),
+        projectData.getTargetMap());
   }
 
   private HeadersSearchRoot searchRootFromExecRoot(

--- a/cpp/tests/unittests/com/google/idea/blaze/cpp/BlazeCompilerSettingsTest.java
+++ b/cpp/tests/unittests/com/google/idea/blaze/cpp/BlazeCompilerSettingsTest.java
@@ -56,7 +56,7 @@ public class BlazeCompilerSettingsTest extends BlazeTestCase {
     applicationServices.register(ExperimentService.class, new MockExperimentService());
 
     Registry.get("bazel.sync.resolve.virtual.includes").setValue(true);
-    Registry.get("bazel.sync.clangd.virtual.includes").setValue(true);
+    Registry.get("bazel.sync.collect.virtual.includes.hints").setValue(true);
 
     applicationServices.register(QuerySyncSettings.class, new QuerySyncSettings());
 

--- a/cpp/tests/unittests/com/google/idea/blaze/cpp/BlazeCompilerSettingsTest.java
+++ b/cpp/tests/unittests/com/google/idea/blaze/cpp/BlazeCompilerSettingsTest.java
@@ -56,6 +56,7 @@ public class BlazeCompilerSettingsTest extends BlazeTestCase {
     applicationServices.register(ExperimentService.class, new MockExperimentService());
 
     Registry.get("bazel.sync.resolve.virtual.includes").setValue(true);
+    Registry.get("bazel.sync.clangd.virtual.includes").setValue(true);
 
     applicationServices.register(QuerySyncSettings.class, new QuerySyncSettings());
 


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #6375

# Description of this change
Since using clangd (-ibazel) to resolve virtual includes only works with the legacy engine and currently breaks it under some circumstances (see #6375) revert back to the old heuristics based approach by default. To enable the usage of clangd the `bazel.sync.clangd.virtual.include` registry flag can be set to true.