### PR TITLE
perf: Pass --override_repository flag to all commands for faster analysis phase

### DIFF
--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/integration/BazelInvokingIntegrationTestRunner.java
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/integration/BazelInvokingIntegrationTestRunner.java
@@ -51,7 +51,7 @@ public class BazelInvokingIntegrationTestRunner {
     // Flags for wiring up the plugin aspect from the external @intellij_aspect repository.
     ImmutableList<String> aspectFlags =
         ImmutableList.of(
-            aspectStrategyBazel.getAspectFlag(),
+            aspectStrategyBazel.getAspectFlag().get(),
             String.format(
                 "%s=%s/%s/aspect",
                 AspectStrategyBazel.OVERRIDE_REPOSITORY_FLAG,

--- a/aswb/tests/unittests/com/google/idea/blaze/android/sync/aspects/strategy/RenderResolveOutputGroupProviderTest.java
+++ b/aswb/tests/unittests/com/google/idea/blaze/android/sync/aspects/strategy/RenderResolveOutputGroupProviderTest.java
@@ -143,7 +143,7 @@ public class RenderResolveOutputGroupProviderTest extends BlazeTestCase {
 
     @Override
     protected String getAspectFlag() {
-      return null
+      return null;
     }
 
   }

--- a/aswb/tests/unittests/com/google/idea/blaze/android/sync/aspects/strategy/RenderResolveOutputGroupProviderTest.java
+++ b/aswb/tests/unittests/com/google/idea/blaze/android/sync/aspects/strategy/RenderResolveOutputGroupProviderTest.java
@@ -137,11 +137,6 @@ public class RenderResolveOutputGroupProviderTest extends BlazeTestCase {
     }
 
     @Override
-    protected List<String> getAspectFlags() {
-      return ImmutableList.of();
-    }
-
-    @Override
     protected String getAspectFlag() {
       return null;
     }

--- a/aswb/tests/unittests/com/google/idea/blaze/android/sync/aspects/strategy/RenderResolveOutputGroupProviderTest.java
+++ b/aswb/tests/unittests/com/google/idea/blaze/android/sync/aspects/strategy/RenderResolveOutputGroupProviderTest.java
@@ -140,5 +140,11 @@ public class RenderResolveOutputGroupProviderTest extends BlazeTestCase {
     protected List<String> getAspectFlags() {
       return ImmutableList.of();
     }
+
+    @Override
+    protected String getAspectFlag() {
+      return null
+    }
+
   }
 }

--- a/aswb/tests/unittests/com/google/idea/blaze/android/sync/aspects/strategy/RenderResolveOutputGroupProviderTest.java
+++ b/aswb/tests/unittests/com/google/idea/blaze/android/sync/aspects/strategy/RenderResolveOutputGroupProviderTest.java
@@ -30,6 +30,7 @@ import com.google.idea.common.experiments.ExperimentService;
 import com.google.idea.common.experiments.MockExperimentService;
 import com.intellij.openapi.extensions.impl.ExtensionPointImpl;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -137,9 +138,8 @@ public class RenderResolveOutputGroupProviderTest extends BlazeTestCase {
     }
 
     @Override
-    protected String getAspectFlag() {
-      return null;
+    protected Optional<String> getAspectFlag() {
+      return Optional.empty();
     }
-
   }
 }

--- a/base/src/com/google/idea/blaze/base/command/BlazeCommand.java
+++ b/base/src/com/google/idea/blaze/base/command/BlazeCommand.java
@@ -20,6 +20,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.idea.blaze.base.bazel.BuildSystem.BuildInvoker;
 import com.google.idea.blaze.base.model.primitives.TargetExpression;
+import com.google.idea.blaze.base.sync.aspects.strategy.AspectStrategyBazel;
+
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
@@ -108,6 +110,9 @@ public final class BlazeCommand {
       this.invokeParallel = false;
       // Tell forge what tool we used to call blaze so we can track usage.
       addBlazeFlags(BlazeFlags.getToolTagFlag());
+      AspectStrategyBazel.getAspectRepositoryOverrideFlag().ifPresent(it ->
+          addBlazeFlags(it)
+      );
     }
 
     private ImmutableList<String> getArguments() {

--- a/base/src/com/google/idea/blaze/base/sync/aspects/strategy/AspectStrategy.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/strategy/AspectStrategy.java
@@ -40,7 +40,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Predicate;
-import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
 /** Aspect strategy for Skylark. */
@@ -90,7 +89,7 @@ public abstract class AspectStrategy {
 
   public abstract String getName();
 
-  protected abstract String getAspectFlag();
+  protected abstract Optional<String> getAspectFlag();
 
   /**
    * Add the aspect to the build and request the given {@code OutputGroup}s. This method should only
@@ -108,9 +107,8 @@ public abstract class AspectStrategy {
         outputGroups.stream()
             .flatMap(g -> getOutputGroups(g, activeLanguages, directDepsOnly).stream())
             .collect(toImmutableList());
-    var aspectFlag = getAspectFlag();
     builder
-        .addBlazeFlags(aspectFlag == null ? List.of() : List.of(aspectFlag))
+        .addBlazeFlags(getAspectFlag().map(List::of).orElse(List.of()))
         .addBlazeFlags("--output_groups=" + Joiner.on(',').join(groups));
   }
 

--- a/base/src/com/google/idea/blaze/base/sync/aspects/strategy/AspectStrategy.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/strategy/AspectStrategy.java
@@ -90,7 +90,7 @@ public abstract class AspectStrategy {
 
   public abstract String getName();
 
-  protected abstract Optional<String> getAspectFlag();
+  protected abstract String getAspectFlag();
 
   /**
    * Add the aspect to the build and request the given {@code OutputGroup}s. This method should only
@@ -108,8 +108,9 @@ public abstract class AspectStrategy {
         outputGroups.stream()
             .flatMap(g -> getOutputGroups(g, activeLanguages, directDepsOnly).stream())
             .collect(toImmutableList());
+    var aspectFlag = getAspectFlag();
     builder
-        .addBlazeFlags(getAspectFlag().map(List::of).orElse(List.of()))
+        .addBlazeFlags(aspectFlag == null ? List.of() : List.of(aspectFlag))
         .addBlazeFlags("--output_groups=" + Joiner.on(',').join(groups));
   }
 

--- a/base/src/com/google/idea/blaze/base/sync/aspects/strategy/AspectStrategy.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/strategy/AspectStrategy.java
@@ -36,9 +36,11 @@ import java.io.InputStreamReader;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
 /** Aspect strategy for Skylark. */
@@ -88,7 +90,7 @@ public abstract class AspectStrategy {
 
   public abstract String getName();
 
-  protected abstract List<String> getAspectFlags();
+  protected abstract Optional<String> getAspectFlag();
 
   /**
    * Add the aspect to the build and request the given {@code OutputGroup}s. This method should only
@@ -107,7 +109,7 @@ public abstract class AspectStrategy {
             .flatMap(g -> getOutputGroups(g, activeLanguages, directDepsOnly).stream())
             .collect(toImmutableList());
     builder
-        .addBlazeFlags(getAspectFlags())
+        .addBlazeFlags(getAspectFlag().map(List::of).orElse(List.of()))
         .addBlazeFlags("--output_groups=" + Joiner.on(',').join(groups));
   }
 

--- a/base/src/com/google/idea/blaze/base/sync/aspects/strategy/AspectStrategyBazel.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/strategy/AspectStrategyBazel.java
@@ -50,8 +50,8 @@ public class AspectStrategyBazel extends AspectStrategy {
 
   @Override
   @VisibleForTesting
-  public Optional<String> getAspectFlag() {
-    return Optional.of(aspectFlag);
+  public String getAspectFlag() {
+    return aspectFlag;
   }
 
   // In tests, the location of @intellij_aspect is not known at compile time.

--- a/base/src/com/google/idea/blaze/base/sync/aspects/strategy/AspectStrategyBazel.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/strategy/AspectStrategyBazel.java
@@ -50,8 +50,8 @@ public class AspectStrategyBazel extends AspectStrategy {
 
   @Override
   @VisibleForTesting
-  public String getAspectFlag() {
-    return aspectFlag;
+  public Optional<String> getAspectFlag() {
+    return Optional.of(aspectFlag);
   }
 
   // In tests, the location of @intellij_aspect is not known at compile time.

--- a/base/src/com/google/idea/blaze/base/sync/aspects/strategy/AspectStrategyBazel.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/strategy/AspectStrategyBazel.java
@@ -16,13 +16,12 @@
 package com.google.idea.blaze.base.sync.aspects.strategy;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
 import com.google.idea.blaze.base.model.BlazeVersionData;
 import com.google.idea.blaze.base.settings.BuildSystemName;
 import com.intellij.ide.plugins.IdeaPluginDescriptor;
 import com.intellij.ide.plugins.PluginManager;
 import java.io.File;
-import java.util.List;
+import java.util.Optional;
 import javax.annotation.Nullable;
 
 /** Aspect strategy for Bazel, where the aspect is situated in an external repository. */
@@ -49,9 +48,10 @@ public class AspectStrategyBazel extends AspectStrategy {
     }
   }
 
+  @Override
   @VisibleForTesting
-  public String getAspectFlag() {
-    return aspectFlag;
+  public Optional<String> getAspectFlag() {
+    return Optional.of(aspectFlag);
   }
 
   // In tests, the location of @intellij_aspect is not known at compile time.
@@ -62,18 +62,16 @@ public class AspectStrategyBazel extends AspectStrategy {
     return "AspectStrategySkylarkBazel";
   }
 
-  @Override
-  protected List<String> getAspectFlags() {
-    return ImmutableList.of(aspectFlag, getAspectRepositoryOverrideFlag());
-  }
-
-  private static File findAspectDirectory() {
+  private static Optional<File> findAspectDirectory() {
     IdeaPluginDescriptor plugin =
         PluginManager.getPlugin(PluginManager.getPluginByClassName(AspectStrategy.class.getName()));
-    return new File(plugin.getPath(), "aspect");
+    if (plugin == null) {
+      return Optional.empty();
+    }
+    return Optional.of(new File(plugin.getPath(), "aspect"));
   }
 
-  private static String getAspectRepositoryOverrideFlag() {
-    return OVERRIDE_REPOSITORY_FLAG + "=" + findAspectDirectory().getPath();
+  public static Optional<String> getAspectRepositoryOverrideFlag() {
+    return findAspectDirectory().map(it -> OVERRIDE_REPOSITORY_FLAG + "=" + it.getPath());
   }
 }

--- a/base/tests/unittests/com/google/idea/blaze/base/sync/aspects/strategy/AspectStrategyTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/sync/aspects/strategy/AspectStrategyTest.java
@@ -28,11 +28,13 @@ import com.google.idea.common.experiments.ExperimentService;
 import com.google.idea.common.experiments.MockExperimentService;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+
 
 /** Unit tests for {@link AspectStrategy}. */
 @RunWith(JUnit4.class)
@@ -212,8 +214,8 @@ public class AspectStrategyTest extends BlazeTestCase {
     }
 
     @Override
-    protected List<String> getAspectFlags() {
-      return ImmutableList.of();
+    protected Optional<String> getAspectFlag() {
+      return Optional.empty();
     }
   }
 }

--- a/base/tests/unittests/com/google/idea/blaze/base/sync/aspects/strategy/AspectStrategyTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/sync/aspects/strategy/AspectStrategyTest.java
@@ -35,6 +35,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import javax.annotation.Nullable;
+
 
 /** Unit tests for {@link AspectStrategy}. */
 @RunWith(JUnit4.class)
@@ -213,9 +215,10 @@ public class AspectStrategyTest extends BlazeTestCase {
       return "MockAspectStrategy";
     }
 
+    @Nullable
     @Override
-    protected Optional<String> getAspectFlag() {
-      return Optional.empty();
+    protected String getAspectFlag() {
+      return null;
     }
   }
 }

--- a/base/tests/unittests/com/google/idea/blaze/base/sync/aspects/strategy/AspectStrategyTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/sync/aspects/strategy/AspectStrategyTest.java
@@ -35,8 +35,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import javax.annotation.Nullable;
-
 
 /** Unit tests for {@link AspectStrategy}. */
 @RunWith(JUnit4.class)
@@ -215,10 +213,9 @@ public class AspectStrategyTest extends BlazeTestCase {
       return "MockAspectStrategy";
     }
 
-    @Nullable
     @Override
-    protected String getAspectFlag() {
-      return null;
+    protected Optional<String> getAspectFlag() {
+      return Optional.empty();
     }
   }
 }


### PR DESCRIPTION
Using this flag ensures consistency across commands and prevents large portions of the Skyframe cache from being evicted. This avoids longer analysis phases. To experiment, view the cache summary with `bazel dump --skyframe=summary`.

