### PR TITLE
fix(qsync): NPE in QuerySyncNotificationProvider

### DIFF
--- a/base/src/com/google/idea/blaze/base/qsync/QuerySyncNotificationProvider.java
+++ b/base/src/com/google/idea/blaze/base/qsync/QuerySyncNotificationProvider.java
@@ -59,6 +59,9 @@ public class QuerySyncNotificationProvider implements EditorNotificationProvider
             if (toBuild.isEmpty()) {
                 return null;
             }
+            if(toBuild.type() != TargetsToBuild.Type.SOURCE_FILE) {
+                return null;
+            }
 
             int missing = buildDepsHelper.getSourceFileMissingDepsCount(toBuild);
             String notificationText;

--- a/base/src/com/google/idea/blaze/base/qsync/QuerySyncNotificationProvider.java
+++ b/base/src/com/google/idea/blaze/base/qsync/QuerySyncNotificationProvider.java
@@ -59,7 +59,7 @@ public class QuerySyncNotificationProvider implements EditorNotificationProvider
             if (toBuild.isEmpty()) {
                 return null;
             }
-            if(toBuild.type() != TargetsToBuild.Type.SOURCE_FILE) {
+            if (toBuild.type() != TargetsToBuild.Type.SOURCE_FILE) {
                 return null;
             }
 


### PR DESCRIPTION
buildDepsHelper.getSourceFileMissingDepsCount will check if toBuild is really a SOURCE one

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

