### PR TITLE
chore: inline `testAnnotator` wrapper method

### DIFF
--- a/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/validation/BuiltInRuleAnnotatorTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/validation/BuiltInRuleAnnotatorTest.java
@@ -28,11 +28,13 @@ import com.google.idea.blaze.base.lang.buildfile.psi.BuildFile;
 import com.google.idea.blaze.base.lang.buildfile.psi.FuncallExpression;
 import com.google.idea.blaze.base.lang.buildfile.psi.util.PsiUtils;
 import com.google.idea.blaze.base.model.primitives.WorkspacePath;
-import com.google.idea.sdkcompat.BaseSdkTestCompat;
 import com.intellij.lang.annotation.Annotation;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+
+import com.intellij.psi.PsiElement;
+import com.intellij.testFramework.fixtures.CodeInsightTestUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -339,9 +341,8 @@ public class BuiltInRuleAnnotatorTest extends BuildFileIntegrationTestCase {
   }
 
   private List<Annotation> validateFile(BuildFile file) {
-    return BaseSdkTestCompat.testAnnotator(
-        new BuiltInRuleAnnotator(),
-        PsiUtils.findAllChildrenOfClassRecursive(file, FuncallExpression.class)
-            .toArray(FuncallExpression[]::new));
+      PsiElement[] elements = PsiUtils.findAllChildrenOfClassRecursive(file, FuncallExpression.class)
+          .toArray(FuncallExpression[]::new);
+      return CodeInsightTestUtil.testAnnotator(new BuiltInRuleAnnotator(), elements);
   }
 }

--- a/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/validation/GlobValidationTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/validation/GlobValidationTest.java
@@ -22,10 +22,12 @@ import com.google.idea.blaze.base.lang.buildfile.psi.BuildFile;
 import com.google.idea.blaze.base.lang.buildfile.psi.GlobExpression;
 import com.google.idea.blaze.base.lang.buildfile.psi.util.PsiUtils;
 import com.google.idea.blaze.base.model.primitives.WorkspacePath;
-import com.google.idea.sdkcompat.BaseSdkTestCompat;
 import com.intellij.lang.annotation.Annotation;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import com.intellij.psi.PsiElement;
+import com.intellij.testFramework.fixtures.CodeInsightTestUtil;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -263,10 +265,9 @@ public class GlobValidationTest extends BuildFileIntegrationTestCase {
   }
 
   private List<Annotation> validateFile(BuildFile file) {
-    return BaseSdkTestCompat.testAnnotator(
-        new GlobErrorAnnotator(),
-        PsiUtils.findAllChildrenOfClassRecursive(file, GlobExpression.class)
-            .toArray(GlobExpression[]::new));
+      PsiElement[] elements = PsiUtils.findAllChildrenOfClassRecursive(file, GlobExpression.class)
+          .toArray(GlobExpression[]::new);
+      return CodeInsightTestUtil.testAnnotator(new GlobErrorAnnotator(), elements);
   }
 
 }

--- a/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/validation/LoadStatementAnnotatorTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/validation/LoadStatementAnnotatorTest.java
@@ -22,11 +22,13 @@ import com.google.idea.blaze.base.lang.buildfile.psi.BuildElement;
 import com.google.idea.blaze.base.lang.buildfile.psi.BuildFile;
 import com.google.idea.blaze.base.lang.buildfile.psi.util.PsiUtils;
 import com.google.idea.blaze.base.model.primitives.WorkspacePath;
-import com.google.idea.sdkcompat.BaseSdkTestCompat;
 import com.intellij.lang.annotation.Annotation;
 import com.intellij.lang.annotation.HighlightSeverity;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import com.intellij.psi.PsiElement;
