### PR TITLE
Stop adding a trailing # when filtering tests for JUnit 5

### DIFF
--- a/java/src/com/google/idea/blaze/java/run/producers/BlazeJUnitTestFilterFlags.java
+++ b/java/src/com/google/idea/blaze/java/run/producers/BlazeJUnitTestFilterFlags.java
@@ -205,7 +205,7 @@ public final class BlazeJUnitTestFilterFlags {
     }
     String methodNamePattern = concatenateMethodNames(methodFilters, jUnitVersion);
     if (Strings.isNullOrEmpty(methodNamePattern)) {
-      if (jUnitVersion == JUnitVersion.JUNIT_4 || jUnitVersion == JUnitVersion.JUNIT_5) {
+      if (jUnitVersion == JUnitVersion.JUNIT_4) {
         output.append('#');
       }
       return output.toString();

--- a/java/tests/integrationtests/com/google/idea/blaze/java/run/producers/BlazeJavaAbstractTestCaseConfigurationProducerTest.java
+++ b/java/tests/integrationtests/com/google/idea/blaze/java/run/producers/BlazeJavaAbstractTestCaseConfigurationProducerTest.java
@@ -196,8 +196,9 @@ public class BlazeJavaAbstractTestCaseConfigurationProducerTest
 
     assertThat(blazeConfig.getTargets())
         .containsExactly(TargetExpression.fromStringSafe("//java/com/google/test:TestClass"));
+    String junit4Hash = (jUnitVersionUnderTest == JUnitVersion.JUNIT_4 ? "#" : "");
     assertThat(getTestFilterContents(blazeConfig))
-        .isEqualTo(BlazeFlags.TEST_FILTER + "=com.google.test.TestClass#");
+        .isEqualTo(BlazeFlags.TEST_FILTER + "=com.google.test.TestClass" + junit4Hash);
   }
 
   @Test

--- a/java/tests/integrationtests/com/google/idea/blaze/java/run/producers/BlazeJavaTestClassConfigurationProducerTest.java
+++ b/java/tests/integrationtests/com/google/idea/blaze/java/run/producers/BlazeJavaTestClassConfigurationProducerTest.java
@@ -27,6 +27,7 @@ import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.model.primitives.TargetExpression;
 import com.google.idea.blaze.base.model.primitives.WorkspacePath;
 import com.google.idea.blaze.base.run.BlazeCommandRunConfiguration;
+import com.google.idea.blaze.java.run.producers.BlazeJUnitTestFilterFlags.JUnitVersion;
 import com.google.idea.blaze.base.run.producers.TestContextRunConfigurationProducer;
 import com.google.idea.blaze.base.run.state.BlazeCommandRunConfigurationCommonState;
 import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
@@ -69,7 +70,9 @@ public class BlazeJavaTestClassConfigurationProducerTest
         (BlazeCommandRunConfiguration) fromContext.getConfiguration();
     assertThat(config.getTargets())
         .containsExactly(TargetExpression.fromStringSafe("//java/com/google/test:TestClass"));
-    assertThat(getTestFilterContents(config)).isEqualTo("--test_filter=com.google.test.TestClass#");
+    String junit4Hash = (jUnitVersionUnderTest == JUnitVersion.JUNIT_4 ? "#" : "");
+    assertThat(getTestFilterContents(config))
+        .isEqualTo("--test_filter=com.google.test.TestClass" + junit4Hash);
     assertThat(config.getName()).isEqualTo("Bazel test TestClass");
     assertThat(getCommandType(config)).isEqualTo(BlazeCommandName.TEST);
   }
@@ -94,7 +97,9 @@ public class BlazeJavaTestClassConfigurationProducerTest
         (BlazeCommandRunConfiguration) fromContext.getConfiguration();
     assertThat(config.getTargets())
         .containsExactly(TargetExpression.fromStringSafe("//java/com/google/test:TestClass"));
-    assertThat(getTestFilterContents(config)).isEqualTo("--test_filter=com.google.test.TestClass#");
+    String junit4Hash = (jUnitVersionUnderTest == JUnitVersion.JUNIT_4 ? "#" : "");
+    assertThat(getTestFilterContents(config))
+        .isEqualTo("--test_filter=com.google.test.TestClass" + junit4Hash);
     assertThat(config.getName()).isEqualTo("Bazel test TestClass");
     assertThat(getCommandType(config)).isEqualTo(BlazeCommandName.TEST);
   }

--- a/java/tests/integrationtests/com/google/idea/blaze/java/run/producers/MultipleJavaClassesTestContextProviderTest.java
+++ b/java/tests/integrationtests/com/google/idea/blaze/java/run/producers/MultipleJavaClassesTestContextProviderTest.java
@@ -284,8 +284,14 @@ public class MultipleJavaClassesTestContextProviderTest
     // THEN expect config to be correct
     assertThat(config.getTargets())
         .containsExactly(TargetExpression.fromStringSafe("//java/com/google/test:allTests"));
+    String junit4Hash = (jUnitVersionUnderTest == JUnitVersion.JUNIT_4 ? "#" : "");
     assertThat(getTestFilterContents(config))
-        .isEqualTo("--test_filter=\"com.google.test.TestClass1#|com.google.test.TestClass2#\"");
+        .isEqualTo(
+            "--test_filter=\"com.google.test.TestClass1"
+                + junit4Hash
+                + "|com.google.test.TestClass2"
+                + junit4Hash
+                + "\"");
     assertThat(config.getName()).isEqualTo("Bazel test TestClass1 and 1 others");
     assertThat(getCommandType(config)).isEqualTo(BlazeCommandName.TEST);
   }

--- a/java/tests/unittests/com/google/idea/blaze/java/run/producers/BlazeJUnitTestFilterFlagsTest.java
+++ b/java/tests/unittests/com/google/idea/blaze/java/run/producers/BlazeJUnitTestFilterFlagsTest.java
@@ -44,7 +44,7 @@ public class BlazeJUnitTestFilterFlagsTest extends BlazeTestCase {
     assertThat(
         BlazeJUnitTestFilterFlags.testFilterForClassAndMethods(
             "com.google.idea.ClassName", JUnitVersion.JUNIT_5, ImmutableList.of(), null))
-        .isEqualTo("com.google.idea.ClassName#");
+        .isEqualTo("com.google.idea.ClassName");
   }
 
   @Test
@@ -82,7 +82,7 @@ public class BlazeJUnitTestFilterFlagsTest extends BlazeTestCase {
                     JUnitVersion.JUNIT_5,
                     ImmutableList.of(),
                     ParameterizedTestInfo.create("ignored", "-ignored")))
-            .isEqualTo("com.google.idea.ClassName#");
+            .isEqualTo("com.google.idea.ClassName");
   }
 
   @Test


### PR DESCRIPTION
The JUnit 5 selector for methods does not support a trailing #.

This is easy to verify:

```
> java -jar junit-platform-console-standalone-<version>.jar execute -cp <my tests jar> --select-class=<my test class>
```

will work, while

```
> java -jar junit-platform-console-standalone-<version>.jar execute -cp <my tests jar> --select-class=<my test class>#
```

will fail.

This will change `--test_filter`'s value from `<my test class>#` to `<my test class>` when filtering for classes. The new value requires no postprocessing and is directly compatible with JUnit's selector "language".

The trailing # was introduced in https://github.com/bazelbuild/intellij/pull/4473/. This undocumented breaking change created issues for our own test runner.

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: https://github.com/bazelbuild/intellij/issues/7061/

# Description of this change

