### PR TITLE
Disable include hints (-ibazel) by default

### DIFF
--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -397,8 +397,8 @@
     />
     <registryKey
       key="bazel.sync.collect.virtual.includes.hints"
-      description="Collect the actual location of includes during sync. Currently, only available with the legacy engine. (requires re-sync)"
-      defaultValue="true"
+      description="CAN BREAK SYNC. Collect the actual location of includes during sync. Currently, only available with the legacy engine. (requires re-sync)"
+      defaultValue="false"
     />
     <registryKey defaultValue="true"
                  description="Enables opening the project view file the first time the project is imported"


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: 

# Description of this change
There seem to be more issues related to the -ibazel approach then initial discovered. Disable -ibazel collection by default.
