### PR TITLE
Improve performance when resolving the workspace root

### DIFF
--- a/base/src/com/google/idea/blaze/base/sync/workspace/WorkspaceHelper.java
+++ b/base/src/com/google/idea/blaze/base/sync/workspace/WorkspaceHelper.java
@@ -16,9 +16,7 @@
 package com.google.idea.blaze.base.sync.workspace;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableMap;
 import com.google.idea.blaze.base.bazel.BuildSystemProvider;
-import com.google.idea.blaze.base.io.FileOperationProvider;
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.model.primitives.TargetName;
@@ -27,22 +25,32 @@ import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
 import com.google.idea.blaze.base.settings.Blaze;
 import com.google.idea.blaze.base.settings.BuildSystemName;
 import com.google.idea.blaze.base.sync.SyncCache;
+import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.io.FileUtil;
+
 import java.io.File;
-import java.util.Arrays;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.stream.Collectors;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import javax.annotation.Nullable;
 
-/** External-workspace-aware resolution of workspace paths. */
+/**
+ * External-workspace-aware resolution of workspace paths.
+ */
 public class WorkspaceHelper {
 
+  private static BlazeProjectData blazeProjectData;
+  private static final Logger logger = Logger.getInstance(WorkspaceHelper.class);
+
   private static class Workspace {
+
     private final WorkspaceRoot root;
-    @Nullable private final String externalWorkspaceName;
+    @Nullable
+    private final String externalWorkspaceName;
 
     private Workspace(WorkspaceRoot root, @Nullable String externalWorkspaceName) {
       this.root = root;
@@ -50,25 +58,31 @@ public class WorkspaceHelper {
     }
   }
 
-  @Nullable
-  public static WorkspaceRoot resolveExternalWorkspace(Project project, String workspaceName) {
-    Map<String, WorkspaceRoot> externalWorkspaces = getExternalWorkspaceRoots(project);
-    return externalWorkspaces != null ? externalWorkspaces.get(workspaceName) : null;
+  private static synchronized BlazeProjectData getBlazeProjectData(Project project) {
+    if (blazeProjectData == null) {
+      blazeProjectData = BlazeProjectDataManager.getInstance(project).getBlazeProjectData();
+    }
+    return blazeProjectData;
   }
 
-  /** Resolves the parent blaze package corresponding to this label. */
+  @Nullable
+  public static WorkspaceRoot resolveExternalWorkspace(Project project, String workspaceName) {
+    return getExternalWorkspaceRootsFile(workspaceName, project);
+  }
+
+  /**
+   * Resolves the parent blaze package corresponding to this label.
+   */
   @Nullable
   public static File resolveBlazePackage(Project project, Label label) {
+    logger.debug("resolveBlazePackage: " + label + " in project " + project.getName());
     if (!label.isExternal()) {
       WorkspacePathResolver pathResolver =
           WorkspacePathResolverProvider.getInstance(project).getPathResolver();
       return pathResolver != null ? pathResolver.resolveToFile(label.blazePackage()) : null;
     }
-    Map<String, WorkspaceRoot> externalWorkspaces = getExternalWorkspaceRoots(project);
-    if (externalWorkspaces == null) {
-      return null;
-    }
-    WorkspaceRoot root = externalWorkspaces.get(label.externalWorkspaceName());
+
+    WorkspaceRoot root = getExternalWorkspaceRootsFile(label.externalWorkspaceName(), project);
     return root != null ? root.fileForPath(label.blazePackage()) : null;
   }
 
@@ -78,9 +92,12 @@ public class WorkspaceHelper {
     return workspace != null ? workspace.root.workspacePathForSafe(absoluteFile) : null;
   }
 
-  /** Converts a file to the corresponding BUILD label for this project, if valid. */
+  /**
+   * Converts a file to the corresponding BUILD label for this project, if valid.
+   */
   @Nullable
   public static Label getBuildLabel(Project project, File absoluteFile) {
+    logger.debug("getBuildLabel for file " + absoluteFile.getAbsolutePath());
     Workspace workspace = resolveWorkspace(project, absoluteFile);
     if (workspace == null) {
       return null;
@@ -103,21 +120,34 @@ public class WorkspaceHelper {
     // try project workspace first
     WorkspaceRoot root = pathResolver.findWorkspaceRoot(absoluteFile);
     if (root != null) {
+      logger.debug("resolveWorkspace: " + root.directory().getAbsolutePath());
       return new Workspace(root, null);
     }
 
-    Map<String, WorkspaceRoot> externalWorkspaces = getExternalWorkspaceRoots(project);
-    if (externalWorkspaces == null) {
+    BlazeProjectData blazeProjectData = getBlazeProjectData(project);
+    Path bzelRootPath = Paths.get(blazeProjectData.getBlazeInfo().getOutputBase().getAbsolutePath(),
+        "external").normalize();
+    Path path = Paths.get(absoluteFile.getAbsolutePath()).normalize();
+
+    // Check if the file path starts with the root directory path
+    if (!path.startsWith(bzelRootPath)) {
       return null;
     }
-    for (Entry<String, WorkspaceRoot> entry : externalWorkspaces.entrySet()) {
-      root = entry.getValue();
-      WorkspacePath workspacePath = root.workspacePathForSafe(absoluteFile);
-      if (workspacePath != null) {
-        return new Workspace(root, entry.getKey());
+
+    Path relativePath = bzelRootPath.relativize(path);
+    if (relativePath.getNameCount() > 0) {
+      String firstFolder = relativePath.getName(0).toString();
+      try {
+        Path workspaceRootPath = Files.createDirectories(bzelRootPath.resolve(firstFolder));
+        logger.debug("resolveWorkspace: " + workspaceRootPath + " firstFolder: " + firstFolder);
+        return new Workspace(new WorkspaceRoot(workspaceRootPath.toFile()), firstFolder);
+      } catch (IOException e) {
+        logger.error("Error creating directories", e);
+        return null;
       }
+    } else {
+      return null;
     }
-    return null;
   }
 
   private static Label deriveLabel(
@@ -155,31 +185,36 @@ public class WorkspaceHelper {
     return null;
   }
 
-  @Nullable
-  private static synchronized Map<String, WorkspaceRoot> getExternalWorkspaceRoots(
-      Project project) {
-    if (Blaze.getBuildSystemName(project) == BuildSystemName.Blaze) {
-      return ImmutableMap.of();
-    }
-    return SyncCache.getInstance(project)
-        .get(WorkspaceHelper.class, WorkspaceHelper::enumerateExternalWorkspaces);
-  }
-
-  @SuppressWarnings("unused")
-  private static Map<String, WorkspaceRoot> enumerateExternalWorkspaces(
-      Project project, BlazeProjectData blazeProjectData) {
-    FileOperationProvider provider = FileOperationProvider.getInstance();
-    File[] children = provider.listFiles(getExternalSourceRoot(blazeProjectData));
-    if (children == null) {
-      return ImmutableMap.of();
-    }
-    return Arrays.stream(children)
-        .filter(provider::isDirectory)
-        .collect(Collectors.toMap(File::getName, WorkspaceRoot::new));
-  }
 
   @VisibleForTesting
   public static File getExternalSourceRoot(BlazeProjectData projectData) {
     return new File(projectData.getBlazeInfo().getOutputBase(), "external");
   }
+
+  @Nullable
+  private static synchronized WorkspaceRoot getExternalWorkspaceRootsFile(String workspaceName,
+      Project project) {
+    if (Blaze.getBuildSystemName(project) == BuildSystemName.Blaze) {
+      return null;
+    }
+    logger.debug("getExternalWorkspaceRootsFile for " + workspaceName);
+    File baseDir = SyncCache.getInstance(project)
+        .get(workspaceName, WorkspaceHelper::getWorkspaceRootDir);
+
+    if (baseDir == null) {
+      return null;
+    }
+    File rootFile = new File(baseDir, "external/" + workspaceName);
+    return rootFile.exists() ? new WorkspaceRoot(rootFile) : null;
+  }
+
+  private static File getWorkspaceRootDir(Project project, BlazeProjectData blazeProjectData) {
+    if (blazeProjectData == null) {
+      logger.debug("the blazeProjectData is null " + project.getName());
+      return null;
+    }
+    File root = blazeProjectData.getBlazeInfo().getOutputBase();
+    return root;
+  }
+
 }

--- a/base/src/com/google/idea/blaze/base/sync/workspace/WorkspaceHelper.java
+++ b/base/src/com/google/idea/blaze/base/sync/workspace/WorkspaceHelper.java
@@ -201,7 +201,7 @@ public class WorkspaceHelper {
     Map<String, WorkspaceRoot> workspaceRootCache = SyncCache.getInstance(project)
         .get(WorkspaceHelper.class, (p, data) -> new ConcurrentHashMap<String, WorkspaceRoot>());
 
-    //this the null cache value case could happen when the blazeProjectData is null.
+    //the null cache value case could happen when the blazeProjectData is null.
     if(workspaceRootCache == null) {
       return null;
     }
@@ -220,22 +220,6 @@ public class WorkspaceHelper {
     }
 
     return root;
-//    File externalBase = SyncCache.getInstance(project)
-//        .get(workspaceName, (Project theProject, BlazeProjectData projectData) -> {
-//          if (blazeProjectData == null) {
-//            logger.debug("the blazeProjectData is null " + project.getName());
-//            return null;
-//          }
-//          return new File(blazeProjectData.getBlazeInfo().getOutputBase(),
-//              "external/" + workspaceName);
-//        });
-//
-//    if (externalBase == null) {
-//      return null;
-//    }
-//
-//    return ((externalBase.exists() || isInTestMode())) ?
-//        new WorkspaceRoot(externalBase) : null;
   }
 
   //The unit test use the TempFileSystem to create VirtualFile which does not exist on disk.

--- a/base/src/com/google/idea/blaze/base/sync/workspace/WorkspaceHelper.java
+++ b/base/src/com/google/idea/blaze/base/sync/workspace/WorkspaceHelper.java
@@ -125,29 +125,28 @@ public class WorkspaceHelper {
     }
 
     BlazeProjectData blazeProjectData = getBlazeProjectData(project);
-    Path bzelRootPath = Paths.get(blazeProjectData.getBlazeInfo().getOutputBase().getAbsolutePath(),
+    Path bazelRootPath = Paths.get(
+        blazeProjectData.getBlazeInfo().getOutputBase().getAbsolutePath(),
         "external").normalize();
+
+    logger.debug("the bazelRootPath is " + bazelRootPath);
     Path path = Paths.get(absoluteFile.getAbsolutePath()).normalize();
 
     // Check if the file path starts with the root directory path
-    if (!path.startsWith(bzelRootPath)) {
+    if (!path.startsWith(bazelRootPath)) {
       return null;
     }
 
-    Path relativePath = bzelRootPath.relativize(path);
+    Path relativePath = bazelRootPath.relativize(path);
     if (relativePath.getNameCount() > 0) {
       String firstFolder = relativePath.getName(0).toString();
-      try {
-        Path workspaceRootPath = Files.createDirectories(bzelRootPath.resolve(firstFolder));
+      Path workspaceRootPath = bazelRootPath.resolve(firstFolder);
+      if (workspaceRootPath.toFile().exists()) {
         logger.debug("resolveWorkspace: " + workspaceRootPath + " firstFolder: " + firstFolder);
         return new Workspace(new WorkspaceRoot(workspaceRootPath.toFile()), firstFolder);
-      } catch (IOException e) {
-        logger.error("Error creating directories", e);
-        return null;
       }
-    } else {
-      return null;
     }
+    return null;
   }
 
   private static Label deriveLabel(
@@ -184,7 +183,6 @@ public class WorkspaceHelper {
     }
     return null;
   }
-
 
   @VisibleForTesting
   public static File getExternalSourceRoot(BlazeProjectData projectData) {

--- a/base/src/com/google/idea/blaze/base/sync/workspace/WorkspaceHelper.java
+++ b/base/src/com/google/idea/blaze/base/sync/workspace/WorkspaceHelper.java
@@ -23,6 +23,8 @@ import com.google.idea.blaze.base.model.primitives.TargetName;
 import com.google.idea.blaze.base.model.primitives.WorkspacePath;
 import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
 import com.google.idea.blaze.base.settings.Blaze;
+import com.google.idea.blaze.base.settings.BuildSystemName;
+import com.google.idea.blaze.base.sync.SyncCache;
 import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
@@ -33,7 +35,6 @@ import com.intellij.openapi.util.io.FileUtil;
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nullable;
 
 /**
@@ -43,13 +44,6 @@ public class WorkspaceHelper {
 
   private static BlazeProjectData blazeProjectData;
   private static final Logger logger = Logger.getInstance(WorkspaceHelper.class);
-
-  /**
-   * The cache for the workspace root path. key is the external workspace name. The value is the
-   * path to the workspace root directory.
-   */
-  private static final ConcurrentHashMap<String, WorkspaceRoot> workspaceRootCache
-      = new ConcurrentHashMap();
 
   private static class Workspace {
 
@@ -197,19 +191,26 @@ public class WorkspaceHelper {
   @Nullable
   private static synchronized WorkspaceRoot getExternalWorkspaceRootsFile(String workspaceName,
       Project project) {
-    BlazeProjectData bazelProjectData = getBlazeProjectData(project);
-    if (bazelProjectData == null) {
+    if (Blaze.getBuildSystemName(project) == BuildSystemName.Blaze) {
+      return null;
+    }
+    logger.debug("getExternalWorkspaceRootsFile for " + workspaceName);
+    File externalBase = SyncCache.getInstance(project)
+        .get(workspaceName, (Project theProject, BlazeProjectData projectData) -> {
+          if (blazeProjectData == null) {
+            logger.debug("the blazeProjectData is null " + project.getName());
+            return null;
+          }
+          return new File(blazeProjectData.getBlazeInfo().getOutputBase(),
+              "external/" + workspaceName);
+        });
+
+    if (externalBase == null) {
       return null;
     }
 
-    if (!workspaceRootCache.containsKey(workspaceName)) {
-      File externalBase = new File(bazelProjectData.getBlazeInfo().getOutputBase(),
-          "external/" + workspaceName);
-      if (externalBase.exists() || isInTestMode()) {
-        workspaceRootCache.put(workspaceName, new WorkspaceRoot(externalBase));
-      }
-    }
-    return workspaceRootCache.get(workspaceName);
+    return ((externalBase.exists() || isInTestMode())) ?
+        new WorkspaceRoot(externalBase) : null;
   }
 
   //The unit test use the TempFileSystem to create VirtualFile which does not exist on disk.

--- a/cpp/BUILD
+++ b/cpp/BUILD
@@ -126,6 +126,7 @@ intellij_unit_test_suite(
         "//common/experiments:unit_test_utils",
         "//intellij_platform_sdk:plugin_api_for_tests",
         "//intellij_platform_sdk:test_libs",
+        "@maven//:org_mockito_mockito_core",
         "@com_google_guava_guava//jar",
         "@junit//jar",
     ] + select_for_ide(


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: [5719](https://github.com/bazelbuild/intellij/issues/5719) 


# Description of this change
We have pretty big bazel project, and we are using the `rule_jvm_external` pinned feature, which download all the external dependencies to the `{baze-base}/external` dir.  The `external` folder could grow very big. One example the smallest cache folder for us:
```
% echo "Total directories:" $(find {root}/.cache/bazel/arm64/96fb5a4ccfb8aa9cafd25443b98fa7e6/external -type d | wc -l) && du -sh {root}.cache/bazel/arm64/96fb5a4ccfb8aa9cafd25443b98fa7e6/external

Total directories: 54733
5.8G	{root}/.cache/bazel/arm64/96fb5a4ccfb8aa9cafd25443b98fa7e6/external

```

The original logic when resolving the dependency label,  it loops through the entire `{baze-base}/external` dir, and check if the file is dir, then create a map for with the workspaceName as key and its dir path as value. Which when the external is really big the IO operation could hang there for a long time cause the IDE freeze. 

This change use the {baze-base}/external/{workspaceName} to construct the workspace root dir. And if it existed then construct the `WorkspaceRoot` and return. 
