### PR TITLE
[#6664] Default disable `ExternalWorkspaceDataProvider`

### DIFF
--- a/base/src/com/google/idea/blaze/base/model/ExternalWorkspaceDataProvider.java
+++ b/base/src/com/google/idea/blaze/base/model/ExternalWorkspaceDataProvider.java
@@ -55,7 +55,12 @@ public class ExternalWorkspaceDataProvider {
   }
 
   static Boolean isEnabled(BlazeVersionData blazeVersionData) {
-    return blazeVersionData.bazelIsAtLeastVersion(MINIMUM_BLAZE_VERSION);
+    // disable this until a more reliable opt-in mechanism is chosen.
+    //
+    // bg: some blaze workspaces with blaze > MINIMUM_BLAZE_VERSION
+    // have explicitly disabled this bzlmod support and this causes
+    // `blaze mod` to fail.
+    return false /* blazeVersionData.bazelIsAtLeastVersion(MINIMUM_BLAZE_VERSION) */;
   }
 
   public ListenableFuture<ExternalWorkspaceData> getExternalWorkspaceData(


### PR DESCRIPTION
 Some blaze workspaces with blaze > MINIMUM_BLAZE_VERSION (7.1.0
 have explicitly disabled bzlmod support and this causes
 `blaze mod` to fail (which fails the whole sync).

  disable the Provider until a more reliable opt-in is found.

# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

# Discussion thread for this change

Issue number: `6703`, `6664` ( #6703, #6664) 

# Description of this change

 Disable ExternalWorkspaceDataProvider until a more reliable opt-in mechanism is chosen.

 Some blaze workspaces with blaze > MINIMUM_BLAZE_VERSION 
 have explicitly disabled bzlmod support and this causes `blaze mod` to fail.
