### PR TITLE
Fix wrong heuristic for when bazel uses a wrapper script

### DIFF
--- a/cpp/src/com/google/idea/blaze/cpp/CompilerWrapperProviderImpl.java
+++ b/cpp/src/com/google/idea/blaze/cpp/CompilerWrapperProviderImpl.java
@@ -37,8 +37,8 @@ public class CompilerWrapperProviderImpl implements CompilerWrapperProvider {
   public File createCompilerExecutableWrapper(
       File executionRoot, File blazeCompilerExecutableFile,
       ImmutableMap<String, String> compilerWrapperEnvVars) {
-    // bazel only uses a wrapper script on Mac, so we only need this script when running on mac
-    if (!SystemInfo.isMac) {
+    // bazel only uses a wrapper script on unix, so we do not need this script when running on windows
+    if (SystemInfo.isWindows) {
       return blazeCompilerExecutableFile;
     }
 


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: 

# Description of this change
My initial perception that bazel only uses a wrapper script on mac was wrong. Checked the bazel sources and as far as I can tell it generates a script on all unix systems.