### PR TITLE
fix: Use "" alias for for the root module back

### DIFF
--- a/base/src/com/google/idea/blaze/base/command/mod/BlazeModRunnerImpl.java
+++ b/base/src/com/google/idea/blaze/base/command/mod/BlazeModRunnerImpl.java
@@ -42,13 +42,6 @@ public class BlazeModRunnerImpl extends BlazeModRunner {
   private static final String DEPS = "deps";
   private static final String ROOT_WORKSPACE = "";
 
-
-  /**
-   * For some reason, dump_repo_mapping reqiures "", while deps requires "<root>".
-   * Probably a bazel bug
-   */
-  private static final String ROOT_WORKSPACE_EXPLICIT = "<root>";
-
   /**
    * {@code bazel mod dump_repo_mapping} takes a canonical repository name and will dump a map from
    * repoName -> canonicalName of all the external repositories available to that repository The
@@ -97,10 +90,9 @@ public class BlazeModRunnerImpl extends BlazeModRunner {
             BlazeContext context,
             BuildSystemName buildSystemName,
             List<String> flags) {
-
         return Futures.transform(
                 runBlazeModGetBytes(
-                        project, invoker, context, ImmutableList.of(DEPS, ROOT_WORKSPACE_EXPLICIT, "--output=json"), flags),
+                        project, invoker, context, ImmutableList.of(DEPS, ROOT_WORKSPACE, "--output=json"), flags),
                 bytes -> new String(bytes, StandardCharsets.UTF_8),
                 BlazeExecutor.getInstance().getExecutor()
         );


### PR DESCRIPTION
It is still not documented well, but "<root>" caused crashes on Windows

closes https://github.com/bazelbuild/intellij/issues/6850

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

