### PR TITLE
Set runfiles vars to absolute paths when debugging Go tests

### DIFF
--- a/golang/src/com/google/idea/blaze/golang/run/BlazeGoRunConfigurationRunner.java
+++ b/golang/src/com/google/idea/blaze/golang/run/BlazeGoRunConfigurationRunner.java
@@ -440,10 +440,13 @@ public class BlazeGoRunConfigurationRunner implements BlazeCommandRunConfigurati
       if (args.size() < 3) {
         throw new ExecutionException("Failed to parse args in script_path: " + scriptPath);
       }
-      envVars.put("TEST_SRCDIR", testScrDir.group(1));
+      // Make paths used for runfiles discovery absolute as the working directory is changed below.
+      envVars.put("TEST_SRCDIR", workspaceRoot.absolutePathFor(testScrDir.group(1)).toString());
       Matcher runfilesVars = RUNFILES_VAR.matcher(text);
       while (runfilesVars.find()) {
-        envVars.put(String.format("RUNFILES_%s", runfilesVars.group(1)), runfilesVars.group(2));
+        envVars.put(
+            String.format("RUNFILES_%s", runfilesVars.group(1)),
+            workspaceRoot.absolutePathFor(runfilesVars.group(2)).toString());
       }
       String workspaceName = execRoot.getName();
       binary =


### PR DESCRIPTION

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: https://github.com/bazelbuild/intellij/pull/6748#issuecomment-2407350654

# Description of this change


Ensure that runfiles vars are not incorrectly interpreted relative to the modified working directory (used as of #6748) by making their paths absolute. This matches the logic in Bazel's test setup script.
