### PR TITLE
fix: Query Sync doesn't crash on projects using BUILD.bazel file names

### DIFF
--- a/aspect/build_dependencies.bzl
+++ b/aspect/build_dependencies.bzl
@@ -5,7 +5,6 @@ load(
     "CPP_COMPILE_ACTION_NAME",
     "C_COMPILE_ACTION_NAME",
 )
-load(":java_info.bzl", "get_java_info")
 
 ALWAYS_BUILD_RULES = "java_proto_library,java_lite_proto_library,java_mutable_proto_library,kt_proto_library_helper,_java_grpc_library,_java_lite_grpc_library,kt_grpc_library_helper,java_stubby_library,kt_stubby_library_helper,aar_import,java_import"
 
@@ -15,6 +14,16 @@ PROTO_RULE_KINDS = [
     "java_mutable_proto_library",
     "kt_proto_library_helper",
 ]
+
+def java_info_in_target(target):
+    return JavaInfo in target
+
+def get_java_info(target):
+    if JavaInfo in target:
+        return target[JavaInfo]
+
+def java_info_reference():
+    return [JavaInfo]
 
 def _package_dependencies_impl(target, ctx):
     java_info_file = _write_java_target_info(target, ctx)

--- a/querysync/java/com/google/idea/blaze/qsync/project/ProjectDefinition.java
+++ b/querysync/java/com/google/idea/blaze/qsync/project/ProjectDefinition.java
@@ -100,7 +100,7 @@ public abstract class ProjectDefinition {
    */
   private static boolean isValidPathForQuery(Context<?> context, Path candidate)
       throws IOException {
-    if (Files.exists(candidate.resolve("BUILD"))) {
+    if (Files.exists(candidate.resolve("BUILD")) || Files.exists(candidate.resolve("BUILD.bazel"))) {
       return true;
     }
     if (!Files.isDirectory(candidate)) {


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