+import com.intellij.testFramework.fixtures.CodeInsightTestUtil;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -105,9 +107,8 @@ public class LoadStatementAnnotatorTest extends BuildFileIntegrationTestCase {
   }
 
   private List<Annotation> validateFile(BuildFile file) {
-    return BaseSdkTestCompat.testAnnotator(
-        new LoadStatementAnnotator(),
-        PsiUtils.findAllChildrenOfClassRecursive(file, BuildElement.class)
-            .toArray(BuildElement[]::new));
+      PsiElement[] elements = PsiUtils.findAllChildrenOfClassRecursive(file, BuildElement.class)
+          .toArray(BuildElement[]::new);
+      return CodeInsightTestUtil.testAnnotator(new LoadStatementAnnotator(), elements);
   }
 }

--- a/testing/testcompat/v221/com/google/idea/sdkcompat/BaseSdkTestCompat.java
+++ b/testing/testcompat/v221/com/google/idea/sdkcompat/BaseSdkTestCompat.java
@@ -33,11 +33,6 @@ import java.util.List;
 public final class BaseSdkTestCompat {
   private BaseSdkTestCompat() {}
 
-  /** #api212: inline into test cases */
-  public static List<Annotation> testAnnotator(Annotator annotator, PsiElement... elements) {
-    return CodeInsightTestUtil.testAnnotator(annotator, elements);
-  }
-
   /** #api212: inline into ServiceHelper */
   public static void unregisterComponent(ComponentManager componentManager, Class<?> key) {
     ((ComponentManagerImpl) componentManager.getPicoContainer()).unregisterComponent(key);

--- a/testing/testcompat/v222/com/google/idea/sdkcompat/BaseSdkTestCompat.java
+++ b/testing/testcompat/v222/com/google/idea/sdkcompat/BaseSdkTestCompat.java
@@ -37,11 +37,6 @@ import java.util.List;
 public final class BaseSdkTestCompat {
   private BaseSdkTestCompat() {}
 
-  /** #api212: inline into test cases */
-  public static List<Annotation> testAnnotator(Annotator annotator, PsiElement... elements) {
-    return CodeInsightTestUtil.testAnnotator(annotator, elements);
-  }
-
   /** #api212: inline into ServiceHelper */
   public static void unregisterComponent(ComponentManager componentManager, Class<?> key) {
     ((ComponentManagerImpl) componentManager).unregisterComponent(key);

--- a/testing/testcompat/v223/com/google/idea/sdkcompat/BaseSdkTestCompat.java
+++ b/testing/testcompat/v223/com/google/idea/sdkcompat/BaseSdkTestCompat.java
@@ -37,11 +37,6 @@ import java.util.List;
 public final class BaseSdkTestCompat {
   private BaseSdkTestCompat() {}
 
-  /** #api212: inline into test cases */
-  public static List<Annotation> testAnnotator(Annotator annotator, PsiElement... elements) {
-    return CodeInsightTestUtil.testAnnotator(annotator, elements);
-  }
-
   /** #api212: inline into ServiceHelper */
   public static void unregisterComponent(ComponentManager componentManager, Class<?> key) {
     ((ComponentManagerImpl) componentManager).unregisterComponent(key);

--- a/testing/testcompat/v231/com/google/idea/sdkcompat/BaseSdkTestCompat.java
+++ b/testing/testcompat/v231/com/google/idea/sdkcompat/BaseSdkTestCompat.java
@@ -37,11 +37,6 @@ import java.util.List;
 public final class BaseSdkTestCompat {
   private BaseSdkTestCompat() {}
 
-  /** #api212: inline into test cases */
-  public static List<Annotation> testAnnotator(Annotator annotator, PsiElement... elements) {
-    return CodeInsightTestUtil.testAnnotator(annotator, elements);
-  }
-
   /** #api223: inline into ServiceHelper */
   public static void unregisterComponent(ComponentManager componentManager, Class<?> componentKey) {
     ((ComponentManagerImpl) componentManager).unregisterComponent(componentKey);

--- a/testing/testcompat/v232/com/google/idea/sdkcompat/BaseSdkTestCompat.java
+++ b/testing/testcompat/v232/com/google/idea/sdkcompat/BaseSdkTestCompat.java
@@ -38,11 +38,6 @@ import java.util.List;
 public final class BaseSdkTestCompat {
   private BaseSdkTestCompat() {}
 
-  /** #api212: inline into test cases */
-  public static List<Annotation> testAnnotator(Annotator annotator, PsiElement... elements) {
-    return CodeInsightTestUtil.testAnnotator(annotator, elements);
-  }
-
   /** #api223: inline into ServiceHelper */
   public static void unregisterComponent(ComponentManager componentManager, Class<?> componentKey) {
     ((ComponentManagerImpl) componentManager).unregisterComponent(componentKey);

--- a/testing/testcompat/v233/com/google/idea/sdkcompat/BaseSdkTestCompat.java
+++ b/testing/testcompat/v233/com/google/idea/sdkcompat/BaseSdkTestCompat.java
@@ -38,11 +38,6 @@ import java.util.List;
 public final class BaseSdkTestCompat {
   private BaseSdkTestCompat() {}
 
-  /** #api212: inline into test cases */
-  public static List<Annotation> testAnnotator(Annotator annotator, PsiElement... elements) {
-    return CodeInsightTestUtil.testAnnotator(annotator, elements);
-  }
-
   /** #api223: inline into ServiceHelper */
   public static void unregisterComponent(ComponentManager componentManager, Class<?> componentKey) {
     ((ComponentManagerImpl) componentManager).unregisterComponent(componentKey);

--- a/testing/testcompat/v241/com/google/idea/sdkcompat/BaseSdkTestCompat.java
+++ b/testing/testcompat/v241/com/google/idea/sdkcompat/BaseSdkTestCompat.java
@@ -38,11 +38,6 @@ import java.util.List;
 public final class BaseSdkTestCompat {
   private BaseSdkTestCompat() {}
 
-  /** #api212: inline into test cases */
-  public static List<Annotation> testAnnotator(Annotator annotator, PsiElement... elements) {
-    return CodeInsightTestUtil.testAnnotator(annotator, elements);
-  }
-
   /** #api223: inline into ServiceHelper */
   public static void unregisterComponent(ComponentManager componentManager, Class<?> componentKey) {
     ((ComponentManagerImpl) componentManager).unregisterComponent(componentKey);

--- a/testing/testcompat/v242/com/google/idea/sdkcompat/BaseSdkTestCompat.java
+++ b/testing/testcompat/v242/com/google/idea/sdkcompat/BaseSdkTestCompat.java
@@ -15,21 +15,12 @@
  */
 package com.google.idea.sdkcompat;
 
-import com.intellij.lang.annotation.Annotation;
-import com.intellij.lang.annotation.Annotator;
 import com.intellij.openapi.components.ComponentManager;
-import com.intellij.psi.PsiElement;
 import com.intellij.serviceContainer.ComponentManagerImpl;
-import com.intellij.testFramework.fixtures.CodeInsightTestUtil;
 import com.intellij.testFramework.fixtures.IdeaProjectTestFixture;
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory;
 import com.intellij.testFramework.fixtures.TestFixtureBuilder;
 import com.intellij.testFramework.UITestUtil;
-import com.intellij.ui.IconManager;
-import com.intellij.ui.icons.CoreIconManager;
-
-import javax.swing.*;
-import java.util.List;
 
 /**
  * Provides SDK compatibility shims for base plugin API classes, available to all IDEs during
@@ -37,11 +28,6 @@ import java.util.List;
  */
 public final class BaseSdkTestCompat {
   private BaseSdkTestCompat() {}
-
-  /** #api212: inline into test cases */
-  public static List<Annotation> testAnnotator(Annotator annotator, PsiElement... elements) {
-    return CodeInsightTestUtil.testAnnotator(annotator, elements);
-  }
 
   /** #api223: inline into ServiceHelper */
   public static void unregisterComponent(ComponentManager componentManager, Class<?> componentKey) {


### PR DESCRIPTION
It was required to provide backward compatiblity with 212

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

