### PR TITLE
Fix over-including when view_project_root is set.

### DIFF
--- a/base/src/com/google/idea/blaze/base/sync/projectview/ImportRoots.java
+++ b/base/src/com/google/idea/blaze/base/sync/projectview/ImportRoots.java
@@ -192,12 +192,13 @@ public final class ImportRoots {
     }
 
     private @NotNull List<WorkspacePath> selectExcludes(ImmutableCollection<WorkspacePath> rootDirectories) {
+      var userDeclaredRootDirectories = rootDirectories.stream().filter(rootDirectory -> !rootDirectory.isWorkspaceRoot()).collect(toImmutableSet());
       Queue<File> files = new LinkedList<>(Collections.singletonList(workspaceRoot.directory()));
       var result = new ArrayList<File>();
       while (!files.isEmpty()) {
         File file = files.poll();
         if (rootDirectories.stream().anyMatch(d -> FileUtil.isAncestor(file, workspaceRoot.fileForPath(d), /*strict=*/ true)) &&
-            rootDirectories.stream().noneMatch(d -> FileUtil.filesEqual(file, workspaceRoot.fileForPath(d)))
+                userDeclaredRootDirectories.stream().noneMatch(d -> FileUtil.filesEqual(file, workspaceRoot.fileForPath(d)))
         ) {
           var children = file.listFiles(File::isDirectory);
           if (children != null) {


### PR DESCRIPTION


# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

https: //github.com/bazelbuild/intellij/pull/6767 introduces a regression. While it fixes the bug with overlapping directories, it causes too many directories to now become included. This happens because the change avoids excluding files under any root directory, however the project root itself is a root directory when `view_project_root` is set. This results in nothing getting excluded, which defeats the purpose of view_project_root (it behaves the same as just adding `.` into directories).

The fix is to only avoid excluding files under any user-declared root directories.
