### PR TITLE
[#6721] Don't set `ExternalWorkspace.repoName()` to null when same as…

### DIFF
--- a/base/src/com/google/idea/blaze/base/model/ExternalWorkspaceData.java
+++ b/base/src/com/google/idea/blaze/base/model/ExternalWorkspaceData.java
@@ -9,7 +9,6 @@ import com.google.idea.blaze.base.model.primitives.ExternalWorkspace;
 
 import javax.annotation.Nullable;
 
-
 public final class ExternalWorkspaceData implements ProtoWrapper<ProjectData.ExternalWorkspaceData> {
   public ImmutableMap<String, ExternalWorkspace> workspaces;
 
@@ -25,14 +24,15 @@ public final class ExternalWorkspaceData implements ProtoWrapper<ProjectData.Ext
             .stream()
             .collect(
                 ImmutableMap.toImmutableMap(
-                    ExternalWorkspace::repositoryName,
+                    ExternalWorkspace::repoName,
                     Functions.identity()))
     );
   }
 
   @Override
   public ProjectData.ExternalWorkspaceData toProto() {
-    ProjectData.ExternalWorkspaceData.Builder builder = ProjectData.ExternalWorkspaceData.newBuilder();
+    ProjectData.ExternalWorkspaceData.Builder builder =
+        ProjectData.ExternalWorkspaceData.newBuilder();
 
     for (ExternalWorkspace externalWorkspace : workspaces.values()) {
       builder = builder.addWorkspaces(externalWorkspace.toProto());

--- a/base/src/com/google/idea/blaze/base/model/primitives/ExternalWorkspace.java
+++ b/base/src/com/google/idea/blaze/base/model/primitives/ExternalWorkspace.java
@@ -12,12 +12,7 @@ public abstract class ExternalWorkspace implements ProtoWrapper<ProjectData.Exte
 
   public abstract String name();
 
-  @Nullable
-  protected abstract String repoName();
-
-  public String repositoryName() {
-    return repoName() != null ? repoName() : name();
-  }
+  public abstract String repoName();
 
   public static ExternalWorkspace fromProto(ProjectData.ExternalWorkspace proto) {
     return create(proto.getName(), proto.getRepoName());
@@ -25,19 +20,17 @@ public abstract class ExternalWorkspace implements ProtoWrapper<ProjectData.Exte
 
   @Override
   public ProjectData.ExternalWorkspace toProto() {
-    return
-        ProjectData.ExternalWorkspace.newBuilder()
-            .setName(name())
-            .setRepoName(repoName())
-            .build();
+    return ProjectData.ExternalWorkspace.newBuilder()
+               .setName(name())
+               .setRepoName(repoName())
+               .build();
   }
 
   public static ExternalWorkspace create(String name, String repoName) {
-    ExternalWorkspace.Builder builder = ExternalWorkspace.builder().setName(name);
-    if (repoName != null && !repoName.isEmpty() && repoName.compareTo(name) != 0) {
-      builder = builder.setRepoName(repoName);
-    }
-    return builder.build();
+    return ExternalWorkspace.builder()
+               .setName(name)
+               .setRepoName(repoName)
+               .build();
   }
 
   public static ExternalWorkspace.Builder builder() {

--- a/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/references/ExternalWorkspaceReferenceBzlModeTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/references/ExternalWorkspaceReferenceBzlModeTest.java
@@ -3,7 +3,6 @@ package com.google.idea.blaze.base.lang.buildfile.references;
 import com.google.common.collect.ImmutableList;
 import com.google.idea.blaze.base.ExternalWorkspaceFixture;
 import com.google.idea.blaze.base.lang.buildfile.BuildFileIntegrationTestCase;
-import com.google.idea.blaze.base.lang.buildfile.psi.BuildFile;
 import com.google.idea.blaze.base.model.ExternalWorkspaceData;
 import com.google.idea.blaze.base.model.primitives.ExternalWorkspace;
 import com.google.idea.blaze.base.model.primitives.Label;
@@ -36,7 +35,7 @@ public class ExternalWorkspaceReferenceBzlModeTest extends BuildFileIntegrationT
         ExternalWorkspace.create("workspace_two", "com_workspace_two"), fileSystem);
 
     return ExternalWorkspaceData.create(
-        ImmutableList.of(workspaceOne.w, workspaceTwoMapped.w));
+        ImmutableList.of(workspaceOne.workspace, workspaceTwoMapped.workspace));
   }
 
   @Before

--- a/base/tests/utils/integration/com/google/idea/blaze/base/ExternalWorkspaceFixture.java
+++ b/base/tests/utils/integration/com/google/idea/blaze/base/ExternalWorkspaceFixture.java
@@ -18,13 +18,13 @@ import static com.google.idea.blaze.base.settings.ui.ProjectViewUi.getProject;
 import static org.junit.Assert.assertNotNull;
 
 public class ExternalWorkspaceFixture {
-  public final ExternalWorkspace w;
+  public final ExternalWorkspace workspace;
 
   final TestFileSystem fileSystem;
   WorkspaceFileSystem workspaceFileSystem;
 
-  public ExternalWorkspaceFixture(ExternalWorkspace w, TestFileSystem fileSystem) {
-    this.w = w;
+  public ExternalWorkspaceFixture(ExternalWorkspace workspace, TestFileSystem fileSystem) {
+    this.workspace = workspace;
     this.fileSystem = fileSystem;
   }
 
@@ -44,7 +44,7 @@ public class ExternalWorkspaceFixture {
 
       WorkspaceRoot workspaceRoot = new WorkspaceRoot(Paths.get(
           blazeProjectData.getBlazeInfo().getOutputBase().getAbsolutePath(),
-          "external", w.name()).normalize().toFile());
+          "external", workspace.name()).normalize().toFile());
 
       File workspaceRootFile = workspaceRoot.directory();
       assertThat(workspaceRootFile).isNotNull();
@@ -55,6 +55,6 @@ public class ExternalWorkspaceFixture {
   }
 
   public Label createLabel(WorkspacePath packagePath, TargetName targetName) {
-    return Label.create(w.repositoryName(), packagePath, targetName);
+    return Label.create(workspace.repoName(), packagePath, targetName);
   }
 }


### PR DESCRIPTION
… name()

# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

# Discussion thread for this change

Issue number:  #6721 

# Description of this change

This reverts a change that collapsed `repoName` to `null` when the same as `name` for an external repository. T'was unnecessary.
