### PR TITLE
fix(coverage): Account for SHA in lcov DA parsing

### DIFF
--- a/java/src/com/google/idea/blaze/java/run/coverage/BlazeCoverageData.java
+++ b/java/src/com/google/idea/blaze/java/run/coverage/BlazeCoverageData.java
@@ -82,12 +82,16 @@ class BlazeCoverageData {
           return hits;
         }
         if (line.startsWith(DA)) {
-          // DA:line,hits
-          int comma = line.indexOf(',');
+          // DA:line,hits,sha
+          String[] segments = line.substring(DA.length()).split(",");
+          if (segments.length < 2) {
+            logger.warn(String.format("Cannot parse LCOV line: Expected entry to have format DA:<number>,<number>, was: %s", line));
+            continue;
+          }
           try {
             hits.put(
-                Integer.parseInt(line.substring(DA.length(), comma)),
-                Integer.parseInt(line.substring(comma + 1)));
+                Integer.parseInt(segments[0]),
+                Integer.parseInt(segments[1]));
           } catch (NumberFormatException e) {
             logger.warn("Cannot parse LCOV line: " + line, e);
           }

--- a/java/tests/unittests/com/google/idea/blaze/java/run/coverage/BlazeCoverageDataTest.java
+++ b/java/tests/unittests/com/google/idea/blaze/java/run/coverage/BlazeCoverageDataTest.java
@@ -81,6 +81,30 @@ public class BlazeCoverageDataTest {
     assertThat(data.perFileData.keySet()).containsExactly("path/to/another/file.txt");
   }
 
+  /**
+   * Some test runners, such as the one for `py_test` in rules_python, append extra data to DA entries.
+   * This test data is taken from a run of one such `py_test`.
+   * @throws IOException
+   */
+  @Test
+  public void testDALinesWithShaCanBeParsed() throws IOException {
+    BlazeCoverageData data =
+       BlazeCoverageData.parse(
+           inputStream(
+               "SF:path/to/file.txt",
+              "DA:1,1,CjTuYq8+gnNfbQNgi09Ocg",
+              "DA:40,1,E/tvV9JPVDhEcTCkgrwOFw",
+              "DA:42,1,SZ/sLwIPxdnoU2xnoUB7pg",
+              "end_of_record"
+           ));
+
+    assertThat(data.perFileData).hasSize(1);
+    FileData fileData = data.perFileData.get("path/to/file.txt");
+    assertThat(fileData).isNotNull();
+    assertThat(fileData.source).isEqualTo("path/to/file.txt");
+    assertThat(toMap(fileData.lineHits)).containsExactly(1, 1, 40, 1, 42, 1);
+  }
+
   private static ImmutableMap<Integer, Integer> toMap(TIntIntHashMap troveMap) {
     return Arrays.stream(troveMap.keys())
         .boxed()


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [X] I have received the approval from the maintainers to make this change.
- [X] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

N/A

# Description of this change

Some coverage formats include a SHA in their report. In those cases, the parser failed and no coverage was reported. This PR fixes that.