### PR TITLE
[#6664] Gate `ExternalWorkspaceDataProvider` on bzlmod being enabled

### DIFF
--- a/base/src/com/google/idea/blaze/base/command/info/BlazeInfo.java
+++ b/base/src/com/google/idea/blaze/base/command/info/BlazeInfo.java
@@ -36,6 +36,8 @@ public abstract class BlazeInfo implements ProtoWrapper<ProjectData.BlazeInfo> {
   public static final String MASTER_LOG = "master-log";
   public static final String RELEASE = "release";
 
+  public static final String STARLARK_SEMANTICS = "starlark-semantics";
+
   public static String blazeBinKey(BuildSystemName buildSystemName) {
     switch (buildSystemName) {
       case Blaze:

--- a/base/src/com/google/idea/blaze/base/sync/ProjectStateSyncTask.java
+++ b/base/src/com/google/idea/blaze/base/sync/ProjectStateSyncTask.java
@@ -161,7 +161,7 @@ final class ProjectStateSyncTask {
     }
 
     ExternalWorkspaceData externalWorkspaceData =
-        getExternalWorkspaceData(context, projectViewSet, blazeVersionData, params.syncMode());
+        getExternalWorkspaceData(context, projectViewSet, blazeVersionData, blazeInfo, params.syncMode());
 
     WorkspacePathResolver workspacePathResolver =
         workspacePathResolverAndProjectView.workspacePathResolver;
@@ -229,6 +229,7 @@ final class ProjectStateSyncTask {
       BlazeContext context,
       ProjectViewSet projectViewSet,
       BlazeVersionData blazeVersionData,
+      BlazeInfo blazeInfo,
       SyncMode syncMode)
       throws SyncCanceledException, SyncFailedException {
 
@@ -242,7 +243,7 @@ final class ProjectStateSyncTask {
 
     ListenableFuture<ExternalWorkspaceData> externalWorkspaceDataFuture =
         ExternalWorkspaceDataProvider.getInstance(project)
-            .getExternalWorkspaceData(context, syncFlags, blazeVersionData);
+            .getExternalWorkspaceData(context, syncFlags, blazeVersionData, blazeInfo);
 
     FutureResult<ExternalWorkspaceData> externalWorkspaceDataResult =
         FutureUtil.waitForFuture(context, externalWorkspaceDataFuture)


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

# Discussion thread for this change

Issue number: `6664` (#6664)
Issue number: `6703` (#6703)

# Description of this change

This change enhances the BlazeInfo collection to also collect the value of `startlark-semantics`. This will tell if any Starlark specific flags have been flipped from default. The flag we care about it `bzlmod`. 

Use this info key contents to gate running of `ExternalWorkspaceDataProvider` (in addition to bazel version).

One thing to note here is: 
 it will always run two `blaze info` commands back to back since making it run only one requires whitelisting all the used info flags in one command. If that can be a problem I can change it back to a whitelist but that has the risk of not pulling all the  used flags.
