### PR TITLE
Reapply "fix: Support bazel 8 and `--noenable_workspace` mode (#6990)…

### DIFF
--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/integration/BazelInvokingIntegrationTestRunner.java
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/integration/BazelInvokingIntegrationTestRunner.java
@@ -22,7 +22,7 @@ import com.google.idea.blaze.base.model.primitives.LanguageClass;
 import com.google.idea.blaze.base.sync.aspects.strategy.AspectStrategy;
 import com.google.idea.blaze.base.sync.aspects.strategy.AspectStrategy.OutputGroup;
 import com.google.idea.blaze.base.sync.aspects.strategy.AspectStrategyBazel;
-import com.google.idea.blaze.base.sync.aspects.strategy.AspectRepositoryProvider;
+import com.google.idea.blaze.base.sync.aspects.strategy.OverrideFlags;
 import java.io.File;
 import java.nio.file.Paths;
 import java.util.Collection;
@@ -55,12 +55,12 @@ public class BazelInvokingIntegrationTestRunner {
             aspectStrategyBazel.getAspectFlag().get(),
             String.format(
                 "%s=%s/%s/aspect",
-                AspectRepositoryProvider.OVERRIDE_REPOSITORY_FLAG,
+                OverrideFlags.overrideRepositoryFlag(false),
                 System.getenv("TEST_SRCDIR"),
                 System.getenv("TEST_WORKSPACE")),
             String.format(
               "%s=%s/%s/aspect_template",
-              AspectRepositoryProvider.OVERRIDE_REPOSITORY_TEMPLATE_FLAG,
+              OverrideFlags.overrideRepositoryTemplateFlag(false),
               System.getenv("TEST_SRCDIR"),
               System.getenv("TEST_WORKSPACE"))
         );

--- a/base/src/com/google/idea/blaze/base/sync/aspects/strategy/AspectRepositoryProvider.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/strategy/AspectRepositoryProvider.java
@@ -1,5 +1,7 @@
 package com.google.idea.blaze.base.sync.aspects.strategy;
 
+import com.google.idea.blaze.base.model.BlazeProjectData;
+import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
 import com.intellij.openapi.extensions.ExtensionPointName;
 import com.intellij.openapi.project.Project;
 
