### PR TITLE
fix(qsync): Fix build_dependencies after AOSP merge

### DIFF
--- a/aspect/build_dependencies.bzl
+++ b/aspect/build_dependencies.bzl
@@ -388,6 +388,8 @@ def _target_within_project_scope(label, include, exclude):
     repo = _get_repo_name(label)
     package = label.package
     result = False
+    if repo != "":
+        return False # We don't support external includes, so all external repos are outside the project scope
     if include:
         for inc in include.split(","):
             # This is not a valid label, but can be passed to aspect when `directories: .` is set in the projectview


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

