### PR TITLE
Use bazel icon for plugin logo

### DIFF
--- a/clwb/BUILD
+++ b/clwb/BUILD
@@ -75,6 +75,7 @@ java_library(
 intellij_plugin(
     name = "clwb_bazel",
     plugin_xml = ":stamped_plugin_xml",
+    plugin_icons = ["//common:pluginIcon.svg"],
     tags = [
         "incomplete-deps",  # remove this suppression and add any missing deps, see go/java-import-deps-checking-lsc
     ],

--- a/common/BUILD
+++ b/common/BUILD
@@ -6,3 +6,5 @@ load(
 licenses(["notice"])
 
 create_common_plugins_package()
+
+exports_files(["pluginIcon.svg"])

--- a/common/pluginIcon.svg
+++ b/common/pluginIcon.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <style>
+    .regular{fill:#43A047;} .dark-left{fill:#00701A;} .dark-right{fill:#004300;} .light{fill:#76D275;}
+  </style>
+
+  <path class="light"      d="M144 32 l112 112 -112 112 l-112 -112z"/>
+  <path class="regular"    d="M32 144 v112 l112 112 v-112z"/>
+
+  <path class="light"      d="M368 32  l112 112 -112 112 -112 -112z"/>
+  <path class="regular"    d="M480 144 v112 l-112 112 v-112z"/>
+
+  <path class="regular"    d="M256 144 l112 112 -112 112 -112 -112z"/>
+  <path class="dark-left"  d="M256 368 v112 l-112 -112  v-112z"/>
+  <path class="dark-right" d="M256 368 l112 -112 v112 l-112 112z"/>
+</svg>
+

--- a/common/pluginIcon.svg
+++ b/common/pluginIcon.svg
@@ -1,10 +1,9 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="40" viewBox="0 0 40 40">
-<path fill-rule="nonzero" fill="rgb(46.27451%, 82.352941%, 45.882353%)" fill-opacity="1" d="M 11.25 2.5 L 20 11.25 L 11.25 20 L 2.5 11.25 Z M 11.25 2.5 "/>
-<path fill-rule="nonzero" fill="rgb(26.27451%, 62.745098%, 27.843137%)" fill-opacity="1" d="M 2.5 11.25 L 2.5 20 L 11.25 28.75 L 11.25 20 Z M 2.5 11.25 "/>
-<path fill-rule="nonzero" fill="rgb(46.27451%, 82.352941%, 45.882353%)" fill-opacity="1" d="M 28.75 2.5 L 37.5 11.25 L 28.75 20 L 20 11.25 Z M 28.75 2.5 "/>
-<path fill-rule="nonzero" fill="rgb(26.27451%, 62.745098%, 27.843137%)" fill-opacity="1" d="M 37.5 11.25 L 37.5 20 L 28.75 28.75 L 28.75 20 Z M 37.5 11.25 "/>
-<path fill-rule="nonzero" fill="rgb(26.27451%, 62.745098%, 27.843137%)" fill-opacity="1" d="M 20 11.25 L 28.75 20 L 20 28.75 L 11.25 20 Z M 20 11.25 "/>
-<path fill-rule="nonzero" fill="rgb(0%, 43.921569%, 10.196078%)" fill-opacity="1" d="M 20 28.75 L 20 37.5 L 11.25 28.75 L 11.25 20 Z M 20 28.75 "/>
-<path fill-rule="nonzero" fill="rgb(0%, 26.27451%, 0%)" fill-opacity="1" d="M 20 28.75 L 28.75 20 L 28.75 28.75 L 20 37.5 Z M 20 28.75 "/>
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11 2L20 11L11 20L2 11L11 2Z" fill="#76D275"/>
+<path d="M2 11V20L11 29V20L2 11Z" fill="#43A047"/>
+<path d="M29 2L38 11L29 20L20 11L29 2Z" fill="#76D275"/>
+<path d="M38 11V20L29 29V20L38 11Z" fill="#43A047"/>
+<path d="M20 11L29 20L20 29L11 20L20 11Z" fill="#43A047"/>
+<path d="M20 29V38L11 29V20L20 29Z" fill="#00701A"/>
+<path d="M20 29L29 20V29L20 38V29Z" fill="#004300"/>
 </svg>

--- a/common/pluginIcon.svg
+++ b/common/pluginIcon.svg
@@ -1,16 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
-  <style>
-    .regular{fill:#43A047;} .dark-left{fill:#00701A;} .dark-right{fill:#004300;} .light{fill:#76D275;}
-  </style>
-
-  <path class="light"      d="M144 32 l112 112 -112 112 l-112 -112z"/>
-  <path class="regular"    d="M32 144 v112 l112 112 v-112z"/>
-
-  <path class="light"      d="M368 32  l112 112 -112 112 -112 -112z"/>
-  <path class="regular"    d="M480 144 v112 l-112 112 v-112z"/>
-
-  <path class="regular"    d="M256 144 l112 112 -112 112 -112 -112z"/>
-  <path class="dark-left"  d="M256 368 v112 l-112 -112  v-112z"/>
-  <path class="dark-right" d="M256 368 l112 -112 v112 l-112 112z"/>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="40" viewBox="0 0 40 40">
+<path fill-rule="nonzero" fill="rgb(46.27451%, 82.352941%, 45.882353%)" fill-opacity="1" d="M 11.25 2.5 L 20 11.25 L 11.25 20 L 2.5 11.25 Z M 11.25 2.5 "/>
+<path fill-rule="nonzero" fill="rgb(26.27451%, 62.745098%, 27.843137%)" fill-opacity="1" d="M 2.5 11.25 L 2.5 20 L 11.25 28.75 L 11.25 20 Z M 2.5 11.25 "/>
+<path fill-rule="nonzero" fill="rgb(46.27451%, 82.352941%, 45.882353%)" fill-opacity="1" d="M 28.75 2.5 L 37.5 11.25 L 28.75 20 L 20 11.25 Z M 28.75 2.5 "/>
+<path fill-rule="nonzero" fill="rgb(26.27451%, 62.745098%, 27.843137%)" fill-opacity="1" d="M 37.5 11.25 L 37.5 20 L 28.75 28.75 L 28.75 20 Z M 37.5 11.25 "/>
+<path fill-rule="nonzero" fill="rgb(26.27451%, 62.745098%, 27.843137%)" fill-opacity="1" d="M 20 11.25 L 28.75 20 L 20 28.75 L 11.25 20 Z M 20 11.25 "/>
+<path fill-rule="nonzero" fill="rgb(0%, 43.921569%, 10.196078%)" fill-opacity="1" d="M 20 28.75 L 20 37.5 L 11.25 28.75 L 11.25 20 Z M 20 28.75 "/>
+<path fill-rule="nonzero" fill="rgb(0%, 26.27451%, 0%)" fill-opacity="1" d="M 20 28.75 L 28.75 20 L 28.75 28.75 L 20 37.5 Z M 20 28.75 "/>
 </svg>
-

--- a/ijwb/BUILD
+++ b/ijwb/BUILD
@@ -75,6 +75,7 @@ java_library(
 intellij_plugin(
     name = "ijwb_bazel",
     plugin_xml = ":stamped_plugin_xml",
+    plugin_icons = ["//common:pluginIcon.svg"],
     tags = [
         "incomplete-deps",  # remove this suppression and add any missing deps, see go/java-import-deps-checking-lsc
     ],


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

We'd like to make plugin more discoverable in the
search output on the marketplace and also make its tile 
look nice on the staff-picked plugins page.

approved by @meistert by email