### PR TITLE
fix: Query Sync: don't check for validity of excludes that are system…

### DIFF
--- a/aswb/tests/unittests/com/google/idea/blaze/android/libraries/RenderJarCacheTest.java
+++ b/aswb/tests/unittests/com/google/idea/blaze/android/libraries/RenderJarCacheTest.java
@@ -26,6 +26,8 @@ import com.google.idea.blaze.android.sync.aspects.strategy.RenderResolveOutputGr
 import com.google.idea.blaze.base.MockProjectViewManager;
 import com.google.idea.blaze.base.async.executor.BlazeExecutor;
 import com.google.idea.blaze.base.async.executor.MockBlazeExecutor;
+import com.google.idea.blaze.base.bazel.BazelBuildSystemProvider;
+import com.google.idea.blaze.base.bazel.BuildSystemProvider;
 import com.google.idea.blaze.base.command.buildresult.LocalFileOutputArtifactWithoutDigest;
 import com.google.idea.blaze.base.filecache.FileCache;
 import com.google.idea.blaze.base.ideinfo.AndroidIdeInfo;
@@ -152,7 +154,7 @@ public class RenderJarCacheTest {
     intellijRule.registerProjectService(ProjectViewManager.class, projectViewManager);
 
     intellijRule.registerApplicationService(BlazeExecutor.class, new MockBlazeExecutor());
-
+    registerExtensionPoint(BuildSystemProvider.EP_NAME, BuildSystemProvider.class).registerExtension(new BazelBuildSystemProvider());
     setupProjectData();
     setProjectView(
         "directories:",

--- a/aswb/tests/unittests/com/google/idea/blaze/android/libraries/RenderJarCacheTest.java
+++ b/aswb/tests/unittests/com/google/idea/blaze/android/libraries/RenderJarCacheTest.java
@@ -154,7 +154,7 @@ public class RenderJarCacheTest {
     intellijRule.registerProjectService(ProjectViewManager.class, projectViewManager);
 
     intellijRule.registerApplicationService(BlazeExecutor.class, new MockBlazeExecutor());
-    registerExtensionPoint(BuildSystemProvider.EP_NAME, BuildSystemProvider.class).registerExtension(new BazelBuildSystemProvider());
+    intellijRule.registerExtensionPoint(BuildSystemProvider.EP_NAME, BuildSystemProvider.class).registerExtension(new BazelBuildSystemProvider());
     setupProjectData();
     setProjectView(
         "directories:",

--- a/aswb/tests/unittests/com/google/idea/blaze/android/libraries/RenderJarCacheTest.java
+++ b/aswb/tests/unittests/com/google/idea/blaze/android/libraries/RenderJarCacheTest.java
@@ -155,7 +155,7 @@ public class RenderJarCacheTest {
 
     intellijRule.registerApplicationService(BlazeExecutor.class, new MockBlazeExecutor());
 
-    intellijRule.registerExtensionPoint(BuildSystemProvider.EP_NAME, BuildSystemProvider.class)
+    intellijRule.registerExtensionPoint(BuildSystemProvider.EP_NAME, BuildSystemProvider.class);
     intellijRule.registerExtension(BuildSystemProvider.EP_NAME, new BazelBuildSystemProvider());
     setupProjectData();
     setProjectView(

--- a/aswb/tests/unittests/com/google/idea/blaze/android/libraries/RenderJarCacheTest.java
+++ b/aswb/tests/unittests/com/google/idea/blaze/android/libraries/RenderJarCacheTest.java
@@ -154,7 +154,9 @@ public class RenderJarCacheTest {
     intellijRule.registerProjectService(ProjectViewManager.class, projectViewManager);
 
     intellijRule.registerApplicationService(BlazeExecutor.class, new MockBlazeExecutor());
-    intellijRule.registerExtensionPoint(BuildSystemProvider.EP_NAME, BuildSystemProvider.class).registerExtension(new BazelBuildSystemProvider());
+
+    intellijRule.registerExtensionPoint(BuildSystemProvider.EP_NAME, BuildSystemProvider.class)
+    intellijRule.registerExtension(BuildSystemProvider.EP_NAME, new BazelBuildSystemProvider());
     setupProjectData();
     setProjectView(
         "directories:",

--- a/base/src/com/google/idea/blaze/base/qsync/ProjectLoader.java
+++ b/base/src/com/google/idea/blaze/base/qsync/ProjectLoader.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.idea.blaze.base.bazel.BuildSystem;
 import com.google.idea.blaze.base.bazel.BuildSystemProvider;
+import com.google.idea.blaze.base.model.primitives.WorkspacePath;
 import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
 import com.google.idea.blaze.base.projectview.ProjectViewManager;
 import com.google.idea.blaze.base.projectview.ProjectViewSet;
@@ -34,6 +35,7 @@ import com.google.idea.blaze.base.qsync.cache.ArtifactTrackerImpl;
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.settings.BlazeImportSettings;
 import com.google.idea.blaze.base.settings.BlazeImportSettingsManager;
+import com.google.idea.blaze.base.settings.BuildSystemName;
 import com.google.idea.blaze.base.sync.data.BlazeDataStorage;
 import com.google.idea.blaze.base.sync.projectview.ImportRoots;
 import com.google.idea.blaze.base.sync.projectview.LanguageSupport;
@@ -122,7 +124,8 @@ public class ProjectLoader {
             importRoots.rootPaths(),
             importRoots.excludePaths(),
             LanguageClasses.toQuerySync(workspaceLanguageSettings.getActiveLanguages()),
-            testSourceGlobs);
+            testSourceGlobs,
+            importRoots.systemExcludes());
 
     Path snapshotFilePath = getSnapshotFilePath(importSettings);
 

--- a/base/src/com/google/idea/blaze/base/qsync/QuerySyncProject.java
+++ b/base/src/com/google/idea/blaze/base/qsync/QuerySyncProject.java
@@ -440,12 +440,14 @@ public class QuerySyncProject {
         projectViewSet.listItems(TestSourceSection.KEY).stream()
             .map(Glob::toString)
             .collect(ImmutableSet.toImmutableSet());
+
     ProjectDefinition projectDefinition =
         ProjectDefinition.create(
             importRoots.rootPaths(),
             importRoots.excludePaths(),
             LanguageClasses.toQuerySync(workspaceLanguageSettings.getActiveLanguages()),
-            testSourceGlobs);
+            testSourceGlobs,
+            importRoots.systemExcludes());
 
     return this.projectDefinition.equals(projectDefinition);
   }

--- a/base/tests/unittests/com/google/idea/blaze/base/sync/projectview/TargetExpressionListTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/sync/projectview/TargetExpressionListTest.java
@@ -182,7 +182,9 @@ public class TargetExpressionListTest extends BlazeTestCase {
             new ProjectDirectoriesHelper(
                 /* rootDirectories= */ ImmutableList.of(new WorkspacePath("foo")),
                 /* excludeDirectories= */ ImmutableSet.of(),
-                /* excludePathsForBazelQuery= */ ImmutableSet.of()
+                /* excludePathsForBazelQuery= */ ImmutableSet.of(),
+                    ImmutableSet.of()
+
                 ));
 
     assertThat(helper.includesTarget(Label.create("//foo:target"))).isTrue();
@@ -203,7 +205,8 @@ public class TargetExpressionListTest extends BlazeTestCase {
             new ProjectDirectoriesHelper(
                 /* rootDirectories= */ ImmutableList.of(new WorkspacePath("foo")),
                 /* excludeDirectories= */ ImmutableSet.of(new WorkspacePath("bar")),
-                /* excludePathsForBazelQuery= */ ImmutableSet.of()
+                /* excludePathsForBazelQuery= */ ImmutableSet.of(),
+                    ImmutableSet.of()
                 ));
 
     assertThat(helper.includesTarget(Label.create("//foo:target"))).isFalse();
@@ -224,7 +227,8 @@ public class TargetExpressionListTest extends BlazeTestCase {
             new ProjectDirectoriesHelper(
                 /* rootDirectories= */ ImmutableList.of(new WorkspacePath("foo")),
                 /* excludeDirectories= */ ImmutableSet.of(new WorkspacePath("foo/bar")),
-                /* excludePathsForBazelQuery= */ ImmutableSet.of()
+                /* excludePathsForBazelQuery= */ ImmutableSet.of(),
+                    ImmutableSet.of()
                 ));
 
     assertThat(helper.includesTarget(Label.create("//foo:target"))).isTrue();

--- a/querysync/java/com/google/idea/blaze/qsync/project/PostQuerySyncData.java
+++ b/querysync/java/com/google/idea/blaze/qsync/project/PostQuerySyncData.java
@@ -42,7 +42,8 @@ public abstract class PostQuerySyncData {
                   /* includes= */ ImmutableSet.of(),
                   /* excludes= */ ImmutableSet.of(),
                   /* languageClasses= */ ImmutableSet.of(),
-                  /* testSources= */ ImmutableSet.of()))
+                  /* testSources= */ ImmutableSet.of(),
+                  /* systemExcludes = */ ImmutableSet.of()))
           .setVcsState(Optional.empty())
           .setBazelVersion(Optional.empty())
           .setQuerySummary(QuerySummary.EMPTY)

--- a/querysync/java/com/google/idea/blaze/qsync/project/ProjectDefinition.java
+++ b/querysync/java/com/google/idea/blaze/qsync/project/ProjectDefinition.java
@@ -42,7 +42,8 @@ public abstract class ProjectDefinition {
           /* includes= */ ImmutableSet.of(),
           /* excludes= */ ImmutableSet.of(),
           /* languageClasses= */ ImmutableSet.of(),
-          /* testSources= */ ImmutableSet.of());
+          /* testSources= */ ImmutableSet.of(),
+          /* systemExcludes = */ ImmutableSet.of());
 
   /**
    * Project includes, also know as root directories. Taken from the users {@code .blazeproject}
@@ -65,12 +66,16 @@ public abstract class ProjectDefinition {
    */
   public abstract ImmutableSet<String> testSources();
 
+  public abstract ImmutableSet<String> systemExcludes();
+
   public static ProjectDefinition create(
       ImmutableSet<Path> includes,
       ImmutableSet<Path> excludes,
       ImmutableSet<QuerySyncLanguage> languageClasses,
-      ImmutableSet<String> testSources) {
-    return new AutoValue_ProjectDefinition(includes, excludes, languageClasses, testSources);
+      ImmutableSet<String> testSources,
+      ImmutableSet<String> systemExcludes
+  ) {
+    return new AutoValue_ProjectDefinition(includes, excludes, languageClasses, testSources, systemExcludes);
   }
 
   /**
@@ -85,6 +90,11 @@ public abstract class ProjectDefinition {
       }
     }
     for (Path exclude : projectExcludes()) {
+     if(systemExcludes().contains(exclude.toString())){
+       // We don't have to check if these dirs are valid for queries, because they also don't fall into //... wildcard
+       continue;
+     }
+
       if (isValidPathForQuery(context, workspaceRoot.resolve(exclude))) {
         result.excludePath(exclude);
       }

--- a/querysync/java/com/google/idea/blaze/qsync/project/SnapshotDeserializer.java
+++ b/querysync/java/com/google/idea/blaze/qsync/project/SnapshotDeserializer.java
@@ -74,7 +74,8 @@ public class SnapshotDeserializer {
             proto.getIncludePathsList().stream().map(Path::of).collect(toImmutableSet()),
             proto.getExcludePathsList().stream().map(Path::of).collect(toImmutableSet()),
             QuerySyncLanguage.fromProtoList(proto.getLanguageClassesList()),
-            ImmutableSet.copyOf(proto.getTestSourcesList())));
+            ImmutableSet.copyOf(proto.getTestSourcesList()),
+            ImmutableSet.copyOf(proto.getSystemExcludesList())));
   }
 
   private void visitVcsState(SnapshotProto.VcsState proto) {

--- a/querysync/java/com/google/idea/blaze/qsync/project/snapshot.proto
+++ b/querysync/java/com/google/idea/blaze/qsync/project/snapshot.proto
@@ -22,6 +22,7 @@ message ProjectDefinition {
   repeated string exclude_paths = 2;
   repeated LanguageClass language_classes = 3;
   repeated string test_sources = 4;
+  repeated string system_excludes = 5;
 }
 
 message VcsState {

--- a/querysync/javatests/com/google/idea/blaze/qsync/GraphToProjectConverters.java
+++ b/querysync/javatests/com/google/idea/blaze/qsync/GraphToProjectConverters.java
@@ -43,6 +43,8 @@ abstract class GraphToProjectConverters {
 
   public abstract ImmutableSet<String> testSources();
 
+  public abstract ImmutableSet<String> systemExcludes();
+
   static Builder builder() {
     return new AutoValue_GraphToProjectConverters.Builder()
         .setPackageReader(EMPTY_PACKAGE_READER)
@@ -50,6 +52,7 @@ abstract class GraphToProjectConverters {
         .setLanguageClasses(ImmutableSet.of())
         .setProjectIncludes(ImmutableSet.of())
         .setProjectExcludes(ImmutableSet.of())
+        .setSystemExcludes(ImmutableSet.of())
         .setTestSources(ImmutableSet.of());
   }
 
@@ -67,6 +70,8 @@ abstract class GraphToProjectConverters {
 
     abstract Builder setTestSources(ImmutableSet<String> value);
 
+    abstract Builder setSystemExcludes(ImmutableSet<String> value);
+
     abstract GraphToProjectConverters autoBuild();
 
     public GraphToProjectConverter build() {
@@ -79,7 +84,8 @@ abstract class GraphToProjectConverters {
               info.projectIncludes(),
               info.projectExcludes(),
               info.languageClasses(),
-              info.testSources()),
+              info.testSources(),
+              info.systemExcludes()),
           newDirectExecutorService(),
           false);
     }

--- a/querysync/javatests/com/google/idea/blaze/qsync/TestDataSyncRunner.java
+++ b/querysync/javatests/com/google/idea/blaze/qsync/TestDataSyncRunner.java
@@ -56,7 +56,9 @@ public class TestDataSyncRunner {
             /* includes= */ ImmutableSet.copyOf(testProject.getRelativeSourcePaths()),
             /* excludes= */ ImmutableSet.of(),
             /* languageClasses= */ ImmutableSet.of(),
-            /* testSources= */ ImmutableSet.of());
+            /* testSources= */ ImmutableSet.of(),
+            /* systemExcludes = */ ImmutableSet.of()
+);
     QuerySummary querySummary = getQuerySummary(testProject);
     PostQuerySyncData pqsd =
         PostQuerySyncData.builder()


### PR DESCRIPTION
…-excludes (bazel-bin, .ijwb, etc.)

Demo for bazelbuild/bazel:


https://github.com/user-attachments/assets/89322a24-bf70-42a8-8636-163ace1326ed



# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

