### PR TITLE
[AOSP-pick] Do not store file to label map

### DIFF
--- a/base/src/com/google/idea/blaze/base/qsync/QuerySyncProject.java
+++ b/base/src/com/google/idea/blaze/base/qsync/QuerySyncProject.java
@@ -552,7 +552,7 @@ public class QuerySyncProject {
     Path workspaceRelative = workspaceRoot.path().relativize(absolutePath);
     if (snapshotHolder
         .getCurrent()
-        .map(s -> s.graph().getAllSourceFiles().contains(workspaceRelative))
+        .map(s -> s.graph().sourceFileToLabel(workspaceRelative).isPresent())
         .orElse(false)) {
       return Optional.of(false);
     }

--- a/java/src/com/google/idea/blaze/java/run/producers/JavaBinaryContextProvider.java
+++ b/java/src/com/google/idea/blaze/java/run/producers/JavaBinaryContextProvider.java
@@ -130,7 +130,7 @@ public class JavaBinaryContextProvider implements BinaryContextProvider {
     }
 
     WorkspacePath path = querySyncProject.getWorkspaceRoot().workspacePathFor(mainClassFile);
-    ImmutableSet<Label> targetOwners = buildGraphData.getTargetOwners(Path.of(path.relativePath()));
+    ImmutableSet<Label> targetOwners = buildGraphData.getSourceFileOwners(Path.of(path.relativePath()));
 
     if (targetOwners == null) {
       return null;

--- a/querysync/java/com/google/idea/blaze/qsync/BlazeQueryParser.java
+++ b/querysync/java/com/google/idea/blaze/qsync/BlazeQueryParser.java
@@ -139,8 +139,7 @@ public class BlazeQueryParser {
         query.getSourceFilesMap().entrySet()) {
       if (sourceFileEntry.getKey().getWorkspaceName().isEmpty()) {
         graphBuilder
-            .locationsBuilder()
-            .put(sourceFileEntry.getKey(), new Location(sourceFileEntry.getValue().getLocation()));
+            .sourceFileLabelsBuilder().add(sourceFileEntry.getKey());
       } else {
         context.output(
             new PrintOutput(
@@ -194,7 +193,7 @@ public class BlazeQueryParser {
 
     BuildGraphData graph = graphBuilder.projectDeps(projectDeps).build();
 
-    context.output(PrintOutput.log("%-10d Source files", graph.locations().size()));
+    context.output(PrintOutput.log("%-10d Source files", graph.sourceFileLabels().size()));
     context.output(PrintOutput.log("%-10d Java sources", graph.javaSources().size()));
     context.output(PrintOutput.log("%-10d Packages", graph.packages().size()));
     context.output(PrintOutput.log("%-10d Dependencies", javaDeps.size()));

--- a/querysync/java/com/google/idea/blaze/qsync/QuerySyncProjectSnapshot.java
+++ b/querysync/java/com/google/idea/blaze/qsync/QuerySyncProjectSnapshot.java
@@ -103,7 +103,7 @@ public abstract class QuerySyncProjectSnapshot {
    * @param path a workspace relative path.
    */
   public ImmutableSet<Label> getTargetOwners(Path path) {
-    return graph().getTargetOwners(path);
+    return graph().getSourceFileOwners(path);
   }
 
   /**
@@ -118,7 +118,7 @@ public abstract class QuerySyncProjectSnapshot {
   @Nullable
   @Deprecated
   public Label getTargetOwner(Path path) {
-    return graph().selectLabelWithLeastDeps(graph().getTargetOwners(path));
+    return graph().selectLabelWithLeastDeps(graph().getSourceFileOwners(path));
   }
 
   /** Returns mapping of targets to {@link BuildTarget} */

--- a/querysync/java/com/google/idea/blaze/qsync/query/QuerySummary.java
+++ b/querysync/java/com/google/idea/blaze/qsync/query/QuerySummary.java
@@ -262,7 +262,6 @@ public abstract class QuerySummary {
         case SOURCE_FILE:
           Query.SourceFile sourceFile =
               Query.SourceFile.newBuilder()
-                  .setLocation(intern(target.getSourceFile().getLocation()))
                   .addAllSubinclude(intern(target.getSourceFile().getSubincludeList()))
                   .build();
           String sourceFileName = intern(target.getSourceFile().getName());

--- a/querysync/java/com/google/idea/blaze/qsync/query/querysummary.proto
+++ b/querysync/java/com/google/idea/blaze/qsync/query/querysummary.proto
@@ -35,7 +35,7 @@ message StringStorage {
 }
 
 message SourceFile {
-  string location = 1;
+  reserved 1;
   // Subincludes of a source file, taken from blaze_query.SourceFile.subinclude
   repeated string subinclude = 2;
 }

--- a/querysync/javatests/com/google/idea/blaze/qsync/BUILD
+++ b/querysync/javatests/com/google/idea/blaze/qsync/BUILD
@@ -53,6 +53,7 @@ java_test(
         "//querysync/java/com/google/idea/blaze/qsync/query",
         "//querysync/javatests/com/google/idea/blaze/qsync/testdata",
         "//querysync/javatests/com/google/idea/blaze/qsync/testdata:build_graphs",
+        "//shared/java/com/google/idea/blaze/common",
         "//third_party/java/junit",
         "//third_party/java/truth",
         "@com_google_guava_guava//jar",

--- a/querysync/javatests/com/google/idea/blaze/qsync/GraphToProjectConverterTest.java
+++ b/querysync/javatests/com/google/idea/blaze/qsync/GraphToProjectConverterTest.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.idea.blaze.common.Label;
 import com.google.idea.blaze.qsync.project.BuildGraphData;
 import com.google.idea.blaze.qsync.project.LanguageClassProto.LanguageClass;
 import com.google.idea.blaze.qsync.project.ProjectProto;
@@ -412,10 +413,10 @@ public class GraphToProjectConverterTest {
 
   @Test
   public void testCalculateAndroidResourceDirectories_single_directory() {
-    ImmutableSet<Path> sourceFiles =
+    final var sourceFiles =
         ImmutableSet.of(
-            Path.of("java/com/test/AndroidManifest.xml"),
-            Path.of("java/com/test/res/values/strings.xml"));
+          Label.of("//java/com/test:AndroidManifest.xml"),
+          Label.of("//java/com/test:res/values/strings.xml"));
 
     ImmutableSet<Path> androidResourceDirectories =
         GraphToProjectConverter.computeAndroidResourceDirectories(sourceFiles);
@@ -424,13 +425,13 @@ public class GraphToProjectConverterTest {
 
   @Test
   public void testCalculateAndroidResourceDirectories_multiple_directories() {
-    ImmutableSet<Path> sourceFiles =
+    final var sourceFiles =
         ImmutableSet.of(
-            Path.of("java/com/test/AndroidManifest.xml"),
-            Path.of("java/com/test/res/values/strings.xml"),
-            Path.of("java/com/test2/AndroidManifest.xml"),
-            Path.of("java/com/test2/res/layout/some-activity.xml"),
-            Path.of("java/com/test2/res/layout/another-activity.xml"));
+          Label.of("//java/com/test:AndroidManifest.xml"),
+          Label.of("//java/com/test:res/values/strings.xml"),
+          Label.of("//java/com/test2:AndroidManifest.xml"),
+          Label.of("//java/com/test2:res/layout/some-activity.xml"),
+          Label.of("//java/com/test2:res/layout/another-activity.xml"));
 
     ImmutableSet<Path> androidResourceDirectories =
         GraphToProjectConverter.computeAndroidResourceDirectories(sourceFiles);
@@ -440,9 +441,9 @@ public class GraphToProjectConverterTest {
 
   @Test
   public void testCalculateAndroidResourceDirectories_manifest_without_res_directory() {
-    ImmutableSet<Path> sourceFiles =
+    final var sourceFiles =
         ImmutableSet.of(
-            Path.of("java/com/nores/AndroidManifest.xml"), Path.of("java/com/nores/Foo.java"));
+          Label.of("//java/com/nores:AndroidManifest.xml"), Label.of("//java/com/nores:Foo.java"));
 
     ImmutableSet<Path> androidResourceDirectories =
         GraphToProjectConverter.computeAndroidResourceDirectories(sourceFiles);

--- a/querysync/javatests/com/google/idea/blaze/qsync/PartialProjectRefreshTest.java
+++ b/querysync/javatests/com/google/idea/blaze/qsync/PartialProjectRefreshTest.java
@@ -46,17 +46,13 @@ public class PartialProjectRefreshTest {
                     .build())
             .putSourceFiles(
                 Label.of("//my/build/package1:Class1.java"),
-                Query.SourceFile.newBuilder()
-                    .setLocation("my/build/package1/Class1.java:1:1")
-                    .build())
+                Query.SourceFile.newBuilder().build())
             .putSourceFiles(
                 Label.of("//my/build/package1:subpackage/AnotherClass.java"),
-                Query.SourceFile.newBuilder()
-                    .setLocation("my/build/package1/subpackage/AnotherClass.java:1:1")
-                    .build())
+                Query.SourceFile.newBuilder().build())
             .putSourceFiles(
                 Label.of("//my/build/package1:BUILD"),
-                Query.SourceFile.newBuilder().setLocation("my/build/package1/BUILD:1:1").build())
+                Query.SourceFile.newBuilder().build())
             .putRules(
                 Label.of("//my/build/package2:rule"),
                 QueryData.Rule.builder()
@@ -65,12 +61,10 @@ public class PartialProjectRefreshTest {
                     .build())
             .putSourceFiles(
                 Label.of("//my/build/package2:Class2.java"),
-                Query.SourceFile.newBuilder()
-                    .setLocation("my/build/package2/Class2.java:1:1")
-                    .build())
+                Query.SourceFile.newBuilder().build())
             .putSourceFiles(
                 Label.of("//my/build/package2:BUILD"),
-                Query.SourceFile.newBuilder().setLocation("my/build/package2/BUILD:1:1").build())
+                Query.SourceFile.newBuilder().build())
             .build();
     PostQuerySyncData baseProject =
         PostQuerySyncData.EMPTY.toBuilder().setQuerySummary(base).build();
@@ -85,12 +79,10 @@ public class PartialProjectRefreshTest {
                     .build())
             .putSourceFiles(
                 Label.of("//my/build/package1:NewClass.java"),
-                Query.SourceFile.newBuilder()
-                    .setLocation("my/build/package1/NewClass.java:1:1")
-                    .build())
+                Query.SourceFile.newBuilder().build())
             .putSourceFiles(
                 Label.of("//my/build/package1:BUILD"),
-                Query.SourceFile.newBuilder().setLocation("my/build/package1/BUILD").build())
+                Query.SourceFile.newBuilder().build())
             .build();
 
     PartialProjectRefresh queryStrategy =
@@ -125,17 +117,13 @@ public class PartialProjectRefreshTest {
                     .build())
             .putSourceFiles(
                 Label.of("//my/build/package1:Class1.java"),
-                Query.SourceFile.newBuilder()
-                    .setLocation("my/build/package1/Class1.java:1:1")
-                    .build())
+                Query.SourceFile.newBuilder().build())
             .putSourceFiles(
                 Label.of("//my/build/package1:subpackage/AnotherClass.java"),
-                Query.SourceFile.newBuilder()
-                    .setLocation("my/build/package1/subpackage/AnotherClass.java:1:1")
-                    .build())
+                Query.SourceFile.newBuilder().build())
             .putSourceFiles(
                 Label.of("//my/build/package1:BUILD"),
-                Query.SourceFile.newBuilder().setLocation("my/build/package1/BUILD:1:1").build())
+                Query.SourceFile.newBuilder().build())
             .putRules(
                 Label.of("//my/build/package2:rule"),
                 QueryData.Rule.builder()
@@ -144,12 +132,10 @@ public class PartialProjectRefreshTest {
                     .build())
             .putSourceFiles(
                 Label.of("//my/build/package2:Class2.java"),
-                Query.SourceFile.newBuilder()
-                    .setLocation("my/build/package2/Class2.java:1:1")
-                    .build())
+                Query.SourceFile.newBuilder().build())
             .putSourceFiles(
                 Label.of("//my/build/package2:BUILD"),
-                Query.SourceFile.newBuilder().setLocation("my/build/package2/BUILD:1:1").build())
+                Query.SourceFile.newBuilder().build())
             .build();
     PostQuerySyncData baseProject =
         PostQuerySyncData.EMPTY.toBuilder().setQuerySummary(base).build();
@@ -183,12 +169,10 @@ public class PartialProjectRefreshTest {
                     .build())
             .putSourceFiles(
                 Label.of("//my/build/package1:Class1.java"),
-                Query.SourceFile.newBuilder()
-                    .setLocation("my/build/package1/Class1.java:1:1")
-                    .build())
+                Query.SourceFile.newBuilder().build())
             .putSourceFiles(
                 Label.of("//my/build/package1:BUILD"),
-                Query.SourceFile.newBuilder().setLocation("my/build/package1/BUILD:1:1").build())
+                Query.SourceFile.newBuilder().build())
             .build();
     PostQuerySyncData baseProject =
         PostQuerySyncData.EMPTY.toBuilder().setQuerySummary(base).build();
@@ -202,12 +186,10 @@ public class PartialProjectRefreshTest {
                     .build())
             .putSourceFiles(
                 Label.of("//my/build/package2:Class2.java"),
-                Query.SourceFile.newBuilder()
-                    .setLocation("my/build/package2/Class2.java:1:1")
-                    .build())
+                Query.SourceFile.newBuilder().build())
             .putSourceFiles(
                 Label.of("//my/build/package2:BUILD"),
-                Query.SourceFile.newBuilder().setLocation("my/build/package2/BUILD:1:1").build())
+                Query.SourceFile.newBuilder().build())
             .build();
 
     PartialProjectRefresh queryStrategy =

