### PR TITLE
trusted project: respect intellij settings controlling project trustness

### DIFF
--- a/base/src/com/google/idea/blaze/base/project/TrustAwareProjectCreator.java
+++ b/base/src/com/google/idea/blaze/base/project/TrustAwareProjectCreator.java
@@ -48,6 +48,10 @@ public class TrustAwareProjectCreator implements ExtendableBazelProjectCreator {
   /** Returns true if the user has trusted the project. */
   @Override
   public boolean canCreateProject(@Nullable BuildSystemName buildSystemName) {
+    if (TrustedProjects.isTrustedCheckDisabled()) {
+      return true;
+    }
+
     var trustText = IdeBundle.message("untrusted.project.dialog.trust.button");
     var dontOpenText = IdeBundle.message("untrusted.project.open.dialog.cancel.button");
 


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

Do not show dialogs to trust if trust checks are disabled in the intellij platform. Project creation code is handled in a custom way in bazel plugin because any project is trusted by default in intellij. However, bazel plugin always creates a fake project in .cl/ij/aswb folder, so the plugin should handle trust checks by itself.
