### PR TITLE
fix: Small codegen libraries were removed from the Project Structure

### DIFF
--- a/java/src/com/google/idea/blaze/java/sync/importer/emptylibrary/EmptyLibraryFilter.java
+++ b/java/src/com/google/idea/blaze/java/sync/importer/emptylibrary/EmptyLibraryFilter.java
@@ -67,7 +67,7 @@ public class EmptyLibraryFilter implements Predicate<BlazeArtifact> {
     return Arrays.stream(EmptyLibraryFilterSettings.EP_NAME.getExtensions())
         .findFirst()
         .map(EmptyLibraryFilterSettings::isEnabled)
-        .orElse(true);
+        .orElse(false);
   }
 
   @Override

--- a/java/tests/unittests/com/google/idea/blaze/java/sync/importer/BlazeJavaWorkspaceImporterTest.java
+++ b/java/tests/unittests/com/google/idea/blaze/java/sync/importer/BlazeJavaWorkspaceImporterTest.java
@@ -97,6 +97,8 @@ import java.util.Map;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -1085,6 +1087,7 @@ public class BlazeJavaWorkspaceImporterTest extends BlazeTestCase {
   }
 
   @Test
+  @Ignore // We disabled empty library exclusion and it is unclear if we will ever reenable it
   public void testEmptyLibraryExcluded() {
     ProjectView projectView =
         ProjectView.builder()


### PR DESCRIPTION
Partially related to https://github.com/bazelbuild/intellij/issues/6547

The EmptyJarFilter is using a heuristic that is really not robust
https://github.com/bazelbuild/intellij/blob/3f81565b4aede217e160adc97a3f3b619bfa0498/java/src/com/google/idea/blaze/java/sync/importer/emptylibrary/EmptyLibraryFilter.java#L42-L50

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

