### PR TITLE
Fix Security Vulnerability with the PR labeler and remove label github actions.

### DIFF
--- a/.github/workflows/pr-label-and-assignee.yml
+++ b/.github/workflows/pr-label-and-assignee.yml
@@ -1,6 +1,6 @@
 name: Auto Add Labels and Assignees
 on:
-  pull_request_target:
+  pull_request:
     types: ["opened", "reopened", "ready_for_review"]
 
 jobs:

--- a/.github/workflows/remove-labels.yml
+++ b/.github/workflows/remove-labels.yml
@@ -1,7 +1,7 @@
 name: Remove PR Labels
 
 on:
-  pull_request_target:
+  pull_request:
     types: ["closed", "merged"]
 
 jobs:


### PR DESCRIPTION
Fix Security Vulnerability with the PR labeler and remove label github actions


As per the b/364700434, there can be a potential risk when using pull_request_target. This change converts the pull_request_target to pull_request event trigger.

