### PR TITLE
fix: Re-realize aspect files after plugin update

### DIFF
--- a/.bazelci/clion.yml
+++ b/.bazelci/clion.yml
@@ -1,43 +1,5 @@
 ---
 tasks:
-  CLion-internal-stable:
-    name: CLion Internal Stable
-    platform: ubuntu2204
-    build_flags:
-      - --define=ij_product=clion-latest
-    build_targets:
-      - //clwb/...
-    test_flags:
-      - --define=ij_product=clion-latest
-      - --test_output=errors
-    test_targets:
-      - //:clwb_tests
-  CLion-internal-beta:
-    name: CLion Internal Beta
-    platform: ubuntu2204
-    build_flags:
-      - --define=ij_product=clion-beta
-    build_targets:
-      - //clwb/...
-    test_flags:
-      - --define=ij_product=clion-beta
-      - --test_output=errors
-    test_targets:
-      - //:clwb_tests
-  CLion-internal-under-dev:
-    name: CLion Internal Under Development
-    platform: ubuntu2204
-    build_flags:
-      - --define=ij_product=clion-under-dev
-    build_targets:
-      - //clwb/...
-    test_flags:
-      - --define=ij_product=clion-under-dev
-      - --test_output=errors
-    test_targets:
-      - //:clwb_tests
-    soft_fail:
-      - exit_status: 1
   CLion-OSS-oldest-stable:
     name: CLion OSS Oldest Stable
     platform: ubuntu2204

--- a/base/src/com/google/idea/blaze/base/sync/aspects/strategy/SyncAspectTemplateProvider.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/strategy/SyncAspectTemplateProvider.java
@@ -59,7 +59,8 @@ public class SyncAspectTemplateProvider implements SyncListener {
       throw new SyncFailedException("Couldn't create realized aspects", e);
     }
 
-    final var templateAspects = AspectRepositoryProvider.findAspectTemplateDirectory().orElse(null);
+    final var templateAspects = AspectRepositoryProvider.findAspectTemplateDirectory()
+            .orElseThrow(() -> new SyncFailedException("Couldn't find aspect template directory"));
     var javaTemplate = "java_info.template.bzl";
     var realizedFile = realizedAspectsPath.resolve("java_info.bzl");
     var templateWriter = new TemplateWriter(templateAspects.toPath());


### PR DESCRIPTION
Scenario
1. Import the project correctly
2. Download a new version of the plugin that contains new templates

Result:
The templates won't be re-realized, old java_info.bzl fil will persist

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

