### PR TITLE
clion: fix broken debug in 2024.2

### DIFF
--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -291,9 +291,9 @@ http_archive(
     url = CLION_241_URL,
 )
 
-CLION_242_SHA = "cd018a71bccd28512dc22d8b3824f68ec9450b37c9e87e6c8553d3292acf9d0e"
+CLION_242_SHA = "83e5305da1f34815ea81e7dd924f5199dab6c48c182e869aa8b55ef850af7bc8"
 
-CLION_242_URL = "https://www.jetbrains.com/intellij-repository/snapshots/com/jetbrains/intellij/clion/clion/242.16677.29-EAP-SNAPSHOT/clion-242.16677.29-EAP-SNAPSHOT.zip"
+CLION_242_URL = "https://www.jetbrains.com/intellij-repository/snapshots/com/jetbrains/intellij/clion/clion/242.19533-EAP-CANDIDATE-SNAPSHOT/clion-242.19533-EAP-CANDIDATE-SNAPSHOT.zip"
 
 http_archive(
     name = "clion_2024_2",

--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrLauncher.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrLauncher.java
@@ -46,6 +46,7 @@ import com.google.idea.blaze.base.settings.BlazeUserSettings;
 import com.google.idea.blaze.base.settings.BuildSystemName;
 import com.google.idea.blaze.clwb.ToolchainUtils;
 import com.google.idea.blaze.cpp.CppBlazeRules;
+import com.google.idea.sdkcompat.clion.CidrDebugProcessCreator;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configuration.EnvironmentVariablesData;
 import com.intellij.execution.configurations.CommandLineState;
@@ -256,7 +257,7 @@ public final class BlazeCidrLauncher extends CidrLauncher {
 
       state.setConsoleBuilder(createConsoleBuilder(null));
       state.addConsoleFilters(getConsoleFilters().toArray(new Filter[0]));
-      return new CidrLocalDebugProcess(parameters, session, state.getConsoleBuilder());
+      return CidrDebugProcessCreator.create(() -> new CidrLocalDebugProcess(parameters, session, state.getConsoleBuilder()));
     }
     List<String> extraDebugFlags = BlazeGDBServerProvider.getFlagsForDebugging(handlerState);
 
@@ -279,8 +280,8 @@ public final class BlazeCidrLauncher extends CidrLauncher {
     BlazeCLionGDBDriverConfiguration debuggerDriverConfiguration =
         new BlazeCLionGDBDriverConfiguration(project);
 
-    return new BlazeCidrRemoteDebugProcess(
-        targetProcess, debuggerDriverConfiguration, parameters, session, state.getConsoleBuilder());
+    return CidrDebugProcessCreator.create(() -> new BlazeCidrRemoteDebugProcess(
+        targetProcess, debuggerDriverConfiguration, parameters, session, state.getConsoleBuilder()));
   }
 
   /** Get the correct test prefix for blaze/bazel */

--- a/sdkcompat/v223/com/google/idea/sdkcompat/clion/CidrDebugProcessCreator.java
+++ b/sdkcompat/v223/com/google/idea/sdkcompat/clion/CidrDebugProcessCreator.java
@@ -1,0 +1,13 @@
+package com.google.idea.sdkcompat.clion;
+
+import com.intellij.execution.ExecutionException;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.ThrowableComputable;
+import com.jetbrains.cidr.execution.debugger.CidrDebugProcess;
+
+// #api242
+public class CidrDebugProcessCreator {
+  public static CidrDebugProcess create(ThrowableComputable<CidrDebugProcess, ExecutionException> creator) throws ExecutionException {
+    return creator.compute();
+  }
+}

--- a/sdkcompat/v231/com/google/idea/sdkcompat/clion/CidrDebugProcessCreator.java
+++ b/sdkcompat/v231/com/google/idea/sdkcompat/clion/CidrDebugProcessCreator.java
@@ -1,0 +1,13 @@
+package com.google.idea.sdkcompat.clion;
+
+import com.intellij.execution.ExecutionException;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.ThrowableComputable;
+import com.jetbrains.cidr.execution.debugger.CidrDebugProcess;
+
+// #api242
+public class CidrDebugProcessCreator {
+  public static CidrDebugProcess create(ThrowableComputable<CidrDebugProcess, ExecutionException> creator) throws ExecutionException {
+    return creator.compute();
+  }
+}

--- a/sdkcompat/v232/com/google/idea/sdkcompat/clion/CidrDebugProcessCreator.java
+++ b/sdkcompat/v232/com/google/idea/sdkcompat/clion/CidrDebugProcessCreator.java
@@ -1,0 +1,13 @@
+package com.google.idea.sdkcompat.clion;
+
+import com.intellij.execution.ExecutionException;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.ThrowableComputable;
+import com.jetbrains.cidr.execution.debugger.CidrDebugProcess;
+
+// #api242
+public class CidrDebugProcessCreator {
+  public static CidrDebugProcess create(ThrowableComputable<CidrDebugProcess, ExecutionException> creator) throws ExecutionException {
+    return creator.compute();
+  }
+}

--- a/sdkcompat/v233/com/google/idea/sdkcompat/clion/CidrDebugProcessCreator.java
+++ b/sdkcompat/v233/com/google/idea/sdkcompat/clion/CidrDebugProcessCreator.java
@@ -1,0 +1,13 @@
+package com.google.idea.sdkcompat.clion;
+
+import com.intellij.execution.ExecutionException;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.ThrowableComputable;
+import com.jetbrains.cidr.execution.debugger.CidrDebugProcess;
+
+// #api242
+public class CidrDebugProcessCreator {
+  public static CidrDebugProcess create(ThrowableComputable<CidrDebugProcess, ExecutionException> creator) throws ExecutionException {
+    return creator.compute();
+  }
+}

--- a/sdkcompat/v241/com/google/idea/sdkcompat/clion/CidrDebugProcessCreator.java
+++ b/sdkcompat/v241/com/google/idea/sdkcompat/clion/CidrDebugProcessCreator.java
@@ -1,0 +1,13 @@
+package com.google.idea.sdkcompat.clion;
+
+import com.intellij.execution.ExecutionException;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.ThrowableComputable;
+import com.jetbrains.cidr.execution.debugger.CidrDebugProcess;
+
+// #api242
+public class CidrDebugProcessCreator {
+  public static CidrDebugProcess create(ThrowableComputable<CidrDebugProcess, ExecutionException> creator) throws ExecutionException {
+    return creator.compute();
+  }
+}

--- a/sdkcompat/v242/com/google/idea/sdkcompat/clion/CidrDebugProcessCreator.java
+++ b/sdkcompat/v242/com/google/idea/sdkcompat/clion/CidrDebugProcessCreator.java
@@ -1,0 +1,13 @@
+package com.google.idea.sdkcompat.clion;
+
+import com.intellij.execution.ExecutionException;
+import com.intellij.openapi.util.ThrowableComputable;
+import com.jetbrains.cidr.execution.CidrCoroutineHelper;
+import com.jetbrains.cidr.execution.debugger.CidrDebugProcess;
+
+// #api242
+public class CidrDebugProcessCreator {
+  public static CidrDebugProcess create(ThrowableComputable<CidrDebugProcess, ExecutionException> creator) throws ExecutionException {
+    return CidrCoroutineHelper.runOnEDT(creator);
+  }
+}


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

in CLion 2024.2 I change contract for createProcess/createDebugProcess and moved them to background thread from UI thread. However historically CidrDebugProcess and derived classes cannot be created outside of UI thread and it requires local wraps in launchers.