### PR TITLE
CLion external include support

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,8 +3,8 @@ build --tool_java_language_version=17 --tool_java_runtime_version=17
 
 # Delete test data packages, needed for bazel integration tests. Update by running the following command:
 # bazel run @rules_bazel_integration_test//tools:update_deleted_packages
-build --deleted_packages=aspect/testing/tests/src/com/google/idea/blaze/aspect/integration/testdata,clwb/tests/projects/simple/main,clwb/tests/projects/virtual_includes/lib/strip_absolut,clwb/tests/projects/virtual_includes/lib/strip_relative,clwb/tests/projects/virtual_includes/main,clwb/tests/projects/llvm_toolchain/main,clwb/tests/projects/virtual_includes/lib/impl_deps
-query --deleted_packages=aspect/testing/tests/src/com/google/idea/blaze/aspect/integration/testdata,clwb/tests/projects/simple/main,clwb/tests/projects/virtual_includes/lib/strip_absolut,clwb/tests/projects/virtual_includes/lib/strip_relative,clwb/tests/projects/virtual_includes/main,clwb/tests/projects/llvm_toolchain/main,clwb/tests/projects/virtual_includes/lib/impl_deps
+build --deleted_packages=aspect/testing/tests/src/com/google/idea/blaze/aspect/integration/testdata,clwb/tests/projects/simple/main,clwb/tests/projects/virtual_includes/lib/strip_absolut,clwb/tests/projects/virtual_includes/lib/strip_relative,clwb/tests/projects/virtual_includes/main,clwb/tests/projects/llvm_toolchain/main,clwb/tests/projects/external_includes/main,clwb/tests/projects/virtual_includes/lib/impl_deps
+query --deleted_packages=aspect/testing/tests/src/com/google/idea/blaze/aspect/integration/testdata,clwb/tests/projects/simple/main,clwb/tests/projects/virtual_includes/lib/strip_absolut,clwb/tests/projects/virtual_includes/lib/strip_relative,clwb/tests/projects/virtual_includes/main,clwb/tests/projects/llvm_toolchain/main,clwb/tests/projects/external_includes/main,clwb/tests/projects/virtual_includes/lib/impl_deps
 
 common --enable_bzlmod
 common --enable_workspace # to load rules_scala from WORKSPACE.bzlmod

--- a/aspect/intellij_info_impl.bzl
+++ b/aspect/intellij_info_impl.bzl
@@ -523,6 +523,9 @@ def collect_cpp_info(target, ctx, semantics, ide_info, ide_info_file, output_gro
                 [compilation_context] + [impl[CcInfo].compilation_context for impl in implementation_deps],
         )
 
+    # external_includes available since bazel 7
+    external_includes = getattr(compilation_context, "external_includes", depset()).to_list()
+
     c_info = struct_omit_none(
         header = headers,
         source = sources,
@@ -531,7 +534,8 @@ def collect_cpp_info(target, ctx, semantics, ide_info, ide_info_file, output_gro
         transitive_define = compilation_context.defines.to_list(),
         transitive_include_directory = compilation_context.includes.to_list(),
         transitive_quote_include_directory = compilation_context.quote_includes.to_list(),
-        transitive_system_include_directory = compilation_context.system_includes.to_list(),
+        # both system and external includes are add using `-isystem`
+        transitive_system_include_directory = compilation_context.system_includes.to_list() + external_includes,
         include_prefix = getattr(ctx.rule.attr, "include_prefix", None),
         strip_include_prefix = getattr(ctx.rule.attr, "strip_include_prefix", None),
     )

--- a/clwb/BUILD
+++ b/clwb/BUILD
@@ -180,11 +180,18 @@ clwb_integration_test(
     srcs = ["tests/integrationtests/com/google/idea/blaze/clwb/LlvmToolchainTest.java"],
 )
 
+clwb_integration_test(
+    name = "external_includes_integration_test",
+    project = "external_includes",
+    srcs = ["tests/integrationtests/com/google/idea/blaze/clwb/ExternalIncludesTest.java"],
+)
+
 test_suite(
     name = "integration_tests",
     tests = [
         ":llvm_toolchain_integration_test",
         ":simple_integration_test",
         ":virtual_includes_integration_test",
+        ":external_includes_integration_test",
     ],
 )

--- a/clwb/tests/integrationtests/com/google/idea/blaze/clwb/ExternalIncludesTest.java
+++ b/clwb/tests/integrationtests/com/google/idea/blaze/clwb/ExternalIncludesTest.java
@@ -1,0 +1,38 @@
+package com.google.idea.blaze.clwb;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.idea.blaze.clwb.base.Assertions.assertContainsHeader;
+
+import com.google.idea.blaze.clwb.base.BazelVersionRule;
+import com.google.idea.blaze.clwb.base.ClwbIntegrationTestCase;
+import com.intellij.openapi.util.SystemInfo;
+import com.jetbrains.cidr.lang.workspace.compiler.ClangCompilerKind;
+import com.jetbrains.cidr.lang.workspace.compiler.GCCCompilerKind;
+import com.jetbrains.cidr.lang.workspace.compiler.MSVCCompilerKind;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ExternalIncludesTest extends ClwbIntegrationTestCase {
+
+  // CompilationContext.external_includes was added in bazel 7
+  @Rule
+  public final BazelVersionRule bazelRule = new BazelVersionRule(7, 0);
+
+  @Test
+  public void testClwb() {
+    final var errors = runSync(defaultSyncParams().build());
+    errors.assertNoErrors();
+
+    checkTest();
+  }
+
+  private void checkTest() {
+    final var compilerSettings = findFileCompilerSettings("main/test.cc");
+
+    assertContainsHeader("iostream", compilerSettings);
+    assertContainsHeader("catch2/catch_test_macros.hpp", compilerSettings);
+  }
+}

--- a/clwb/tests/integrationtests/com/google/idea/blaze/clwb/SimpleTest.java
+++ b/clwb/tests/integrationtests/com/google/idea/blaze/clwb/SimpleTest.java
@@ -21,6 +21,7 @@ public class SimpleTest extends ClwbIntegrationTestCase {
     errors.assertNoErrors();
 
     checkCompiler();
+    checkTest();
   }
 
   private void checkCompiler() {
@@ -35,5 +36,12 @@ public class SimpleTest extends ClwbIntegrationTestCase {
     }
 
     assertContainsHeader("iostream", compilerSettings);
+  }
+
+  private void checkTest() {
+    final var compilerSettings = findFileCompilerSettings("main/test.cc");
+
+    assertContainsHeader("iostream", compilerSettings);
+    assertContainsHeader("catch2/catch_test_macros.hpp", compilerSettings);
   }
 }

