### PR TITLE
fix: Query Sync can now work with '.' in the directories section

### DIFF
--- a/querysync/java/com/google/idea/blaze/qsync/BlazeQueryParser.java
+++ b/querysync/java/com/google/idea/blaze/qsync/BlazeQueryParser.java
@@ -37,6 +37,7 @@ import com.google.idea.blaze.qsync.query.Query;
 import com.google.idea.blaze.qsync.query.Query.Rule;
 import com.google.idea.blaze.qsync.query.QuerySummary;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -97,8 +98,12 @@ public class BlazeQueryParser {
     for (Map.Entry<Label, Query.SourceFile> sourceFileEntry :
         query.getSourceFilesMap().entrySet()) {
       Location l = new Location(sourceFileEntry.getValue().getLocation());
-      if (l.file.endsWith(Path.of("BUILD"))) {
-        packages.add(l.file.getParent());
+      if (l.file.endsWith(Path.of("BUILD")) || l.file.endsWith(Path.of("BUILD.bazel"))){
+        if(l.file.getParent() == null){
+          packages.add(Paths.get(""));
+        } else{
+          packages.add(l.file.getParent());
+        }
       }
       graphBuilder.locationsBuilder().put(sourceFileEntry.getKey(), l);
       graphBuilder.fileToTargetBuilder().put(l.file, sourceFileEntry.getKey());

--- a/querysync/java/com/google/idea/blaze/qsync/GraphToProjectConverter.java
+++ b/querysync/java/com/google/idea/blaze/qsync/GraphToProjectConverter.java
@@ -219,7 +219,7 @@ public class GraphToProjectConverter {
       ImmutableMap.Builder<Path, String> inRoot = ImmutableMap.builder();
       for (Entry<Path, String> pkg : prefixes.entrySet()) {
         Path rel = pkg.getKey();
-        if (rel.startsWith(root)) {
+        if (rel.startsWith(root) || root.toString().equals("")) {
           Path relToRoot = root.relativize(rel);
           inRoot.put(relToRoot, pkg.getValue());
         }


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

