### PR TITLE
Fix view_project_root with overlapping directories

### DIFF
--- a/base/src/com/google/idea/blaze/base/sync/projectview/ImportRoots.java
+++ b/base/src/com/google/idea/blaze/base/sync/projectview/ImportRoots.java
@@ -183,7 +183,9 @@ public final class ImportRoots {
       var result = new ArrayList<File>();
       while (!files.isEmpty()) {
         File file = files.poll();
-        if (rootDirectories.stream().anyMatch(d -> FileUtil.isAncestor(file, workspaceRoot.fileForPath(d), /*strict=*/ true))) {
+        if (rootDirectories.stream().anyMatch(d -> FileUtil.isAncestor(file, workspaceRoot.fileForPath(d), /*strict=*/ true)) &&
+            rootDirectories.stream().noneMatch(d -> FileUtil.filesEqual(file, workspaceRoot.fileForPath(d)))
+        ) {
           var children = file.listFiles(File::isDirectory);
           if (children != null) {
             files.addAll(List.of(children));


### PR DESCRIPTION

# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change
When `view_project_root: true` and there are overlapping directories, for example:

The repo contains these directories:
- foo
- foo/bar
- foo/baz

And .bazelproject is:
```
view_project_root: true

directories:
  foo
  foo/bar
```

Then, `foo/baz` will incorrectly be excluded. This is unexpected because it's contained under the `foo` directory.

This commit fixes the behavior, so that files are not excluded if they are under any root directory.