### PR TITLE
[#6664]: Collapse two bazel info invocations into one

### DIFF
--- a/base/src/com/google/idea/blaze/base/bazel/BazelVersion.java
+++ b/base/src/com/google/idea/blaze/base/bazel/BazelVersion.java
@@ -102,7 +102,7 @@ public class BazelVersion implements ProtoWrapper<ProjectData.BazelVersion> {
   }
 
   static BazelVersion parseVersion(BlazeInfo blazeInfo) {
-    return parseVersion(blazeInfo.get(BlazeInfo.RELEASE));
+    return parseVersion(blazeInfo.getRelease());
   }
 
   @Override

--- a/base/src/com/google/idea/blaze/base/command/info/BlazeInfo.java
+++ b/base/src/com/google/idea/blaze/base/command/info/BlazeInfo.java
@@ -18,6 +18,7 @@ package com.google.idea.blaze.base.command.info;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.devtools.intellij.model.ProjectData;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.idea.blaze.base.ideinfo.ProtoWrapper;
@@ -33,7 +34,6 @@ public abstract class BlazeInfo implements ProtoWrapper<ProjectData.BlazeInfo> {
   public static final String BUILD_LANGUAGE = "build-language";
   public static final String OUTPUT_BASE_KEY = "output_base";
   public static final String OUTPUT_PATH_KEY = "output_path";
-  public static final String MASTER_LOG = "master-log";
   public static final String RELEASE = "release";
 
   public static final String STARLARK_SEMANTICS = "starlark-semantics";
@@ -114,7 +114,7 @@ public abstract class BlazeInfo implements ProtoWrapper<ProjectData.BlazeInfo> {
 
   abstract ImmutableMap<String, String> getBlazeInfoMap();
 
-  public String get(String key) {
+  protected String get(String key) {
     return getBlazeInfoMap().get(key);
   }
 
@@ -139,6 +139,14 @@ public abstract class BlazeInfo implements ProtoWrapper<ProjectData.BlazeInfo> {
   }
 
   public abstract File getOutputBase();
+
+  public String getStarlarkSemantics() {
+    return getBlazeInfoMap().get(STARLARK_SEMANTICS);
+  }
+
+  public String getRelease() {
+    return getBlazeInfoMap().get(RELEASE);
+  }
 
   /** Creates a mock blaze info with the minimum information required for syncing. */
   @VisibleForTesting

--- a/base/src/com/google/idea/blaze/base/command/info/BlazeInfoRunner.java
+++ b/base/src/com/google/idea/blaze/base/command/info/BlazeInfoRunner.java
@@ -19,6 +19,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.idea.blaze.base.bazel.BuildSystem.BuildInvoker;
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.settings.BuildSystemName;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.project.Project;
 import java.util.List;
@@ -27,12 +28,12 @@ import java.util.List;
 public abstract class BlazeInfoRunner {
 
   public static BlazeInfoRunner getInstance() {
-    return ServiceManager.getService(BlazeInfoRunner.class);
+    return ApplicationManager.getApplication().getService(BlazeInfoRunner.class);
   }
 
   /**
    * @param blazeFlags The blaze flags that will be passed to Blaze.
-   * @param key The key passed to blaze info
+   * @param keys The key passed to blaze info
    * @return The blaze info value associated with the specified key
    */
   public abstract ListenableFuture<String> runBlazeInfo(
@@ -40,11 +41,11 @@ public abstract class BlazeInfoRunner {
       BuildInvoker invoker,
       BlazeContext context,
       List<String> blazeFlags,
-      String key);
+      String ...keys);
 
   /**
    * @param blazeFlags The blaze flags that will be passed to Blaze.
-   * @param key The key passed to blaze info
+   * @param keys The keys passed to blaze info
    * @return The blaze info value associated with the specified key
    */
   public abstract ListenableFuture<byte[]> runBlazeInfoGetBytes(
@@ -52,7 +53,7 @@ public abstract class BlazeInfoRunner {
       BuildInvoker invoker,
       BlazeContext context,
       List<String> blazeFlags,
-      String key);
+      String ...keys);
 
   /**
    * This calls blaze info without any specific key so blaze info will return all keys and values

--- a/base/src/com/google/idea/blaze/base/model/ExternalWorkspaceDataProvider.java
+++ b/base/src/com/google/idea/blaze/base/model/ExternalWorkspaceDataProvider.java
@@ -78,7 +78,7 @@ public class ExternalWorkspaceDataProvider {
 
     // validate that bzlmod is enabled (technically this validates that the --enable_bzlmod is not
     // changed from the default `true` aka set to false)
-    String starLarkSemantics = blazeInfo.get(BlazeInfo.STARLARK_SEMANTICS);
+    String starLarkSemantics = blazeInfo.getStarlarkSemantics();
     if (starLarkSemantics == null || starLarkSemantics.isEmpty() || starLarkSemantics.contains("enable_bzlmod=false")) {
       return Futures.immediateFuture(ExternalWorkspaceData.EMPTY);
     }

--- a/base/src/com/google/idea/blaze/base/run/coverage/CoverageUtils.java
+++ b/base/src/com/google/idea/blaze/base/run/coverage/CoverageUtils.java
@@ -66,7 +66,7 @@ public class CoverageUtils {
   }
 
   public static File getOutputFile(BlazeInfo blazeInfo) {
-    File coverageRoot = new File(blazeInfo.get(BlazeInfo.OUTPUT_PATH_KEY), "_coverage");
+    File coverageRoot = new File(blazeInfo.getOutputBase(), "_coverage");
     return new File(coverageRoot, "_coverage_report.dat");
   }
 }

--- a/base/tests/utils/integration/com/google/idea/blaze/base/sync/BlazeSyncIntegrationTestCase.java
+++ b/base/tests/utils/integration/com/google/idea/blaze/base/sync/BlazeSyncIntegrationTestCase.java
@@ -80,10 +80,13 @@ import com.intellij.pom.java.LanguageLevel;
 import com.intellij.testFramework.EdtTestUtil;
 import com.intellij.testFramework.IdeaTestUtil;
 import com.intellij.util.lang.JavaVersion;
+
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.junit.After;
 import org.junit.Before;
@@ -287,8 +290,11 @@ public abstract class BlazeSyncIntegrationTestCase extends BlazeIntegrationTestC
         BuildInvoker invoker,
         BlazeContext context,
         List<String> blazeFlags,
-        String key) {
-      return Futures.immediateFuture(results.get(key));
+        String ...keys) {
+      return Futures.immediateFuture(
+          Arrays.stream(keys)
+              .map(key -> String.format("%s: %s", key, results.get(key)))
+              .collect(Collectors.joining("\n")));
     }
 
     @Override
@@ -308,7 +314,7 @@ public abstract class BlazeSyncIntegrationTestCase extends BlazeIntegrationTestC
         BuildInvoker invoker,
         BlazeContext context,
         List<String> blazeFlags,
-        String key) {
+        String ...key) {
       return Futures.immediateFuture(null);
     }
 


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

# Discussion thread for this change

Issue number: #6664 

# Description of this change

  In PR #6711 I added two back to back bazel info calls.
  This PR collapsed  those calls into one.
  Also trying to remove an obsolete Service registration.

