### PR TITLE
Fix unrecognized options by bazel mod command

### DIFF
--- a/base/src/com/google/idea/blaze/base/command/BlazeFlags.java
+++ b/base/src/com/google/idea/blaze/base/command/BlazeFlags.java
@@ -77,7 +77,9 @@ public final class BlazeFlags {
     for (BuildFlagsProvider buildFlagsProvider : BuildFlagsProvider.EP_NAME.getExtensions()) {
       buildFlagsProvider.addBuildFlags(project, projectViewSet, command, invocationContext, flags);
     }
-    flags.addAll(expandBuildFlags(projectViewSet.listItems(BuildFlagsSection.KEY)));
+    if (command != BlazeCommandName.MOD) {
+      flags.addAll(expandBuildFlags(projectViewSet.listItems(BuildFlagsSection.KEY)));
+    }
     if (invocationContext.type() == ContextType.Sync) {
       for (BuildFlagsProvider buildFlagsProvider : BuildFlagsProvider.EP_NAME.getExtensions()) {
         buildFlagsProvider.addSyncFlags(


### PR DESCRIPTION
Build flags defined in the project view are forwarded to `bazel mod` which breaks sync, since `--define` is not a known option for the mod command.

Not sure if excluding build flags from the mod command is the right way to go. But fixes the sync.