### PR TITLE
[#6664] Add basic model for ExternalWorkspaces - 1/n

### DIFF
--- a/base/src/com/google/idea/blaze/base/model/AspectSyncProjectData.java
+++ b/base/src/com/google/idea/blaze/base/model/AspectSyncProjectData.java
@@ -52,6 +52,7 @@ public final class AspectSyncProjectData implements BlazeProjectData {
   private final WorkspacePathResolver workspacePathResolver;
   private final ArtifactLocationDecoder artifactLocationDecoder;
   private final WorkspaceLanguageSettings workspaceLanguageSettings;
+  private final ExternalWorkspaceData externalWorkspaceData;
   private final SyncState syncState;
 
   public AspectSyncProjectData(
@@ -61,6 +62,7 @@ public final class AspectSyncProjectData implements BlazeProjectData {
       WorkspacePathResolver workspacePathResolver,
       ArtifactLocationDecoder artifactLocationDecoder,
       WorkspaceLanguageSettings workspaceLanguageSettings,
+      ExternalWorkspaceData externalWorkspaceData,
       SyncState syncState) {
     this.targetData = targetData;
     this.blazeInfo = blazeInfo;
@@ -68,6 +70,7 @@ public final class AspectSyncProjectData implements BlazeProjectData {
     this.workspacePathResolver = workspacePathResolver;
     this.artifactLocationDecoder = artifactLocationDecoder;
     this.workspaceLanguageSettings = workspaceLanguageSettings;
+    this.externalWorkspaceData = externalWorkspaceData;
     this.syncState = syncState;
   }
 
@@ -85,6 +88,7 @@ public final class AspectSyncProjectData implements BlazeProjectData {
         workspacePathResolver,
         new ArtifactLocationDecoderImpl(blazeInfo, workspacePathResolver, targetData.remoteOutputs),
         WorkspaceLanguageSettings.fromProto(proto.getWorkspaceLanguageSettings()),
+        ExternalWorkspaceData.fromProto(proto.getExternalWorkspaceData()),
         SyncState.fromProto(proto.getSyncState()));
   }
 
@@ -112,6 +116,7 @@ public final class AspectSyncProjectData implements BlazeProjectData {
         .setWorkspacePathResolver(workspacePathResolver.toProto())
         .setWorkspaceLanguageSettings(workspaceLanguageSettings.toProto())
         .setSyncState(syncState.toProto())
+        .setExternalWorkspaceData(externalWorkspaceData.toProto())
         .build();
   }
 
@@ -188,6 +193,11 @@ public final class AspectSyncProjectData implements BlazeProjectData {
   }
 
   @Override
+  public ExternalWorkspaceData getExternalWorkspaceData() {
+    return externalWorkspaceData;
+  }
+
+  @Override
   public SyncState getSyncState() {
     return syncState;
   }
@@ -222,6 +232,7 @@ public final class AspectSyncProjectData implements BlazeProjectData {
     AspectSyncProjectData other = (AspectSyncProjectData) o;
     return Objects.equals(targetData, other.targetData)
         && Objects.equals(blazeInfo, other.blazeInfo)
+        && Objects.equals(externalWorkspaceData, other.externalWorkspaceData)
         && Objects.equals(blazeVersionData, other.blazeVersionData)
         && Objects.equals(workspacePathResolver, other.workspacePathResolver)
         && Objects.equals(artifactLocationDecoder, other.artifactLocationDecoder)
@@ -238,6 +249,7 @@ public final class AspectSyncProjectData implements BlazeProjectData {
         workspaceLanguageSettings,
         artifactLocationDecoder,
         workspaceLanguageSettings,
+        externalWorkspaceData,
         syncState);
   }
 }

--- a/base/src/com/google/idea/blaze/base/model/BlazeProjectData.java
+++ b/base/src/com/google/idea/blaze/base/model/BlazeProjectData.java
@@ -51,6 +51,8 @@ public interface BlazeProjectData {
 
   RemoteOutputArtifacts getRemoteOutputs();
 
+  ExternalWorkspaceData getExternalWorkspaceData();
+
   SyncState getSyncState();
 
   boolean isQuerySync();

--- a/base/src/com/google/idea/blaze/base/model/ExternalWorkspaceData.java
+++ b/base/src/com/google/idea/blaze/base/model/ExternalWorkspaceData.java
@@ -1,5 +1,6 @@
 package com.google.idea.blaze.base.model;
 
+import com.google.common.base.Functions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.intellij.model.ProjectData;
@@ -22,7 +23,7 @@ public final class ExternalWorkspaceData implements ProtoWrapper<ProjectData.Ext
             .collect(
                 ImmutableMap.toImmutableMap(
                     ExternalWorkspace::name,
-                    e -> e))
+                    Functions.identity()))
     );
   }
 

