### PR TITLE
fix: "Error: 'list' value has no field or method 'jars'" error when o…

### DIFF
--- a/aspect/intellij_info_impl.bzl
+++ b/aspect/intellij_info_impl.bzl
@@ -798,7 +798,7 @@ def _build_filtered_gen_jar(ctx, target, java_outputs, gen_java_sources, srcjars
 
     if should_optimize_building_jars:
         if len(source_jar_artifacts) == 0 or len(jar_artifacts) == 0:
-            jar_artifacts.extend([jar.class_jar for jar in java_outputs.jars if jar.class_jar])
+            jar_artifacts.extend([jar.class_jar for jar in java_outputs if jar.class_jar])
 
     filtered_jar = ctx.actions.declare_file(target.label.name + "-filtered-gen.jar")
     filtered_source_jar = ctx.actions.declare_file(target.label.name + "-filtered-gen-src.jar")


### PR DESCRIPTION
…ptimize_building_jars is enabled

closes #6614

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

