### PR TITLE
feat(clion): Add working directory to CLion Run configurations

### DIFF
--- a/base/src/com/google/idea/blaze/base/run/state/WorkingDirectoryState.java
+++ b/base/src/com/google/idea/blaze/base/run/state/WorkingDirectoryState.java
@@ -1,0 +1,97 @@
+package com.google.idea.blaze.base.run.state;
+
+import com.google.common.base.Strings;
+import com.google.idea.blaze.base.ui.UiUtil;
+import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.LabeledComponent;
+import com.intellij.openapi.ui.TextBrowseFolderListener;
+import com.intellij.openapi.ui.TextFieldWithBrowseButton;
+import com.intellij.openapi.util.InvalidDataException;
+import com.intellij.openapi.util.WriteExternalException;
+import java.nio.file.Path;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.swing.JComponent;
+import org.jdom.Element;
+
+/**
+ * State to enable setting a Working Directory for run configurations. Currently, it's only
+ * supported for CLion debug runs. When every debugger supports it, it can be moved into the general
+ * {@link RunConfigurationState}.
+ */
+public class WorkingDirectoryState implements RunConfigurationState {
+
+  private static final String WORKING_DIRECTORY_ATTR = "working-directory";
+
+  @Nullable
+  private Optional<Path> workingDirectory = Optional.empty();
+
+  @Nullable
+  public Optional<Path> getWorkingDirectory() {
+    return workingDirectory;
+  }
+
+  public void setWorkingDirectory(@Nullable String workingDirectory) {
+    if (!Strings.isNullOrEmpty(workingDirectory)) {
+      this.workingDirectory = Optional.of(Path.of(workingDirectory));
+    }
+  }
+
+  @Override
+  public void readExternal(Element element) throws InvalidDataException {
+    String attr = element.getAttributeValue(WORKING_DIRECTORY_ATTR);
+    if (Strings.isNullOrEmpty(attr)) {
+      workingDirectory = Optional.empty();
+    } else {
+      workingDirectory = Optional.of(Path.of(element.getAttributeValue(WORKING_DIRECTORY_ATTR)));
+    }
+  }
+
+  @Override
+  public void writeExternal(Element element) throws WriteExternalException {
+    if (workingDirectory.isEmpty()) {
+      element.removeAttribute(WORKING_DIRECTORY_ATTR);
+    } else {
+      element.setAttribute(WORKING_DIRECTORY_ATTR, workingDirectory.get().toString());
+    }
+  }
+
+  @Override
+  public RunConfigurationStateEditor getEditor(Project project) {
+    return new WorkingDirectoryStateEditor();
+  }
+
+  private static class WorkingDirectoryStateEditor implements RunConfigurationStateEditor {
+
+    private final TextFieldWithBrowseButton component = new TextFieldWithBrowseButton();
+
+    @Override
+    public void resetEditorFrom(RunConfigurationState genericState) {
+      WorkingDirectoryState state = (WorkingDirectoryState) genericState;
+      component.setText(state.getWorkingDirectory().map(Path::toString).orElse(""));
+    }
+
+    @Override
+    public void applyEditorTo(RunConfigurationState genericState) {
+      WorkingDirectoryState state = (WorkingDirectoryState) genericState;
+      state.setWorkingDirectory(component.getText());
+    }
+
+    @Override
+    public JComponent createComponent() {
+      LabeledComponent withLabel = new LabeledComponent<TextFieldWithBrowseButton>();
+      withLabel.setText("Working directory (only set when debugging):");
+      component.addBrowseFolderListener(new TextBrowseFolderListener(
+          FileChooserDescriptorFactory.createSingleFolderDescriptor()));
+      withLabel.setComponent(component);
+      return UiUtil.createBox(withLabel);
+    }
+
+    @Override
+    public void setComponentEnabled(boolean enabled) {
+      component.setEnabled(enabled);
+    }
+  }
+}