--- a/base/src/com/google/idea/blaze/base/model/ExternalWorkspaceData.java
+++ b/base/src/com/google/idea/blaze/base/model/ExternalWorkspaceData.java
@@ -1,0 +1,45 @@
+package com.google.idea.blaze.base.model;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.devtools.intellij.model.ProjectData;
+import com.google.idea.blaze.base.ideinfo.ProtoWrapper;
+import com.google.idea.blaze.base.model.primitives.ExternalWorkspace;
+
+public final class ExternalWorkspaceData implements ProtoWrapper<ProjectData.ExternalWorkspaceData> {
+    public ImmutableMap<String, ExternalWorkspace> workspaces;
+
+    public static ExternalWorkspaceData EMPTY = new ExternalWorkspaceData(ImmutableList.of());
+
+    public static ExternalWorkspaceData create(ImmutableList<ExternalWorkspace> workspaces) {
+        return new ExternalWorkspaceData(workspaces);
+    }
+
+    ExternalWorkspaceData(ImmutableList<ExternalWorkspace> workspaces) {
+        this.workspaces = ImmutableMap.copyOf(
+                workspaces
+                        .stream()
+                        .collect(
+                                ImmutableMap.toImmutableMap(
+                                        ExternalWorkspace::name,
+                                        e -> e))
+        );
+    }
+
+    @Override
+    public ProjectData.ExternalWorkspaceData toProto() {
+        ImmutableList<ProjectData.ExternalWorkspace> protoWorkspaces = workspaces
+                .values()
+                .stream()
+                .map(ExternalWorkspace::toProto)
+                .collect(ImmutableList.toImmutableList());
+
+        return ProjectData.ExternalWorkspaceData.newBuilder()
+                .addAllWorkspaces(protoWorkspaces)
+                .build();
+    }
+
+    public static ExternalWorkspaceData fromProto(ProjectData.ExternalWorkspaceData proto) {
+        return new ExternalWorkspaceData(proto.getWorkspacesList().stream().map(ExternalWorkspace::fromProto).collect(ImmutableList.toImmutableList()));
+    }
+}

--- a/base/src/com/google/idea/blaze/base/model/ExternalWorkspaceData.java
+++ b/base/src/com/google/idea/blaze/base/model/ExternalWorkspaceData.java
@@ -7,39 +7,39 @@ import com.google.idea.blaze.base.ideinfo.ProtoWrapper;
 import com.google.idea.blaze.base.model.primitives.ExternalWorkspace;
 
 public final class ExternalWorkspaceData implements ProtoWrapper<ProjectData.ExternalWorkspaceData> {
-    public ImmutableMap<String, ExternalWorkspace> workspaces;
+  public ImmutableMap<String, ExternalWorkspace> workspaces;
 
-    public static ExternalWorkspaceData EMPTY = new ExternalWorkspaceData(ImmutableList.of());
+  public static ExternalWorkspaceData EMPTY = new ExternalWorkspaceData(ImmutableList.of());
 
-    public static ExternalWorkspaceData create(ImmutableList<ExternalWorkspace> workspaces) {
-        return new ExternalWorkspaceData(workspaces);
-    }
+  public static ExternalWorkspaceData create(ImmutableList<ExternalWorkspace> workspaces) {
+    return new ExternalWorkspaceData(workspaces);
+  }
 
-    ExternalWorkspaceData(ImmutableList<ExternalWorkspace> workspaces) {
-        this.workspaces = ImmutableMap.copyOf(
-                workspaces
-                        .stream()
-                        .collect(
-                                ImmutableMap.toImmutableMap(
-                                        ExternalWorkspace::name,
-                                        e -> e))
-        );
-    }
+  ExternalWorkspaceData(ImmutableList<ExternalWorkspace> workspaces) {
+    this.workspaces = ImmutableMap.copyOf(
+        workspaces
+            .stream()
+            .collect(
+                ImmutableMap.toImmutableMap(
+                    ExternalWorkspace::name,
+                    e -> e))
+    );
+  }
 
-    @Override
-    public ProjectData.ExternalWorkspaceData toProto() {
-        ImmutableList<ProjectData.ExternalWorkspace> protoWorkspaces = workspaces
-                .values()
-                .stream()
-                .map(ExternalWorkspace::toProto)
-                .collect(ImmutableList.toImmutableList());
+  @Override
+  public ProjectData.ExternalWorkspaceData toProto() {
+    ImmutableList<ProjectData.ExternalWorkspace> protoWorkspaces = workspaces
+        .values()
+        .stream()
+        .map(ExternalWorkspace::toProto)
+        .collect(ImmutableList.toImmutableList());
 
-        return ProjectData.ExternalWorkspaceData.newBuilder()
-                .addAllWorkspaces(protoWorkspaces)
-                .build();
-    }
+    return ProjectData.ExternalWorkspaceData.newBuilder()
+        .addAllWorkspaces(protoWorkspaces)
+        .build();
+  }
 
-    public static ExternalWorkspaceData fromProto(ProjectData.ExternalWorkspaceData proto) {
-        return new ExternalWorkspaceData(proto.getWorkspacesList().stream().map(ExternalWorkspace::fromProto).collect(ImmutableList.toImmutableList()));
-    }
+  public static ExternalWorkspaceData fromProto(ProjectData.ExternalWorkspaceData proto) {
+    return new ExternalWorkspaceData(proto.getWorkspacesList().stream().map(ExternalWorkspace::fromProto).collect(ImmutableList.toImmutableList()));
+  }
 }

