### PR TITLE
handling for rules that involve transitions

### DIFF
--- a/base/src/com/google/idea/blaze/base/model/primitives/Kind.java
+++ b/base/src/com/google/idea/blaze/base/model/primitives/Kind.java
@@ -45,6 +45,13 @@ import javax.annotation.Nullable;
 public abstract class Kind {
 
   /**
+   * When a rule has a transition applied to it then it will present with this
+   * prefix on it.
+   */
+
+  private final static String RULE_NAME_PREFIX_TRANSITION = "_transition_";
+
+  /**
    * Provides a set of recognized blaze rule names. Individual language-specific sub-plugins can use
    * this EP to register rule types relevant to that language.
    *
@@ -134,7 +141,13 @@ public abstract class Kind {
 
   @Nullable
   public static Kind fromRuleName(String ruleName) {
-    return ApplicationState.getService().stringToKind.get(ruleName);
+    if (null != ruleName) {
+      if (ruleName.startsWith(RULE_NAME_PREFIX_TRANSITION)) {
+        ruleName = ruleName.substring(RULE_NAME_PREFIX_TRANSITION.length());
+      }
+      return ApplicationState.getService().stringToKind.get(ruleName);
+    }
+    return null;
   }
 
   /**


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: [6600](https://github.com/bazelbuild/intellij/issues/6600)

# Description of this change

When a Python rule is used such as `py_binary` and the rule is using a pinned Python interpreter, the `ruleName` is coming through as `_transition_py_binary` from the aspect but is still a `py_binary`. This change will still detect the transitioned rule name as `Kind.Provider.create("py_binary", LanguageClass.PYTHON, RuleType.BINARY)` from `PythonBlazeRules.java` so that debugging works for `py_binary`-s that are using the pinned interpreter.

See the issue discussion for further details and an example.