### PR TITLE
2024.2 update: promote 2024.2 builds to stable

### DIFF
--- a/intellij_platform_sdk/build_defs.bzl
+++ b/intellij_platform_sdk/build_defs.bzl
@@ -26,17 +26,17 @@ INDIRECT_IJ_PRODUCTS = {
     # Indirect ij_product mapping for Bazel Plugin OSS
     # The old names for -oss-oldest-stable and -oss-latest-stable were
     # -oss-stable and -oss-beta respectively.
-    "intellij-oss-oldest-stable": "intellij-2023.3",
-    "intellij-oss-latest-stable": "intellij-2024.1",
+    "intellij-oss-oldest-stable": "intellij-2024.1",
+    "intellij-oss-latest-stable": "intellij-2024.2",
     "intellij-oss-under-dev": "intellij-2024.2",
-    "intellij-ue-oss-oldest-stable": "intellij-ue-2023.3",
-    "intellij-ue-oss-latest-stable": "intellij-ue-2024.1",
+    "intellij-ue-oss-oldest-stable": "intellij-ue-2024.1",
+    "intellij-ue-oss-latest-stable": "intellij-ue-2024.2",
     "intellij-ue-oss-under-dev": "intellij-ue-2024.2",
     "android-studio-oss-oldest-stable": "android-studio-2023.1",
     "android-studio-oss-latest-stable": "android-studio-2023.2",
     "android-studio-oss-under-dev": "android-studio-2023.2",
-    "clion-oss-oldest-stable": "clion-2023.3",
-    "clion-oss-latest-stable": "clion-2024.1",
+    "clion-oss-oldest-stable": "clion-2024.1",
+    "clion-oss-latest-stable": "clion-2024.2",
     "clion-oss-under-dev": "clion-2024.2",
     # Indirect ij_product mapping for Cloud Code Plugin OSS
     "intellij-cc-oldest-stable": "intellij-2022.3",


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

As 2024.2 version is getting close to the release date we'd like to deprecate 2023.3 builds and move forward to 2024.2 in the stable feed.

