### PR TITLE
[AOSP-pick] Expose bazel workspace_status to handlers

### DIFF
--- a/base/src/com/google/idea/blaze/base/qsync/BazelDependencyBuilder.java
+++ b/base/src/com/google/idea/blaze/base/qsync/BazelDependencyBuilder.java
@@ -19,7 +19,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.common.util.concurrent.Futures.immediateFailedFuture;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.stream.Collectors.joining;
@@ -31,13 +30,11 @@ import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.io.ByteSource;
 import com.google.common.io.MoreFiles;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.Uninterruptibles;
 import com.google.idea.blaze.base.bazel.BazelExitCodeException;
 import com.google.idea.blaze.base.bazel.BazelExitCodeException.ThrowOption;
 import com.google.idea.blaze.base.bazel.BuildSystem;
@@ -58,9 +55,7 @@ import com.google.idea.blaze.base.sync.aspects.BlazeBuildOutputs;
 import com.google.idea.blaze.base.vcs.BlazeVcsHandlerProvider.BlazeVcsHandler;
 import com.google.idea.blaze.common.Context;
 import com.google.idea.blaze.common.Label;
-import com.google.idea.blaze.common.Output;
 import com.google.idea.blaze.common.PrintOutput;
-import com.google.idea.blaze.common.artifact.BlazeArtifact;
 import com.google.idea.blaze.common.artifact.BuildArtifactCache;
 import com.google.idea.blaze.common.artifact.CachedArtifact;
 import com.google.idea.blaze.common.artifact.OutputArtifact;
@@ -96,7 +91,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.function.Function;
 
 /** An object that knows how to build dependencies for given targets */
 public class BazelDependencyBuilder implements DependencyBuilder {
@@ -329,9 +323,9 @@ public class BazelDependencyBuilder implements DependencyBuilder {
         PrintOutput.log(String.format("Fetched and parsed artifact info files in %d ms", elapsed)));
     }
     Optional<VcsState> vcsState = Optional.empty();
-    if (blazeBuildOutputs.sourceUri.isPresent() && vcsHandler.isPresent()) {
+    if (vcsHandler.isPresent()) {
       try {
-        vcsState = vcsHandler.get().vcsStateForSourceUri(blazeBuildOutputs.sourceUri.get());
+        vcsState = vcsHandler.get().vcsStateForWorkspaceStatus(blazeBuildOutputs.workspaceStatus);
       } catch (BuildException e) {
         context.handleExceptionAsWarning("Failed to get VCS state", e);
       }

--- a/base/src/com/google/idea/blaze/base/vcs/BlazeVcsHandlerProvider.java
+++ b/base/src/com/google/idea/blaze/base/vcs/BlazeVcsHandlerProvider.java
@@ -31,6 +31,7 @@ import com.google.idea.blaze.qsync.VcsStateDiffer;
 import com.intellij.openapi.extensions.ExtensionPointName;
 import com.intellij.openapi.project.Project;
 import java.nio.file.Path;
+import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nullable;
 
@@ -122,7 +123,7 @@ public interface BlazeVcsHandlerProvider {
                   executor));
     }
 
-    Optional<VcsState> vcsStateForSourceUri(String sourceUri) throws BuildException;
+    Optional<VcsState> vcsStateForWorkspaceStatus(Map<String, String> workspaceStatus) throws BuildException;
 
     /**
      * Diffs two VCS states from different points in time.

--- a/base/src/com/google/idea/blaze/base/vcs/FallbackBlazeVcsHandlerProvider.java
+++ b/base/src/com/google/idea/blaze/base/vcs/FallbackBlazeVcsHandlerProvider.java
@@ -26,8 +26,10 @@ import com.google.idea.blaze.base.settings.Blaze;
 import com.google.idea.blaze.base.settings.BuildSystemName;
 import com.google.idea.blaze.base.sync.workspace.WorkingSet;
 import com.google.idea.blaze.common.vcs.VcsState;
+import com.google.idea.blaze.exception.BuildException;
 import com.intellij.openapi.project.Project;
 import java.nio.file.Path;
+import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nullable;
 
@@ -79,7 +81,8 @@ public class FallbackBlazeVcsHandlerProvider implements BlazeVcsHandlerProvider 
     }
 
     @Override
-    public Optional<VcsState> vcsStateForSourceUri(String sourceUri) {
+    public Optional<VcsState> vcsStateForWorkspaceStatus(Map<String, String> workspaceStatus)
+      throws BuildException {
       return Optional.empty();
     }
 

--- a/base/src/com/google/idea/blaze/base/vcs/git/GitBlazeVcsHandlerProvider.java
+++ b/base/src/com/google/idea/blaze/base/vcs/git/GitBlazeVcsHandlerProvider.java
@@ -31,12 +31,14 @@ import com.google.idea.blaze.base.settings.BuildSystemName;
 import com.google.idea.blaze.base.sync.workspace.WorkingSet;
 import com.google.idea.blaze.base.vcs.BlazeVcsHandlerProvider;
 import com.google.idea.blaze.common.vcs.VcsState;
+import com.google.idea.blaze.exception.BuildException;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.text.StringUtil;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.nio.file.Path;
+import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nullable;
 
@@ -113,7 +115,8 @@ public class GitBlazeVcsHandlerProvider implements BlazeVcsHandlerProvider {
     }
 
     @Override
-    public Optional<VcsState> vcsStateForSourceUri(String sourceUri) {
+    public Optional<VcsState> vcsStateForWorkspaceStatus(Map<String, String> workspaceStatus)
+      throws BuildException {
       return Optional.empty();
     }
   }

--- a/base/tests/utils/integration/com/google/idea/blaze/base/sync/MockBlazeVcsHandlerProvider.java
+++ b/base/tests/utils/integration/com/google/idea/blaze/base/sync/MockBlazeVcsHandlerProvider.java
@@ -93,7 +93,7 @@ public class MockBlazeVcsHandlerProvider implements BlazeVcsHandlerProvider {
     }
 
     @Override
-    public Optional<VcsState> vcsStateForSourceUri(String sourceUri) {
+    public Optional<VcsState> vcsStateForWorkspaceStatus(Map<String, String> workspaceStatus) {
       return Optional.empty();
     }
 


### PR DESCRIPTION
Cherry pick AOSP commit [cb89e1d2aff31858d26a4044de9253c972e0c219](https://cs.android.com/android-studio/platform/tools/adt/idea/+/cb89e1d2aff31858d26a4044de9253c972e0c219).

There is no need to parse URIs when their components are accessible
directly.

This is in preparation to a unified Bazel VCS handler.

Bug: n/a
Test: n/a
Change-Id: I9c97f6e4ddcf56a76a6b9831c34972a4e7e7c2c3

AOSP: cb89e1d2aff31858d26a4044de9253c972e0c219
