### PR TITLE
Handle included MODULE.bazel files as well

### DIFF
--- a/base/src/com/google/idea/blaze/base/lang/buildfile/psi/BuildFile.java
+++ b/base/src/com/google/idea/blaze/base/lang/buildfile/psi/BuildFile.java
@@ -81,7 +81,8 @@ public class BuildFile extends PsiFileBase implements BuildElement, DocStringOwn
     if (fileName.startsWith("WORKSPACE")) {
       return BlazeFileType.Workspace;
     }
-    if (fileName.equals("MODULE.bazel")) {
+    // Files included in a MODULE.bazel must end with '.MODULE.bazel'
+    if (fileName.equals("MODULE.bazel") || fileName.endsWith(".MODULE.bazel") {
       return BlazeFileType.MODULE;
     }
     return BlazeFileType.SkylarkExtension;


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: https://github.com/bazelbuild/intellij/issues/6882

# Description of this change
include directives in MODULE.bazel must reference files that end in '.MODULE.bazel'; this change makes the plugin recognize those as module files.
