### PR TITLE
fix(qsync): Enable basic syntax highlighting in 'analysis disabled' mode

### DIFF
--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -412,7 +412,7 @@
                  key="bazel.read.external.workspace.data"/>
     <registryKey defaultValue="true"
                  description="Enable basic syntax highliting in Query Sync's 'Analysis Disabled' mode"
-                 key="bazel.qsync.enable.basic.highlighting.in.non.analysis.mode"
+                 key="bazel.qsync.enable.basic.highlighting.in.non.analysis.mode"/>
     <editorNotificationProvider implementation="com.google.idea.blaze.base.wizard2.BazelNotificationProvider"/>
   </extensions>
 

--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -412,7 +412,7 @@
                  key="bazel.read.external.workspace.data"/>
     <registryKey defaultValue="true"
                  description="Enable basic syntax highliting in Query Sync's 'Analysis Disabled' mode"
-                 key="bazel.qsync.enable.basic.highlighting.when.analysis.disabled"/>
+                 key="bazel.qsync.enable.basic.highlighting.in.non.analysis.mode"
     <editorNotificationProvider implementation="com.google.idea.blaze.base.wizard2.BazelNotificationProvider"/>
   </extensions>
 

--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -377,6 +377,7 @@
     <codeInsight.lineMarkerProvider
         language="BUILD"
         implementationClass="com.google.idea.blaze.base.query.MacroLineMarkerProvider"/>
+    <defaultHighlightingSettingProvider implementation="com.google.idea.blaze.base.qsync.QuerySyncHighlightingSettingProvider" order="first"/>
     <lookup.charFilter implementation="com.google.idea.blaze.base.lang.buildfile.completion.BuildLabelCharFilter"/>
     <runLineMarkerContributor
         language="BUILD"
@@ -409,6 +410,9 @@
     <registryKey defaultValue="true"
                  description="Causes the plugin to read external workspace data, enabling features such as code completion for external targets. This may incur the cost of an additional 'bazel mod' call, which could cause issues with older versions or setups."
                  key="bazel.read.external.workspace.data"/>
+    <registryKey defaultValue="true"
+                 description="Enable basic syntax highliting in Query Sync's 'Analysis Disabled' mode"
+                 key="bazel.qsync.enable.basic.highlighting.when.analysis.disabled"/>
     <editorNotificationProvider implementation="com.google.idea.blaze.base.wizard2.BazelNotificationProvider"/>
   </extensions>
 

--- a/base/src/com/google/idea/blaze/base/qsync/QuerySyncHighlightingFilter.java
+++ b/base/src/com/google/idea/blaze/base/qsync/QuerySyncHighlightingFilter.java
@@ -19,6 +19,7 @@ import com.google.idea.blaze.base.settings.Blaze;
 import com.google.idea.blaze.base.settings.BlazeImportSettings.ProjectType;
 import com.intellij.codeInsight.daemon.impl.HighlightInfo;
 import com.intellij.codeInsight.daemon.impl.HighlightInfoFilter;
+import com.intellij.openapi.util.registry.Registry;
 import com.intellij.psi.PsiFile;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -28,6 +29,9 @@ public class QuerySyncHighlightingFilter implements HighlightInfoFilter {
 
   @Override
   public boolean accept(@NotNull HighlightInfo highlightInfo, @Nullable PsiFile psiFile) {
+    if(Registry.is("bazel.qsync.enable.basic.highlighting.when.analysis.disabled")) {
+      return true;
+    }
     if (psiFile == null) {
       return true;
     }

--- a/base/src/com/google/idea/blaze/base/qsync/QuerySyncHighlightingFilter.java
+++ b/base/src/com/google/idea/blaze/base/qsync/QuerySyncHighlightingFilter.java
@@ -29,7 +29,7 @@ public class QuerySyncHighlightingFilter implements HighlightInfoFilter {
 
   @Override
   public boolean accept(@NotNull HighlightInfo highlightInfo, @Nullable PsiFile psiFile) {
-    if(Registry.is("bazel.qsync.enable.basic.highlighting.when.analysis.disabled")) {
+    if(Registry.is("bazel.qsync.enable.basic.highlighting.in.non.analysis.mode")) {
       return true;
     }
     if (psiFile == null) {

--- a/base/src/com/google/idea/blaze/base/qsync/QuerySyncHighlightingSettingProvider.java
+++ b/base/src/com/google/idea/blaze/base/qsync/QuerySyncHighlightingSettingProvider.java
@@ -1,0 +1,25 @@
+package com.google.idea.blaze.base.qsync;
+
+import com.google.idea.blaze.base.settings.Blaze;
+import com.google.idea.blaze.base.settings.BlazeImportSettings;
+import com.intellij.codeInsight.daemon.impl.analysis.DefaultHighlightingSettingProvider;
+import com.intellij.codeInsight.daemon.impl.analysis.FileHighlightingSetting;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiManager;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class QuerySyncHighlightingSettingProvider extends DefaultHighlightingSettingProvider {
+    @Override
+    public @Nullable FileHighlightingSetting getDefaultSetting(@NotNull Project project, @NotNull VirtualFile file) {
+        var psiFile = PsiManager.getInstance(project).findFile(file);
+        if (Blaze.getProjectType(psiFile.getProject()) == BlazeImportSettings.ProjectType.QUERY_SYNC) {
+            if(!QuerySyncManager.getInstance(psiFile.getProject()).isReadyForAnalysis(psiFile)){
+                return FileHighlightingSetting.ESSENTIAL;
+            }
+        }
+        return null;
+
+    }
+}


### PR DESCRIPTION
## Before:
<img width="849" alt="Screenshot 2024-10-29 at 17 36 26" src="https://github.com/user-attachments/assets/3c236619-6f9f-48f6-b91d-9403bfdaba91">

## After
<img width="849" alt="Screenshot 2024-10-29 at 16 44 22" src="https://github.com/user-attachments/assets/32fccf28-44e6-4e65-a0c5-676bc2ed5020">
