### PR TITLE
fix(qsync): NPE in "Add to project" panel action

### DIFF
--- a/base/src/com/google/idea/blaze/base/qsync/CandidatePackageFinder.java
+++ b/base/src/com/google/idea/blaze/base/qsync/CandidatePackageFinder.java
@@ -90,6 +90,8 @@ public class CandidatePackageFinder {
     // - at least two paths with any packages in
     // this is to offer the user some choice, and ensure we don't add paths with no packages in
     // (which would cause the query to fail later on).
+    // However, sometimes there might be a case where there's only one valid package.
+    // in such a case, we return it, but we don't add it unconditionally.
     do {
       cancellationCheck.run();
       packages = runQuery(forPath);
@@ -97,7 +99,7 @@ public class CandidatePackageFinder {
         candidates.add(new CandidatePackage(forPath, packages.size()));
       }
       forPath = forPath.getParent();
-    } while (candidates.size() < 2 && packages.size() < 2);
+    } while (candidates.size() < 2 && packages.size() < 2 && forPath != null);
     return ImmutableList.copyOf(candidates);
   }
 

--- a/base/src/com/google/idea/blaze/base/qsync/action/AddToProjectAction.java
+++ b/base/src/com/google/idea/blaze/base/qsync/action/AddToProjectAction.java
@@ -221,16 +221,12 @@ public class AddToProjectAction extends BlazeProjectAction {
                             }
                           });
 
-                  if (candidatePackages.size() == 1) {
-                    doAddToProjectView(Iterables.getOnlyElement(candidatePackages));
-                  } else {
                     ListPopup popup =
-                        JBPopupFactory.getInstance()
-                            .createListPopup(
-                                SelectPackagePopupStep.create(
-                                    candidatePackages, Performer.this::doAddToProjectView));
+                            JBPopupFactory.getInstance()
+                                    .createListPopup(
+                                            SelectPackagePopupStep.create(
+                                                    candidatePackages, Performer.this::doAddToProjectView));
                     popupPositioner.showInCorrectPosition(popup);
-                  }
                 } catch (BuildException e) {
                   notify(
                       NotificationType.ERROR,


### PR DESCRIPTION
A comment contains a warning that there should be at least two packages found in order to provide user a choice. However in some cases there is only a single package to add.

For this reason, we stop the lookup if it reaches project root, but we don't add a package automatically, so a user can always reject the change.

closes #6966

https://github.com/user-attachments/assets/593377c4-84d6-48e1-89a5-6ebc9beb0c9e


# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