--- a/base/src/com/google/idea/blaze/base/model/primitives/ExternalWorkspace.java
+++ b/base/src/com/google/idea/blaze/base/model/primitives/ExternalWorkspace.java
@@ -1,0 +1,49 @@
+package com.google.idea.blaze.base.model.primitives;
+
+import com.google.devtools.intellij.model.ProjectData;
+
+import javax.annotation.Nullable;
+import com.google.auto.value.AutoValue;
+import com.google.idea.blaze.base.ideinfo.ProtoWrapper;
+
+@AutoValue
+public abstract class ExternalWorkspace implements ProtoWrapper<ProjectData.ExternalWorkspace> {
+
+    public abstract String name();
+
+    @Nullable
+    public abstract String repoName();
+
+    public static ExternalWorkspace fromProto(ProjectData.ExternalWorkspace proto) {
+        return create(proto.getName(), proto.getRepoName());
+    }
+
+    @Override
+    public ProjectData.ExternalWorkspace toProto() {
+        ProjectData.ExternalWorkspace.Builder builder = ProjectData.ExternalWorkspace.newBuilder().setName(name());
+        if (repoName() != null && !repoName().isEmpty()) {
+            builder = builder.setRepoName(repoName());
+        }
+        return builder.build();
+    }
+
+    public static ExternalWorkspace create(String name, String repoName) {
+        ExternalWorkspace.Builder builder = ExternalWorkspace.builder().setName(name);
+        if (repoName != null && !repoName.isEmpty()) {
+            builder = builder.setRepoName(repoName);
+        }
+        return builder.build();
+    }
+
+    public static ExternalWorkspace.Builder builder() {
+        return new AutoValue_ExternalWorkspace.Builder();
+    }
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+        public abstract Builder setName(String name);
+        public abstract Builder setRepoName(String repoName);
+        public abstract ExternalWorkspace build();
+    }
+
+}

--- a/base/src/com/google/idea/blaze/base/model/primitives/ExternalWorkspace.java
+++ b/base/src/com/google/idea/blaze/base/model/primitives/ExternalWorkspace.java
@@ -3,47 +3,49 @@ package com.google.idea.blaze.base.model.primitives;
 import com.google.devtools.intellij.model.ProjectData;
 
 import javax.annotation.Nullable;
