### PR TITLE
Invoke bazel build during sync using --target_pattern_fi…

### DIFF
--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -405,6 +405,9 @@
     <registryKey defaultValue="false"
                  description="The Bazel Plugin sometimes uses the --query_file option to pass the query via a file. By default, the file is deleted immediately after the query execution is finished. Set this flag to true to avoid file deletion"
                  key="bazel.sync.keep.query.files"/>
+    <registryKey defaultValue="false"
+                 description="The Bazel Plugin uses the --target_pattern_file option to pass the targets via a file. By default, the file is deleted immediately after the build execution is finished. Set this flag to true to avoid file deletion"
+                 key="bazel.sync.keep.target.files"/>
     <editorNotificationProvider implementation="com.google.idea.blaze.base.wizard2.BazelNotificationProvider"/>
   </extensions>
 

--- a/base/src/com/google/idea/blaze/base/command/BlazeFlags.java
+++ b/base/src/com/google/idea/blaze/base/command/BlazeFlags.java
@@ -63,6 +63,9 @@ public final class BlazeFlags {
   // Custom build metadata. This option takes a key-value pair as an argument.
   public static final String BUILD_METADATA = "--build_metadata=";
 
+  // New line separated file with list of target patterns to build.
+  public static final String TARGET_PATTERN_FILE = "--target_pattern_file";
+
   /** Flags to add to blaze/bazel invocations of the given type. */
   public static List<String> blazeFlags(
       Project project,

--- a/base/src/com/google/idea/blaze/base/sync/aspects/BlazeIdeInterfaceAspectsImpl.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/BlazeIdeInterfaceAspectsImpl.java
@@ -750,7 +750,7 @@ public class BlazeIdeInterfaceAspectsImpl implements BlazeIdeInterface {
     boolean onlyDirectDeps =
         viewSet.getScalarValue(AutomaticallyDeriveTargetsSection.KEY).orElse(false);
 
-    Path targetPatternFile = prepareTargetPatternFile(targets);
+    Path targetPatternFile = prepareTargetPatternFile(project, targets);
     try (BuildResultHelper buildResultHelper = invoker.createBuildResultHelper()) {
       BlazeCommand.Builder builder = BlazeCommand.builder(invoker, BlazeCommandName.BUILD);
       builder
@@ -784,7 +784,7 @@ public class BlazeIdeInterfaceAspectsImpl implements BlazeIdeInterface {
     }
   }
 
-  private static @NotNull Path prepareTargetPatternFile(List<? extends TargetExpression> targets) throws BuildException {
+  private static @NotNull Path prepareTargetPatternFile(Project project, List<? extends TargetExpression> targets) throws BuildException {
     Path targetPatternFile = null;
     try {
       Path targetsDir = Paths.get(project.getBasePath()).resolve("targets");

--- a/base/src/com/google/idea/blaze/base/sync/aspects/BlazeIdeInterfaceAspectsImpl.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/BlazeIdeInterfaceAspectsImpl.java
@@ -788,7 +788,7 @@ public class BlazeIdeInterfaceAspectsImpl implements BlazeIdeInterface {
     try {
       Path targetsDir = Paths.get(project.getBasePath()).resolve("targets");
       Files.createDirectories(targetsDir);
-      targetPatternFile = Files.createTempFile(queriesDir, "targets-", "");
+      targetPatternFile = Files.createTempFile(targetsDir, "targets-", "");
       String targetsString =
           targets.stream()
               .map(t -> t.toString())

--- a/base/src/com/google/idea/blaze/base/sync/aspects/BlazeIdeInterfaceAspectsImpl.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/BlazeIdeInterfaceAspectsImpl.java
@@ -786,7 +786,9 @@ public class BlazeIdeInterfaceAspectsImpl implements BlazeIdeInterface {
   private static @NotNull Path prepareTargetPatternFile(List<? extends TargetExpression> targets) throws BuildException {
     Path targetPatternFile = null;
     try {
-      targetPatternFile = Files.createTempFile("targets-", "");
+      Path targetsDir = Paths.get(project.getBasePath()).resolve("targets");
+      Files.createDirectories(targetsDir);
+      targetPatternFile = Files.createTempFile(queriesDir, "targets-", "");
       String targetsString =
           targets.stream()
               .map(t -> t.toString())

--- a/base/src/com/google/idea/blaze/base/sync/aspects/BlazeIdeInterfaceAspectsImpl.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/BlazeIdeInterfaceAspectsImpl.java
@@ -106,7 +106,6 @@ import java.io.IOException;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.time.Instant;
 import java.util.ArrayList;

--- a/base/src/com/google/idea/blaze/base/sync/aspects/BlazeIdeInterfaceAspectsImpl.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/BlazeIdeInterfaceAspectsImpl.java
@@ -106,6 +106,7 @@ import java.io.IOException;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.time.Instant;
 import java.util.ArrayList;

--- a/base/src/com/google/idea/blaze/base/sync/aspects/BlazeIdeInterfaceAspectsImpl.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/BlazeIdeInterfaceAspectsImpl.java
@@ -100,8 +100,14 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Ref;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.openapi.util.registry.Registry;
 import com.intellij.pom.NavigatableAdapter;
+import java.io.IOException;
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -117,7 +123,11 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+
+import org.jetbrains.annotations.NotNull;
+
 
 /** Implementation of BlazeIdeInterface based on aspects. */
 public class BlazeIdeInterfaceAspectsImpl implements BlazeIdeInterface {
@@ -740,12 +750,12 @@ public class BlazeIdeInterfaceAspectsImpl implements BlazeIdeInterface {
     boolean onlyDirectDeps =
         viewSet.getScalarValue(AutomaticallyDeriveTargetsSection.KEY).orElse(false);
 
+    Path targetPatternFile = prepareTargetPatternFile(targets);
     try (BuildResultHelper buildResultHelper = invoker.createBuildResultHelper()) {
-
       BlazeCommand.Builder builder = BlazeCommand.builder(invoker, BlazeCommandName.BUILD);
       builder
           .setInvokeParallel(invokeParallel)
-          .addTargets(targets)
+          .addBlazeFlags(BlazeFlags.TARGET_PATTERN_FILE, targetPatternFile.toString())
           .addBlazeFlags(BlazeFlags.KEEP_GOING)
           .addBlazeFlags(buildResultHelper.getBuildFlags())
           .addBlazeFlags(additionalBlazeFlags);
@@ -763,6 +773,36 @@ public class BlazeIdeInterfaceAspectsImpl implements BlazeIdeInterface {
           builder, outputGroups, activeLanguages, onlyDirectDeps);
 
       return invoker.getCommandRunner().run(project, builder, buildResultHelper, context, ImmutableMap.of());
+    } finally {
+      if (!Registry.is("bazel.sync.keep.target.files")) {
+          try {
+              Files.deleteIfExists(targetPatternFile);
+          } catch (IOException e) {
+              logger.error("Failed to delete target pattern file", e);
+          }
+      }
     }
+  }
+
+  private static @NotNull Path prepareTargetPatternFile(List<? extends TargetExpression> targets) throws BuildException {
+    Path targetPatternFile = null;
+    try {
+      targetPatternFile = Files.createTempFile("targets-", "");
+      String targetsString =
+          targets.stream()
+              .map(t -> t.toString())
+              .collect(Collectors.joining(System.lineSeparator()));
+      Files.writeString(targetPatternFile, targetsString, StandardOpenOption.WRITE);
+    } catch (IOException e) {
+      if (targetPatternFile != null) {
+        try {
+          Files.deleteIfExists(targetPatternFile);
+        } catch (IOException ex) {
+          throw new BuildException("Couldn't delete file after creation failure", e);
+        }
+      }
+      throw new BuildException("Couldn't create target pattern file", e);
+    }
+    return targetPatternFile;
   }
 }


### PR DESCRIPTION

Use --target_pattern_file flag during sync instead of passing list of targets to avoid large command line errors in the same spirit as https://github.com/bazelbuild/intellij/pull/6537.


