### PR TITLE
Add java home to the blaze info

### DIFF
--- a/base/src/com/google/idea/blaze/base/command/info/BlazeInfo.java
+++ b/base/src/com/google/idea/blaze/base/command/info/BlazeInfo.java
@@ -35,6 +35,7 @@ public abstract class BlazeInfo implements ProtoWrapper<ProjectData.BlazeInfo> {
   public static final String OUTPUT_BASE_KEY = "output_base";
   public static final String OUTPUT_PATH_KEY = "output_path";
   public static final String RELEASE = "release";
+  public static final String JAVA_HOME = "java-home";
 
   public static final String STARLARK_SEMANTICS = "starlark-semantics";
 
@@ -86,6 +87,7 @@ public abstract class BlazeInfo implements ProtoWrapper<ProjectData.BlazeInfo> {
             executionRoot, new File(getOrThrow(blazeInfoMap, blazeTestlogsKey(buildSystemName))));
     File outputBase = new File(getOrThrow(blazeInfoMap, OUTPUT_BASE_KEY).trim());
     File outputPath = new File(getOrThrow(blazeInfoMap, OUTPUT_PATH_KEY).trim());
+    File javaHome = new File(getOrThrow(blazeInfoMap, JAVA_HOME).trim());
     return AutoValue_BlazeInfo.builder()
         .setBlazeInfoMap(blazeInfoMap)
         .setExecutionRoot(executionRoot)
@@ -94,6 +96,7 @@ public abstract class BlazeInfo implements ProtoWrapper<ProjectData.BlazeInfo> {
         .setBlazeTestlogs(blazeTestlogs)
         .setOutputBase(outputBase)
         .setOutputPath(outputPath)
+        .setJavaHome(javaHome)
         .autoBuild();
   }
 
@@ -152,6 +155,8 @@ public abstract class BlazeInfo implements ProtoWrapper<ProjectData.BlazeInfo> {
     return getBlazeInfoMap().get(RELEASE);
   }
 
+  public abstract File getJavaHome();
+
   /** Creates a mock blaze info with the minimum information required for syncing. */
   @VisibleForTesting
   public static BlazeInfo createMockBlazeInfo(
@@ -188,6 +193,8 @@ public abstract class BlazeInfo implements ProtoWrapper<ProjectData.BlazeInfo> {
 
     public abstract Builder setOutputPath(File value);
 
+    public abstract Builder setJavaHome(File value);
+
     public abstract BlazeInfo autoBuild();
 
     // A build method to populate the blazeInfoMap
@@ -196,6 +203,7 @@ public abstract class BlazeInfo implements ProtoWrapper<ProjectData.BlazeInfo> {
       blazeInfoMapBuilder().put(OUTPUT_BASE_KEY, blazeInfo.getOutputBase().getPath());
       blazeInfoMapBuilder().put(OUTPUT_PATH_KEY, blazeInfo.getOutputPath().getPath());
       blazeInfoMapBuilder().put(EXECUTION_ROOT_KEY, blazeInfo.getExecutionRoot().getPath());
+      blazeInfoMapBuilder().put(JAVA_HOME, blazeInfo.getJavaHome().getPath());
       File execRoot = new File(blazeInfo.getExecutionRoot().getAbsolutePath());
       blazeInfoMapBuilder()
           .put(

--- a/base/src/com/google/idea/blaze/base/command/info/BlazeInfo.java
+++ b/base/src/com/google/idea/blaze/base/command/info/BlazeInfo.java
@@ -173,7 +173,8 @@ public abstract class BlazeInfo implements ProtoWrapper<ProjectData.BlazeInfo> {
             .put(EXECUTION_ROOT_KEY, executionRoot)
             .put(blazeBinKey(buildSystemName), blazeBin)
             .put(blazeGenfilesKey(buildSystemName), blazeGenFiles)
-            .put(blazeTestlogsKey(buildSystemName), blazeTestlogs);
+            .put(blazeTestlogsKey(buildSystemName), blazeTestlogs)
+            .put(JAVA_HOME, "/tmp/java");
     return BlazeInfo.create(buildSystemName, blazeInfoMap.build());
   }
 

--- a/base/src/com/google/idea/blaze/base/command/info/BlazeInfoRunnerImpl.java
+++ b/base/src/com/google/idea/blaze/base/command/info/BlazeInfoRunnerImpl.java
@@ -92,7 +92,8 @@ class BlazeInfoRunnerImpl extends BlazeInfoRunner {
             BlazeInfo.OUTPUT_PATH_KEY,
             BlazeInfo.OUTPUT_BASE_KEY,
             BlazeInfo.RELEASE,
-            BlazeInfo.STARLARK_SEMANTICS),
+            BlazeInfo.STARLARK_SEMANTICS,
+            BlazeInfo.JAVA_HOME),
         bytes ->
             BlazeInfo.create(
                 buildSystemName,

--- a/base/tests/utils/integration/com/google/idea/blaze/base/sync/BlazeSyncIntegrationTestCase.java
+++ b/base/tests/utils/integration/com/google/idea/blaze/base/sync/BlazeSyncIntegrationTestCase.java
@@ -152,6 +152,7 @@ public abstract class BlazeSyncIntegrationTestCase extends BlazeIntegrationTestC
             .put(BlazeInfo.OUTPUT_BASE_KEY, outputBase)
             .put(BlazeInfo.OUTPUT_PATH_KEY, outputPath)
             .put(BlazeInfo.PACKAGE_PATH_KEY, workspaceRoot.toString())
+            .put(BlazeInfo.JAVA_HOME, "/tmp/java")
             .build());
 
     // The tests run a full sync and hence also include the JDK setup part (if the workspace is

--- a/java/tests/integrationtests/com/google/idea/blaze/java/fastbuild/FastBuildChangedFilesServiceTest.java
+++ b/java/tests/integrationtests/com/google/idea/blaze/java/fastbuild/FastBuildChangedFilesServiceTest.java
@@ -64,7 +64,8 @@ public class FastBuildChangedFilesServiceTest extends BlazeIntegrationTestCase {
               "blaze-testlogs", BLAZE_TESTLOGS,
               "execution_root", BLAZE_EXECROOT,
               "output_base", "/blaze/output-base",
-              "output_path", "/blaze/output-base/output-path"
+              "output_path", "/blaze/output-base/output-path",
+              "java-home", "/tmp/java"
           ));
 
   private FastBuildChangedFilesService changedFilesService;


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Related to 

# Description of this change

Related to #6728. We were relying on the info cache to have java home that bazel uses. After that change the value is no longer provided causing issues on our extension plugin.

