### PR TITLE
Fix getPackageName which didn't respect "build ignore"

### DIFF
--- a/golang/src/com/google/idea/blaze/golang/resolve/BlazeGoPackage.java
+++ b/golang/src/com/google/idea/blaze/golang/resolve/BlazeGoPackage.java
@@ -272,6 +272,7 @@ public class BlazeGoPackage extends GoPackage {
         .map(psiManager::findFile)
         .filter(GoFile.class::isInstance)
         .map(GoFile.class::cast)
+        .filter(goFile -> !Objects.equals(goFile.getBuildFlags(), "ignore"))
         .map(GoFile::getCanonicalPackageName) // strips _test suffix from test packages
         .filter(Objects::nonNull)
         .findFirst() // short circuit


### PR DESCRIPTION
This fixed the indexing problem caused by retrieving the wrong package name.

fixes #7010

# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `7010`

# Description of this change

getPackageName wrongly returns "ignore" which should be ignored. This change will check "build ignore" (the build tag) and respect this tag (that is, ignore files containing this tag).