+
 import com.google.auto.value.AutoValue;
 import com.google.idea.blaze.base.ideinfo.ProtoWrapper;
 
 @AutoValue
 public abstract class ExternalWorkspace implements ProtoWrapper<ProjectData.ExternalWorkspace> {
 
-    public abstract String name();
+  public abstract String name();
 
-    @Nullable
-    public abstract String repoName();
+  @Nullable
+  public abstract String repoName();
 
-    public static ExternalWorkspace fromProto(ProjectData.ExternalWorkspace proto) {
-        return create(proto.getName(), proto.getRepoName());
+  public static ExternalWorkspace fromProto(ProjectData.ExternalWorkspace proto) {
+    return create(proto.getName(), proto.getRepoName());
+  }
+
+  @Override
+  public ProjectData.ExternalWorkspace toProto() {
+    ProjectData.ExternalWorkspace.Builder builder = ProjectData.ExternalWorkspace.newBuilder().setName(name());
+    if (repoName() != null && !repoName().isEmpty()) {
+      builder = builder.setRepoName(repoName());
     }
+    return builder.build();
+  }
 
-    @Override
-    public ProjectData.ExternalWorkspace toProto() {
-        ProjectData.ExternalWorkspace.Builder builder = ProjectData.ExternalWorkspace.newBuilder().setName(name());
-        if (repoName() != null && !repoName().isEmpty()) {
-            builder = builder.setRepoName(repoName());
-        }
-        return builder.build();
+  public static ExternalWorkspace create(String name, String repoName) {
+    ExternalWorkspace.Builder builder = ExternalWorkspace.builder().setName(name);
+    if (repoName != null && !repoName.isEmpty()) {
+      builder = builder.setRepoName(repoName);
     }
+    return builder.build();
+  }
 
-    public static ExternalWorkspace create(String name, String repoName) {
-        ExternalWorkspace.Builder builder = ExternalWorkspace.builder().setName(name);
-        if (repoName != null && !repoName.isEmpty()) {
-            builder = builder.setRepoName(repoName);
-        }
-        return builder.build();
-    }
+  public static ExternalWorkspace.Builder builder() {
+    return new AutoValue_ExternalWorkspace.Builder();
+  }
 
-    public static ExternalWorkspace.Builder builder() {
-        return new AutoValue_ExternalWorkspace.Builder();
-    }
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder setName(String name);
 
-    @AutoValue.Builder
-    public abstract static class Builder {
-        public abstract Builder setName(String name);
-        public abstract Builder setRepoName(String repoName);
-        public abstract ExternalWorkspace build();
-    }
+    public abstract Builder setRepoName(String repoName);
 
+    public abstract ExternalWorkspace build();
+  }
 }

--- a/base/src/com/google/idea/blaze/base/qsync/QuerySyncProjectData.java
+++ b/base/src/com/google/idea/blaze/base/qsync/QuerySyncProjectData.java
@@ -23,6 +23,7 @@ import com.google.idea.blaze.base.dependencies.TargetInfo;
 import com.google.idea.blaze.base.ideinfo.TargetMap;
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.BlazeVersionData;
+import com.google.idea.blaze.base.model.ExternalWorkspaceData;
 import com.google.idea.blaze.base.model.RemoteOutputArtifacts;
 import com.google.idea.blaze.base.model.SyncState;
 import com.google.idea.blaze.base.model.primitives.Label;
@@ -34,12 +35,16 @@ import com.google.idea.blaze.qsync.BlazeProjectSnapshot;
 import com.google.idea.blaze.qsync.project.ProjectTarget;
 import com.google.idea.blaze.qsync.project.QuerySyncLanguage;
 import com.intellij.openapi.diagnostic.Logger;
+
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Optional;
+
 import org.jetbrains.annotations.Nullable;
 
-/** Implementation of {@link BlazeProjectData} specific to querysync. */
+/**
+ * Implementation of {@link BlazeProjectData} specific to querysync.
+ */
 public class QuerySyncProjectData implements BlazeProjectData {
 
   private static final Logger logger = Logger.getInstance(QuerySyncProjectData.class);
@@ -172,6 +177,11 @@ public class QuerySyncProjectData implements BlazeProjectData {
   @Override
   public RemoteOutputArtifacts getRemoteOutputs() {
     throw new NotSupportedWithQuerySyncException("getRemoteOutputs");
+  }
+
+  @Override
+  public ExternalWorkspaceData getExternalWorkspaceData() {
+    throw new NotSupportedWithQuerySyncException("getExternalWorkspaceData");
   }
 
   @Override

--- a/base/src/com/google/idea/blaze/base/qsync/QuerySyncProjectData.java
+++ b/base/src/com/google/idea/blaze/base/qsync/QuerySyncProjectData.java
@@ -42,9 +42,7 @@ import java.util.Optional;
 
 import org.jetbrains.annotations.Nullable;
 
-/**
- * Implementation of {@link BlazeProjectData} specific to querysync.
- */
+/** Implementation of {@link BlazeProjectData} specific to querysync. */
 public class QuerySyncProjectData implements BlazeProjectData {
 
   private static final Logger logger = Logger.getInstance(QuerySyncProjectData.class);

--- a/base/src/com/google/idea/blaze/base/sync/ProjectUpdateSyncTask.java
+++ b/base/src/com/google/idea/blaze/base/sync/ProjectUpdateSyncTask.java
@@ -28,6 +28,7 @@ import com.google.idea.blaze.base.model.AspectSyncProjectData;
 import com.google.idea.blaze.base.model.BlazeLibrary;
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.BlazeVersionData;
+import com.google.idea.blaze.base.model.ExternalWorkspaceData;
 import com.google.idea.blaze.base.model.ProjectTargetData;
 import com.google.idea.blaze.base.model.RemoteOutputArtifacts;
 import com.google.idea.blaze.base.model.SyncState;
@@ -227,6 +228,7 @@ final class ProjectUpdateSyncTask {
             projectState.getWorkspacePathResolver(),
             artifactLocationDecoder,
             projectState.getLanguageSettings(),
+            ExternalWorkspaceData.EMPTY,
             syncStateBuilder.build());
 
     FileCaches.onSync(

--- a/base/tests/utils/unit/com/google/idea/blaze/base/model/MockBlazeProjectDataBuilder.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/model/MockBlazeProjectDataBuilder.java
@@ -37,133 +37,133 @@ import java.io.File;
  * objects using whatever data you have supplied if applicable.
  */
 public class MockBlazeProjectDataBuilder {
-    private final WorkspaceRoot workspaceRoot;
+  private final WorkspaceRoot workspaceRoot;
 
-    private TargetMap targetMap;
-    private String outputBase;
-    private BlazeInfo blazeInfo;
-    private BlazeVersionData blazeVersionData;
-    private WorkspacePathResolver workspacePathResolver;
-    private ArtifactLocationDecoder artifactLocationDecoder;
-    private WorkspaceLanguageSettings workspaceLanguageSettings;
-    private ExternalWorkspaceData externalWorkspaceData;
-    private SyncState syncState;
+  private TargetMap targetMap;
+  private String outputBase;
+  private BlazeInfo blazeInfo;
+  private BlazeVersionData blazeVersionData;
+  private WorkspacePathResolver workspacePathResolver;
+  private ArtifactLocationDecoder artifactLocationDecoder;
+  private WorkspaceLanguageSettings workspaceLanguageSettings;
+  private ExternalWorkspaceData externalWorkspaceData;
+  private SyncState syncState;
 
-    private MockBlazeProjectDataBuilder(WorkspaceRoot workspaceRoot) {
-        this.workspaceRoot = workspaceRoot;
+  private MockBlazeProjectDataBuilder(WorkspaceRoot workspaceRoot) {
+    this.workspaceRoot = workspaceRoot;
+  }
+
+  public static MockBlazeProjectDataBuilder builder() {
+    return builder(new WorkspaceRoot(new File("/")));
+  }
+
+  public static MockBlazeProjectDataBuilder builder(WorkspaceRoot workspaceRoot) {
+    return new MockBlazeProjectDataBuilder(workspaceRoot);
+  }
+
+  @CanIgnoreReturnValue
+  public MockBlazeProjectDataBuilder setTargetMap(TargetMap targetMap) {
+    this.targetMap = targetMap;
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public MockBlazeProjectDataBuilder setOutputBase(String outputBase) {
+    this.outputBase = outputBase;
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public MockBlazeProjectDataBuilder setBlazeInfo(BlazeInfo blazeInfo) {
+    this.blazeInfo = blazeInfo;
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public MockBlazeProjectDataBuilder setBlazeVersionData(BlazeVersionData blazeVersionData) {
+    this.blazeVersionData = blazeVersionData;
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public MockBlazeProjectDataBuilder setWorkspacePathResolver(
+      WorkspacePathResolver workspacePathResolver) {
+    this.workspacePathResolver = workspacePathResolver;
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public MockBlazeProjectDataBuilder setArtifactLocationDecoder(
+      ArtifactLocationDecoder artifactLocationDecoder) {
+    this.artifactLocationDecoder = artifactLocationDecoder;
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public MockBlazeProjectDataBuilder setWorkspaceLanguageSettings(
+      WorkspaceLanguageSettings workspaceLanguageSettings) {
+    this.workspaceLanguageSettings = workspaceLanguageSettings;
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public MockBlazeProjectDataBuilder setExternalWorkspaceData(ExternalWorkspaceData externalWorkspaceData) {
+    this.externalWorkspaceData = externalWorkspaceData;
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public MockBlazeProjectDataBuilder setSyncState(SyncState syncState) {
+    this.syncState = syncState;
+    return this;
+  }
+
+  public BlazeProjectData build() {
+    TargetMap targetMap =
+        this.targetMap != null ? this.targetMap : new TargetMap(ImmutableMap.of());
+    BlazeInfo blazeInfo = this.blazeInfo;
+    if (blazeInfo == null) {
+      String outputBase = this.outputBase != null ? this.outputBase : "/usr/workspace/1234";
+      blazeInfo =
+          BlazeInfo.createMockBlazeInfo(
+              outputBase,
+              outputBase + "/execroot",
+              outputBase + "/execroot/bin",
+              outputBase + "/execroot/gen",
+              outputBase + "/execroot/testlogs");
     }
+    BlazeVersionData blazeVersionData =
+        this.blazeVersionData != null ? this.blazeVersionData : BlazeVersionData.builder().build();
+    WorkspacePathResolver workspacePathResolver =
+        this.workspacePathResolver != null
+            ? this.workspacePathResolver
+            : new WorkspacePathResolverImpl(workspaceRoot);
+    ArtifactLocationDecoder artifactLocationDecoder =
+        this.artifactLocationDecoder != null
+            ? this.artifactLocationDecoder
+            : new ArtifactLocationDecoderImpl(
+            blazeInfo, workspacePathResolver, RemoteOutputArtifacts.EMPTY);
+    WorkspaceLanguageSettings workspaceLanguageSettings =
+        this.workspaceLanguageSettings != null
+            ? this.workspaceLanguageSettings
+            : new WorkspaceLanguageSettings(WorkspaceType.JAVA, ImmutableSet.of());
+    SyncState syncState =
+        this.syncState != null ? this.syncState : new SyncState(ImmutableMap.of());
 
-    public static MockBlazeProjectDataBuilder builder() {
-        return builder(new WorkspaceRoot(new File("/")));
-    }
+    ExternalWorkspaceData externalWorkspaceData =
+        this.externalWorkspaceData != null
+            ? this.externalWorkspaceData
+            : ExternalWorkspaceData.EMPTY;
 
-    public static MockBlazeProjectDataBuilder builder(WorkspaceRoot workspaceRoot) {
-        return new MockBlazeProjectDataBuilder(workspaceRoot);
-    }
-
-    @CanIgnoreReturnValue
-    public MockBlazeProjectDataBuilder setTargetMap(TargetMap targetMap) {
-        this.targetMap = targetMap;
-        return this;
-    }
-
-    @CanIgnoreReturnValue
-    public MockBlazeProjectDataBuilder setOutputBase(String outputBase) {
-        this.outputBase = outputBase;
-        return this;
-    }
-
-    @CanIgnoreReturnValue
-    public MockBlazeProjectDataBuilder setBlazeInfo(BlazeInfo blazeInfo) {
-        this.blazeInfo = blazeInfo;
-        return this;
-    }
-
-    @CanIgnoreReturnValue
-    public MockBlazeProjectDataBuilder setBlazeVersionData(BlazeVersionData blazeVersionData) {
-        this.blazeVersionData = blazeVersionData;
-        return this;
-    }
-
-    @CanIgnoreReturnValue
-    public MockBlazeProjectDataBuilder setWorkspacePathResolver(
-            WorkspacePathResolver workspacePathResolver) {
-        this.workspacePathResolver = workspacePathResolver;
-        return this;
-    }
-
-    @CanIgnoreReturnValue
-    public MockBlazeProjectDataBuilder setArtifactLocationDecoder(
-            ArtifactLocationDecoder artifactLocationDecoder) {
-        this.artifactLocationDecoder = artifactLocationDecoder;
-        return this;
-    }
-
-    @CanIgnoreReturnValue
-    public MockBlazeProjectDataBuilder setWorkspaceLanguageSettings(
-            WorkspaceLanguageSettings workspaceLanguageSettings) {
-        this.workspaceLanguageSettings = workspaceLanguageSettings;
-        return this;
-    }
-
-    @CanIgnoreReturnValue
-    public MockBlazeProjectDataBuilder setExternalWorkspaceData(ExternalWorkspaceData externalWorkspaceData) {
-        this.externalWorkspaceData = externalWorkspaceData;
-        return this;
-    }
-
-    @CanIgnoreReturnValue
-    public MockBlazeProjectDataBuilder setSyncState(SyncState syncState) {
-        this.syncState = syncState;
-        return this;
-    }
-
-    public BlazeProjectData build() {
-        TargetMap targetMap =
-                this.targetMap != null ? this.targetMap : new TargetMap(ImmutableMap.of());
-        BlazeInfo blazeInfo = this.blazeInfo;
-        if (blazeInfo == null) {
-            String outputBase = this.outputBase != null ? this.outputBase : "/usr/workspace/1234";
-            blazeInfo =
-                    BlazeInfo.createMockBlazeInfo(
-                            outputBase,
-                            outputBase + "/execroot",
-                            outputBase + "/execroot/bin",
-                            outputBase + "/execroot/gen",
-                            outputBase + "/execroot/testlogs");
-        }
-        BlazeVersionData blazeVersionData =
-                this.blazeVersionData != null ? this.blazeVersionData : BlazeVersionData.builder().build();
-        WorkspacePathResolver workspacePathResolver =
-                this.workspacePathResolver != null
-                        ? this.workspacePathResolver
-                        : new WorkspacePathResolverImpl(workspaceRoot);
-        ArtifactLocationDecoder artifactLocationDecoder =
-                this.artifactLocationDecoder != null
-                        ? this.artifactLocationDecoder
-                        : new ArtifactLocationDecoderImpl(
-                        blazeInfo, workspacePathResolver, RemoteOutputArtifacts.EMPTY);
-        WorkspaceLanguageSettings workspaceLanguageSettings =
-                this.workspaceLanguageSettings != null
-                        ? this.workspaceLanguageSettings
-                        : new WorkspaceLanguageSettings(WorkspaceType.JAVA, ImmutableSet.of());
-        SyncState syncState =
-                this.syncState != null ? this.syncState : new SyncState(ImmutableMap.of());
-
-        ExternalWorkspaceData externalWorkspaceData =
-                this.externalWorkspaceData != null
-                        ? this.externalWorkspaceData
-                        : ExternalWorkspaceData.EMPTY;
-
-        return new AspectSyncProjectData(
-                new ProjectTargetData(
-                        targetMap, /* ideInterfaceState= */ null, RemoteOutputArtifacts.EMPTY),
-                blazeInfo,
-                blazeVersionData,
-                workspacePathResolver,
-                artifactLocationDecoder,
-                workspaceLanguageSettings,
-                externalWorkspaceData,
-                syncState);
-    }
+    return new AspectSyncProjectData(
+        new ProjectTargetData(
+            targetMap, /* ideInterfaceState= */ null, RemoteOutputArtifacts.EMPTY),
+        blazeInfo,
+        blazeVersionData,
+        workspacePathResolver,
+        artifactLocationDecoder,
+        workspaceLanguageSettings,
+        externalWorkspaceData,
+        syncState);
+  }
 }

--- a/base/tests/utils/unit/com/google/idea/blaze/base/model/MockBlazeProjectDataBuilder.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/model/MockBlazeProjectDataBuilder.java
@@ -27,6 +27,7 @@ import com.google.idea.blaze.base.sync.workspace.ArtifactLocationDecoder;
 import com.google.idea.blaze.base.sync.workspace.ArtifactLocationDecoderImpl;
 import com.google.idea.blaze.base.sync.workspace.WorkspacePathResolver;
 import com.google.idea.blaze.base.sync.workspace.WorkspacePathResolverImpl;
+
 import java.io.File;
 
 /**
@@ -36,120 +37,133 @@ import java.io.File;
  * objects using whatever data you have supplied if applicable.
  */
 public class MockBlazeProjectDataBuilder {
-  private final WorkspaceRoot workspaceRoot;
+    private final WorkspaceRoot workspaceRoot;
 
-  private TargetMap targetMap;
-  private String outputBase;
-  private BlazeInfo blazeInfo;
-  private BlazeVersionData blazeVersionData;
-  private WorkspacePathResolver workspacePathResolver;
-  private ArtifactLocationDecoder artifactLocationDecoder;
-  private WorkspaceLanguageSettings workspaceLanguageSettings;
-  private SyncState syncState;
+    private TargetMap targetMap;
+    private String outputBase;
+    private BlazeInfo blazeInfo;
+    private BlazeVersionData blazeVersionData;
+    private WorkspacePathResolver workspacePathResolver;
+    private ArtifactLocationDecoder artifactLocationDecoder;
+    private WorkspaceLanguageSettings workspaceLanguageSettings;
+    private ExternalWorkspaceData externalWorkspaceData;
+    private SyncState syncState;
 
-  private MockBlazeProjectDataBuilder(WorkspaceRoot workspaceRoot) {
-    this.workspaceRoot = workspaceRoot;
-  }
-
-  public static MockBlazeProjectDataBuilder builder() {
-    return builder(new WorkspaceRoot(new File("/")));
-  }
-
-  public static MockBlazeProjectDataBuilder builder(WorkspaceRoot workspaceRoot) {
-    return new MockBlazeProjectDataBuilder(workspaceRoot);
-  }
-
-  @CanIgnoreReturnValue
-  public MockBlazeProjectDataBuilder setTargetMap(TargetMap targetMap) {
-    this.targetMap = targetMap;
-    return this;
-  }
-
-  @CanIgnoreReturnValue
-  public MockBlazeProjectDataBuilder setOutputBase(String outputBase) {
-    this.outputBase = outputBase;
-    return this;
-  }
-
-  @CanIgnoreReturnValue
-  public MockBlazeProjectDataBuilder setBlazeInfo(BlazeInfo blazeInfo) {
-    this.blazeInfo = blazeInfo;
-    return this;
-  }
-
-  @CanIgnoreReturnValue
-  public MockBlazeProjectDataBuilder setBlazeVersionData(BlazeVersionData blazeVersionData) {
-    this.blazeVersionData = blazeVersionData;
-    return this;
-  }
-
-  @CanIgnoreReturnValue
-  public MockBlazeProjectDataBuilder setWorkspacePathResolver(
-      WorkspacePathResolver workspacePathResolver) {
-    this.workspacePathResolver = workspacePathResolver;
-    return this;
-  }
-
-  @CanIgnoreReturnValue
-  public MockBlazeProjectDataBuilder setArtifactLocationDecoder(
-      ArtifactLocationDecoder artifactLocationDecoder) {
-    this.artifactLocationDecoder = artifactLocationDecoder;
-    return this;
-  }
-
-  @CanIgnoreReturnValue
-  public MockBlazeProjectDataBuilder setWorkspaceLanguageSettings(
-      WorkspaceLanguageSettings workspaceLanguageSettings) {
-    this.workspaceLanguageSettings = workspaceLanguageSettings;
-    return this;
-  }
-
-  @CanIgnoreReturnValue
-  public MockBlazeProjectDataBuilder setSyncState(SyncState syncState) {
-    this.syncState = syncState;
-    return this;
-  }
-
-  public BlazeProjectData build() {
-    TargetMap targetMap =
-        this.targetMap != null ? this.targetMap : new TargetMap(ImmutableMap.of());
-    BlazeInfo blazeInfo = this.blazeInfo;
-    if (blazeInfo == null) {
-      String outputBase = this.outputBase != null ? this.outputBase : "/usr/workspace/1234";
-      blazeInfo =
-          BlazeInfo.createMockBlazeInfo(
-              outputBase,
-              outputBase + "/execroot",
-              outputBase + "/execroot/bin",
-              outputBase + "/execroot/gen",
-              outputBase + "/execroot/testlogs");
+    private MockBlazeProjectDataBuilder(WorkspaceRoot workspaceRoot) {
+        this.workspaceRoot = workspaceRoot;
     }
-    BlazeVersionData blazeVersionData =
-        this.blazeVersionData != null ? this.blazeVersionData : BlazeVersionData.builder().build();
-    WorkspacePathResolver workspacePathResolver =
-        this.workspacePathResolver != null
-            ? this.workspacePathResolver
-            : new WorkspacePathResolverImpl(workspaceRoot);
-    ArtifactLocationDecoder artifactLocationDecoder =
-        this.artifactLocationDecoder != null
-            ? this.artifactLocationDecoder
-            : new ArtifactLocationDecoderImpl(
-                blazeInfo, workspacePathResolver, RemoteOutputArtifacts.EMPTY);
-    WorkspaceLanguageSettings workspaceLanguageSettings =
-        this.workspaceLanguageSettings != null
-            ? this.workspaceLanguageSettings
-            : new WorkspaceLanguageSettings(WorkspaceType.JAVA, ImmutableSet.of());
-    SyncState syncState =
-        this.syncState != null ? this.syncState : new SyncState(ImmutableMap.of());
 
-    return new AspectSyncProjectData(
-        new ProjectTargetData(
-            targetMap, /* ideInterfaceState= */ null, RemoteOutputArtifacts.EMPTY),
-        blazeInfo,
-        blazeVersionData,
-        workspacePathResolver,
-        artifactLocationDecoder,
-        workspaceLanguageSettings,
-        syncState);
-  }
+    public static MockBlazeProjectDataBuilder builder() {
+        return builder(new WorkspaceRoot(new File("/")));
+    }
+
+    public static MockBlazeProjectDataBuilder builder(WorkspaceRoot workspaceRoot) {
+        return new MockBlazeProjectDataBuilder(workspaceRoot);
+    }
+
+    @CanIgnoreReturnValue
+    public MockBlazeProjectDataBuilder setTargetMap(TargetMap targetMap) {
+        this.targetMap = targetMap;
+        return this;
+    }
+
+    @CanIgnoreReturnValue
+    public MockBlazeProjectDataBuilder setOutputBase(String outputBase) {
+        this.outputBase = outputBase;
+        return this;
+    }
+
+    @CanIgnoreReturnValue
+    public MockBlazeProjectDataBuilder setBlazeInfo(BlazeInfo blazeInfo) {
+        this.blazeInfo = blazeInfo;
+        return this;
+    }
+
+    @CanIgnoreReturnValue
+    public MockBlazeProjectDataBuilder setBlazeVersionData(BlazeVersionData blazeVersionData) {
+        this.blazeVersionData = blazeVersionData;
+        return this;
+    }
+
+    @CanIgnoreReturnValue
+    public MockBlazeProjectDataBuilder setWorkspacePathResolver(
+            WorkspacePathResolver workspacePathResolver) {
+        this.workspacePathResolver = workspacePathResolver;
+        return this;
+    }
+
+    @CanIgnoreReturnValue
+    public MockBlazeProjectDataBuilder setArtifactLocationDecoder(
+            ArtifactLocationDecoder artifactLocationDecoder) {
+        this.artifactLocationDecoder = artifactLocationDecoder;
+        return this;
+    }
+
+    @CanIgnoreReturnValue
+    public MockBlazeProjectDataBuilder setWorkspaceLanguageSettings(
+            WorkspaceLanguageSettings workspaceLanguageSettings) {
+        this.workspaceLanguageSettings = workspaceLanguageSettings;
+        return this;
+    }
+
+    @CanIgnoreReturnValue
+    public MockBlazeProjectDataBuilder setExternalWorkspaceData(ExternalWorkspaceData externalWorkspaceData) {
+        this.externalWorkspaceData = externalWorkspaceData;
+        return this;
+    }
+
+    @CanIgnoreReturnValue
+    public MockBlazeProjectDataBuilder setSyncState(SyncState syncState) {
+        this.syncState = syncState;
+        return this;
+    }
+
+    public BlazeProjectData build() {
+        TargetMap targetMap =
+                this.targetMap != null ? this.targetMap : new TargetMap(ImmutableMap.of());
+        BlazeInfo blazeInfo = this.blazeInfo;
+        if (blazeInfo == null) {
+            String outputBase = this.outputBase != null ? this.outputBase : "/usr/workspace/1234";
+            blazeInfo =
+                    BlazeInfo.createMockBlazeInfo(
+                            outputBase,
+                            outputBase + "/execroot",
+                            outputBase + "/execroot/bin",
+                            outputBase + "/execroot/gen",
+                            outputBase + "/execroot/testlogs");
+        }
+        BlazeVersionData blazeVersionData =
+                this.blazeVersionData != null ? this.blazeVersionData : BlazeVersionData.builder().build();
+        WorkspacePathResolver workspacePathResolver =
+                this.workspacePathResolver != null
+                        ? this.workspacePathResolver
+                        : new WorkspacePathResolverImpl(workspaceRoot);
+        ArtifactLocationDecoder artifactLocationDecoder =
+                this.artifactLocationDecoder != null
+                        ? this.artifactLocationDecoder
+                        : new ArtifactLocationDecoderImpl(
+                        blazeInfo, workspacePathResolver, RemoteOutputArtifacts.EMPTY);
+        WorkspaceLanguageSettings workspaceLanguageSettings =
+                this.workspaceLanguageSettings != null
+                        ? this.workspaceLanguageSettings
+                        : new WorkspaceLanguageSettings(WorkspaceType.JAVA, ImmutableSet.of());
+        SyncState syncState =
+                this.syncState != null ? this.syncState : new SyncState(ImmutableMap.of());
+
+        ExternalWorkspaceData externalWorkspaceData =
+                this.externalWorkspaceData != null
+                        ? this.externalWorkspaceData
+                        : ExternalWorkspaceData.EMPTY;
+
+        return new AspectSyncProjectData(
+                new ProjectTargetData(
+                        targetMap, /* ideInterfaceState= */ null, RemoteOutputArtifacts.EMPTY),
+                blazeInfo,
+                blazeVersionData,
+                workspacePathResolver,
+                artifactLocationDecoder,
+                workspaceLanguageSettings,
+                externalWorkspaceData,
+                syncState);
+    }
 }

--- a/base/tests/utils/unit/com/google/idea/blaze/base/model/MockBlazeProjectDataBuilder.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/model/MockBlazeProjectDataBuilder.java
@@ -142,7 +142,7 @@ public class MockBlazeProjectDataBuilder {
         this.artifactLocationDecoder != null
             ? this.artifactLocationDecoder
             : new ArtifactLocationDecoderImpl(
-            blazeInfo, workspacePathResolver, RemoteOutputArtifacts.EMPTY);
+                blazeInfo, workspacePathResolver, RemoteOutputArtifacts.EMPTY);
     WorkspaceLanguageSettings workspaceLanguageSettings =
         this.workspaceLanguageSettings != null
             ? this.workspaceLanguageSettings

--- a/proto/project_data.proto
+++ b/proto/project_data.proto
@@ -240,6 +240,14 @@ message SyncState {
   RemoteOutputArtifacts remote_output_artifacts = 7 [deprecated = true];
 }
 
+message ExternalWorkspace {
+  string name = 1;
+  string repo_name = 2;
+}
+message ExternalWorkspaceData {
+  repeated ExternalWorkspace workspaces = 1;
+}
+
 message BlazeProjectData {
   reserved 1;
   TargetMap target_map = 2 [deprecated = true];
@@ -249,4 +257,5 @@ message BlazeProjectData {
   WorkspaceLanguageSettings workspace_language_settings = 6;
   SyncState sync_state = 7;
   TargetData target_data = 8;
+  ExternalWorkspaceData external_workspace_data = 9;
 }

--- a/proto/project_data.proto
+++ b/proto/project_data.proto
@@ -244,6 +244,7 @@ message ExternalWorkspace {
   string name = 1;
   string repo_name = 2;
 }
+
 message ExternalWorkspaceData {
   repeated ExternalWorkspace workspaces = 1;
 }


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

# Discussion thread for this change

Issue number: `#6664`

# Description of this change

This adds a basic data model for `ExternalWorkspace`. Will be followed up with a runner hooked into the sync machinery that will get / update this internal piece of data. Once this is landed and proper invalidated on sync will be followed by a PR changing `ExternalWorkspaceReferenceFragment` to use this data in completion and resolution.


