### PR TITLE
Python code-gen; rename query methods

### DIFF
--- a/base/src/com/google/idea/blaze/base/dependencies/BlazeQueryTargetTagFilter.java
+++ b/base/src/com/google/idea/blaze/base/dependencies/BlazeQueryTargetTagFilter.java
@@ -64,7 +64,7 @@ public class BlazeQueryTargetTagFilter implements TargetTagFilter {
 
   @Nullable
   @Override
-  public List<TargetExpression> doFilterCodeGen(
+  public List<TargetExpression> doFilter(
       Project project,
       BlazeContext context,
       List<TargetExpression> targets,

--- a/base/src/com/google/idea/blaze/base/dependencies/TargetTagFilter.java
+++ b/base/src/com/google/idea/blaze/base/dependencies/TargetTagFilter.java
@@ -49,13 +49,13 @@ public interface TargetTagFilter {
    * @param targets is a list of Bazel targets to filter.
    * @return a subset of the supplied targets that include one of the supplied {code tags}.
    */
-  static List<TargetExpression> filterCodeGen(
+  static List<TargetExpression> filter(
       Project project,
       BlazeContext context,
       List<TargetExpression> targets,
       Set<String> tags) {
     return Arrays.stream(EP_NAME.getExtensions())
-        .map(p -> p.doFilterCodeGen(project, context, targets, tags))
+        .map(p -> p.doFilter(project, context, targets, tags))
         .filter(Objects::nonNull)
         .findFirst()
         .orElse(ImmutableList.of());
@@ -65,7 +65,7 @@ public interface TargetTagFilter {
    * {@see #filterCodeGen}
    */
   @Nullable
-  List<TargetExpression> doFilterCodeGen(
+  List<TargetExpression> doFilter(
       Project project,
       BlazeContext context,
       List<TargetExpression> targets,

--- a/base/src/com/google/idea/blaze/base/sync/SyncProjectTargetsHelper.java
+++ b/base/src/com/google/idea/blaze/base/sync/SyncProjectTargetsHelper.java
@@ -196,7 +196,7 @@ public final class SyncProjectTargetsHelper {
           .collect(Collectors.toSet());
 
       if (!activeLanguageCodeGeneratorTags.isEmpty() && projectViewSet.getScalarValue(EnablePythonCodegenSupport.KEY).orElse(false)) {
-        retainedByCodeGen = TargetTagFilter.filterCodeGen(
+        retainedByCodeGen = TargetTagFilter.filter(
             project,
             context,
             rejectedByKind,


### PR DESCRIPTION
# Checklist

- [x] I have filed an [issue](https://github.com/bazelbuild/intellij/issues/6725) about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: [6725](https://github.com/bazelbuild/intellij/issues/6725)

# Description of this change

The class `TargetTagFilter` is about filtering targets by tag and is agnostic about its use for the code-gen filtering. This commit renames the methods to make this more obvious.