### PR TITLE
Update testing platform for ubuntu

### DIFF
--- a/.bazelci/android-studio.yml
+++ b/.bazelci/android-studio.yml
@@ -2,7 +2,7 @@
 tasks:
   Android-Studio-internal-stable:
     name: Android Studio Internal Stable
-    platform: ubuntu1804
+    platform: ubuntu2204
     build_flags:
       - --define=ij_product=android-studio-latest
     build_targets:
@@ -14,7 +14,7 @@ tasks:
       - //:aswb_tests
   Android-Studio-internal-beta:
     name: Android Studio Internal Beta
-    platform: ubuntu1804
+    platform: ubuntu2204
     build_flags:
       - --define=ij_product=android-studio-beta
     build_targets:
@@ -26,7 +26,7 @@ tasks:
       - //:aswb_tests
   Android-Studio-internal-canary:
     name: Android Studio Internal Canary
-    platform: ubuntu1804
+    platform: ubuntu2204
     build_flags:
       - --define=ij_product=android-studio-canary
     build_targets:
@@ -40,7 +40,7 @@ tasks:
       - exit_status: 1
   Android-Studio-OSS-oldest-stable:
     name: Android Studio OSS Oldest Stable
-    platform: ubuntu1804
+    platform: ubuntu2204
     build_flags:
       - --define=ij_product=android-studio-oss-oldest-stable
     build_targets:
@@ -52,7 +52,7 @@ tasks:
       - //:aswb_tests
   Android-Studio-OSS-latest-stable:
     name: Android Studio OSS Latest Stable
-    platform: ubuntu1804
+    platform: ubuntu2204
     build_flags:
       - --define=ij_product=android-studio-oss-latest-stable
     build_targets:
@@ -64,7 +64,7 @@ tasks:
       - //:aswb_tests
   Android-Studio-OSS-under-dev:
     name: Android Studio OSS Under Development
-    platform: ubuntu1804
+    platform: ubuntu2204
     build_flags:
       - --define=ij_product=android-studio-oss-under-dev
     build_targets:

--- a/.bazelci/aspect.yml
+++ b/.bazelci/aspect.yml
@@ -2,7 +2,7 @@
 tasks:
   Aspect-internal-stable:
     name: Aspect Tests for IJ Internal Stable
-    platform: ubuntu1804
+    platform: ubuntu2204
     build_flags:
       - --define=ij_product=intellij-latest
     build_targets:
@@ -16,7 +16,7 @@ tasks:
     skip_use_bazel_version_for_test: true
   Aspect-internal-beta:
     name: Aspect Tests for IJ Internal Beta
-    platform: ubuntu1804
+    platform: ubuntu2204
     build_flags:
       - --define=ij_product=intellij-beta
     build_targets:
@@ -30,7 +30,7 @@ tasks:
     skip_use_bazel_version_for_test: true
   Aspect-internal-under-dev:
     name: Aspect Tests for IJ Internal Under Development
-    platform: ubuntu1804
+    platform: ubuntu2204
     build_flags:
       - --define=ij_product=intellij-under-dev
     build_targets:
@@ -46,7 +46,7 @@ tasks:
     skip_use_bazel_version_for_test: true
   Aspect-oss-oldest-stable:
     name: Aspect Tests for IJ OSS Oldest Stable
-    platform: ubuntu1804
+    platform: ubuntu2204
     build_flags:
       - --define=ij_product=intellij-oss-oldest-stable
     build_targets:
@@ -60,7 +60,7 @@ tasks:
     skip_use_bazel_version_for_test: true
   Aspect-oss-latest-stable:
     name: Aspect Tests for IJ OSS Latest Stable
-    platform: ubuntu1804
+    platform: ubuntu2204
     build_flags:
       - --define=ij_product=intellij-oss-latest-stable
     build_targets:
@@ -74,7 +74,7 @@ tasks:
     skip_use_bazel_version_for_test: true
   Aspect-oss-under-dev:
     name: Aspect Tests for IJ OSS Under Development
-    platform: ubuntu1804
+    platform: ubuntu2204
     build_flags:
       - --define=ij_product=intellij-oss-under-dev
     build_targets:

--- a/.bazelci/clion.yml
+++ b/.bazelci/clion.yml
@@ -2,7 +2,7 @@
 tasks:
   CLion-internal-stable:
     name: CLion Internal Stable
-    platform: ubuntu1804
+    platform: ubuntu2204
     build_flags:
       - --define=ij_product=clion-latest
     build_targets:
@@ -14,7 +14,7 @@ tasks:
       - //:clwb_tests
   CLion-internal-beta:
     name: CLion Internal Beta
-    platform: ubuntu1804
+    platform: ubuntu2204
     build_flags:
       - --define=ij_product=clion-beta
     build_targets:
@@ -26,7 +26,7 @@ tasks:
       - //:clwb_tests
   CLion-internal-under-dev:
     name: CLion Internal Under Development
-    platform: ubuntu1804
+    platform: ubuntu2204
     build_flags:
       - --define=ij_product=clion-under-dev
     build_targets:
@@ -40,7 +40,7 @@ tasks:
       - exit_status: 1
   CLion-OSS-oldest-stable:
     name: CLion OSS Oldest Stable
