### PR TITLE
[AOSP-pick] Use BuildArtifactCache to fetch -info.txt files

### DIFF
--- a/base/src/com/google/idea/blaze/base/qsync/ProjectLoader.java
+++ b/base/src/com/google/idea/blaze/base/qsync/ProjectLoader.java
@@ -62,7 +62,6 @@ import com.google.idea.blaze.qsync.java.PackageStatementParser;
 import com.google.idea.blaze.qsync.java.ParallelPackageReader;
 import com.google.idea.blaze.qsync.project.ProjectDefinition;
 import com.google.idea.blaze.qsync.project.ProjectPath;
-import com.google.idea.blaze.qsync.query.QuerySpec;
 import com.google.idea.blaze.qsync.query.QuerySpec.QueryStrategy;
 import com.google.idea.common.experiments.BoolExperiment;
 import com.intellij.openapi.project.Project;
@@ -139,9 +138,6 @@ public class ProjectLoader {
     ImmutableSet<String> handledRules = getHandledRuleKinds();
     Optional<BlazeVcsHandler> vcsHandler =
         Optional.ofNullable(BlazeVcsHandlerProvider.vcsHandlerForProject(project));
-    DependencyBuilder dependencyBuilder =
-        createDependencyBuilder(
-            workspaceRoot, latestProjectDef, buildSystem, vcsHandler, handledRules);
     RenderJarBuilder renderJarBuilder = createRenderJarBuilder(workspaceRoot, buildSystem);
     AppInspectorBuilder appInspectorBuilder = createAppInspectorBuilder(buildSystem);
 
@@ -158,6 +154,10 @@ public class ProjectLoader {
             createArtifactFetcher(),
             executor,
             QuerySyncManager.getInstance(project).cacheCleanRequest());
+
+    DependencyBuilder dependencyBuilder =
+      createDependencyBuilder(
+        workspaceRoot, latestProjectDef, buildSystem, vcsHandler, artifactCache, handledRules);
 
     ArtifactTracker<BlazeContext> artifactTracker;
     RenderJarArtifactTracker renderJarArtifactTracker;
@@ -273,9 +273,10 @@ public class ProjectLoader {
       ProjectDefinition projectDefinition,
       BuildSystem buildSystem,
       Optional<BlazeVcsHandler> vcsHandler,
+      BuildArtifactCache buildArtifactCache,
       ImmutableSet<String> handledRuleKinds) {
     return new BazelDependencyBuilder(
-        project, buildSystem, projectDefinition, workspaceRoot, vcsHandler, handledRuleKinds);
+      project, buildSystem, projectDefinition, workspaceRoot, vcsHandler, buildArtifactCache, handledRuleKinds);
   }
 
   protected RenderJarBuilder createRenderJarBuilder(


### PR DESCRIPTION
Cherry pick AOSP commit [9c2f4c7143874defeb9cb9c69f69168975f38d5b](https://cs.android.com/android-studio/platform/tools/adt/idea/+/9c2f4c7143874defeb9cb9c69f69168975f38d5b).

Fetching multiple info files sequentially is slow especially whey they
are enormous in size. (The total size reaching 6gb+).

Instead fetch artifacts through the `BuildArtifactCache` which already
handles parallel and asynchronous downloading well.

Also, remove the `qsync.parallel.artifact.info.fetch` experiment as it
not longer controls anything. Info files are not different to other
artifacts and thus the same mode that works for other artifacts should
work for info files.

Bug: n/a
Test: n/a
Change-Id: I6f023154ca318af390956e78678dc899a359d31d

AOSP: 9c2f4c7143874defeb9cb9c69f69168975f38d5b