### PR TITLE
Remove unused custom java 17 toolchain

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,5 +1,3 @@
-load("@bazel_tools//tools/jdk:default_java_toolchain.bzl", "default_java_toolchain")
-
 #
 # Description: Blaze plugin for various IntelliJ products.
 #
@@ -98,31 +96,4 @@ test_suite(
         "//skylark:unit_tests",
     ],
     visibility = DEFAULT_TEST_VISIBILITY,
-)
-
-default_java_toolchain(
-    name = "custom_java_17_toolchain",
-    configuration = dict(),
-    java_runtime = "@rules_java//toolchains:remotejdk_17",
-    package_configuration = [
-        ":java_8",
-    ],
-    source_version = "17",
-    target_version = "17",
-)
-
-# this associates a set of javac flags with a set of packages
-java_package_configuration(
-    name = "java_8",
-    javacopts = ["-source 8 -target 8"],
-    packages = ["java_8_packages"],
-)
-
-# this is a regular package_group, which is used to specify a set of packages to apply flags to
-package_group(
-    name = "java_8_packages",
-    packages = [
-        "//proto/...",
-        "//third_party/bazel/src/main/protobuf/...",
-    ],
 )

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -870,9 +870,6 @@ load("@io_grpc_grpc_java//:repositories.bzl", "grpc_java_repositories")
 
 grpc_java_repositories()
 
-# Register custom java 17 toolchain
-register_toolchains("//:custom_java_17_toolchain_definition")
-
 # Dependency needed for Go test library
 http_archive(
     name = "bazel_gazelle",


### PR DESCRIPTION
it is no longer needed as the aspect tools are being built for java 8 via a transition in `repackaged_files` rule (https://github.com/bazelbuild/intellij/blob/master/build_defs/build_defs.bzl#L198)