### PR TITLE
[#6664] Completion of FilePath and targets from external repositories

### DIFF
--- a/base/src/com/google/idea/blaze/base/lang/buildfile/references/FileLookupData.java
+++ b/base/src/com/google/idea/blaze/base/lang/buildfile/references/FileLookupData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 The Bazel Authors. All rights reserved.
+ * Copyright 2024 The Bazel Authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,8 @@ import javax.swing.Icon;
 
 /** The data relevant to finding file lookups. */
 public class FileLookupData {
-  private static final ImmutableSet<String> BUILDFILE_NAMES = ImmutableSet.of("BUILD", "BUILD.bazel");
+  private static final ImmutableSet<String> BUILDFILE_NAMES =
+      ImmutableSet.of("BUILD", "BUILD.bazel");
 
   /** The type of path string format */
   public enum PathFormat {
@@ -70,7 +71,9 @@ public class FileLookupData {
       return null;
     }
     // handle the single '/' case by calling twice.
-    String relativePath = StringUtil.trimStart(StringUtil.trimStart(originalLabel, "/"), "/");
+    String relativePath =
+        StringUtil.trimStart(
+            StringUtil.trimStart(LabelUtils.getPackagePathComponent(originalLabel), "/"), "/");
     if (relativePath.startsWith("/")) {
       return null;
     }
@@ -119,6 +122,7 @@ public class FileLookupData {
   private final BuildFile containingFile;
   @Nullable private final String containingPackage;
   public final String filePathFragment;
+  @Nullable public final String externalWorkspace;
   public final PathFormat pathFormat;
   private final QuoteType quoteType;
   @Nullable private final VirtualFileFilter fileFilter;
@@ -139,6 +143,7 @@ public class FileLookupData {
     this.filePathFragment = filePathFragment;
     this.pathFormat = pathFormat;
     this.quoteType = quoteType;
+    this.externalWorkspace = LabelUtils.getExternalWorkspaceComponent(originalLabel);
 
     assert (pathFormat != PathFormat.PackageLocal
         || (containingPackage != null && containingFile != null));
@@ -187,6 +192,9 @@ public class FileLookupData {
     if (pathFormat != PathFormat.PackageLocal) {
       if (pathFormat == PathFormat.NonLocal) {
         relativePath = "//" + relativePath;
+        if (externalWorkspace != null) {
+          relativePath = "@" + externalWorkspace + relativePath;
+        }
       }
       return relativePath;
     }

--- a/base/src/com/google/idea/blaze/base/lang/buildfile/references/LabelReference.java
+++ b/base/src/com/google/idea/blaze/base/lang/buildfile/references/LabelReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 The Bazel Authors. All rights reserved.
+ * Copyright 2024 The Bazel Authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -98,15 +98,21 @@ public class LabelReference extends PsiReferenceBase<StringLiteral> {
   private BuildLookupElement[] getRuleLookups(String labelString) {
     if (labelString.endsWith("/")
         || (labelString.startsWith("/") && !labelString.contains(":"))
+        || (labelString.startsWith("@") && !labelString.contains(":"))
         || skylarkExtensionReference(myElement)) {
       return BuildLookupElement.EMPTY_ARRAY;
     }
+
     String packagePrefix = LabelUtils.getPackagePathComponent(labelString);
+    String externalWorkspace = LabelUtils.getExternalWorkspaceComponent(labelString);
+
     BuildFile referencedBuildFile =
-        LabelUtils.getReferencedBuildFile(myElement.getContainingFile(), packagePrefix);
+        LabelUtils.getReferencedBuildFile(
+            myElement.getContainingFile(), externalWorkspace, packagePrefix);
     if (referencedBuildFile == null) {
       return BuildLookupElement.EMPTY_ARRAY;
     }
+
     String self = null;
     if (referencedBuildFile == myElement.getContainingFile()) {
       FuncallExpression funcall =
@@ -116,11 +122,11 @@ public class LabelReference extends PsiReferenceBase<StringLiteral> {
       }
     }
     return LabelRuleLookupElement.collectAllRules(
-        referencedBuildFile, labelString, packagePrefix, self, myElement.getQuoteType());
+        referencedBuildFile, labelString, self, myElement.getQuoteType());
   }
 
   private BuildLookupElement[] getFileLookups(String labelString) {
-    if (labelString.startsWith("//") || labelString.equals("/")) {
+    if (labelString.startsWith("//") || labelString.equals("/") || labelString.startsWith("@")) {
       return getNonLocalFileLookups(labelString);
     }
     return getPackageLocalFileLookups(labelString);
@@ -151,6 +157,7 @@ public class LabelReference extends PsiReferenceBase<StringLiteral> {
       return BuildLookupElement.EMPTY_ARRAY;
     }
     String packagePrefix = LabelUtils.getPackagePathComponent(labelString);
+    String externalWorkspace = LabelUtils.getExternalWorkspaceComponent(labelString);
     BuildFile parentFile = myElement.getContainingFile();
     if (parentFile == null) {
       return BuildLookupElement.EMPTY_ARRAY;
@@ -160,7 +167,8 @@ public class LabelReference extends PsiReferenceBase<StringLiteral> {
       return BuildLookupElement.EMPTY_ARRAY;
     }
     BuildFile referencedBuildFile =
-        LabelUtils.getReferencedBuildFile(containingPackage.buildFile, packagePrefix);
+        LabelUtils.getReferencedBuildFile(
+            containingPackage.buildFile, externalWorkspace, packagePrefix);
 
     // Directories before the colon are already covered.
     // We're only concerned with package-local directories.

--- a/base/src/com/google/idea/blaze/base/lang/buildfile/references/PackageReferenceFragment.java
+++ b/base/src/com/google/idea/blaze/base/lang/buildfile/references/PackageReferenceFragment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 The Bazel Authors. All rights reserved.
+ * Copyright 2024 The Bazel Authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,9 +62,11 @@ public class PackageReferenceFragment extends PsiReferenceBase<StringLiteral> {
   @Nullable
   @Override
   public BuildFile resolve() {
-    WorkspacePath workspacePath = getWorkspacePath(myElement.getStringContents());
+    String labelString = myElement.getStringContents();
+    WorkspacePath workspacePath = getWorkspacePath(labelString);
+    String externalWorkspace = LabelUtils.getExternalWorkspaceComponent(labelString);
     return BuildReferenceManager.getInstance(myElement.getProject())
-        .resolveBlazePackage(workspacePath);
+        .resolveBlazePackage(workspacePath, externalWorkspace);
   }
 
   @Override

--- a/base/src/com/google/idea/blaze/base/lang/projectview/references/ProjectViewLabelReference.java
+++ b/base/src/com/google/idea/blaze/base/lang/projectview/references/ProjectViewLabelReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 The Bazel Authors. All rights reserved.
+ * Copyright 2024 The Bazel Authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -109,12 +109,12 @@ public class ProjectViewLabelReference extends PsiReferenceBase<ProjectViewPsiSe
     }
     String packagePrefix = LabelUtils.getPackagePathComponent(labelString);
     BuildFile referencedBuildFile =
-        BuildReferenceManager.getInstance(getProject()).resolveBlazePackage(packagePrefix);
+        BuildReferenceManager.getInstance(getProject()).resolveBlazePackage(packagePrefix, null);
     if (referencedBuildFile == null) {
       return BuildLookupElement.EMPTY_ARRAY;
     }
     return LabelRuleLookupElement.collectAllRules(
-        referencedBuildFile, labelString, packagePrefix, null, QuoteType.NoQuotes);
+        referencedBuildFile, labelString, null, QuoteType.NoQuotes);
   }
 
   private BuildLookupElement[] getFileLookups(String labelString) {

--- a/base/src/com/google/idea/blaze/base/sync/workspace/WorkspaceHelper.java
+++ b/base/src/com/google/idea/blaze/base/sync/workspace/WorkspaceHelper.java
@@ -190,6 +190,7 @@ public class WorkspaceHelper {
     return Paths.get(projectData.getBlazeInfo().getOutputBase().getAbsolutePath(), "external").normalize();
   }
 
+  /** resolve workspace root for a named external repository. needs context since the same name can mean something different in different workspaces. */
   @Nullable
   private static synchronized WorkspaceRoot resolveExternalWorkspaceRoot(
       Project project, String workspaceName, @Nullable BuildFile buildFile) {

--- a/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/completion/ExternalWorkspaceCompletionTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/completion/ExternalWorkspaceCompletionTest.java
@@ -25,11 +25,12 @@ public class ExternalWorkspaceCompletionTest extends BuildFileIntegrationTestCas
 
   @Override
   protected ExternalWorkspaceData mockExternalWorkspaceData() {
-    workspaceOne = new ExternalWorkspaceFixture(
-        ExternalWorkspace.create("workspace_one", "workspace_one"), fileSystem);
+    workspaceOne =
+        createExternalWorkspaceFixture(ExternalWorkspace.create("workspace_one", "workspace_one"));
 
-    workspaceTwoMapped = new ExternalWorkspaceFixture(
-        ExternalWorkspace.create("workspace_two", "com_workspace_two"), fileSystem);
+    workspaceTwoMapped =
+        createExternalWorkspaceFixture(
+            ExternalWorkspace.create("workspace_two", "com_workspace_two"));
 
     return ExternalWorkspaceData.create(
         ImmutableList.of(workspaceOne.workspace, workspaceTwoMapped.workspace));
@@ -41,13 +42,11 @@ public class ExternalWorkspaceCompletionTest extends BuildFileIntegrationTestCas
 
     String[] strings = editorTest.getCompletionItemsAsStrings();
     assertThat(strings).hasLength(2);
-    assertThat(strings)
-        .asList()
-        .containsExactly("@com_workspace_two", "@workspace_one");
+    assertThat(strings).asList().containsExactly("@com_workspace_two", "@workspace_one");
   }
 
   @Test
-  public void testCompleteWillIncludeSlashes () {
+  public void testCompleteWillIncludeSlashes() {
     PsiFile file = testFixture.configureByText("BUILD", "'@com<caret>'");
     assertThat(editorTest.completeIfUnique()).isTrue();
 
@@ -55,7 +54,7 @@ public class ExternalWorkspaceCompletionTest extends BuildFileIntegrationTestCas
   }
 
   @Test
-  public void testCompleteWillFixUpRemainingSlashed () {
+  public void testCompleteWillFixUpRemainingSlashed() {
     PsiFile file = testFixture.configureByText("BUILD", "'@com<caret>//'");
     assertThat(editorTest.completeIfUnique()).isTrue();
 
@@ -73,9 +72,10 @@ public class ExternalWorkspaceCompletionTest extends BuildFileIntegrationTestCas
   @Test
   public void testCompleteWillRespectAutoQuoting() {
     boolean old = CodeInsightSettings.getInstance().AUTOINSERT_PAIR_QUOTE;
+    PsiFile file;
     try {
       CodeInsightSettings.getInstance().AUTOINSERT_PAIR_QUOTE = false;
-      PsiFile file = testFixture.configureByText("BUILD", "'@com<caret>");
+      file = testFixture.configureByText("BUILD", "'@com<caret>");
 
       assertThat(editorTest.completeIfUnique()).isTrue();
       assertFileContents(file, "'@com_workspace_two//");

--- a/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/completion/FilePathInExternalWorkspaceCompletionTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/completion/FilePathInExternalWorkspaceCompletionTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2024 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.lang.buildfile.completion;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.idea.blaze.base.ExternalWorkspaceFixture;
+import com.google.idea.blaze.base.lang.buildfile.BuildFileIntegrationTestCase;
+import com.google.idea.blaze.base.lang.buildfile.psi.BuildFile;
+import com.google.idea.blaze.base.model.ExternalWorkspaceData;
+import com.google.idea.blaze.base.model.primitives.ExternalWorkspace;
+import com.google.idea.blaze.base.model.primitives.WorkspacePath;
+import com.intellij.codeInsight.CodeInsightSettings;
+import com.intellij.openapi.editor.Editor;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests file path code completion in BUILD file labels to paths inside visible external workspaces.
+ */
+@RunWith(JUnit4.class)
+public class FilePathInExternalWorkspaceCompletionTest extends BuildFileIntegrationTestCase {
+  protected ExternalWorkspaceFixture workspace;
+
+  @Override
+  protected ExternalWorkspaceData mockExternalWorkspaceData() {
+    workspace =
+        createExternalWorkspaceFixture(
+            ExternalWorkspace.create("workspace_two", "com_workspace_two"));
+
+    return ExternalWorkspaceData.create(ImmutableList.of(workspace.workspace));
+  }
+
+  @Test
+  public void testUniqueDirectoryCompleted() throws Throwable {
+    workspace.createBuildFile(new WorkspacePath("java/BUILD"), "'//'");
+
+    BuildFile file =
+        createBuildFileWithCaret(new WorkspacePath("file/BUILD"), "'@com_workspace_two//<caret>");
+
+    assertThat(editorTest.completeIfUnique()).isTrue();
+    assertFileContents(file, "'@com_workspace_two//java'");
+    // check caret remains inside closing quote
+    editorTest.assertCaretPosition(
+        testFixture.getEditor(), 0, "'@com_workspace_two//java".length());
+  }
+
+  @Test
+  public void testInsertPairQuoteOptionRespected() throws Throwable {
+    workspace.createBuildFile(new WorkspacePath("java/BUILD"), "'//'");
+
+    boolean old = CodeInsightSettings.getInstance().AUTOINSERT_PAIR_QUOTE;
+    BuildFile file;
+    try {
+      CodeInsightSettings.getInstance().AUTOINSERT_PAIR_QUOTE = false;
+      file =
+          createBuildFileWithCaret(
+              new WorkspacePath("file1/BUILD"), "'@com_workspace_two//j<caret>");
+      assertThat(editorTest.completeIfUnique()).isTrue();
+      assertFileContents(file, "'@com_workspace_two//java");
+
+      CodeInsightSettings.getInstance().AUTOINSERT_PAIR_QUOTE = true;
+      file =
+          createBuildFileWithCaret(
+              new WorkspacePath("file2/BUILD"), "'@com_workspace_two//j<caret>");
+      assertThat(editorTest.completeIfUnique()).isTrue();
+      assertFileContents(file, "'@com_workspace_two//java'");
+    } finally {
+      CodeInsightSettings.getInstance().AUTOINSERT_PAIR_QUOTE = old;
+    }
+  }
+
+  @Test
+  public void testUniqueMultiSegmentDirectoryCompleted() throws Throwable {
+    workspace.createBuildFile(new WorkspacePath("java/com/google/BUILD"), "'//'");
+
+    BuildFile file =
+        createBuildFileWithCaret(new WorkspacePath("BUILD"), "'@com_workspace_two//<caret>");
+
+    assertThat(editorTest.completeIfUnique()).isTrue();
+    assertFileContents(file, "'@com_workspace_two//java/com/google'");
+  }
+
+  @Test
+  public void testStopDirectoryTraversalAtBuildPackage() throws Throwable {
+    workspace.createBuildFile(new WorkspacePath("foo/bar/BUILD"));
+    workspace.createBuildFile(new WorkspacePath("foo/bar/baz/BUILD"));
+
+    BuildFile file =
+        createBuildFileWithCaret(new WorkspacePath("file/BUILD"), "'@com_workspace_two//f<caret>");
+    assertThat(editorTest.completeIfUnique()).isTrue();
+
+    assertFileContents(file, "'@com_workspace_two//foo/bar'");
+  }
+
+  // expected to be a typical workflow -- complete a segment,
+  // get the possibilities, then start typing
+  // next segment and complete again
+  @Test
+  public void testMultiStageCompletion() throws Throwable {
+    workspace.createDirectory(new WorkspacePath("foo"));
+    workspace.createDirectory(new WorkspacePath("bar"));
+    workspace.createDirectory(new WorkspacePath("other"));
+    workspace.createDirectory(new WorkspacePath("other/foo"));
+    workspace.createDirectory(new WorkspacePath("other/bar"));
+
+    BuildFile file =
+        createBuildFileWithCaret(new WorkspacePath("file/BUILD"), "'@com_workspace_two//<caret>'");
+
+    String[] completionItems = editorTest.getCompletionItemsAsStrings();
+    assertThat(completionItems).hasLength(3);
+
+    Editor editor = testFixture.getEditor();
+    editorTest.performTypingAction(editor, 'o');
+    assertThat(editorTest.completeIfUnique()).isTrue();
+    assertFileContents(file, "'@com_workspace_two//other'");
+    editorTest.assertCaretPosition(editor, 0, "'@com_workspace_two//other".length());
+
+    editorTest.performTypingAction(editor, '/');
+    editorTest.performTypingAction(editor, 'f');
+    assertThat(editorTest.completeIfUnique()).isTrue();
+    assertFileContents(file, "'@com_workspace_two//other/foo'");
+    editorTest.assertCaretPosition(editor, 0, "'@com_workspace_two//other/foo".length());
+  }
+
+  @Test
+  public void testCompletionSuggestionString() {
+    workspace.createDirectory(new WorkspacePath("foo"));
+    workspace.createDirectory(new WorkspacePath("bar"));
+    workspace.createDirectory(new WorkspacePath("other"));
+    workspace.createDirectory(new WorkspacePath("ostrich/foo"));
+    workspace.createDirectory(new WorkspacePath("ostrich/fooz"));
+
+    BuildFile file =
+        createBuildFileWithCaret(new WorkspacePath("BUILD"), "'@com_workspace_two//o<caret>'");
+
+    String[] completionItems = editorTest.getCompletionItemsAsSuggestionStrings();
+    assertThat(completionItems).asList().containsExactly("other", "ostrich");
+
+    editorTest.performTypingAction(testFixture.getEditor(), 's');
+
+    assertThat(editorTest.completeIfUnique()).isTrue();
+    assertFileContents(file, "'@com_workspace_two//ostrich'");
+
+    completionItems = editorTest.getCompletionItemsAsSuggestionStrings();
+    assertThat(completionItems).asList().containsExactly("/foo", "/fooz");
+
+    editorTest.performTypingAction(testFixture.getEditor(), '/');
+
+    completionItems = editorTest.getCompletionItemsAsSuggestionStrings();
+    assertThat(completionItems).asList().containsExactly("foo", "fooz");
+
+    editorTest.performTypingAction(testFixture.getEditor(), 'f');
+
+    completionItems = editorTest.getCompletionItemsAsSuggestionStrings();
+    assertThat(completionItems).asList().containsExactly("foo", "fooz");
+  }
+}

--- a/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/completion/RuleTargetCompletionTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/completion/RuleTargetCompletionTest.java
@@ -189,11 +189,6 @@ public class RuleTargetCompletionTest extends BuildFileIntegrationTestCase {
     assertThat(completionItems).asList().doesNotContain("'//java/com/google:other_rule'");
   }
 
-  @Test
-  public void testExternalRepoCompletion() throws Throwable {
-
-  }
-
   private static void setBuildLanguageSpecRules(
       MockBuildLanguageSpecProvider specProvider, String... ruleNames) {
     ImmutableMap.Builder<String, RuleDefinition> rules = ImmutableMap.builder();

--- a/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/completion/RuleTargetInExternalWorkspaceCompletionTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/completion/RuleTargetInExternalWorkspaceCompletionTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2024 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.lang.buildfile.completion;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.idea.blaze.base.ExternalWorkspaceFixture;
+import com.google.idea.blaze.base.lang.buildfile.BuildFileIntegrationTestCase;
+import com.google.idea.blaze.base.lang.buildfile.language.semantics.BuildLanguageSpec;
+import com.google.idea.blaze.base.lang.buildfile.language.semantics.BuildLanguageSpecProvider;
+import com.google.idea.blaze.base.lang.buildfile.language.semantics.RuleDefinition;
+import com.google.idea.blaze.base.lang.buildfile.psi.BuildFile;
+import com.google.idea.blaze.base.model.ExternalWorkspaceData;
+import com.google.idea.blaze.base.model.primitives.ExternalWorkspace;
+import com.google.idea.blaze.base.model.primitives.WorkspacePath;
+import javax.annotation.Nullable;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests code completion of rule target labels inside visible external workspaces. */
+@RunWith(JUnit4.class)
+public class RuleTargetInExternalWorkspaceCompletionTest extends BuildFileIntegrationTestCase {
+  protected ExternalWorkspaceFixture workspace;
+
+  @Override
+  protected ExternalWorkspaceData mockExternalWorkspaceData() {
+    workspace = createExternalWorkspaceFixture(ExternalWorkspace.create("workspace+", "workspace"));
+
+    return ExternalWorkspaceData.create(ImmutableList.of(workspace.workspace));
+  }
+
+  @Test
+  public void testCustomRuleCompletion() {
+    MockBuildLanguageSpecProvider specProvider = new MockBuildLanguageSpecProvider();
+    setBuildLanguageSpecRules(specProvider, "java_library");
+    registerProjectService(BuildLanguageSpecProvider.class, specProvider);
+
+    workspace.createBuildFile(new WorkspacePath("java/BUILD"), "custom_rule(name = 'lib')");
+
+    createBuildFileWithCaret(
+        new WorkspacePath("java/com/google/BUILD"),
+        "java_library(",
+        "    name = 'test',",
+        "    deps = ['@workspace//java:<caret>']");
+
+    assertThat(editorTest.getCompletionItemsAsStrings())
+        .asList()
+        .containsExactly("'@workspace//java:lib'");
+  }
+
+  @Test
+  public void testWorkspaceTarget() {
+    workspace.createBuildFile(
+        new WorkspacePath("java/com/google/foo/BUILD"), "java_library(name = 'foo_lib')");
+
+    createBuildFileWithCaret(
+        new WorkspacePath("java/com/google/bar/BUILD"),
+        "java_library(",
+        "    name = 'bar_lib',",
+        "    deps = '@workspace//java/com/google/foo:<caret>')");
+
+    assertThat(editorTest.getCompletionItemsAsStrings())
+        .asList()
+        .containsExactly("'@workspace//java/com/google/foo:foo_lib'");
+  }
+
+  @Test
+  public void testNotCompletedWithoutColon() {
+    workspace.createBuildFile(
+        new WorkspacePath("java/com/google/foo/BUILD"), "java_library(name = 'foo_lib')");
+
+    BuildFile bar =
+        createBuildFileWithCaret(
+            new WorkspacePath("java/com/google/bar/BUILD"),
+            "java_library(",
+            "    name = 'bar_lib',",
+            "    deps = '@workspace//java/com/google/foo<caret>')");
+
+    String[] completionItems = editorTest.getCompletionItemsAsStrings();
+    assertThat(completionItems).isEmpty();
+  }
+
+  @Test
+  public void testLocalPathIgnored() {
+    workspace.createBuildFile(new WorkspacePath("java/BUILD"), "java_library(name = 'root_rule')");
+
+    createBuildFileWithCaret(
+        new WorkspacePath("java/com/google/BUILD"),
+        "java_library(name = 'other_rule')",
+        "java_library(",
+        "    name = 'lib',",
+        "    deps = ['@workspace//java:<caret>']");
+
+    String[] completionItems = editorTest.getCompletionItemsAsStrings();
+    assertThat(completionItems).asList().contains("'@workspace//java:root_rule'");
+    assertThat(completionItems).asList().doesNotContain("'//java/com/google:other_rule'");
+  }
+
+  private static void setBuildLanguageSpecRules(
+      MockBuildLanguageSpecProvider specProvider, String... ruleNames) {
+    ImmutableMap.Builder<String, RuleDefinition> rules = ImmutableMap.builder();
+    for (String name : ruleNames) {
+      rules.put(name, new RuleDefinition(name, ImmutableMap.of(), null));
+    }
+    specProvider.setRules(rules.build());
+  }
+
+  private static class MockBuildLanguageSpecProvider implements BuildLanguageSpecProvider {
+
+    BuildLanguageSpec languageSpec = new BuildLanguageSpec(ImmutableMap.of());
+
+    void setRules(ImmutableMap<String, RuleDefinition> rules) {
+      languageSpec = new BuildLanguageSpec(rules);
+    }
+
+    @Nullable
+    @Override
+    public BuildLanguageSpec getLanguageSpec() {
+      return languageSpec;
+    }
+  }
+}

--- a/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/findusages/ExternalWorkspaceFindUsagesTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/findusages/ExternalWorkspaceFindUsagesTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.google.idea.blaze.base.lang.buildfile.findusages;
 
 import static com.google.common.truth.Truth.assertThat;

--- a/base/tests/utils/integration/com/google/idea/blaze/base/ExternalWorkspaceFixture.java
+++ b/base/tests/utils/integration/com/google/idea/blaze/base/ExternalWorkspaceFixture.java
@@ -8,7 +8,9 @@ import com.google.idea.blaze.base.model.primitives.TargetName;
 import com.google.idea.blaze.base.model.primitives.WorkspacePath;
 import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
 import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
+import com.intellij.testFramework.fixtures.CodeInsightTestFixture;
 
 import java.io.File;
 import java.nio.file.Paths;
@@ -21,11 +23,17 @@ public class ExternalWorkspaceFixture {
   public final ExternalWorkspace workspace;
 
   final TestFileSystem fileSystem;
+  final CodeInsightTestFixture testFixture;
   WorkspaceFileSystem workspaceFileSystem;
 
-  public ExternalWorkspaceFixture(ExternalWorkspace workspace, TestFileSystem fileSystem) {
+  public ExternalWorkspaceFixture(ExternalWorkspace workspace, TestFileSystem fileSystem, CodeInsightTestFixture testFixture) {
     this.workspace = workspace;
     this.fileSystem = fileSystem;
+    this.testFixture = testFixture;
+  }
+
+  public VirtualFile createDirectory(WorkspacePath path) {
+    return getWorkspaceFileSystem().createDirectory(path);
   }
 
   public BuildFile createBuildFile(WorkspacePath workspacePath, String... contentLines) {
@@ -33,6 +41,14 @@ public class ExternalWorkspaceFixture {
     assertThat(file).isInstanceOf(BuildFile.class);
     return (BuildFile) file;
   }
+
+  protected BuildFile configureByFile(WorkspacePath workspacePath, String... contentLines) {
+    PsiFile file = getWorkspaceFileSystem().createPsiFile(workspacePath, contentLines);
+    assertThat(file).isInstanceOf(BuildFile.class);
+    testFixture.configureFromExistingVirtualFile(file.getVirtualFile());
+    return (BuildFile) file;
+  }
+
 
   WorkspaceFileSystem getWorkspaceFileSystem() {
     if (workspaceFileSystem == null) {

--- a/base/tests/utils/integration/com/google/idea/blaze/base/lang/buildfile/BuildFileIntegrationTestCase.java
+++ b/base/tests/utils/integration/com/google/idea/blaze/base/lang/buildfile/BuildFileIntegrationTestCase.java
@@ -18,11 +18,13 @@ package com.google.idea.blaze.base.lang.buildfile;
 import com.google.common.base.Joiner;
 import com.google.idea.blaze.base.BlazeIntegrationTestCase;
 import com.google.idea.blaze.base.EditorTestHelper;
+import com.google.idea.blaze.base.ExternalWorkspaceFixture;
 import com.google.idea.blaze.base.lang.buildfile.psi.BuildFile;
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.ExternalWorkspaceData;
 import com.google.idea.blaze.base.model.MockBlazeProjectDataBuilder;
 import com.google.idea.blaze.base.model.MockBlazeProjectDataManager;
+import com.google.idea.blaze.base.model.primitives.ExternalWorkspace;
 import com.google.idea.blaze.base.model.primitives.WorkspacePath;
 import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
 import com.google.idea.blaze.base.sync.workspace.WorkspaceHelper;
@@ -66,6 +68,13 @@ public abstract class BuildFileIntegrationTestCase extends BlazeIntegrationTestC
     return (BuildFile) file;
   }
 
+  protected BuildFile createBuildFileWithCaret(WorkspacePath workspacePath, String... contentLines) {
+    PsiFile file = workspace.createPsiFile(workspacePath, contentLines);
+    assertThat(file).isInstanceOf(BuildFile.class);
+    testFixture.configureFromExistingVirtualFile(file.getVirtualFile());
+    return (BuildFile) file;
+  }
+
   protected void assertFileContents(VirtualFile file, String... contentLines) {
     assertFileContents(fileSystem.getPsiFile(file), contentLines);
   }
@@ -92,5 +101,9 @@ public abstract class BuildFileIntegrationTestCase extends BlazeIntegrationTestC
     assertThat(blazeProjectData).isNotNull();
 
     return WorkspaceHelper.getExternalSourceRoot(blazeProjectData).toFile();
+  }
+
+  protected ExternalWorkspaceFixture createExternalWorkspaceFixture(ExternalWorkspace workspace) {
+    return new ExternalWorkspaceFixture(workspace, fileSystem, testFixture);
   }
 }


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

# Discussion thread for this change

Issue number: #6664, #505

# Description of this change

This hould be the last big PR closing those two issues. It adds external workspace prefixed path and rule completion. Semantics should be similar to the current completion semantics. Added tests for it and tweaked the test fixtures to help.

