### PR TITLE
Remove soft-fail marker from the CI tests

### DIFF
--- a/.bazelci/aspect.yml
+++ b/.bazelci/aspect.yml
@@ -41,8 +41,6 @@ tasks:
       - --notrim_test_configuration
     test_targets:
       - //aspect/testing/...
-    soft_fail:
-      - exit_status: 1
     skip_use_bazel_version_for_test: true
   Aspect-oss-oldest-stable:
     name: Aspect Tests for IJ OSS Oldest Stable
@@ -85,6 +83,4 @@ tasks:
       - --notrim_test_configuration
     test_targets:
       - //aspect/testing/...
-    soft_fail:
-      - exit_status: 1
     skip_use_bazel_version_for_test: true

--- a/.bazelci/clion.yml
+++ b/.bazelci/clion.yml
@@ -84,8 +84,6 @@ tasks:
       - --test_output=errors
     test_targets:
       - //:clwb_tests
-    soft_fail:
-      - exit_status: 1
   CLion-Windows-OSS-under-dev:
     name: CLion Windows OSS Under Development
     platform: windows
@@ -98,8 +96,6 @@ tasks:
       - --test_output=errors
     test_targets:
       - //clwb:integration_tests
-    soft_fail:
-      - exit_status: 1
   CLion-MacOS-OSS-under-dev:
     name: CLion MacOS OSS Under Development
     platform: macos_arm64
@@ -112,5 +108,3 @@ tasks:
       - --test_output=errors
     test_targets:
       - //:clwb_tests
-    soft_fail:
-      - exit_status: 1

--- a/.bazelci/intellij-ue.yml
+++ b/.bazelci/intellij-ue.yml
@@ -36,8 +36,6 @@ tasks:
       - --test_output=errors
     test_targets:
       - //:ijwb_ue_tests
-    soft_fail:
-      - exit_status: 1
   IntelliJ-UE-OSS-under-dev-windows:
     name: IntelliJ UE OSS Under Development
     platform: windows
@@ -45,6 +43,4 @@ tasks:
       - --define=ij_product=intellij-ue-oss-under-dev
     build_targets:
       - //ijwb/...
-    soft_fail:
-      - exit_status: 1
 

--- a/.bazelci/intellij.yml
+++ b/.bazelci/intellij.yml
@@ -36,8 +36,6 @@ tasks:
       - --test_output=errors
     test_targets:
       - //:ijwb_ce_tests
-    soft_fail:
-      - exit_status: 1
   IntelliJ-CE-OSS-under-dev-windows:
     name: IntelliJ CE OSS Under Development
     platform: windows
@@ -45,6 +43,4 @@ tasks:
       - --define=ij_product=intellij-oss-under-dev
     build_targets:
       - //ijwb/...
-    soft_fail:
-      - exit_status: 1
 


### PR DESCRIPTION
it hides failures on the under-dev IDE versions and it is no longer needed since the compatibility changes for the new IDE versions are usually sent out in the same PR now