### PR TITLE
Fixes after sync freeze on MacOS 

### DIFF
--- a/common/util/src/com/google/idea/async/process/CommandLineTask.java
+++ b/common/util/src/com/google/idea/async/process/CommandLineTask.java
@@ -23,9 +23,11 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.io.ByteStreams;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.util.EnvironmentUtil;
 import com.intellij.util.execution.ParametersListUtil;
+import com.intellij.util.ui.EDT;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -181,6 +183,11 @@ public interface CommandLineTask {
 
     @Override
     public int run() throws IOException, InterruptedException, TimeoutException {
+
+      // ensure execution on background thread
+      assert !EDT.isCurrentThreadEdt();
+      // ensure no read lock is kept
+      assert !ApplicationManager.getApplication().isReadAccessAllowed();
 
       String logCommand = ParametersListUtil.join(command);
       if (logCommand.length() > 2000) {

--- a/cpp/src/com/google/idea/blaze/cpp/BlazeCSyncPlugin.java
+++ b/cpp/src/com/google/idea/blaze/cpp/BlazeCSyncPlugin.java
@@ -27,7 +27,6 @@ import com.google.idea.blaze.base.scope.scopes.TimingScope;
 import com.google.idea.blaze.base.scope.scopes.TimingScope.EventType;
 import com.google.idea.blaze.base.sync.BlazeSyncPlugin;
 import com.google.idea.blaze.base.sync.SyncMode;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import java.util.Set;
@@ -59,13 +58,9 @@ final class BlazeCSyncPlugin implements BlazeSyncPlugin {
         childContext -> {
           childContext.push(new TimingScope("Setup C Workspace", EventType.Other));
 
-          ApplicationManager.getApplication()
-              .runReadAction(
-                  () -> {
-                    BlazeCWorkspace blazeCWorkspace = BlazeCWorkspace.getInstance(project);
-                    blazeCWorkspace.update(
-                        childContext, workspaceRoot, projectViewSet, blazeProjectData, syncMode);
-                  });
+          BlazeCWorkspace blazeCWorkspace = BlazeCWorkspace.getInstance(project);
+          blazeCWorkspace.update(
+              childContext, workspaceRoot, projectViewSet, blazeProjectData, syncMode);
         });
   }
 


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: 

# Description of this change
CLion freezes every time after sync because the `XcodeCompilerSettings` are resolved under read lock. 

I think we can drop the read lock for the entire workspace update since as far as I can tell nothing actually requires a read lock. And the actual update of the workspace is performed under write lock.

Or we could just move the compiler settings resolution before the read lock is taken. But dropping the read lock might prevent freezes in future.