### PR TITLE
fix: Use argfile with bazel zipper

### DIFF
--- a/intellij_platform_sdk/build_defs.bzl
+++ b/intellij_platform_sdk/build_defs.bzl
@@ -629,9 +629,8 @@ def no_mockito_extensions(name, jars, **kwargs):
             # We store the results from `find` in a file to deal with filenames with spaces
             files_to_tar_file=$$(mktemp)
             find . -type f | sed 's:^./::' > "$${files_to_tar_file}"
-            IFS="\n" read -r -d "" -a files_to_tar < "$${files_to_tar_file}" || true
 
-            "$$zipper" cC "../out.jar" "$${files_to_tar[@]}"
+            "$$zipper" cC "../out.jar" "@$${files_to_tar_file}"
             popd
 
             cp "$$tmpdir/out.jar" "$@"


### PR DESCRIPTION
# Checklist

- [X] I have filed an issue about this change and discussed potential changes with the maintainers.
- [X] I have received the approval from the maintainers to make this change.
- [X] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #6468

# Description of this change

Switch to use the `@argfile` pattern. As a bonus, we delete a line of Bash, which is always a good thing. I don't have access to a Windows machine, so I'd appreciate if someone with access to one could give it a shot.