### PR TITLE
[#6664,#505]: Enable External Workspace completions and tests - 5/n

### DIFF
--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -376,6 +376,7 @@
     <codeInsight.lineMarkerProvider
         language="BUILD"
         implementationClass="com.google.idea.blaze.base.query.MacroLineMarkerProvider"/>
+    <lookup.charFilter implementation="com.google.idea.blaze.base.lang.buildfile.completion.BuildLabelCharFilter"/>
     <runLineMarkerContributor
         language="BUILD"
         implementationClass="com.google.idea.blaze.base.run.producers.BuildFileRunLineMarkerContributor"/>

--- a/base/src/com/google/idea/blaze/base/lang/buildfile/completion/BuildLabelCharFilter.java
+++ b/base/src/com/google/idea/blaze/base/lang/buildfile/completion/BuildLabelCharFilter.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.lang.buildfile.completion;
+
+import com.google.idea.blaze.base.lang.buildfile.language.BuildFileLanguage;
+import com.google.idea.blaze.base.lang.buildfile.psi.StringLiteral;
+import com.intellij.codeInsight.lookup.CharFilter;
+import com.intellij.codeInsight.lookup.Lookup;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.util.PsiTreeUtil;
+import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.Nullable;
+
+/** Allows '@' to be typed (and appended to completion) inside a label from a build file. */
+public final class BuildLabelCharFilter extends CharFilter {
+  @Nullable
+  public CharFilter.Result acceptChar(char c, int prefixLength, @NotNull Lookup lookup) {
+    if (!lookup.isCompletion()) {
+      return null;
+    }
+
+    PsiFile file = lookup.getPsiFile();
+    if (file == null ||
+            file.getLanguage() != BuildFileLanguage.INSTANCE ||
+            PsiTreeUtil.getParentOfType(lookup.getPsiElement(), StringLiteral.class) == null) {
+      return null;
+    }
+
+    switch (c) {
+      case '@':
+        return Result.ADD_TO_PREFIX;
+
+      case '/':
+        if (lookup.getCurrentItem() instanceof ExternalWorkspaceLookupElement) {
+          return Result.SELECT_ITEM_AND_FINISH_LOOKUP;
+        }
+    }
+
+    return null;
+  }
+}

--- a/base/src/com/google/idea/blaze/base/lang/buildfile/completion/BuildLookupElement.java
+++ b/base/src/com/google/idea/blaze/base/lang/buildfile/completion/BuildLookupElement.java
@@ -43,7 +43,7 @@ public abstract class BuildLookupElement extends LookupElement {
     this.wrapWithQuotes = quoteWrapping != QuoteType.NoQuotes;
   }
 
-  private static boolean insertClosingQuotes() {
+  protected static boolean insertClosingQuotes() {
     return CodeInsightSettings.getInstance().AUTOINSERT_PAIR_QUOTE;
   }
 

--- a/base/src/com/google/idea/blaze/base/lang/buildfile/completion/ExternalWorkspaceLookupElement.java
+++ b/base/src/com/google/idea/blaze/base/lang/buildfile/completion/ExternalWorkspaceLookupElement.java
@@ -1,0 +1,100 @@
+package com.google.idea.blaze.base.lang.buildfile.completion;
+
+import com.google.idea.blaze.base.lang.buildfile.psi.StringLiteral;
+import com.google.idea.blaze.base.lang.buildfile.references.QuoteType;
+import com.google.idea.blaze.base.model.primitives.ExternalWorkspace;
+import com.intellij.codeInsight.completion.InsertionContext;
+import com.intellij.codeInsight.lookup.AutoCompletionPolicy;
+import com.intellij.openapi.editor.CaretModel;
+import com.intellij.openapi.editor.Document;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.intellij.util.PlatformIcons;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+
+public class ExternalWorkspaceLookupElement extends BuildLookupElement {
+  private final ExternalWorkspace workspace;
+
+  public ExternalWorkspaceLookupElement(ExternalWorkspace workspace) {
+    super('@' + workspace.repoName(), QuoteType.NoQuotes);
+    this.workspace = workspace;
+  }
+
+  @Override
+  public String getLookupString() {
+    return super.getItemText();
+  }
+
+  @Override
+  @Nullable
+  protected String getTypeText() {
+    return !workspace.repoName().equals(workspace.name()) ? '@' + workspace.name() : null;
+  }
+
+  @Override
+  @Nullable
+  protected String getTailText() {
+    return "//";
+  }
+
+  @Override
+  public @Nullable Icon getIcon() {
+    return PlatformIcons.LIBRARY_ICON;
+  }
+
+  @Override
+  public void handleInsert(InsertionContext context) {
+    StringLiteral literal = PsiTreeUtil.findElementOfClassAtOffset(context.getFile(), context.getStartOffset(), StringLiteral.class, false);
+    if (literal == null) {
+      super.handleInsert(context);
+      return;
+    }
+
+    Document document = context.getDocument();
+    context.commitDocument();
+
+    // if we completed by pressing '/' (since this lookup element should never complete using '/') .
+    if (context.getCompletionChar() == '/') {
+      context.setAddCompletionChar(false);
+    }
+
+    CaretModel caret = context.getEditor().getCaretModel();
+        // find an remove trailing package path after insert / replace.
+    //  current element text looks like `@workspace`. If this is complete inside an existing workspace name the
+    //  result would look like: @workspace<caret>old_workspace_path//. The following bit will remove `old_workspace_path//`
+    int replaceStart = context.getTailOffset();
+    int replaceEnd = context.getTailOffset();
+
+    int indexOfPackageStart = literal.getText().lastIndexOf("//");
+    if (indexOfPackageStart != -1) {
+      // shift to be a document offset
+      replaceEnd = indexOfPackageStart + 2 + literal.getTextOffset();
+    }
+
+    document.replaceString(replaceStart, replaceEnd, "//");
+    context.commitDocument();
+    caret.moveToOffset(replaceStart + 2);
+
+    // handle auto insertion of end quote. This will have to be if the completion is triggered inside a `"@<caret` bit
+    if (insertClosingQuotes()) {
+      QuoteType quoteType = literal.getQuoteType();
+      if (quoteType != QuoteType.NoQuotes && !literal.getText().endsWith(quoteType.quoteString)) {
+        document.insertString(literal.getTextOffset() + literal.getTextLength(), quoteType.quoteString);
+        context.commitDocument();
+      }
+    }
+
+    super.handleInsert(context);
+  }
+
+  @Override
+  public boolean requiresCommittedDocuments() {
+    return false;
+  }
+
+  @Override
+  public AutoCompletionPolicy getAutoCompletionPolicy() {
+    return AutoCompletionPolicy.ALWAYS_AUTOCOMPLETE;
+  }
+}

--- a/base/src/com/google/idea/blaze/base/lang/buildfile/references/LabelReference.java
+++ b/base/src/com/google/idea/blaze/base/lang/buildfile/references/LabelReference.java
@@ -32,11 +32,9 @@ import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.vfs.VirtualFileFilter;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
-import com.intellij.psi.PsiReference;
 import com.intellij.psi.PsiReferenceBase;
 import com.intellij.util.ArrayUtil;
 import com.intellij.util.IncorrectOperationException;
-import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
 

--- a/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/completion/ExternalWorkspaceCompletionTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/completion/ExternalWorkspaceCompletionTest.java
@@ -1,0 +1,107 @@
+package com.google.idea.blaze.base.lang.buildfile.completion;
+
+import com.google.common.collect.ImmutableList;
+import com.google.idea.blaze.base.ExternalWorkspaceFixture;
+import com.google.idea.blaze.base.lang.buildfile.BuildFileIntegrationTestCase;
+import com.google.idea.blaze.base.lang.buildfile.psi.BuildFile;
+import com.google.idea.blaze.base.model.ExternalWorkspaceData;
+import com.google.idea.blaze.base.model.primitives.ExternalWorkspace;
+import com.google.idea.blaze.base.model.primitives.WorkspacePath;
+import com.intellij.codeInsight.CodeInsightSettings;
+import com.intellij.codeInsight.lookup.Lookup;
+import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.codeInsight.lookup.LookupEx;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.psi.PsiFile;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import static com.google.common.truth.ExpectFailure.expectFailure;
+import static com.google.common.truth.Truth.assertThat;
+
+public class ExternalWorkspaceCompletionTest extends BuildFileIntegrationTestCase {
+  protected ExternalWorkspaceFixture workspaceOne;
+  protected ExternalWorkspaceFixture workspaceTwoMapped;
+
+  @Override
+  protected ExternalWorkspaceData mockExternalWorkspaceData() {
+    workspaceOne = new ExternalWorkspaceFixture(
+        ExternalWorkspace.create("workspace_one", "workspace_one"), fileSystem);
+
+    workspaceTwoMapped = new ExternalWorkspaceFixture(
+        ExternalWorkspace.create("workspace_two", "com_workspace_two"), fileSystem);
+
+    return ExternalWorkspaceData.create(
+        ImmutableList.of(workspaceOne.workspace, workspaceTwoMapped.workspace));
+  }
+
+  @Test
+  public void testEmptyLabelCompletion() throws Throwable {
+    PsiFile file = testFixture.configureByText("BUILD", "'<caret>'");
+
+    String[] strings = editorTest.getCompletionItemsAsStrings();
+    assertThat(strings).hasLength(2);
+    assertThat(strings)
+        .asList()
+        .containsExactly("@com_workspace_two", "@workspace_one");
+  }
+
+  @Test
+  public void testCompleteWillIncludeSlashes () {
+    PsiFile file = testFixture.configureByText("BUILD", "'@com<caret>'");
+    assertThat(editorTest.completeIfUnique()).isTrue();
+
+    assertFileContents(file, "'@com_workspace_two//'");
+  }
+
+  @Test
+  public void testCompleteWillFixUpRemainingSlashed () {
+    PsiFile file = testFixture.configureByText("BUILD", "'@com<caret>//'");
+    assertThat(editorTest.completeIfUnique()).isTrue();
+
+    assertFileContents(file, "'@com_workspace_two//'");
+  }
+
+  @Test
+  public void testCompleteWillAlwaysReplaceWorkspace() {
+    PsiFile file = testFixture.configureByText("BUILD", "'@com<caret>xxxx//'");
+    assertThat(editorTest.completeIfUnique()).isTrue();
+
+    assertFileContents(file, "'@com_workspace_two//'");
+  }
+
+  @Test
+  public void testCompleteWillRespectAutoQuoting() {
+    boolean old = CodeInsightSettings.getInstance().AUTOINSERT_PAIR_QUOTE;
+    try {
+      CodeInsightSettings.getInstance().AUTOINSERT_PAIR_QUOTE = false;
+      PsiFile file = testFixture.configureByText("BUILD", "'@com<caret>");
+
+      assertThat(editorTest.completeIfUnique()).isTrue();
+      assertFileContents(file, "'@com_workspace_two//");
+
+      CodeInsightSettings.getInstance().AUTOINSERT_PAIR_QUOTE = true;
+      file = testFixture.configureByText("BUILD", "'@com<caret>");
+
+      assertThat(editorTest.completeIfUnique()).isTrue();
+      assertFileContents(file, "'@com_workspace_two//'");
+
+    } finally {
+      CodeInsightSettings.getInstance().AUTOINSERT_PAIR_QUOTE = old;
+    }
+  }
+
+  @Test
+  public void testSlashWillAutoCompleteCurrentItem() throws Throwable {
+    PsiFile file = testFixture.configureByText("BUILD", "'@<caret>comxxxx//'");
+
+    assertThat(testFixture.completeBasic()).isNotNull();
+    LookupEx lookup = testFixture.getLookup();
+
+    LookupElement currentItem = lookup.getCurrentItem();
+    assertThat(currentItem).isNotNull();
+
+    testFixture.type('/');
+    assertFileContents(file, String.format("'%s//'", currentItem.getLookupString()));
+  }
+}

--- a/base/tests/utils/integration/com/google/idea/blaze/base/lang/buildfile/BuildFileIntegrationTestCase.java
+++ b/base/tests/utils/integration/com/google/idea/blaze/base/lang/buildfile/BuildFileIntegrationTestCase.java
@@ -91,6 +91,6 @@ public abstract class BuildFileIntegrationTestCase extends BlazeIntegrationTestC
     BlazeProjectData blazeProjectData = BlazeProjectDataManager.getInstance(getProject()).getBlazeProjectData();
     assertThat(blazeProjectData).isNotNull();
 
-    return WorkspaceHelper.getExternalSourceRoot(blazeProjectData);
+    return WorkspaceHelper.getExternalSourceRoot(blazeProjectData).toFile();
   }
 }

