### PR TITLE
#6403 Fix remote development project import

### DIFF
--- a/base/src/com/google/idea/blaze/base/wizard2/BlazeImportProjectAction.java
+++ b/base/src/com/google/idea/blaze/base/wizard2/BlazeImportProjectAction.java
@@ -58,7 +58,7 @@ class BlazeImportProjectAction extends AnAction {
 
   @Override
   public ActionUpdateThread getActionUpdateThread() {
-    return ActionUpdateThread.EDT;
+    return ActionUpdateThread.BGT;
   }
 
   private static void createFromWizard(


### PR DESCRIPTION
Fix remote development by reverting the thread type used for importing projects

# Checklist

- [X] I have filed an issue about this change and discussed potential changes with the maintainers.
- [X] I have received the approval from the maintainers to make this change.
- [X] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `6403`

# Description of this change
Changing the thread type used for importing projects to EDT causes Goland to create a corrupted project file. This is most probably attributed to freezing following by a dropped connection. Switching to BGT solved the problem in all of my tests.