### PR TITLE
Remove registration of `IntelliJExtManager`

### DIFF
--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -270,7 +270,6 @@
     <projectService serviceInterface="com.google.idea.blaze.base.sync.libraries.LibraryFilesProviderFactory"
                     serviceImplementation="com.google.idea.blaze.base.sync.libraries.DefaultLibraryFilesProviderFactory"/>
 
-    <applicationService serviceImplementation="com.google.idea.blaze.base.ext.IntelliJExtManager"/>
     <applicationService serviceInterface="com.google.idea.blaze.base.async.executor.BlazeExecutor"
                         serviceImplementation="com.google.idea.blaze.base.async.executor.BlazeExecutorImpl"/>
     <fileDocumentManagerListener implementation="com.google.idea.blaze.base.buildmodifier.BuildFileFormatOnSaveHandler" order="first"/>


### PR DESCRIPTION
no longer needed after https://github.com/bazelbuild/intellij/commit/aee0a55ad7c54e88535855e72731eb8756f8df86