--- a/cpp/src/com/google/idea/blaze/cpp/BlazeConfigurationResolver.java
+++ b/cpp/src/com/google/idea/blaze/cpp/BlazeConfigurationResolver.java
@@ -149,7 +149,7 @@ final class BlazeConfigurationResolver {
       Project project,
       WorkspacePathResolver workspacePathResolver) {
     if (target.toTargetInfo().getLabel().isExternal()) {
-      WorkspaceRoot externalWorkspace = WorkspaceHelper.resolveExternalWorkspace(project,
+      WorkspaceRoot externalWorkspace = WorkspaceHelper.getExternalWorkspace(project,
           target.getKey().getLabel().externalWorkspaceName());
 
       if (externalWorkspace != null) {

--- a/cpp/tests/unittests/com/google/idea/blaze/cpp/BlazeConfigurationResolverTest.java
+++ b/cpp/tests/unittests/com/google/idea/blaze/cpp/BlazeConfigurationResolverTest.java
@@ -826,7 +826,7 @@ public class BlazeConfigurationResolverTest extends BlazeTestCase {
             .build();
 
     File externalRoot = WorkspaceHelper.getExternalSourceRoot(
-        BlazeProjectDataManager.getInstance(project).getBlazeProjectData());
+        BlazeProjectDataManager.getInstance(project).getBlazeProjectData()).toFile();
 
     File spyExternalDependencyRoot = spy(new File(externalRoot, "external_dependency"));
     doReturn(true).when(spyExternalDependencyRoot).isDirectory();
@@ -844,7 +844,7 @@ public class BlazeConfigurationResolverTest extends BlazeTestCase {
 
    try (MockedStatic<WorkspaceHelper> mockedStatic = Mockito.mockStatic(WorkspaceHelper.class)) {
      mockedStatic.when(
-         () -> WorkspaceHelper.resolveExternalWorkspace(Mockito.any(MockProject.class),
+         () -> WorkspaceHelper.getExternalWorkspace(Mockito.any(MockProject.class),
              Mockito.any(String.class))).thenReturn(new WorkspaceRoot(spyExternalDependencyRoot));
 
      assertThatResolving(projectView, targetMap).producesConfigurationsFor(


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

# Discussion thread for this change

Issue number: #6664, #505

# Description of this change

  Also add a CharFilter that enable:
    * '@' to filter the lookup elements and not hide the lookup.
    * '/' to autocomplete selected item

