### PR TITLE
fix: Display "Coverage" tool window correctly after executing "run wi…

### DIFF
--- a/java/src/com/google/idea/blaze/java/run/coverage/BlazeCoverageEngine.java
+++ b/java/src/com/google/idea/blaze/java/run/coverage/BlazeCoverageEngine.java
@@ -178,6 +178,16 @@ public class BlazeCoverageEngine extends CoverageEngine {
     return Blaze.defaultBuildSystemName() + " Coverage";
   }
 
+
+  // #api241 inline
+  // https://github.com/JetBrains/intellij-community/commit/a3ccb39c0a49173ceee13e0eb7d06598b0e1a2de
+  // Add @Override after we drop 241 support
+  @Nullable
+  public CoverageViewExtension createCoverageViewExtension(
+          Project project, CoverageSuitesBundle suites) {
+    return createCoverageViewExtension(project, suites, null);
+  }
+
   @Nullable
   @Override
   public CoverageViewExtension createCoverageViewExtension(


### PR DESCRIPTION
…th coverage"

closes #6501

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

