### PR TITLE
fix(output): Ignore sync errors in excluded directories

### DIFF
--- a/base/src/com/google/idea/blaze/base/issueparser/ToolWindowTaskIssueOutputFilter.java
+++ b/base/src/com/google/idea/blaze/base/issueparser/ToolWindowTaskIssueOutputFilter.java
@@ -85,12 +85,12 @@ public class ToolWindowTaskIssueOutputFilter implements Filter {
     if (linkedTask != null) {
       ResultItem dummyResult = dummyResult(offset);
       BuildTasksProblemsView.getInstance(project)
-          .addMessage(
+          .tryAddMessage(
               issue,
               openConsoleToHyperlink(project, linkedTask, dummyResult.getHyperlinkInfo(), offset));
       links.add(dummyResult);
     } else {
-      BuildTasksProblemsView.getInstance(project).addMessage(issue, null);
+      BuildTasksProblemsView.getInstance(project).tryAddMessage(issue, null);
     }
     ResultItem hyperlink = hyperlinkItem(issue, offset);
     if (hyperlink != null) {

--- a/base/src/com/google/idea/blaze/base/scope/output/IssueOutput.java
+++ b/base/src/com/google/idea/blaze/base/scope/output/IssueOutput.java
@@ -45,6 +45,7 @@ public class IssueOutput implements Output {
     NOTE,
     STATISTICS,
     INFORMATION,
+    IGNORE,
   }
 
   public static Builder issue(Category category, String message) {
@@ -57,6 +58,10 @@ public class IssueOutput implements Output {
 
   public static Builder warn(String message) {
     return new Builder(Category.WARNING, message);
+  }
+
+  public static Builder ignore() {
+    return new Builder(Category.IGNORE, null);
   }
 
   /** Builder for an issue */

--- a/base/src/com/google/idea/blaze/base/scope/scopes/ProblemsViewScope.java
+++ b/base/src/com/google/idea/blaze/base/scope/scopes/ProblemsViewScope.java
@@ -51,7 +51,7 @@ public class ProblemsViewScope implements BlazeScope, OutputSink<IssueOutput> {
 
   @Override
   public Propagation onOutput(IssueOutput output) {
-      BuildTasksProblemsView.getInstance(project).addMessage(output, null);
+      BuildTasksProblemsView.getInstance(project).tryAddMessage(output, null);
     return Propagation.Continue;
   }
 }


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [X] I have received the approval from the maintainers to make this change.
- [X] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `N/A`

# Description of this change
Even if a directory is excluded, Bazel can try to read it and issue
errors during sync. We should ignore Bazel errors that come from
excluded packages.

Implementation details:
- We create a new issue category, `IGNORE`.
- We modify the relevant `BlazeIssueParsers` to hold references to `workspaceRoot` and the `projectViewSet`
- When parsing an issue, if the issue happens in an excluded package or directory or label, we emit it as `IGNORE`.
