### PR TITLE
chore: Support Jetbrains IDEs 243 - go and js plugin require json plugin since 243

### DIFF
--- a/golang/BUILD
+++ b/golang/BUILD
@@ -110,6 +110,7 @@ intellij_integration_test_suite(
         "//common/experiments",
         "//common/experiments:unit_test_utils",
         "//intellij_platform_sdk:intellilang_for_tests",
+        "//intellij_platform_sdk:json_for_tests",
         "//intellij_platform_sdk:jsr305",
         "//intellij_platform_sdk:plugin_api_for_tests",
         "//intellij_platform_sdk:test_libs",

--- a/intellij_platform_sdk/BUILD
+++ b/intellij_platform_sdk/BUILD
@@ -1056,6 +1056,16 @@ java_library(
     ),
 )
 
+java_library(
+    name = "json_for_tests",
+    testonly = 1,
+    exports = select_from_plugin_api_directory(
+        android_studio = [],
+        clion = [],
+        intellij = [":json"],
+    ),
+)
+
 filegroup(
     name = "application_info_json",
     srcs = select_from_plugin_api_directory(

--- a/intellij_platform_sdk/BUILD.ue223
+++ b/intellij_platform_sdk/BUILD.ue223
@@ -141,6 +141,11 @@ java_import(
     tags = ["intellij-provided-by-sdk"],
 )
 
+java_import(
+    name = "json",
+    jars = glob(["plugins/json/lib/*.jar"])
+)
+
 filegroup(
     name = "application_info_json",
     srcs = ["product-info.json"],

--- a/intellij_platform_sdk/BUILD.ue231
+++ b/intellij_platform_sdk/BUILD.ue231
@@ -141,6 +141,11 @@ java_import(
     tags = ["intellij-provided-by-sdk"],
 )
 
+java_import(
+    name = "json",
+    jars = glob(["plugins/json/lib/*.jar"])
+)
+
 filegroup(
     name = "application_info_json",
     srcs = ["product-info.json"],

--- a/intellij_platform_sdk/BUILD.ue232
+++ b/intellij_platform_sdk/BUILD.ue232
@@ -141,6 +141,11 @@ java_import(
     tags = ["intellij-provided-by-sdk"],
 )
 
+java_import(
+    name = "json",
+    jars = glob(["plugins/json/lib/*.jar"])
+)
+
 filegroup(
     name = "application_info_json",
     srcs = ["product-info.json"],

--- a/intellij_platform_sdk/BUILD.ue233
+++ b/intellij_platform_sdk/BUILD.ue233
@@ -141,6 +141,11 @@ java_import(
     tags = ["intellij-provided-by-sdk"],
 )
 
+java_import(
+    name = "json",
+    jars = glob(["plugins/json/lib/*.jar"])
+)
+
 filegroup(
     name = "application_info_json",
     srcs = ["product-info.json"],

--- a/intellij_platform_sdk/BUILD.ue241
+++ b/intellij_platform_sdk/BUILD.ue241
@@ -155,6 +155,11 @@ java_import(
     tags = ["intellij-provided-by-sdk"],
 )
 
+java_import(
+    name = "json",
+    jars = glob(["plugins/json/lib/*.jar"])
+)
+
 filegroup(
     name = "application_info_json",
     srcs = ["product-info.json"],

--- a/intellij_platform_sdk/BUILD.ue242
+++ b/intellij_platform_sdk/BUILD.ue242
@@ -157,6 +157,11 @@ java_import(
     tags = ["intellij-provided-by-sdk"],
 )
 
+java_import(
+    name = "json",
+    jars = glob(["plugins/json/lib/*.jar"])
+)
+
 filegroup(
     name = "application_info_json",
     srcs = ["product-info.json"],

--- a/intellij_platform_sdk/BUILD.ue243
+++ b/intellij_platform_sdk/BUILD.ue243
@@ -145,6 +145,11 @@ java_import(
     jars = glob(["plugins/cwm-plugin/lib/*.jar"]),
 )
 
+java_import(
+    name = "json",
+    jars = glob(["plugins/json/lib/*.jar"])
+)
+
 # The plugins required by IJwB. We need to include them
 # when running integration tests.
 java_import(

--- a/javascript/BUILD
+++ b/javascript/BUILD
@@ -97,6 +97,7 @@ intellij_integration_test_suite(
         "//base",
         "//base:integration_test_utils",
         "//base:unit_test_utils",
+        "//intellij_platform_sdk:json_for_tests",
         "//intellij_platform_sdk:jsr305",
         "//intellij_platform_sdk:plugin_api_for_tests",
         "//intellij_platform_sdk:test_libs",


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

