### PR TITLE
disable warmup service

### DIFF
--- a/base/src/com/google/idea/blaze/base/project/indexing/FileSystemWarmUpService.kt
+++ b/base/src/com/google/idea/blaze/base/project/indexing/FileSystemWarmUpService.kt
@@ -56,7 +56,7 @@ class FileSystemWarmUpService(val project: Project, val coroutineScope: Coroutin
   private val logger = thisLogger()
 
   companion object {
-    private val fileSystemWarmUpExperimentEnabled = BoolExperiment("file.system.warm.up.enabled", true)
+    private val fileSystemWarmUpExperimentEnabled = BoolExperiment("file.system.warm.up.enabled", false)
     private val fileSystemWarmUpExperimentThreads = IntExperiment("file.system.warm.up.threads", 50)
   }
 


### PR DESCRIPTION
we've received this change from AOSP recently and then discovered that on large projects it does 50-threads rescans every minute and makes the IDE basically unusable.

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

