### PR TITLE
fix: Properly support non-Java Bazel 8 projects in IntelliJ

### DIFF
--- a/base/src/com/google/idea/blaze/base/sync/aspects/strategy/SyncAspectTemplateProvider.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/strategy/SyncAspectTemplateProvider.java
@@ -77,7 +77,7 @@ public class SyncAspectTemplateProvider implements SyncListener {
     final var templateAspects = AspectRepositoryProvider.findAspectTemplateDirectory()
             .orElseThrow(() -> new SyncFailedException("Couldn't find aspect template directory"));
 
-    writeJavaInfo(manager, realizedAspectsPath, templateAspects);
+    writeJavaInfo(manager, realizedAspectsPath, templateAspects, project);
     writeCodeGeneratorInfo(manager, project, realizedAspectsPath, templateAspects);
   }
 
@@ -106,25 +106,29 @@ public class SyncAspectTemplateProvider implements SyncListener {
   }
 
   private void writeJavaInfo(
-      BlazeProjectDataManager manager,
-      Path realizedAspectsPath,
-      File templateAspects) throws SyncFailedException {
+          BlazeProjectDataManager manager,
+          Path realizedAspectsPath,
+          File templateAspects, Project project) throws SyncFailedException {
     var realizedFile = realizedAspectsPath.resolve(REALIZED_JAVA);
     var templateWriter = new TemplateWriter(templateAspects.toPath());
-    var templateVariableMap = getJavaStringStringMap(manager);
+    var templateVariableMap = getJavaStringStringMap(manager, project);
     if (!templateWriter.writeToFile(TEMPLATE_JAVA, realizedFile, templateVariableMap)) {
       throw new SyncFailedException("Could not create template for: " + REALIZED_JAVA);
     }
   }
 
-  private static @NotNull Map<String, String> getJavaStringStringMap(BlazeProjectDataManager manager) {
+  private static @NotNull Map<String, String> getJavaStringStringMap(BlazeProjectDataManager manager, Project project) throws SyncFailedException {
     var projectData = Optional.ofNullable(manager.getBlazeProjectData()); // It can be empty on intial sync. Fall back to no lauguage support
+    var blazeProjectData = BlazeProjectDataManager.getInstance(project).getBlazeProjectData();
     var activeLanguages = projectData.map(it -> it.getWorkspaceLanguageSettings().getActiveLanguages()).orElse(ImmutableSet.of());
+    var isJavaEnabled = activeLanguages.contains(LanguageClass.JAVA)
+            && blazeProjectData != null
+            && blazeProjectData.getExternalWorkspaceData().getByRepoName("rules_java") != null;
     var isAtLeastBazel8 = projectData.map(it -> it.getBlazeVersionData().bazelIsAtLeastVersion(8, 0, 0)).orElse(false);
-      return Map.of(
-              "bazel8OrAbove", isAtLeastBazel8 ? "true" : "false",
-              "isJavaEnabled", activeLanguages.contains(LanguageClass.JAVA) ? "true" : "false"
-      );
+    return Map.of(
+            "bazel8OrAbove", isAtLeastBazel8 ? "true" : "false",
+            "isJavaEnabled", isJavaEnabled ? "true" : "false"
+    );
   }
 
   private static List<String> ruleNamesForLanguageClass(LanguageClass languageClass, ProjectViewSet viewSet) {


### PR DESCRIPTION
Previously, the condition to load rules_java was based on the "additional languages" field, which led to issues as Java is always present in IntelliJ (unlike PyCharm). This change modifies the condition to explicitly check if rules_java is actually loaded in the project, ensuring proper handling of non-Java projects in IntelliJ.

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

