### PR TITLE
fix: Don't require rules_java and rules_python for bazel 7 and older

### DIFF
--- a/base/src/com/google/idea/blaze/base/sync/aspects/strategy/SyncAspectTemplateProvider.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/strategy/SyncAspectTemplateProvider.java
@@ -146,11 +146,11 @@ public class SyncAspectTemplateProvider implements SyncListener {
     // TODO: adapt the logic to query sync
     boolean isQuerySync = projectData.map(BlazeProjectData::isQuerySync).orElse(false);
     var externalWorkspaceData = isQuerySync ? null : projectData.map(BlazeProjectData::getExternalWorkspaceData).orElse(null);
-    var isJavaEnabled = activeLanguages.contains(LanguageClass.JAVA) &&
-            (isQuerySync || (externalWorkspaceData != null && externalWorkspaceData.getByRepoName("rules_java") != null));
-    var isPythonEnabled = activeLanguages.contains(LanguageClass.PYTHON) &&
-            (isQuerySync || (externalWorkspaceData != null && externalWorkspaceData.getByRepoName("rules_python") != null));
     var isAtLeastBazel8 = projectData.map(it -> it.getBlazeVersionData().bazelIsAtLeastVersion(8, 0, 0)).orElse(false);
+    var isJavaEnabled = activeLanguages.contains(LanguageClass.JAVA) &&
+            (isQuerySync || (externalWorkspaceData != null && (!isAtLeastBazel8 || externalWorkspaceData.getByRepoName("rules_java") != null)));
+    var isPythonEnabled = activeLanguages.contains(LanguageClass.PYTHON) &&
+            (isQuerySync || (externalWorkspaceData != null && (!isAtLeastBazel8 || externalWorkspaceData.getByRepoName("rules_python") != null)));
     return Map.of(
             "bazel8OrAbove", isAtLeastBazel8 ? "true" : "false",
             "isJavaEnabled", isJavaEnabled ? "true" : "false",


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

