### PR TITLE
Resolve aspect test build issue on mac

### DIFF
--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/cpp/coptsmakevars/CoptsMakeVarsTest.java
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/cpp/coptsmakevars/CoptsMakeVarsTest.java
@@ -42,7 +42,7 @@ public class CoptsMakeVarsTest extends BazelIntellijAspectTest {
     assertThat(cTargetIdeInfo.getTargetCoptList()).hasSize(2);
     // These predefined variables' values are dependent on build system and configuration.
     assertThat(cTargetIdeInfo.getTargetCoptList().get(0))
-        .containsMatch("^-DPREFINED_BINDIR=(blaze|bazel)-out/[-0-9a-z]+/bin$");
+        .containsMatch("^-DPREFINED_BINDIR=(blaze|bazel)-out/[0-9a-z_-]+/bin$");
     assertThat(cTargetIdeInfo.getTargetCoptList().get(1)).isEqualTo("-DPREFINED_BINDIR2=$(BINDIR)");
   }
 }


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: [6917](https://github.com/bazelbuild/intellij/issues/6917)

# Description of this change

This resolves a problem in the test where the pattern for matching `bazel-out` does not accommodate the Mac's directory paths.