### PR TITLE
fix: "Read access is allowed from inside read-action" exception when opening a file

### DIFF
--- a/base/src/com/google/idea/blaze/base/syncstatus/SyncStatusEditorTabTitleProvider.java
+++ b/base/src/com/google/idea/blaze/base/syncstatus/SyncStatusEditorTabTitleProvider.java
@@ -18,10 +18,13 @@ package com.google.idea.blaze.base.syncstatus;
 import com.google.idea.blaze.base.settings.Blaze;
 import com.google.idea.blaze.base.settings.BlazeImportSettings;
 import com.google.idea.blaze.base.sync.autosync.ProjectTargetManager.SyncStatus;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.fileEditor.impl.EditorTabTitleProvider;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.vfs.VirtualFile;
+
 import javax.annotation.Nullable;
 
 /** Changes the tab title for unsynced files. */
@@ -32,8 +35,10 @@ public class SyncStatusEditorTabTitleProvider implements EditorTabTitleProvider,
     if (Blaze.getProjectType(project).equals(BlazeImportSettings.ProjectType.UNKNOWN)) {
       return null;
     }
-    
-    SyncStatus status = SyncStatusContributor.getSyncStatus(project, file);
+
+    SyncStatus status = ApplicationManager.getApplication()
+        .runReadAction((Computable<SyncStatus>) () -> SyncStatusContributor.getSyncStatus(project, file));
+
     if (status == null) {
       return null;
     }


### PR DESCRIPTION
It is not executed in read mode by default since 242 https://github.com/JetBrains/intellij-community/commit/c92a99d43581659231d24b22f8c5ac04279c9c4d

fixes #6473

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