--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrLauncher.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrLauncher.java
@@ -97,8 +97,7 @@ public final class BlazeCidrLauncher extends CidrLauncher {
   BlazeCidrLauncher(
       BlazeCommandRunConfiguration configuration,
       BlazeCidrRunConfigurationRunner runner,
-      ExecutionEnvironment env
-      ) {
+      ExecutionEnvironment env) {
     this.configuration = configuration;
     this.handlerState = (BlazeCidrRunConfigState) configuration.getHandler().getState();
     this.runner = runner;

--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrRunConfigState.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrRunConfigState.java
@@ -20,6 +20,7 @@ import com.google.idea.blaze.base.run.state.BlazeCommandRunConfigurationCommonSt
 import com.google.idea.blaze.base.run.state.DebugPortState;
 import com.google.idea.blaze.base.run.state.EnvironmentVariablesState;
 import com.google.idea.blaze.base.run.state.RunConfigurationState;
+import com.google.idea.blaze.base.run.state.WorkingDirectoryState;
 import com.google.idea.blaze.base.settings.BuildSystemName;
 
 /** A version of the common state allowing environment variables to be set when debugging. */
@@ -27,6 +28,8 @@ final class BlazeCidrRunConfigState extends BlazeCommandRunConfigurationCommonSt
   private static final int DEFAULT_DEBUG_PORT = 5006;
 
   private final EnvironmentVariablesState envVars = new EnvironmentVariablesState();
+
+  private final WorkingDirectoryState workingDir = new WorkingDirectoryState();
   private final DebugPortState debugPortState = new DebugPortState(DEFAULT_DEBUG_PORT);
 
   BlazeCidrRunConfigState(BuildSystemName buildSystemName) {
@@ -35,11 +38,15 @@ final class BlazeCidrRunConfigState extends BlazeCommandRunConfigurationCommonSt
 
   @Override
   protected ImmutableList<RunConfigurationState> initializeStates() {
-    return ImmutableList.of(command, blazeFlags, exeFlags, envVars, debugPortState, blazeBinary);
+    return ImmutableList.of(command, blazeFlags, exeFlags, envVars, workingDir, debugPortState, blazeBinary);
   }
 
   EnvironmentVariablesState getEnvVarsState() {
     return envVars;
+  }
+
+  public WorkingDirectoryState getWorkingDirState() {
+    return workingDir;
   }
 
   DebugPortState getDebugPortState() {

--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeLLDBDriverConfiguration.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeLLDBDriverConfiguration.java
@@ -1,5 +1,6 @@
 package com.google.idea.blaze.clwb.run;
 
+import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
 import com.google.idea.blaze.clwb.ToolchainUtils;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
@@ -9,21 +10,19 @@ import com.jetbrains.cidr.cpp.execution.debugger.backend.CLionLLDBDriverConfigur
 import com.jetbrains.cidr.execution.debugger.backend.DebuggerDriver;
 import org.jetbrains.annotations.NotNull;
 
-import java.nio.file.Path;
-
 public class BlazeLLDBDriverConfiguration extends CLionLLDBDriverConfiguration {
-    private final Path workingDirectory;
+    private final WorkspaceRoot workspaceRoot;
 
-    public BlazeLLDBDriverConfiguration(@NotNull Project project, Path workingDirectory) {
+    public BlazeLLDBDriverConfiguration(@NotNull Project project, WorkspaceRoot workspaceRoot) {
         super(project, ToolchainUtils.getToolchain());
-        this.workingDirectory = workingDirectory;
+        this.workspaceRoot = workspaceRoot;
     }
 
     @NotNull
     @Override
     public GeneralCommandLine createDriverCommandLine(@NotNull DebuggerDriver driver, @NotNull ArchitectureType architectureType) throws ExecutionException {
         GeneralCommandLine commandLine = super.createDriverCommandLine(driver, architectureType);
-        commandLine.setWorkDirectory(this.workingDirectory.toFile());
+        commandLine.setWorkDirectory(this.workspaceRoot.directory());
         return commandLine;
     }
 }


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: N/A

# Description of this change

In CMake CLion, one has the option of setting a working directory under which the binary will be run. This is useful for debugging single binaries (i.e. they need no runfiles) under different contexts.

This PR adds some of that capability to the Bazel plugin by creating a setting for run configurations, and adding it to the Cidr debug process handlers.

Limitations:

 * For now, this only applies to CLion debugging configurations. Other debuggers will have to be modified to use the setting, as well as non-debug configurations.
 * Previously, we defaulted to the runfiles dir as the pwd if there was one. The explicit working dir has precedence over it now.

<img width="1033" alt="242549858-02f0d9e3-aa6a-4e78-9bf3-90f25b296e60" src="https://github.com/user-attachments/assets/65e213e0-d1b5-4803-961d-02f63a5f4f7c">

