### PR TITLE
Auto import not using any context so there is nowhere to report that …

### DIFF
--- a/base/src/com/google/idea/blaze/base/projectview/section/sections/ImportSection.java
+++ b/base/src/com/google/idea/blaze/base/projectview/section/sections/ImportSection.java
@@ -66,7 +66,7 @@ public class ImportSection {
           if (projectViewImportsMandatory || projectViewFile.exists()) {
             parser.parseProjectView(projectViewFile);
           } else {
-            String warningMessage = String.format("Could not load optional project view file: '%s'", projectViewFile.getPath());
+            String warningMessage = String.format("Could not load project view file: '%s'", projectViewFile.getPath());
             if (parseContext.getContext() != null) {
               IssueOutput.warn(warningMessage).submit(parseContext.getContext());
             } else {

--- a/base/src/com/google/idea/blaze/base/projectview/section/sections/ImportSection.java
+++ b/base/src/com/google/idea/blaze/base/projectview/section/sections/ImportSection.java
@@ -66,9 +66,11 @@ public class ImportSection {
           if (projectViewImportsMandatory || projectViewFile.exists()) {
             parser.parseProjectView(projectViewFile);
           } else {
-            IssueOutput.warn(
-                            String.format("Could not load project view file: '%s'", projectViewFile.getPath()))
-                    .submit(parseContext.getContext());
+              if (parseContext.getContext() != null) {
+                  IssueOutput.warn(
+                                  String.format("Could not load project view file: '%s'", projectViewFile.getPath()))
+                          .submit(parseContext.getContext());
+              }
           }
         } else {
           parseContext.addError("Could not resolve import: " + workspacePath);

--- a/base/src/com/google/idea/blaze/base/projectview/section/sections/ImportSection.java
+++ b/base/src/com/google/idea/blaze/base/projectview/section/sections/ImportSection.java
@@ -66,10 +66,13 @@ public class ImportSection {
           if (projectViewImportsMandatory || projectViewFile.exists()) {
             parser.parseProjectView(projectViewFile);
           } else {
-              if (parseContext.getContext() != null) {
-                  IssueOutput.warn(
-                                  String.format("Could not load project view file: '%s'", projectViewFile.getPath()))
+            String warningMessage = String.format("Could not load optional project view file: '%s'", projectViewFile.getPath());
+            if (parseContext.getContext() != null) {
+                IssueOutput.warn(
+                                warningMessage)
                           .submit(parseContext.getContext());
+              } else {
+                parseContext.addWarning(warningMessage);
               }
           }
         } else {

--- a/base/src/com/google/idea/blaze/base/projectview/section/sections/ImportSection.java
+++ b/base/src/com/google/idea/blaze/base/projectview/section/sections/ImportSection.java
@@ -68,12 +68,10 @@ public class ImportSection {
           } else {
             String warningMessage = String.format("Could not load optional project view file: '%s'", projectViewFile.getPath());
             if (parseContext.getContext() != null) {
-                IssueOutput.warn(
-                                warningMessage)
-                          .submit(parseContext.getContext());
-              } else {
-                parseContext.addWarning(warningMessage);
-              }
+              IssueOutput.warn(warningMessage).submit(parseContext.getContext());
+            } else {
+              parseContext.addWarning(warningMessage);
+            }
           }
         } else {
           parseContext.addError("Could not resolve import: " + workspacePath);


### PR DESCRIPTION
…optional file is missing.

To address auto-import exception

```
2024-09-10 21:25:18,988 [   1913]   INFO - #c.j.r.u.UnattendedHostStarter - message: Cannot invoke "com.google.idea.blaze.common.Context.output(com.google.idea.blaze.common.Output)" because "context" is null, stacktrace
:java.lang.NullPointerException: Cannot invoke "com.google.idea.blaze.common.Context.output(com.google.idea.blaze.common.Output)" because "context" is null
	at com.google.idea.blaze.base.scope.output.IssueOutput$Builder.submit(IssueOutput.java:113)
	at com.google.idea.blaze.base.projectview.section.sections.ImportSection$ImportSectionParser.parseItem(ImportSection.java:71)
	at com.google.idea.blaze.base.projectview.section.sections.TryImportSection$TryImportSectionParser.parseItem(TryImportSection.java:30)
	at com.google.idea.blaze.base.projectview.section.sections.TryImportSection$TryImportSectionParser.parseItem(TryImportSection.java:20)
	at com.google.idea.blaze.base.projectview.section.ScalarSectionParser.parse(ScalarSectionParser.java:53)
	at com.google.idea.blaze.base.projectview.section.ScalarSectionParser.parse(ScalarSectionParser.java:23)
	at com.google.idea.blaze.base.projectview.parser.ProjectViewParser.parseProjectView(ProjectViewParser.java:86)
	at com.google.idea.blaze.base.projectview.parser.ProjectViewParser.parseProjectView(ProjectViewParser.java:66)
	at com.google.idea.blaze.base.project.AutoImportProjectOpenProcessor.fromFileProjectView(AutoImportProjectOpenProcessor.java:255)
	at com.google.idea.blaze.base.project.AutoImportProjectOpenProcessor.createProjectView(AutoImportProjectOpenProcessor.java:243)
	at com.google.idea.blaze.base.project.AutoImportProjectOpenProcessor.createProject(AutoImportProjectOpenProcessor.java:161)
	at com.google.idea.blaze.base.project.AutoImportProjectOpenProcessor.doOpenProject(AutoImportProjectOpenProcessor.java:116)
	at com.intellij.ide.impl.ProjectUtil$chooseProcessorAndOpenAsync$2.invokeSuspend(ProjectUtil.kt:319)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:104)
	at com.intellij.openapi.application.impl.DispatchedRunnable.run(DispatchedRunnable.kt:44)
	at com.intellij.openapi.application.TransactionGuardImpl.runWithWritingAllowed(TransactionGuardImpl.java:229)
	at com.intellij.openapi.application.TransactionGuardImpl.access$100(TransactionGuardImpl.java:22)
	at com.intellij.openapi.application.TransactionGuardImpl$2.run(TransactionGuardImpl.java:211)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWithImplicitRead(AnyThreadWriteThreadingSupport.kt:122)
	at com.intellij.openapi.application.impl.ApplicationImpl.runWithImplicitRead(ApplicationImpl.java:1162)
	at com.intellij.openapi.application.impl.FlushQueue.doRun(FlushQueue.java:78)
	at com.intellij.openapi.application.impl.FlushQueue.runNextEvent(FlushQueue.java:119)
	at com.intellij.openapi.application.impl.FlushQueue.flushNow(FlushQueue.java:41)
	at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:318)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:781)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:728)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:722)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:87)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:750)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.kt:696)
	at com.intellij.ide.IdeEventQueue._dispatchEvent$lambda$16(IdeEventQueue.kt:590)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWithoutImplicitRead(AnyThreadWriteThreadingSupport.kt:117)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.kt:590)
	at com.intellij.ide.IdeEventQueue.access$_dispatchEvent(IdeEventQueue.kt:73)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1$1$1.compute(IdeEventQueue.kt:357)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1$1$1.compute(IdeEventQueue.kt:356)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:843)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1$1.invoke(IdeEventQueue.kt:356)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1$1.invoke(IdeEventQueue.kt:351)
	at com.intellij.ide.IdeEventQueueKt$performActivity$runnableWithWIL$1.invoke$lambda$0(IdeEventQueue.kt:1035)
	at com.intellij.openapi.application.WriteIntentReadAction.lambda$run$0(WriteIntentReadAction.java:24)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteIntentReadAction(AnyThreadWriteThreadingSupport.kt:84)
	at com.intellij.openapi.application.impl.ApplicationImpl.runWriteIntentReadAction(ApplicationImpl.java:910)
	at com.intellij.openapi.application.WriteIntentReadAction.compute(WriteIntentReadAction.java:55)
	at com.intellij.openapi.application.WriteIntentReadAction.run(WriteIntentReadAction.java:23)
	at com.intellij.ide.IdeEventQueueKt$performActivity$runnableWithWIL$1.invoke(IdeEventQueue.kt:1035)
	at com.intellij.ide.IdeEventQueueKt$performActivity$runnableWithWIL$1.invoke(IdeEventQueue.kt:1035)
	at com.intellij.ide.IdeEventQueueKt.performActivity$lambda$1(IdeEventQueue.kt:1036)
	at com.intellij.openapi.application.TransactionGuardImpl.performActivity(TransactionGuardImpl.java:106)
	at com.intellij.ide.IdeEventQueueKt.performActivity(IdeEventQueue.kt:1036)
	at com.intellij.ide.IdeEventQueue.dispatchEvent$lambda$10(IdeEventQueue.kt:351)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.kt:397)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:207)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:128)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:117)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:105)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:92)
```

# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: [`6752`](https://github.com/bazelbuild/intellij/issues/6752)

# Description of this change

