### PR TITLE
Set go DebugConfguration working directory for tests

### DIFF
--- a/golang/src/com/google/idea/blaze/golang/run/BlazeGoRunConfigurationRunner.java
+++ b/golang/src/com/google/idea/blaze/golang/run/BlazeGoRunConfigurationRunner.java
@@ -409,6 +409,8 @@ public class BlazeGoRunConfigurationRunner implements BlazeCommandRunConfigurati
   private static final Pattern TEST_SRCDIR = Pattern.compile("TEST_SRCDIR=([^ ]+)");
   // Matches RUNFILES_<NAME>=<value>
   private static final Pattern RUNFILES_VAR = Pattern.compile("RUNFILES_([A-Z_]+)=([^ ]+)");
+  // Matches TEST_TARGET=//<package_path>:<target>
+  private static final Pattern TEST_TARGET = Pattern.compile("TEST_TARGET=//([^:]*):([^\\s]+)");
   // Matches a space-delimited arg list. Supports wrapping arg in single quotes.
   private static final Pattern ARGS = Pattern.compile("([^\']\\S*|\'.+?\')\\s*");
 
@@ -443,7 +445,6 @@ public class BlazeGoRunConfigurationRunner implements BlazeCommandRunConfigurati
       while (runfilesVars.find()) {
         envVars.put(String.format("RUNFILES_%s", runfilesVars.group(1)), runfilesVars.group(2));
       }
-      workingDir = workspaceRoot.directory();
       String workspaceName = execRoot.getName();
       binary =
           Paths.get(
@@ -452,6 +453,21 @@ public class BlazeGoRunConfigurationRunner implements BlazeCommandRunConfigurati
                   workspaceName,
                   args.get(1))
               .toFile();
+
+      Matcher testTarget = TEST_TARGET.matcher(text);
+      if (testTarget.find()) {
+        String packagePath = testTarget.group(1);
+        workingDir = 
+            Paths.get(
+                    workspaceRoot.directory().getPath(),
+                    testScrDir.group(1),
+                    workspaceName,
+                    packagePath)
+                .toFile();
+      } else {
+        workingDir = workspaceRoot.directory();
+      }
+
       // Remove everything except the args.
       args = args.subList(2, args.size() - 1);
     } else {


### PR DESCRIPTION
Fixes #2213

# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: https://github.com/bazelbuild/intellij/issues/2213

# Description of this change

I have ran into the same issue and wanted to fix it. I don't know if it is desirable for someone to have a different working directory for "run" and "debug" actions and I'm not familiar enough with the project to make a feature flag for this.

I have tested multiple project layouts to figure out the working directory used for bazel test and the "run" action for the ide. The mattern always seems to match the `<path_to_workspace>/<package_path>` which I went for and which fixed the issues for me. `<path_to_workspace>` is the directory with the BUILD file where the corresponding target is defined