### PR TITLE
Do not decorate tabs for BUILD files in non-bazel projects

### DIFF
--- a/base/src/com/google/idea/blaze/base/editor/BazelEditorTabTitleProvider.java
+++ b/base/src/com/google/idea/blaze/base/editor/BazelEditorTabTitleProvider.java
@@ -2,6 +2,7 @@ package com.google.idea.blaze.base.editor;
 
 import com.google.idea.blaze.base.lang.buildfile.psi.BuildFile;
 import com.google.idea.blaze.base.settings.Blaze;
+import com.google.idea.blaze.base.settings.BlazeImportSettings.ProjectType;
 import com.intellij.openapi.fileEditor.impl.EditorTabTitleProvider;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -15,6 +16,10 @@ public class BazelEditorTabTitleProvider implements EditorTabTitleProvider {
   @Override
   public @Nullable String getEditorTabTitle(@NotNull Project project,
       @NotNull VirtualFile virtualFile) {
+    if (Blaze.getProjectType(project) == ProjectType.UNKNOWN) {
+      return null;
+    }
+
     var fileName = virtualFile.getName();
     if (!requiresDecoration(project, fileName)) {
       return null;


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

If a project isn't imported then do not try to decorate as otherwise tab name has a full path to file.