-    platform: ubuntu1804
+    platform: ubuntu2204
     build_flags:
       - --define=ij_product=clion-oss-oldest-stable
     build_targets:
@@ -52,7 +52,7 @@ tasks:
       - //:clwb_tests
   CLion-OSS-latest-stable:
     name: CLion OSS Latest Stable
-    platform: ubuntu1804
+    platform: ubuntu2204
     build_flags:
       - --define=ij_product=clion-oss-latest-stable
     build_targets:
@@ -64,7 +64,7 @@ tasks:
       - //:clwb_tests
   CLion-Linux-OSS-under-dev:
     name: CLion Linux OSS Under Development
-    platform: ubuntu1804
+    platform: ubuntu2204
     build_flags:
       - --define=ij_product=clion-oss-under-dev
     build_targets:

--- a/.bazelci/intellij-ue.yml
+++ b/.bazelci/intellij-ue.yml
@@ -2,7 +2,7 @@
 tasks:
   IntelliJ-UE-internal-stable:
     name: IntelliJ UE Internal Stable
-    platform: ubuntu1804
+    platform: ubuntu2204
     build_flags:
       - --define=ij_product=intellij-ue-latest
     build_targets:
@@ -14,7 +14,7 @@ tasks:
       - //:ijwb_ue_tests
   IntelliJ-UE-internal-beta:
     name: IntelliJ UE Internal Beta
-    platform: ubuntu1804
+    platform: ubuntu2204
     build_flags:
       - --define=ij_product=intellij-ue-beta
     build_targets:
@@ -26,7 +26,7 @@ tasks:
       - //:ijwb_ue_tests
   IntelliJ-UE-internal-under-dev:
     name: IntelliJ UE Internal Under Development
-    platform: ubuntu1804
+    platform: ubuntu2204
     build_flags:
       - --define=ij_product=intellij-ue-under-dev
     build_targets:
@@ -40,7 +40,7 @@ tasks:
       - exit_status: 1
   IntelliJ-UE-OSS-oldest-stable:
     name: IntelliJ UE OSS Oldest Stable
-    platform: ubuntu1804
+    platform: ubuntu2204
     build_flags:
       - --define=ij_product=intellij-ue-oss-oldest-stable
     build_targets:
@@ -52,7 +52,7 @@ tasks:
       - //:ijwb_ue_tests
   IntelliJ-UE-OSS-latest-stable:
     name: IntelliJ UE OSS Latest Stable
-    platform: ubuntu1804
+    platform: ubuntu2204
     build_flags:
       - --define=ij_product=intellij-ue-oss-latest-stable
     build_targets:
@@ -64,7 +64,7 @@ tasks:
       - //:ijwb_ue_tests
   IntelliJ-UE-OSS-under-dev:
     name: IntelliJ UE OSS Under Development
-    platform: ubuntu1804
+    platform: ubuntu2204
     build_flags:
       - --define=ij_product=intellij-ue-oss-under-dev
     build_targets:

--- a/.bazelci/intellij.yml
+++ b/.bazelci/intellij.yml
@@ -2,7 +2,7 @@
 tasks:
   IntelliJ-CE-internal-stable:
     name: IntelliJ CE Internal Stable
-    platform: ubuntu1804
+    platform: ubuntu2204
     build_flags:
       - --define=ij_product=intellij-latest
     build_targets:
@@ -14,7 +14,7 @@ tasks:
       - //:ijwb_ce_tests
   IntelliJ-CE-internal-beta:
     name: IntelliJ CE Internal Beta
-    platform: ubuntu1804
+    platform: ubuntu2204
     build_flags:
       - --define=ij_product=intellij-beta
     build_targets:
@@ -26,7 +26,7 @@ tasks:
       - //:ijwb_ce_tests
   IntelliJ-CE-internal-under-dev:
     name: IntelliJ CE Internal Under Development
-    platform: ubuntu1804
+    platform: ubuntu2204
     build_flags:
       - --define=ij_product=intellij-under-dev
     build_targets:
@@ -40,7 +40,7 @@ tasks:
       - exit_status: 1
   IntelliJ-CE-OSS-oldest-stable:
     name: IntelliJ CE OSS Oldest Stable
-    platform: ubuntu1804
+    platform: ubuntu2204
     build_flags:
       - --define=ij_product=intellij-oss-oldest-stable
     build_targets:
@@ -52,7 +52,7 @@ tasks:
       - //:ijwb_ce_tests
   IntelliJ-CE-OSS-latest-stable:
     name: IntelliJ CE OSS Latest Stable
-    platform: ubuntu1804
+    platform: ubuntu2204
     build_flags:
       - --define=ij_product=intellij-oss-latest-stable
     build_targets:
@@ -64,7 +64,7 @@ tasks:
       - //:ijwb_ce_tests
   IntelliJ-CE-OSS-under-dev:
     name: IntelliJ CE OSS Under Development
-    platform: ubuntu1804
+    platform: ubuntu2204
     build_flags:
       - --define=ij_product=intellij-oss-under-dev
     build_targets:


### PR DESCRIPTION
gcc compiler on ubuntu1804 is too old for Bazel@HEAD

https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/4152#019231ab-a1e4-46bd-916c-7be8b8028756
