### PR TITLE
Implement py imports handling

### DIFF
--- a/aspect/intellij_info_impl.bzl
+++ b/aspect/intellij_info_impl.bzl
@@ -357,6 +357,7 @@ def collect_py_info(target, ctx, semantics, ide_info, ide_info_file, output_grou
     args = getattr(ctx.rule.attr, "args", [])
     data_deps = getattr(ctx.rule.attr, "data", [])
     args = _do_starlark_string_expansion(ctx, "args", args, data_deps)
+    imports = getattr(ctx.rule.attr, "imports", [])
 
     ide_info["py_ide_info"] = struct_omit_none(
         launcher = py_launcher,
@@ -364,6 +365,7 @@ def collect_py_info(target, ctx, semantics, ide_info, ide_info_file, output_grou
         sources = sources,
         srcs_version = _get_python_srcs_version(ctx),
         args = args,
+        imports = imports,
     )
 
     update_sync_output_groups(output_groups, "intellij-info-py", depset([ide_info_file]))

--- a/proto/intellij_ide_info.proto
+++ b/proto/intellij_ide_info.proto
@@ -151,6 +151,7 @@ message PyIdeInfo {
   // the python versions this target is compatible with
   PythonSrcsVersion srcs_version = 4;
   repeated string args = 5;
+  repeated string imports = 6;
 }
 
 message GoIdeInfo {

--- a/python/src/com/google/idea/blaze/python/resolve/provider/AbstractPyImportResolverStrategy.java
+++ b/python/src/com/google/idea/blaze/python/resolve/provider/AbstractPyImportResolverStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 The Bazel Authors. All rights reserved.
+ * Copyright 2017-2024 The Bazel Authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.idea.blaze.base.command.buildresult.OutputArtifactResolver;
 import com.google.idea.blaze.base.ideinfo.ArtifactLocation;
+import com.google.idea.blaze.base.ideinfo.PyIdeInfo;
 import com.google.idea.blaze.base.ideinfo.TargetIdeInfo;
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.primitives.LanguageClass;
@@ -41,8 +42,10 @@ import com.jetbrains.python.codeInsight.imports.AutoImportQuickFix;
 import com.jetbrains.python.psi.PyUtil;
 import com.jetbrains.python.psi.resolve.PyQualifiedNameResolveContext;
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -51,6 +54,23 @@ import javax.annotation.Nullable;
  * import strings are resolved to python packages and modules.
  */
 public abstract class AbstractPyImportResolverStrategy implements PyImportResolverStrategy {
+
+  private final static Path PATH_CURRENT_DIR = Path.of(".");
+
+  private final ArtifactSupplierToPsiElementProviderMapper artifactSupplierToPsiElementProviderMapper;
+
+  public AbstractPyImportResolverStrategy() {
+    this(new DefaultArtifactSupplierToPsiElementProviderMapper());
+  }
+
+  /**
+   * This constructor is exposed package-private for testing purposes.
+   * @param artifactSupplierToPsiElementProviderMapper is supplied so that it is possible to mock.
+   */
+  AbstractPyImportResolverStrategy(
+      ArtifactSupplierToPsiElementProviderMapper artifactSupplierToPsiElementProviderMapper) {
+    this.artifactSupplierToPsiElementProviderMapper = artifactSupplierToPsiElementProviderMapper;
+  }
 
   @Nullable
   @Override
@@ -97,40 +117,31 @@ public abstract class AbstractPyImportResolverStrategy implements PyImportResolv
     return SyncCache.getInstance(project).get(getClass(), this::buildSourcesIndex);
   }
 
+  // exposed package-private for testing
   @SuppressWarnings("unused")
-  private PySourcesIndex buildSourcesIndex(Project project, BlazeProjectData projectData) {
+  PySourcesIndex buildSourcesIndex(Project project, BlazeProjectData projectData) {
     ImmutableSetMultimap.Builder<String, QualifiedName> shortNames = ImmutableSetMultimap.builder();
     Map<QualifiedName, PsiElementProvider> map = new HashMap<>();
     ArtifactLocationDecoder decoder = projectData.getArtifactLocationDecoder();
     for (TargetIdeInfo target : projectData.getTargetMap().targets()) {
+      List<QualifiedName> importRoots = assembleImportRoots(target);
       for (ArtifactLocation source : getPySources(target)) {
-        QualifiedName name = toImportString(source);
-        if (name == null || name.getLastComponent() == null) {
-          continue;
-        }
-        shortNames.put(name.getLastComponent(), name);
-        PsiElementProvider psiProvider = psiProviderFromArtifact(project, decoder, source);
-        map.put(name, psiProvider);
-        if (includeParentDirectory(source)) {
-          map.put(name.removeTail(1), PsiElementProvider.getParent(psiProvider));
+        List<QualifiedName> sourceImports = assembleSourceImportsFromImportRoots(importRoots,
+            toImportString(source));
+        for (QualifiedName sourceImport : sourceImports) {
+          if (null != sourceImport.getLastComponent()) {
+            shortNames.put(sourceImport.getLastComponent(), sourceImport);
+            PsiElementProvider psiProvider = artifactSupplierToPsiElementProviderMapper
+                .map(project, decoder, source);
+            map.put(sourceImport, psiProvider);
+            if (includeParentDirectory(source)) {
+              map.put(sourceImport.removeTail(1), PsiElementProvider.getParent(psiProvider));
+            }
+          }
         }
       }
     }
     return new PySourcesIndex(shortNames.build(), ImmutableMap.copyOf(map));
-  }
-
-  private static PsiElementProvider psiProviderFromArtifact(
-      Project project, ArtifactLocationDecoder decoder, ArtifactLocation source) {
-    return (manager) -> {
-      File file = OutputArtifactResolver.resolve(project, decoder, source);
-      if (file == null) {
-        return null;
-      }
-      if (PyNames.INIT_DOT_PY.equals(file.getName())) {
-        file = file.getParentFile();
-      }
-      return BlazePyResolverUtils.resolveFile(manager, file);
-    };
   }
 
   private static Collection<ArtifactLocation> getPySources(TargetIdeInfo target) {
@@ -143,7 +154,9 @@ public abstract class AbstractPyImportResolverStrategy implements PyImportResolv
     return ImmutableList.of();
   }
 
-  /** Maps a blaze artifact to the import string used to reference it. */
+  /**
+   * Maps a blaze artifact to the import string used to reference it.
+   */
   @Nullable
   abstract QualifiedName toImportString(ArtifactLocation source);
 
@@ -156,4 +169,139 @@ public abstract class AbstractPyImportResolverStrategy implements PyImportResolv
     relativePath = StringUtil.trimExtensions(relativePath);
     return QualifiedName.fromComponents(StringUtil.split(relativePath, File.separator));
   }
+
+  /**
+   * <p>
+   * Introspects the target and extracts any imports as {@link QualifiedName} objects. The imports
+   * are relative to the basedir of the `BUILD` file and so the logic will adjust the imports to be
+   * from that directory. Later the file-paths related to the Bazel target are converted to
+   * {@link QualifiedName}s as well. By looking for the imports' {@link QualifiedName} as prefix on
+   * the source files' fully formed {@link QualifiedName}s, it is possible to derive how the Python
+   * interpreter would experience the modules and therefore reflect this in the mapping from the
+   * module names to the sources.
+   * </p>
+   * <p>
+   * An example; Consider a `py_library` target `:mylib` that is defined in a
+   * <code>BUILD.bazel</code> file;
+   * </p>
+   *
+   * <pre>{@code
+   * a/
+   *  b/
+   *   c/
+   *     BUILD.bazel
+   *     d/
+   *       e.py
+   * }</pre>
+   *
+   * <p>
+   * The <code>py_library</code> might have an <code>imports</code> attribute of <code>.</code>
+   * and in consideration of the <code>BUILD.bazel</code> path <code>a/b/c/BUILD.bazel</code>, this
+   * means that the <code>imports</code> {@link QualifiedName} will have components
+   * <code>a,b,c</code>. The logic at {@link #buildSourcesIndex(Project, BlazeProjectData)} will
+   * consider file <code>a/b/c/d/e.py</code> which will convert to a {@link QualifiedName} with
+   * components <code>a,b,c,d,e</code> and by removing the prefix obtained from
+   * <code>imports</code>, the final module {@link QualifiedName} will have components
+   * <code>d,e</code>.
+   * </p>
+   */
+  private static List<QualifiedName> assembleImportRoots(TargetIdeInfo target) {
+    ArtifactLocation buildFileArtifactLocation = target.getBuildFile();
+
+    if (null == buildFileArtifactLocation) {
+      return ImmutableList.of();
+    }
+
+    PyIdeInfo ideInfo = target.getPyIdeInfo();
+
+    if (null == ideInfo) {
+      return ImmutableList.of();
+    }
+
+    Path buildPath = Path.of(target.getBuildFile().getExecutionRootRelativePath());
+    Path buildParentPath = buildPath.getParent();
+
+    // In the case of an external repo the build path could be `/BUILD`
+    // which is problematic because the basedir is `/` which makes sense
+    // in the context of a Bazel repo but not in the context of the overall
+    // file-system. For this reason, the special case of `/BUILD` is taken
+    // to have a basedir of `.`.
+
+    if (null == buildParentPath || 0 == buildParentPath.getNameCount()) {
+      buildParentPath = PATH_CURRENT_DIR;
+    }
+
+    ImmutableList.Builder<QualifiedName> resultBuilder = ImmutableList.builder();
+
+    for (String imp : ideInfo.getImports()) {
+      Path impPath = buildParentPath.resolve(imp).normalize();
+      String[] impPathParts = new String[impPath.getNameCount()];
+
+      for (int i = impPath.getNameCount() - 1; i >= 0; i--) {
+        impPathParts[i] = impPath.getName(i).toString();
+      }
+
+      resultBuilder.add(QualifiedName.fromComponents(impPathParts));
+    }
+
+    return resultBuilder.build();
+  }
+
+  /**
+   * For each of the <code>importRoots</code>, see if it matches as a prefix on the
+   * <code>sourceImport</code> and then trim off the prefix; yielding the true module name.
+   * Also include the original in the list as well because this still seems to be able to be
+   * used as well. See {@link #assembleImportRoots(TargetIdeInfo)} for additional background.
+   */
+  private static List<QualifiedName> assembleSourceImportsFromImportRoots(
+      List<QualifiedName> importRoots,
+      QualifiedName sourceImport) {
+    if (null == sourceImport || null == sourceImport.getLastComponent()) {
+      return ImmutableList.of();
+    }
+
+    ImmutableList.Builder<QualifiedName> result = ImmutableList.builder();
+
+    result.add(sourceImport);
+
+    for (QualifiedName importsName : importRoots) {
+      // if the import name equals the name this is a strange situation.
+      if (!importsName.equals(sourceImport) && sourceImport.matchesPrefix(importsName)) {
+        result.add(sourceImport.subQualifiedName(importsName.getComponentCount(),
+            sourceImport.getComponentCount()));
+      }
+    }
+
+    return result.build();
+  }
+
+  /**
+   * This interface is used to isolate out the calls to statics so that unit testing is possible
+   * on this class.
+   */
+  interface ArtifactSupplierToPsiElementProviderMapper {
+
+    PsiElementProvider map(Project project, ArtifactLocationDecoder decoder,
+        ArtifactLocation source);
+  }
+
+  private static class DefaultArtifactSupplierToPsiElementProviderMapper implements
+      ArtifactSupplierToPsiElementProviderMapper {
+
+    @Override
+    public PsiElementProvider map(Project project, ArtifactLocationDecoder decoder,
+        ArtifactLocation source) {
+      return (manager) -> {
+        File file = OutputArtifactResolver.resolve(project, decoder, source);
+        if (file == null) {
+          return null;
+        }
+        if (PyNames.INIT_DOT_PY.equals(file.getName())) {
+          file = file.getParentFile();
+        }
+        return BlazePyResolverUtils.resolveFile(manager, file);
+      };
+    }
+  }
+
 }

--- a/python/src/com/google/idea/blaze/python/resolve/provider/BazelPyImportResolverStrategy.java
+++ b/python/src/com/google/idea/blaze/python/resolve/provider/BazelPyImportResolverStrategy.java
@@ -51,15 +51,6 @@ public class BazelPyImportResolverStrategy extends AbstractPyImportResolverStrat
     if (source.isGenerated() || !source.getRelativePath().endsWith(".py")) {
       return null;
     }
-    QualifiedName name = fromRelativePath(source.getRelativePath());
-    // pip_parse and pip_install macros unzip pip wheels into site-packages dir
-    // as result import strings get site-packages prefix, remove the prefix.
-    // Reference to python rules where site-packages is added:
-    //   https://github.com/bazelbuild/rules_python/blob/834149dfcd9e0dcb9d713caeb6bf5b0584601392/python/pip_install/extract_wheels/wheel.py#L75
-    if (name != null
-        && name.toString().startsWith("site-packages.")) {
-      name = name.removeHead(1);
-    }
-    return name;
+    return fromRelativePath(source.getRelativePath());
   }
 }

--- a/python/tests/unittests/com/google/idea/blaze/python/resolve/provider/AbstractPyImportResolverStrategyTest.java
+++ b/python/tests/unittests/com/google/idea/blaze/python/resolve/provider/AbstractPyImportResolverStrategyTest.java
@@ -1,0 +1,336 @@
+/*
+ * Copyright 2024 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.python.resolve.provider;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.idea.blaze.base.BlazeTestCase;
+import com.google.idea.blaze.base.ideinfo.*;
+import com.google.idea.blaze.base.model.BlazeProjectData;
+import com.google.idea.blaze.base.settings.BuildSystemName;
+import com.google.idea.blaze.base.sync.workspace.ArtifactLocationDecoder;
+import com.google.idea.blaze.base.sync.workspace.MockArtifactLocationDecoder;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiManager;
+import com.intellij.psi.util.QualifiedName;
+import com.jetbrains.python.psi.resolve.PyQualifiedNameResolveContext;
+import org.jetbrains.annotations.Nullable;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.util.Set;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class AbstractPyImportResolverStrategyTest extends BlazeTestCase {
+
+  /**
+   * It is possible to specify import paths for a <code>py_...</code> target so that the modules in
+   * the Python side can be specified. This test checks what happens in this situation.
+   */
+  @Test
+  public void testBuildSourcesIndexWithAnImportRoot() {
+    AbstractPyImportResolverStrategy strategy = new TestPyImportResolverStrategy();
+    TargetMap targetMap = assembleTestTargetMap(Set.of("river"));
+
+    Project project = Mockito.mock(Project.class);
+    BlazeProjectData projectData = Mockito.mock(BlazeProjectData.class);
+
+    Mockito.when(projectData.getTargetMap()).thenReturn(targetMap);
+    Mockito.when(projectData.getArtifactLocationDecoder()).thenReturn(
+        new MockArtifactLocationDecoder(new File("/workspaceroot"), false));
+
+    // code under test
+    PySourcesIndex actualSourcesIndex = strategy.buildSourcesIndex(project, projectData);
+
+    // Verify the short names capture the right mapping to possible modules.
+    Set<QualifiedName> shortNamesImports = actualSourcesIndex.shortNames.get("bar");
+    assertThat(shortNamesImports).containsExactly(
+        QualifiedName.fromComponents("whistle", "foo", "river", "lib", "bar"),
+        // ^ this one is the default which is the complete path in the Bazel repo to the Python file
+        QualifiedName.fromComponents("lib", "bar")
+        // ^ this one is created from the target's `imports`.
+    );
+
+    // Verify that the mappings from possible modules to actual files works.
+    // Because the strategy class was initialized with a special class to provide the PsiElement, we know that the
+    // `toString()` method will return specific information that we can relay on in this test.
+
+    assertThat(actualSourcesIndex.sourceMap).hasSize(4);
+    // ^ the mapping to the Python file, and also it's parent with the two possible paths
+    // one from the imports and one being the default.
+
+    PsiManager manager = Mockito.mock(PsiManager.class);
+
+    QualifiedName[] expectedBarModules = new QualifiedName[]{
+        QualifiedName.fromComponents("whistle", "foo", "river", "lib", "bar"),
+        QualifiedName.fromComponents("lib", "bar")
+    };
+
+    for (QualifiedName expectedBarModule : expectedBarModules) {
+      PsiElement fullElement = actualSourcesIndex.sourceMap.get(expectedBarModule).get(manager);
+      assertThat(fullElement).isNotNull();
+      assertThat(fullElement.toString()).isEqualTo("whistle/foo/river/lib/bar.py");
+    }
+
+    // the parent dir of the Python file is also included in the mapping.
+
+    QualifiedName[] expectedLibModules = new QualifiedName[]{
+        QualifiedName.fromComponents("whistle", "foo", "river", "lib"),
+        QualifiedName.fromComponents("lib"),
+    };
+
+    for (QualifiedName expectedLibModule : expectedLibModules) {
+      PsiElement fullElement = actualSourcesIndex.sourceMap.get(expectedLibModule).get(manager);
+      assertThat(fullElement).isNotNull();
+      assertThat(fullElement.toString()).isEqualTo("whistle/foo/river/lib");
+    }
+  }
+
+  /**
+   * This is the case where there is no import roots supplied. In this case, we expect that the only
+   * allowed Python module path will be the one from the root of the Bazel repo.
+   */
+  @Test
+  public void testBuildSourcesIndexWithNoImportRoot() {
+    AbstractPyImportResolverStrategy strategy = new TestPyImportResolverStrategy();
+    TargetMap targetMap = assembleTestTargetMap(Set.of()); // <-- note empty
+
+    Project project = Mockito.mock(Project.class);
+    BlazeProjectData projectData = Mockito.mock(BlazeProjectData.class);
+
+    Mockito.when(projectData.getTargetMap()).thenReturn(targetMap);
+    Mockito.when(projectData.getArtifactLocationDecoder()).thenReturn(
+        new MockArtifactLocationDecoder(new File("/workspaceroot"), false));
+
+    // code under test
+    PySourcesIndex actualSourcesIndex = strategy.buildSourcesIndex(project, projectData);
+
+    // Verify the short names capture the right mapping to possible modules.
+    Set<QualifiedName> shortNamesImports = actualSourcesIndex.shortNames.get("bar");
+    assertThat(shortNamesImports).containsExactly(
+        QualifiedName.fromComponents("whistle", "foo", "river", "lib", "bar")
+        // ^ this one is the default which is the complete path in the Bazel repo to the Python file
+    );
+
+    // Verify that the mappings from possible modules to actual files works.
+    // Because the strategy class was initialized with a special class to provide the PsiElement, we know that the
+    // `toString()` method will return specific information that we can relay on in this test.
+
+    assertThat(actualSourcesIndex.sourceMap).hasSize(2);
+    // ^ the mapping to the Python file, and also it's parent.
+
+    PsiManager manager = Mockito.mock(PsiManager.class);
+
+    QualifiedName[] expectedBarModules = new QualifiedName[]{
+        QualifiedName.fromComponents("whistle", "foo", "river", "lib", "bar"),
+    };
+
+    for (QualifiedName expectedBarModule : expectedBarModules) {
+      PsiElement fullElement = actualSourcesIndex.sourceMap.get(expectedBarModule).get(manager);
+      assertThat(fullElement).isNotNull();
+      assertThat(fullElement.toString()).isEqualTo("whistle/foo/river/lib/bar.py");
+    }
+
+    // Check that the parent dir of the Python file is also included in the mapping.
+
+    QualifiedName[] expectedLibModules = new QualifiedName[]{
+        QualifiedName.fromComponents("whistle", "foo", "river", "lib"),
+    };
+
+    for (QualifiedName expectedLibModule : expectedLibModules) {
+      PsiElement fullElement = actualSourcesIndex.sourceMap.get(expectedLibModule).get(manager);
+      assertThat(fullElement).isNotNull();
+      assertThat(fullElement.toString()).isEqualTo("whistle/foo/river/lib");
+    }
+  }
+
+  /**
+   * This is similar to {@link #testBuildSourcesIndexWithAnImportRoot()} but covers the case where
+   * the import path is `.` to check that this will root the import statements from the top of the
+   * Bazel project.
+   */
+  @Test
+  public void testBuildSourcesIndexWithDotImportRoot() {
+    AbstractPyImportResolverStrategy strategy = new TestPyImportResolverStrategy();
+    TargetMap targetMap = assembleTestTargetMap(Set.of("."));
+
+    Project project = Mockito.mock(Project.class);
+    BlazeProjectData projectData = Mockito.mock(BlazeProjectData.class);
+
+    Mockito.when(projectData.getTargetMap()).thenReturn(targetMap);
+    Mockito.when(projectData.getArtifactLocationDecoder()).thenReturn(
+        new MockArtifactLocationDecoder(new File("/workspaceroot"), false));
+
+    // code under test
+    PySourcesIndex actualSourcesIndex = strategy.buildSourcesIndex(project, projectData);
+
+    // Verify the short names capture the right mapping to possible modules.
+    Set<QualifiedName> shortNamesImports = actualSourcesIndex.shortNames.get("bar");
+    assertThat(shortNamesImports).containsExactly(
+        QualifiedName.fromComponents("whistle", "foo", "river", "lib", "bar"),
+        // ^ this one is the default which is the complete path in the Bazel repo to the Python file
+        QualifiedName.fromComponents("river", "lib", "bar")
+        // ^ this one is created from the target's `imports`.
+    );
+
+    // Verify that the mappings from possible modules to actual files works.
+    // Because the strategy class was initialized with a special class to provide the PsiElement, we know that the
+    // `toString()` method will return specific information that we can relay on in this test.
+
+    // Checks for the imports to the directory which is parent to the Python file have
+    // been done in other tests and won't be repeated here.
+
+    PsiManager manager = Mockito.mock(PsiManager.class);
+
+    QualifiedName[] expectedBarModules = new QualifiedName[]{
+        QualifiedName.fromComponents("whistle", "foo", "river", "lib", "bar"),
+        QualifiedName.fromComponents("river", "lib", "bar")
+    };
+
+    for (QualifiedName expectedBarModule : expectedBarModules) {
+      PsiElement fullElement = actualSourcesIndex.sourceMap.get(expectedBarModule).get(manager);
+      assertThat(fullElement).isNotNull();
+      assertThat(fullElement.toString()).isEqualTo("whistle/foo/river/lib/bar.py");
+    }
+  }
+
+  /**
+   * This case covers a special situation where the `BUILD.bazel` file is at the top of the repo.
+   * This happens for a Python wheel and because the `BUILD.bazel` file is `/` we have to be careful
+   * that we don't make reference to the top of the file system.
+   */
+  @Test
+  public void testBuildSourcesIndexWithBuildAtRootAndImport() {
+    AbstractPyImportResolverStrategy strategy = new TestPyImportResolverStrategy();
+
+    PyIdeInfo.Builder pyIdeInfoBuilder = PyIdeInfo.builder()
+        .addSources(ImmutableSet.of(source("top_level/lib/tea.py")))
+        .addImports(ImmutableSet.copyOf(Set.of("top_level")));
+
+    TargetMap targetMap = TargetMapBuilder.builder()
+        .addTarget(
+            TargetIdeInfo.builder()
+                .setLabel("//:tea")
+                .setBuildFile(source("/BUILD.bazel")) // <- note
+                .setPyInfo(pyIdeInfoBuilder)
+        )
+        .build();
+
+    Project project = Mockito.mock(Project.class);
+    BlazeProjectData projectData = Mockito.mock(BlazeProjectData.class);
+
+    Mockito.when(projectData.getTargetMap()).thenReturn(targetMap);
+    Mockito.when(projectData.getArtifactLocationDecoder()).thenReturn(
+        new MockArtifactLocationDecoder(new File("/workspaceroot"), false));
+
+    // code under test
+    PySourcesIndex actualSourcesIndex = strategy.buildSourcesIndex(project, projectData);
+
+    // Verify the short names capture the right mapping to possible modules.
+    Set<QualifiedName> shortNamesImports = actualSourcesIndex.shortNames.get("tea");
+    assertThat(shortNamesImports).containsExactly(
+        QualifiedName.fromComponents("top_level", "lib", "tea"),
+        // ^ this one is the default which is the complete path in the Bazel repo to the Python file
+        QualifiedName.fromComponents("lib", "tea")
+        // ^ this one is created from the target's `imports`.
+    );
+
+    // Verify that the mappings from possible modules to actual files works.
+    // Because the strategy class was initialized with a special class to provide the PsiElement, we know that the
+    // `toString()` method will return specific information that we can relay on in this test.
+
+    // Checks for the imports to the directory which is parent to the Python file have
+    // been done in other tests and won't be repeated here.
+
+    PsiManager manager = Mockito.mock(PsiManager.class);
+
+    QualifiedName[] expectedBarModules = new QualifiedName[]{
+        QualifiedName.fromComponents("top_level", "lib", "tea"),
+        QualifiedName.fromComponents("lib", "tea")
+    };
+
+    for (QualifiedName expectedBarModule : expectedBarModules) {
+      PsiElement fullElement = actualSourcesIndex.sourceMap.get(expectedBarModule).get(manager);
+      assertThat(fullElement).isNotNull();
+      assertThat(fullElement.toString()).isEqualTo("top_level/lib/tea.py");
+    }
+  }
+
+  private TargetMap assembleTestTargetMap(Set<String> importPaths) {
+    PyIdeInfo.Builder pyIdeInfoBuilder = PyIdeInfo.builder()
+        .addSources(ImmutableSet.of(source("whistle/foo/river/lib/bar.py")))
+        .addImports(ImmutableSet.copyOf(importPaths));
+
+    return TargetMapBuilder.builder()
+        .addTarget(
+            TargetIdeInfo.builder()
+                .setLabel("//whistle/foo:foo")
+                .setBuildFile(source("whistle/foo/BUILD.bazel"))
+                .setPyInfo(pyIdeInfoBuilder)
+        )
+        .build();
+  }
+
+  private static ArtifactLocation source(String relativePath) {
+    return ArtifactLocation.builder().setRelativePath(relativePath).setIsSource(true).build();
+  }
+
+  private static class MockArtifactSupplierToPsiElementProviderMapper
+      implements AbstractPyImportResolverStrategy.ArtifactSupplierToPsiElementProviderMapper {
+
+    @Override
+    public PsiElementProvider map(
+        Project project, ArtifactLocationDecoder decoder, ArtifactLocation source) {
+      return (manager) -> new MockArtifactLocationPsiElement(source.getExecutionRootRelativePath());
+    }
+  }
+
+  /**
+   * This is a concrete implementation of {@link AbstractPyImportResolverStrategy} so there is
+   * something to test.
+   */
+  private static class TestPyImportResolverStrategy extends AbstractPyImportResolverStrategy {
+
+    /**
+     * This constructor will install a fake mapper to {@link PsiElementProvider} so that the results
+     * can be captured to assert on.
+     */
+    public TestPyImportResolverStrategy() {
+      super(new MockArtifactSupplierToPsiElementProviderMapper());
+    }
+
+    @Nullable
+    @Override
+    QualifiedName toImportString(ArtifactLocation source) {
+      return fromRelativePath(source.getRelativePath());
+    }
+
+    @Nullable
+    @Override
+    public PsiElement resolveToWorkspaceSource(QualifiedName name,
+        PyQualifiedNameResolveContext context) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean appliesToBuildSystem(BuildSystemName buildSystemName) {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+}

--- a/python/tests/unittests/com/google/idea/blaze/python/resolve/provider/MockArtifactLocationPsiElement.java
+++ b/python/tests/unittests/com/google/idea/blaze/python/resolve/provider/MockArtifactLocationPsiElement.java
@@ -1,0 +1,326 @@
+/*
+ * Copyright 2024 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.python.resolve.provider;
+
+import com.intellij.lang.ASTNode;
+import com.intellij.lang.Language;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Key;
+import com.intellij.openapi.util.NlsSafe;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.*;
+import com.intellij.psi.scope.PsiScopeProcessor;
+import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.psi.search.SearchScope;
+import com.intellij.util.IncorrectOperationException;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.io.File;
+
+/**
+ * This is a fake {@link PsiElement} that is mostly dummy methods; just covering enough to support
+ * the adjacent unit tests.
+ */
+
+public class MockArtifactLocationPsiElement implements PsiElement {
+
+  private final File executionRelativeFile;
+
+  public MockArtifactLocationPsiElement(String executationRelativePath) {
+    this.executionRelativeFile = new File(executationRelativePath);
+  }
+
+  @Override
+  public @NotNull Project getProject() throws PsiInvalidElementAccessException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public @NotNull Language getLanguage() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public PsiManager getManager() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public @NotNull PsiElement[] getChildren() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public PsiElement getParent() {
+    return new MockArtifactLocationPsiElement(executionRelativeFile.getParent());
+  }
+
+  @Override
+  public PsiElement getFirstChild() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public PsiElement getLastChild() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public PsiElement getNextSibling() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public PsiElement getPrevSibling() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public PsiFile getContainingFile() throws PsiInvalidElementAccessException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public TextRange getTextRange() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public int getStartOffsetInParent() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public int getTextLength() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public @Nullable PsiElement findElementAt(int i) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public @Nullable PsiReference findReferenceAt(int i) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public int getTextOffset() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public @NlsSafe String getText() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public char[] textToCharArray() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public PsiElement getNavigationElement() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public PsiElement getOriginalElement() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean textMatches(@NotNull @NonNls CharSequence charSequence) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean textMatches(@NotNull PsiElement psiElement) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean textContains(char c) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void accept(@NotNull PsiElementVisitor psiElementVisitor) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void acceptChildren(@NotNull PsiElementVisitor psiElementVisitor) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public PsiElement copy() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public PsiElement add(@NotNull PsiElement psiElement) throws IncorrectOperationException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public PsiElement addBefore(@NotNull PsiElement psiElement, @Nullable PsiElement psiElement1)
+      throws IncorrectOperationException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public PsiElement addAfter(@NotNull PsiElement psiElement, @Nullable PsiElement psiElement1)
+      throws IncorrectOperationException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void checkAdd(@NotNull PsiElement psiElement) throws IncorrectOperationException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public PsiElement addRange(PsiElement psiElement, PsiElement psiElement1)
+      throws IncorrectOperationException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public PsiElement addRangeBefore(@NotNull PsiElement psiElement, @NotNull PsiElement psiElement1,
+      PsiElement psiElement2) throws IncorrectOperationException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public PsiElement addRangeAfter(PsiElement psiElement, PsiElement psiElement1,
+      PsiElement psiElement2) throws IncorrectOperationException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void delete() throws IncorrectOperationException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void checkDelete() throws IncorrectOperationException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void deleteChildRange(PsiElement psiElement, PsiElement psiElement1)
+      throws IncorrectOperationException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public PsiElement replace(@NotNull PsiElement psiElement) throws IncorrectOperationException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean isValid() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean isWritable() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public @Nullable PsiReference getReference() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public PsiReference[] getReferences() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public <T> @Nullable T getCopyableUserData(@NotNull Key<T> key) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public <T> void putCopyableUserData(@NotNull Key<T> key, @Nullable T t) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean processDeclarations(@NotNull PsiScopeProcessor psiScopeProcessor,
+      @NotNull ResolveState resolveState, @Nullable PsiElement psiElement,
+      @NotNull PsiElement psiElement1) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public @Nullable PsiElement getContext() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean isPhysical() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public @NotNull GlobalSearchScope getResolveScope() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public @NotNull SearchScope getUseScope() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ASTNode getNode() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean isEquivalentTo(PsiElement psiElement) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Icon getIcon(int i) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public <T> @Nullable T getUserData(@NotNull Key<T> key) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public <T> void putUserData(@NotNull Key<T> key, @Nullable T t) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String toString() {
+    return executionRelativeFile.getPath();
+  }
+}


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: [6599](https://github.com/bazelbuild/intellij/issues/6599)

# Description of this change

Some `py_...` rules such as `py_binary` and `py_library` allow for an `imports` attribute. The `imports` attribute allows control over how the Python files are vended in terms of modules. This change will mean that the use of the `imports` attribute in Bazel targets is reflected in how the modules are auto-completed and recognized in the IDE.