### PR TITLE
chore: Remove 212 kotlin producers from the Supressor

### DIFF
--- a/java/src/com/google/idea/blaze/java/run/producers/NonBlazeProducerSuppressor.java
+++ b/java/src/com/google/idea/blaze/java/run/producers/NonBlazeProducerSuppressor.java
@@ -45,13 +45,7 @@ public class NonBlazeProducerSuppressor implements StartupActivity.DumbAware {
           "org.jetbrains.kotlin.idea.run.KotlinJvmTestClassGradleConfigurationProducer",
           "org.jetbrains.kotlin.idea.run.KotlinMultiplatformJvmTestClassGradleConfigurationProducer",
           "org.jetbrains.kotlin.idea.run.KotlinMultiplatformJvmTestMethodGradleConfigurationProducer",
-          "org.jetbrains.kotlin.idea.run.KotlinRunConfigurationProducer",
-          /** #api212: remove these duplicate producers. */
-          "org.jetbrains.kotlin.idea.run.KotlinJUnitRunConfigurationProducer",
-          "org.jetbrains.kotlin.idea.run.KotlinPatternConfigurationProducer",
-          "org.jetbrains.kotlin.idea.run.KotlinTestClassGradleConfigurationProducer",
-          "org.jetbrains.kotlin.idea.run.KotlinTestMethodGradleConfigurationProducer",
-          "org.jetbrains.kotlin.idea.run.KotlinJvmTestMethodGradleConfigurationProducer");
+          "org.jetbrains.kotlin.idea.run.KotlinRunConfigurationProducer");
 
   private static final ImmutableList<String> ANDROID_PRODUCERS =
       ImmutableList.of(


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

