### PR TITLE
Stop adding $ as "terminators" when filtering tests for JUnit 5

### DIFF
--- a/java/src/com/google/idea/blaze/java/run/producers/BlazeJUnitTestFilterFlags.java
+++ b/java/src/com/google/idea/blaze/java/run/producers/BlazeJUnitTestFilterFlags.java
@@ -211,12 +211,11 @@ public final class BlazeJUnitTestFilterFlags {
       return output.toString();
     }
     output.append('#').append(methodNamePattern);
-    // JUnit 4 and 5 test filters are regexes, and must be terminated to avoid matching
-    // unintended classes/methods. JUnit 3 test filters do not need or support this syntax.
-    if (jUnitVersion == JUnitVersion.JUNIT_3) {
-      return output.toString();
+    // JUnit 4 test filters are regexes and must be terminated to avoid matching unintended
+    // classes/methods.
+    if (jUnitVersion == JUnitVersion.JUNIT_4) {
+      output.append('$');
     }
-    output.append('$');
     return output.toString();
   }
 

--- a/java/tests/integrationtests/com/google/idea/blaze/java/run/producers/BlazeJUnitTestFilterFlagsIntegrationTest.java
+++ b/java/tests/integrationtests/com/google/idea/blaze/java/run/producers/BlazeJUnitTestFilterFlagsIntegrationTest.java
@@ -80,10 +80,11 @@ public class BlazeJUnitTestFilterFlagsIntegrationTest extends BlazeIntegrationTe
     Location<?> location2 =
         new PsiMemberParameterizedLocation(getProject(), method2, javaClass, "[3]");
 
+    String junit4Dollar = (jUnitVersionUnderTest == JUnitVersion.JUNIT_4 ? "$" : "");
     assertThat(
             BlazeJUnitTestFilterFlags.testFilterForClassesAndMethods(
                 ImmutableMap.of(javaClass, ImmutableList.of(location1, location2))))
-        .isEqualTo("com.google.test.TestClass#(testMethod1\\[param\\]|testMethod2\\[3\\])$");
+        .isEqualTo("com.google.test.TestClass#(testMethod1\\[param\\]|testMethod2\\[3\\])" + junit4Dollar);
   }
 
   @Test
@@ -127,6 +128,7 @@ public class BlazeJUnitTestFilterFlagsIntegrationTest extends BlazeIntegrationTe
     PsiClass javaClass2 = ((PsiClassOwner) javaFile2).getClasses()[0];
     PsiMethod class2Method = javaClass2.findMethodsByName("testMethod", false)[0];
 
+    String junit4Dollar = (jUnitVersionUnderTest == JUnitVersion.JUNIT_4 ? "$" : "");
     assertThat(
             BlazeJUnitTestFilterFlags.testFilterForClassesAndMethods(
                 ImmutableMap.of(
@@ -137,8 +139,8 @@ public class BlazeJUnitTestFilterFlagsIntegrationTest extends BlazeIntegrationTe
         .isEqualTo(
             Joiner.on('|')
                 .join(
-                    "com.google.test.OtherTestClass#testMethod$",
-                    "com.google.test.TestClass#(testMethod1\\[param\\]|testMethod2\\[3\\])$"
+                    "com.google.test.OtherTestClass#testMethod" + junit4Dollar,
+                    "com.google.test.TestClass#(testMethod1\\[param\\]|testMethod2\\[3\\])" + junit4Dollar
                 ));
   }
 }

--- a/java/tests/integrationtests/com/google/idea/blaze/java/run/producers/BlazeJavaAbstractTestCaseConfigurationProducerTest.java
+++ b/java/tests/integrationtests/com/google/idea/blaze/java/run/producers/BlazeJavaAbstractTestCaseConfigurationProducerTest.java
@@ -264,8 +264,9 @@ public class BlazeJavaAbstractTestCaseConfigurationProducerTest
 
     assertThat(blazeConfig.getTargets())
         .containsExactly(TargetExpression.fromStringSafe("//java/com/google/test:TestClass"));
+    String junit4Dollar = (jUnitVersionUnderTest == JUnitVersion.JUNIT_4 ? "$" : "");
     assertThat(getTestFilterContents(blazeConfig))
-        .isEqualTo(BlazeFlags.TEST_FILTER + "=com.google.test.TestClass#testMethod$");
+        .isEqualTo(BlazeFlags.TEST_FILTER + "=com.google.test.TestClass#testMethod" + junit4Dollar);
   }
 
   @Test

