### PR TITLE
fix: fast sync with bazel 8 or when --incompatible_use_plus_in_repo_names is on

### DIFF
--- a/java/src/com/google/idea/blaze/java/run/fastbuild/BazelFastBuildTestEnvironmentCreator.java
+++ b/java/src/com/google/idea/blaze/java/run/fastbuild/BazelFastBuildTestEnvironmentCreator.java
@@ -74,7 +74,7 @@ final class BazelFastBuildTestEnvironmentCreator extends FastBuildTestEnvironmen
   private static File getStandardJavaBinary(String runfilesPath) {
     for (File file :
         new File(runfilesPath)
-            .listFiles(fn -> fn.getName().matches("rules_java~.*~toolchains~local_jdk"))) {
+            .listFiles(fn -> fn.getName().matches("rules_java[+~].*[+~]toolchains[+~]local_jdk"))) {
       if (file.isDirectory()) {
         return file.toPath().resolve("bin/java").toFile();
       }


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