@@ -11,8 +13,6 @@ public interface AspectRepositoryProvider {
   ExtensionPointName<AspectRepositoryProvider> EP_NAME =
       ExtensionPointName.create("com.google.idea.blaze.AspectRepositoryProvider");
 
-  String OVERRIDE_REPOSITORY_FLAG = "--override_repository=intellij_aspect";
-  String OVERRIDE_REPOSITORY_TEMPLATE_FLAG = "--override_repository=intellij_aspect_template";
 
   Optional<File> aspectDirectory();
 
@@ -41,17 +41,24 @@ public interface AspectRepositoryProvider {
   }
 
   static Optional<String>[] getOverrideFlags(Project project) {
-    return new Optional[] {
-      getOverrideFlagForAspectDirectory(),
-      getOverrideFlagForProjectAspectDirectory(project),
+
+    Optional<BlazeProjectData> projectData =
+            Optional.ofNullable(BlazeProjectDataManager.getInstance(project))
+                    .flatMap(it -> Optional.ofNullable(it.getBlazeProjectData()));
+    boolean useInjectedRepository = projectData
+            .map(it -> it.getBlazeVersionData().bazelIsAtLeastVersion(8, 0, 0))
+            .orElse(false); //fall back to false, as override_repository is available for all bazel versions
+    return new Optional[]{
+      getOverrideFlagForAspectDirectory(useInjectedRepository),
+      getOverrideFlagForProjectAspectDirectory(project, useInjectedRepository),
     };
   }
 
-  private static Optional<String> getOverrideFlagForAspectDirectory() {
-    return findAspectDirectory().map(it -> OVERRIDE_REPOSITORY_FLAG + "=" + it.getPath());
+  private static Optional<String> getOverrideFlagForAspectDirectory(boolean useInjectedRepository) {
+    return findAspectDirectory().map(it -> OverrideFlags.overrideRepositoryFlag(useInjectedRepository) + "=" + it.getPath());
   }
 
-  private static Optional<String> getOverrideFlagForProjectAspectDirectory(Project project) {
-    return getProjectAspectDirectory(project).map(it -> OVERRIDE_REPOSITORY_TEMPLATE_FLAG + "=" + it.getPath());
+  private static Optional<String> getOverrideFlagForProjectAspectDirectory(Project project, boolean useInjectedRepository) {
+    return getProjectAspectDirectory(project).map(it -> OverrideFlags.overrideRepositoryTemplateFlag(useInjectedRepository) + "=" + it.getPath());
   }
 }

--- a/base/src/com/google/idea/blaze/base/sync/aspects/strategy/AspectStrategyBazel.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/strategy/AspectStrategyBazel.java
@@ -58,7 +58,10 @@ public class AspectStrategyBazel extends AspectStrategy {
   @VisibleForTesting
   public AspectStrategyBazel(BlazeVersionData versionData) {
     super(/* aspectSupportsDirectDepsTrimming= */ true);
-    if (versionData.bazelIsAtLeastVersion(6, 0, 0)) {
+    boolean useInjectedRepository = versionData.bazelIsAtLeastVersion(8, 0, 0);
+    if (useInjectedRepository) {
+      aspectFlag = "--aspects=@intellij_aspect//:intellij_info_bundled.bzl%intellij_info_aspect";
+    } else if (versionData.bazelIsAtLeastVersion(6, 0, 0)) {
       aspectFlag = "--aspects=@@intellij_aspect//:intellij_info_bundled.bzl%intellij_info_aspect";
     } else {
       aspectFlag = "--aspects=@intellij_aspect//:intellij_info_bundled.bzl%intellij_info_aspect";

--- a/base/src/com/google/idea/blaze/base/sync/aspects/strategy/OverrideFlags.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/strategy/OverrideFlags.java
@@ -1,0 +1,23 @@
+package com.google.idea.blaze.base.sync.aspects.strategy;
+
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+public  class OverrideFlags {
+    @Contract(pure = true)
+    static @NotNull String newRepositoryFlag(boolean useInjectedRepository) {
+        if (useInjectedRepository) {
+            return "--inject_repository";
+        } else {
+            return "--override_repository";
+        }
+    }
+
+    public static @NotNull String overrideRepositoryFlag(boolean useInjectedRepository) {
+        return String.format("%s=intellij_aspect", newRepositoryFlag(useInjectedRepository));
+    }
+
+    public static @NotNull String overrideRepositoryTemplateFlag(boolean useInjectedRepository) {
+        return String.format("%s=intellij_aspect_template", newRepositoryFlag(useInjectedRepository));
+    }
+}

--- a/java/src/com/google/idea/blaze/java/fastbuild/BazelFastBuildAspectStrategy.java
+++ b/java/src/com/google/idea/blaze/java/fastbuild/BazelFastBuildAspectStrategy.java
@@ -32,7 +32,10 @@ final class BazelFastBuildAspectStrategy extends FastBuildAspectStrategy {
   @Override
   protected List<String> getAspectFlags(BlazeVersionData versionData, Project project) {
     String intellijAspectFile;
-    if (versionData.bazelIsAtLeastVersion(6, 0, 0)) {
+    boolean useInjectedRepository = versionData.bazelIsAtLeastVersion(8, 0, 0);
+    if(useInjectedRepository) {
+      intellijAspectFile = "--aspects=@intellij_aspect//:fast_build_info_bundled.bzl%fast_build_info_aspect";
+    } else if (versionData.bazelIsAtLeastVersion(6, 0, 0)) {
       intellijAspectFile = "--aspects=@@intellij_aspect//:fast_build_info_bundled.bzl%fast_build_info_aspect";
     } else {
       intellijAspectFile = "--aspects=@intellij_aspect//:fast_build_info_bundled.bzl%fast_build_info_aspect";

--- a/java/src/com/google/idea/blaze/java/run/hotswap/JavaClasspathAspectStrategy.java
+++ b/java/src/com/google/idea/blaze/java/run/hotswap/JavaClasspathAspectStrategy.java
@@ -25,7 +25,6 @@ import com.intellij.openapi.project.Project;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
@@ -61,9 +60,12 @@ public interface JavaClasspathAspectStrategy {
     @Override
     public ImmutableList<String> getBuildFlags(BlazeVersionData versionData, Project project) {
       String intellijAspect;
-      if (versionData.bazelIsAtLeastVersion(6, 0, 0)) {
+      boolean useInjectedRepository = versionData.bazelIsAtLeastVersion(8, 0, 0);
+      if (useInjectedRepository) {
+        intellijAspect = "--aspects=@intellij_aspect//:java_classpath.bzl%java_classpath_aspect";
+      } else if (versionData.bazelIsAtLeastVersion(6, 0, 0)) {
         intellijAspect = "--aspects=@@intellij_aspect//:java_classpath.bzl%java_classpath_aspect";
-      } else {
+      } else { // #bazel5 we are going to drop bazel 5 support in Feb 2025
         intellijAspect = "--aspects=@intellij_aspect//:java_classpath.bzl%java_classpath_aspect";
       }
 


### PR DESCRIPTION
…" (#6997)

This reverts commit b3cb63429a0bee5b760e4f5b6a375d81d85b23d9.

We can now safely push it, as bazel 8rc3 supports the `--inject_repository` flag

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