--- a/java/tests/integrationtests/com/google/idea/blaze/java/run/producers/BlazeJavaTestMethodConfigurationProducerTest.java
+++ b/java/tests/integrationtests/com/google/idea/blaze/java/run/producers/BlazeJavaTestMethodConfigurationProducerTest.java
@@ -23,6 +23,7 @@ import com.google.idea.blaze.base.lang.buildfile.psi.util.PsiUtils;
 import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.model.primitives.TargetExpression;
 import com.google.idea.blaze.base.run.BlazeCommandRunConfiguration;
+import com.google.idea.blaze.java.run.producers.BlazeJUnitTestFilterFlags.JUnitVersion;
 import com.google.idea.blaze.base.run.producers.TestContextRunConfigurationProducer;
 import com.google.idea.blaze.base.run.state.BlazeCommandRunConfigurationCommonState;
 import com.google.idea.blaze.java.utils.BlazeJUnitRunConfigurationProducerTestCase;
@@ -62,8 +63,9 @@ public class BlazeJavaTestMethodConfigurationProducerTest
         (BlazeCommandRunConfiguration) fromContext.getConfiguration();
     assertThat(config.getTargets())
         .containsExactly(TargetExpression.fromStringSafe("//java/com/google/test:TestClass"));
+    String junit4Dollar = (jUnitVersionUnderTest == JUnitVersion.JUNIT_4 ? "$" : "");
     assertThat(getTestFilterContents(config))
-        .isEqualTo("--test_filter=com.google.test.TestClass#testMethod1$");
+        .isEqualTo("--test_filter=com.google.test.TestClass#testMethod1" + junit4Dollar);
     assertThat(config.getName()).isEqualTo("Bazel test TestClass.testMethod1");
     assertThat(getCommandType(config)).isEqualTo(BlazeCommandName.TEST);
 

--- a/java/tests/unittests/com/google/idea/blaze/java/run/producers/BlazeJUnitTestFilterFlagsTest.java
+++ b/java/tests/unittests/com/google/idea/blaze/java/run/producers/BlazeJUnitTestFilterFlagsTest.java
@@ -93,7 +93,7 @@ public class BlazeJUnitTestFilterFlagsTest extends BlazeTestCase {
             JUnitVersion.JUNIT_5,
             ImmutableList.of("testMethod1"),
             null))
-        .isEqualTo("com.google.idea.ClassName#testMethod1$");
+        .isEqualTo("com.google.idea.ClassName#testMethod1");
   }
 
   @Test
@@ -126,7 +126,7 @@ public class BlazeJUnitTestFilterFlagsTest extends BlazeTestCase {
             JUnitVersion.JUNIT_5,
             ImmutableList.of("testMethod1", "testMethod2"),
             null))
-        .isEqualTo("com.google.idea.ClassName#(testMethod1|testMethod2)$");
+        .isEqualTo("com.google.idea.ClassName#(testMethod1|testMethod2)");
   }
 
   @Test


### PR DESCRIPTION
While `$` may be useful in other JUnit versions to determine where a "class boundary" ends, as the plugin is using `,` for enumeration in that case (i.e. `mypackage.myClass1#myMethod1,myMethod2$|...`), it is not needed when the enumeration is between `()` as in JUnit5 (i.e. `mypackage.myClass1#(myMethod1|myMethod2)|...`).

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: https://github.com/bazelbuild/intellij/issues/7061

# Description of this change

