### PR TITLE
[AOSP-pick] [querysync] Fix building dependencies when workspace root is included

### DIFF
--- a/querysync/javatests/com/google/idea/blaze/qsync/AspectUnitTest.java
+++ b/querysync/javatests/com/google/idea/blaze/qsync/AspectUnitTest.java
@@ -96,4 +96,15 @@ public class AspectUnitTest {
       assertWithMessage("targets for jar " + jarPath).that(jarToTarget.get(jarPath)).hasSize(1);
     }
   }
+
+  @Test
+  public void workspaceRootIncluded_getTargetSources() throws IOException {
+    ImmutableMap<Label, JavaTargetArtifacts> byTarget =
+        Maps.uniqueIndex(
+            JavaInfoTxt.WORKSPACE_ROOT_INCLUDED.readOnlyProto().getArtifactsList(),
+            t -> Label.of(t.getTarget()));
+    TestData target = TestData.WORKSPACE_ROOT_INCLUDED_QUERY;
+    // no sources should be there for a target within project scope.
+    assertThat(byTarget.get(target.getAssumedOnlyLabel()).getSrcsList()).isEmpty();
+  }
 }

--- a/querysync/javatests/com/google/idea/blaze/qsync/testdata/BUILD
+++ b/querysync/javatests/com/google/idea/blaze/qsync/testdata/BUILD
@@ -119,6 +119,16 @@ genquery(
 )
 
 genquery(
+    name = "workspacerootincluded_query",
+    expression = "//querysync/javatests/com/google/idea/blaze/qsync/testdata/workspacerootincluded:*",
+    opts = ["--output=streamed_proto"],
+    scope =
+        scopeForJavaPackage("//querysync/javatests/com/google/idea/blaze/qsync/testdata/workspacerootincluded:workspacerootincluded") + [
+            "//querysync/javatests/com/google/idea/blaze/qsync/testdata/workspacerootincluded:java_info",
+        ],
+)
+
+genquery(
     name = "filegroup_query",
     expression = "//querysync/javatests/com/google/idea/blaze/qsync/testdata/filegroup:*",
     opts = ["--output=streamed_proto"],
@@ -186,6 +196,7 @@ java_library(
         ":java_library_transitive_dep_query",
         ":java_library_transitive_internal_dep_query",
         ":tags_query",
+        ":workspacerootincluded_query",
     ],
     deps = [
         "//shared",
@@ -230,6 +241,7 @@ java_library(
         "//querysync/javatests/com/google/idea/blaze/qsync/testdata/externaldep:java_info",
         "//querysync/javatests/com/google/idea/blaze/qsync/testdata/externalexports:java_info",
         "//querysync/javatests/com/google/idea/blaze/qsync/testdata/internaldep:java_info",
+        "//querysync/javatests/com/google/idea/blaze/qsync/testdata/workspacerootincluded:java_info",
     ],
     deps = [
         "//querysync/java/com/google/idea/blaze/qsync/java:java_target_info_java_proto",

--- a/querysync/javatests/com/google/idea/blaze/qsync/testdata/JavaInfoTxt.java
+++ b/querysync/javatests/com/google/idea/blaze/qsync/testdata/JavaInfoTxt.java
@@ -40,7 +40,9 @@ public enum JavaInfoTxt {
   /** A simple java project with a single internal dependency */
   INTERNAL_DEP("internaldep", "java_info", "internaldep"),
   /** A simple java project with a single external dependency, which in turn exports another external target. */
-  EXTERNAL_EXPORTS("externalexports", "java_info", "externalexports");
+  EXTERNAL_EXPORTS("externalexports", "java_info", "externalexports"),
+  /** A simple java project that loads the workspace root. */
+  WORKSPACE_ROOT_INCLUDED("workspacerootincluded", "java_info", "workspacerootincluded");
 
   public final ImmutableList<String> paths;
 

--- a/querysync/javatests/com/google/idea/blaze/qsync/testdata/TestData.java
+++ b/querysync/javatests/com/google/idea/blaze/qsync/testdata/TestData.java
@@ -48,7 +48,8 @@ public enum TestData {
   PROTO_ONLY_QUERY("protoonly"),
   NESTED_PROTO_QUERY("nestedproto"),
   TAGS_QUERY("tags"),
-  EMPTY_QUERY("empty");
+  EMPTY_QUERY("empty"),
+  WORKSPACE_ROOT_INCLUDED_QUERY("workspacerootincluded");
 
   public final ImmutableList<Path> srcPaths;
 

--- a/querysync/javatests/com/google/idea/blaze/qsync/testdata/workspacerootincluded/BUILD
+++ b/querysync/javatests/com/google/idea/blaze/qsync/testdata/workspacerootincluded/BUILD
@@ -1,0 +1,12 @@
+load(":collect_deps.bzl", "java_info_txt")
+
+java_library(
+    name = "workspacerootincluded",
+    srcs = ["MyClass.java"],
+)
+
+java_info_txt(
+    name = "java_info",
+    visibility = ["//querysync/javatests/com/google/idea/blaze/qsync/testdata:__subpackages__"],
+    deps = [":workspacerootincluded"],
+)

--- a/querysync/javatests/com/google/idea/blaze/qsync/testdata/workspacerootincluded/MyClass.java
+++ b/querysync/javatests/com/google/idea/blaze/qsync/testdata/workspacerootincluded/MyClass.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2024 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.qsync.testdata.workspacerootincluded;
+
+public class MyClass {}

--- a/querysync/javatests/com/google/idea/blaze/qsync/testdata/workspacerootincluded/collect_deps.bzl
+++ b/querysync/javatests/com/google/idea/blaze/qsync/testdata/workspacerootincluded/collect_deps.bzl
@@ -1,0 +1,13 @@
+load(
+    "//aspect:build_dependencies.bzl",
+    "collect_dependencies_aspect_for_tests",
+    "collect_dependencies_for_test",
+    "write_java_info_txt_rule_for_tests",
+)
+
+def _collect_deps_impl(target, ctx):
+    return collect_dependencies_for_test(target, ctx, include = ["//"])
+
+collect_deps = collect_dependencies_aspect_for_tests(_collect_deps_impl)
+
+java_info_txt = write_java_info_txt_rule_for_tests(collect_deps)


### PR DESCRIPTION
Cherry pick AOSP commit [43bfac8a806e125bdea33a7270f359fc1454b33b](https://cs.android.com/android-studio/platform/tools/adt/idea/+/43bfac8a806e125bdea33a7270f359fc1454b33b).

NOTE: conflicts with our changes to `aspect/build_dependencies.bzl`, but as far as I can tell ours handles more edge cases.

Change-Id: I2d28bf336e95c410da5f159b6bc37a38b7139f72
Bug: 309706901
Tests: manual and presubmit tests

AOSP: 43bfac8a806e125bdea33a7270f359fc1454b33b