### PR TITLE
Decorate tabs for BUILD files with package name

### DIFF
--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -462,6 +462,7 @@
     <completion.confidence language="BUILD" implementationClass="com.google.idea.blaze.base.lang.buildfile.completion.BuildFileCompletionConfidence"/>
     <spellchecker.support language="BUILD" implementationClass="com.google.idea.blaze.base.lang.buildfile.validation.BuildSpellcheckingStrategy"/>
     <highlightVisitor implementation="com.google.idea.blaze.base.editor.HighlightingStatsCollector"/>
+    <editorTabTitleProvider implementation="com.google.idea.blaze.base.editor.BazelEditorTabTitleProvider"/>
    <formattingService implementation="com.google.idea.blaze.base.buildmodifier.BuildifierFormattingService"/>
   </extensions>
 

--- a/base/src/com/google/idea/blaze/base/editor/BazelEditorTabTitleProvider.java
+++ b/base/src/com/google/idea/blaze/base/editor/BazelEditorTabTitleProvider.java
@@ -1,0 +1,31 @@
+package com.google.idea.blaze.base.editor;
+
+import com.google.idea.blaze.base.lang.buildfile.psi.BuildFile;
+import com.google.idea.blaze.base.settings.Blaze;
+import com.intellij.openapi.fileEditor.impl.EditorTabTitleProvider;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class BazelEditorTabTitleProvider implements EditorTabTitleProvider {
+  private static boolean requiresDecoration(Project project, String fileName) {
+    return Blaze.getBuildSystemProvider(project).possibleBuildFileNames().contains(fileName);
+  }
+  @Override
+  public @Nullable String getEditorTabTitle(@NotNull Project project,
+      @NotNull VirtualFile virtualFile) {
+    var fileName = virtualFile.getName();
+    if (!requiresDecoration(project, fileName)) {
+      return null;
+    }
+
+    return BuildFile.getBuildFileString(project, virtualFile.getPath());
+  }
+
+  @Override
+  public @Nullable String getEditorTabTooltipText(@NotNull Project project,
+      @NotNull VirtualFile virtualFile) {
+    return EditorTabTitleProvider.super.getEditorTabTooltipText(project, virtualFile);
+  }
+}


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

Since BUILD files all have the same name it's hard to distinguish them, so we can use EditorTabTitleProvider to write full label in the editor tab title

Before: 
![image](https://github.com/user-attachments/assets/fee81fd5-c67e-4e91-87b4-6c2aadfdbb80)

After: 
![image](https://github.com/user-attachments/assets/c2e8a6eb-8034-4a46-9a3f-77cadcc34e49)
