### PR TITLE
Revert "Automatic code cleanup." - Remove dependency on rules_java

### DIFF
--- a/aspect/build_dependencies.bzl
+++ b/aspect/build_dependencies.bzl
@@ -5,7 +5,6 @@ load(
     "CPP_COMPILE_ACTION_NAME",
     "C_COMPILE_ACTION_NAME",
 )
-load("@rules_java//java:defs.bzl", "JavaInfo")
 
 ALWAYS_BUILD_RULES = "java_proto_library,java_lite_proto_library,java_mutable_proto_library,kt_proto_library_helper,_java_grpc_library,_java_lite_grpc_library,kt_grpc_library_helper,java_stubby_library,kt_stubby_library_helper,aar_import,java_import"
 

--- a/aspect/fast_build_info.bzl
+++ b/aspect/fast_build_info.bzl
@@ -1,6 +1,5 @@
 """An aspect to gather info needed by the FastBuildService."""
 
-load("@rules_java//java:defs.bzl", "JavaInfo", "java_common")
 load(
     ":artifacts.bzl",
     "artifact_location",

--- a/aspect/intellij_info_impl.bzl
+++ b/aspect/intellij_info_impl.bzl
@@ -1,6 +1,5 @@
 """Implementation of IntelliJ-specific information collecting aspect."""
 
-load("@rules_java//java:defs.bzl", "JavaInfo", "java_common")
 load(
     ":artifacts.bzl",
     "artifact_location",

--- a/aspect/java_classpath.bzl
+++ b/aspect/java_classpath.bzl
@@ -1,7 +1,5 @@
 """An aspect which extracts the runtime classpath from a java target."""
 
-load("@rules_java//java:defs.bzl", "JavaInfo")
-
 def _runtime_classpath_impl(target, ctx):
     """The top level aspect implementation function.
 


### PR DESCRIPTION
This reverts commit 697b9a9a9fe4d0b3c0672a694d8bbd3a5e5a5d4e.

# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #6474

# Description of this change
It seems to be the case that if a project:
- depends directly or transitively on rules_java < 5.3.5 
- or uses bazel <= 6.3.2 

The project can no longer be synced because of an error like this:
```
ERROR: Traceback (most recent call last):
	File "<redacted>/external/intellij_aspect/intellij_info_impl_bundled.bzl", line 3, column 37, in <toplevel>
		load("@rules_java//java:defs.bzl", "JavaInfo", "java_common")
Error: file '@rules_java//java:defs.bzl' does not contain symbol 'JavaInfo'
```

I would suggest reverting this commit for now and to release a hotfix. 