### PR TITLE
[AOSP-pick] Inline trivial default interface method

### DIFF
--- a/base/src/com/google/idea/blaze/base/qsync/ProjectLoader.java
+++ b/base/src/com/google/idea/blaze/base/qsync/ProjectLoader.java
@@ -197,7 +197,7 @@ public class ProjectLoader {
         new DependencyTrackerImpl(graph, dependencyBuilder, artifactTracker);
     ProjectRefresher projectRefresher =
         new ProjectRefresher(
-            vcsHandler.map(BlazeVcsHandler::getVcsStateDiffer).orElse(VcsStateDiffer.NONE),
+            vcsHandler.map(it -> (VcsStateDiffer)it::diffVcsState).orElse(VcsStateDiffer.NONE),
             workspaceRoot.path(),
             enableExperimentalQuery.getValue() ? QueryStrategy.FILTERING_TO_KNOWN_AND_USED_TARGETS : QueryStrategy.PLAIN,
             graph::getCurrent,

--- a/base/src/com/google/idea/blaze/base/vcs/BlazeVcsHandlerProvider.java
+++ b/base/src/com/google/idea/blaze/base/vcs/BlazeVcsHandlerProvider.java
@@ -135,10 +135,6 @@ public interface BlazeVcsHandlerProvider {
      */
     Optional<ImmutableSet<Path>> diffVcsState(VcsState current, VcsState previous)
         throws BuildException;
-
-    default VcsStateDiffer getVcsStateDiffer() {
-      return this::diffVcsState;
-    }
   }
 
   /** Sync handler that performs VCS specific computation. */


### PR DESCRIPTION
Cherry pick AOSP commit [1ceafed6aad1f8ac6a737ac5012f4ee3022b9a2c](https://cs.android.com/android-studio/platform/tools/adt/idea/+/1ceafed6aad1f8ac6a737ac5012f4ee3022b9a2c).

Helper methods should not be implemented as interface default methods.
They should be static methods.

Bug: n/a
Test: n/a
Change-Id: I02abafe3e981df4540589d727bdd30a3d9e18bd5