--- a/querysync/javatests/com/google/idea/blaze/qsync/query/QuerySummaryTestBuilder.java
+++ b/querysync/javatests/com/google/idea/blaze/qsync/query/QuerySummaryTestBuilder.java
@@ -80,7 +80,6 @@ public class QuerySummaryTestBuilder {
                     l -> QueryData.Rule.builder().ruleClass("java_library").build())));
     builder.putAllSourceFiles(
       sourceFiles.stream().collect(toImmutableMap(src -> src, src -> SourceFile.newBuilder()
-        .setLocation(src + ":1:1")
         .addAllSubinclude(includes.get(src.toString()))
         .build()))
     );

--- a/shared/java/com/google/idea/blaze/common/BUILD
+++ b/shared/java/com/google/idea/blaze/common/BUILD
@@ -5,7 +5,10 @@ licenses(["notice"])
 java_library(
     name = "common",
     srcs = glob(["*.java"]),
-    visibility = ["//shared:__subpackages__"],
+    visibility = [
+        "//querysync/javatests/com/google/idea/blaze/qsync:__subpackages__",
+        "//shared:__subpackages__",
+    ],
     deps = [
         "@jsr305_annotations//jar",
         "//third_party/java/auto_value",


### PR DESCRIPTION
Cherry pick AOSP commit [11ec4229bdd494a9bcb466728abc3a201cc2423d](https://cs.android.com/android-studio/platform/tools/adt/idea/+/11ec4229bdd494a9bcb466728abc3a201cc2423d).

It is not needed. Labels can be made more efficient in the future by
splitting package and name parts.

Bug: 362727747
Test: existing unit tests
Change-Id: I05af42a434a238729a8d63ee756bf6e44c18a814

AOSP: 11ec4229bdd494a9bcb466728abc3a201cc2423d
