### PR TITLE
Use Logger.assertTrue in CommandLineTask

### DIFF
--- a/common/util/src/com/google/idea/async/process/CommandLineTask.java
+++ b/common/util/src/com/google/idea/async/process/CommandLineTask.java
@@ -183,11 +183,8 @@ public interface CommandLineTask {
 
     @Override
     public int run() throws IOException, InterruptedException, TimeoutException {
-
-      // ensure execution on background thread
-      assert !EDT.isCurrentThreadEdt();
-      // ensure no read lock is kept
-      assert !ApplicationManager.getApplication().isReadAccessAllowed();
+      logger.assertTrue(!EDT.isCurrentThreadEdt(), "runs on background thread");
+      logger.assertTrue(!ApplicationManager.getApplication().isReadAccessAllowed(), "runs without read lock");
 
       String logCommand = ParametersListUtil.join(command);
       if (logCommand.length() > 2000) {


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: 

# Description of this change
These assertions should not cause a failure in production. However, java assertions seem to enabled in production. 