--- a/clwb/tests/projects/external_includes/.bazelrc
+++ b/clwb/tests/projects/external_includes/.bazelrc
@@ -1,0 +1,2 @@
+# test external includes explicitly
+build --features=external_include_paths

--- a/clwb/tests/projects/external_includes/MODULE.bazel
+++ b/clwb/tests/projects/external_includes/MODULE.bazel
@@ -1,0 +1,1 @@
+bazel_dep(name = "catch2", version = "3.7.1")

--- a/clwb/tests/projects/external_includes/main/BUILD
+++ b/clwb/tests/projects/external_includes/main/BUILD
@@ -1,0 +1,7 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+cc_test(
+    name = "test",
+    srcs = ["test.cc"],
+    deps = ["@catch2//:catch2_main"],
+)

--- a/clwb/tests/projects/external_includes/main/test.cc
+++ b/clwb/tests/projects/external_includes/main/test.cc
@@ -1,0 +1,5 @@
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("0") {
+    REQUIRE(0 == 0);
+}

--- a/clwb/tests/projects/simple/WORKSPACE
+++ b/clwb/tests/projects/simple/WORKSPACE
@@ -1,0 +1,20 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "bazel_skylib",
+    sha256 = "bc283cdfcd526a52c3201279cda4bc298652efa898b10b4db0837dc51652756f",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.7.1/bazel-skylib-1.7.1.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.7.1/bazel-skylib-1.7.1.tar.gz",
+    ],
+)
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+bazel_skylib_workspace()
+
+http_archive(
+    name = "catch2",
+    sha256 = "c991b247a1a0d7bb9c39aa35faf0fe9e19764213f28ffba3109388e62ee0269c",
+    strip_prefix = "Catch2-3.7.1",
+    urls = ["https://github.com/catchorg/Catch2/archive/v3.7.1.tar.gz"],
+)

--- a/clwb/tests/projects/simple/main/BUILD
+++ b/clwb/tests/projects/simple/main/BUILD
@@ -1,7 +1,12 @@
-load("@rules_cc//cc:defs.bzl", "cc_binary")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_test")
 
 cc_binary(
     name = "hello-world",
     srcs = ["hello-world.cc"],
-    visibility = ["//visibility:public"]
+)
+
+cc_test(
+    name = "test",
+    srcs = ["test.cc"],
+    deps = ["@catch2//:catch2_main"],
 )

--- a/clwb/tests/projects/simple/main/test.cc
+++ b/clwb/tests/projects/simple/main/test.cc
@@ -1,0 +1,5 @@
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("0") {
+    REQUIRE(0 == 0);
+}


### PR DESCRIPTION
# Discussion thread for this change

Issue number: #4980

# Description of this change

Forwards all external_includes from the compilation context to system includes since they are treated the same. Also modifies the simple integration test to test for external includes. Closes #4980