### PR TITLE
[AOSP-pick] Improve performance and decrease memory usage

### DIFF
--- a/querysync/java/com/google/idea/blaze/qsync/BlazeQueryParser.java
+++ b/querysync/java/com/google/idea/blaze/qsync/BlazeQueryParser.java
@@ -135,7 +135,7 @@ public class BlazeQueryParser {
 
     long now = System.nanoTime();
     final var visitors = new RuleVisitors();
-    for (Map.Entry<Label, Query.SourceFile> sourceFileEntry :
+    for (Map.Entry<Label, QueryData.SourceFile> sourceFileEntry :
         query.getSourceFilesMap().entrySet()) {
       if (sourceFileEntry.getKey().getWorkspaceName().isEmpty()) {
         graphBuilder
@@ -210,10 +210,10 @@ public class BlazeQueryParser {
             .putAll(SourceType.REGULAR, expandFileGroupValues(rule.sources()));
 
 
-    Set<Label> thisDeps = Sets.newHashSet(toLabelList(rule.deps()));
+    Set<Label> thisDeps = Sets.newHashSet(rule.deps());
     targetBuilder.depsBuilder().addAll(thisDeps);
 
-    targetBuilder.runtimeDepsBuilder().addAll(toLabelList(rule.runtimeDeps()));
+    targetBuilder.runtimeDepsBuilder().addAll(rule.runtimeDeps());
     javaDeps.addAll(thisDeps);
   }
 
@@ -222,7 +222,7 @@ public class BlazeQueryParser {
         .sourceLabelsBuilder()
         .putAll(SourceType.REGULAR, expandFileGroupValues(rule.sources()));
 
-    Set<Label> thisDeps = Sets.newHashSet(toLabelList(rule.deps()));
+    Set<Label> thisDeps = Sets.newHashSet(rule.deps());
     targetBuilder.depsBuilder().addAll(thisDeps);
   }
 
@@ -235,10 +235,10 @@ public class BlazeQueryParser {
         .putAll(SourceType.REGULAR, expandFileGroupValues(rule.sources()))
         .putAll(SourceType.ANDROID_RESOURCES, expandFileGroupValues(rule.resourceFiles()));
 
-    Set<Label> thisDeps = Sets.newHashSet(toLabelList(rule.deps()));
+    Set<Label> thisDeps = Sets.newHashSet(rule.deps());
     targetBuilder.depsBuilder().addAll(thisDeps);
 
-    targetBuilder.runtimeDepsBuilder().addAll(toLabelList(rule.runtimeDeps()));
+    targetBuilder.runtimeDepsBuilder().addAll(rule.runtimeDeps());
     javaDeps.addAll(thisDeps);
 
     if (RuleKinds.isAndroid(rule.ruleClass())) {
@@ -247,10 +247,10 @@ public class BlazeQueryParser {
       if (!rule.idlSources().isEmpty()) {
         projectTargetsToBuild.add(label);
       }
-      if (!rule.manifest().isEmpty()) {
+      if (rule.manifest().isPresent()) {
         targetBuilder
             .sourceLabelsBuilder()
-            .put(SourceType.ANDROID_MANIFEST, Label.of(rule.manifest()));
+            .put(SourceType.ANDROID_MANIFEST, rule.manifest().get());
       }
     }
   }
@@ -264,7 +264,7 @@ public class BlazeQueryParser {
         .putAll(SourceType.REGULAR, expandFileGroupValues(rule.sources()))
         .putAll(SourceType.CC_HEADERS, expandFileGroupValues(rule.hdrs()));
 
-    Set<Label> thisDeps = Sets.newHashSet(toLabelList(rule.deps()));
+    Set<Label> thisDeps = Sets.newHashSet(rule.deps());
     targetBuilder.depsBuilder().addAll(thisDeps);
   }
 
@@ -276,10 +276,8 @@ public class BlazeQueryParser {
   }
 
   /** Returns a set of sources for a rule, expanding any in-project {@code filegroup} rules */
-  private ImmutableSet<Label> expandFileGroupValues(List<String>... labelLists) {
-    return stream(labelLists)
-        .map(Label::toLabelList)
-        .flatMap(List::stream)
+  private ImmutableSet<Label> expandFileGroupValues(List<Label> labelLists) {
+    return labelLists.stream()
         .map(this::expandSourceLabel)
         .flatMap(Set::stream)
         .collect(toImmutableSet());
@@ -292,10 +290,9 @@ public class BlazeQueryParser {
     Set<Label> visited = Sets.newHashSet();
     ImmutableSet.Builder<Label> result = ImmutableSet.builder();
 
-    for (String source : requireNonNull(query.getRulesMap().get(label)).sources()) {
-      Label asLabel = Label.of(source);
-      if (visited.add(asLabel)) {
-        result.addAll(expandSourceLabel(asLabel));
+    for (Label source : requireNonNull(query.getRulesMap().get(label)).sources()) {
+      if (visited.add(source)) {
+        result.addAll(expandSourceLabel(source));
       }
     }
 

--- a/querysync/java/com/google/idea/blaze/qsync/PartialProjectRefresh.java
+++ b/querysync/java/com/google/idea/blaze/qsync/PartialProjectRefresh.java
@@ -22,7 +22,6 @@ import com.google.common.collect.Maps;
 import com.google.idea.blaze.common.Label;
 import com.google.idea.blaze.common.vcs.VcsState;
 import com.google.idea.blaze.qsync.project.PostQuerySyncData;
-import com.google.idea.blaze.qsync.query.Query.SourceFile;
 import com.google.idea.blaze.qsync.query.QueryData;
 import com.google.idea.blaze.qsync.query.QuerySpec;
 import com.google.idea.blaze.qsync.query.QuerySummary;
@@ -99,8 +98,8 @@ class PartialProjectRefresh implements RefreshOperation {
   @VisibleForTesting
   QuerySummary applyDelta(QuerySummary partialQuery) {
     // copy all unaffected rules / source files to result:
-    Map<Label, SourceFile> newSourceFiles = Maps.newHashMap();
-    for (Map.Entry<Label, SourceFile> sfEntry :
+    Map<Label, QueryData.SourceFile> newSourceFiles = Maps.newHashMap();
+    for (Map.Entry<Label, QueryData.SourceFile> sfEntry :
         previousState.querySummary().getSourceFilesMap().entrySet()) {
       Path buildPackage = sfEntry.getKey().getPackage();
       if (!(deletedPackages.contains(buildPackage)
@@ -122,7 +121,7 @@ class PartialProjectRefresh implements RefreshOperation {
     newRules.putAll(partialQuery.getRulesMap());
     return QuerySummary.newBuilder()
         .putAllSourceFiles(newSourceFiles)
-        .putAllRules(newRules)
+        .putAllRules(newRules.values())
         .putAllPackagesWithErrors(partialQuery.getPackagesWithErrors())
         .build();
   }

--- a/querysync/java/com/google/idea/blaze/qsync/query/QueryData.java
+++ b/querysync/java/com/google/idea/blaze/qsync/query/QueryData.java
@@ -16,7 +16,10 @@
 package com.google.idea.blaze.qsync.query;
 
 import com.google.auto.value.AutoBuilder;
+import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
+import com.google.idea.blaze.common.Label;
+import java.util.Optional;
 
 /** Contains records for storing query summary data, as an alternative to protos. */
 public class QueryData {
@@ -26,65 +29,68 @@ public class QueryData {
    * com.google.devtools.build.lib.query2.proto.proto2api.Build.Rule}.
    */
   public record Rule(
+      Label label,
       String ruleClass,
-      ImmutableList<String> sources,
-      ImmutableList<String> deps,
-      ImmutableList<String> idlSources,
-      ImmutableList<String> runtimeDeps,
-      ImmutableList<String> resourceFiles,
-      String manifest,
+      ImmutableList<Label> sources,
+      ImmutableList<Label> deps,
+      ImmutableList<Label> idlSources,
+      ImmutableList<Label> runtimeDeps,
+      ImmutableList<Label> resourceFiles,
+      Optional<Label> manifest,
       String testApp,
       String instruments,
       String customPackage,
-      ImmutableList<String> hdrs,
+      ImmutableList<Label> hdrs,
       ImmutableList<String> copts,
       ImmutableList<String> tags,
       String mainClass,
       ImmutableList<String> imports) {
-
-    public static final Rule EMPTY =
-        new AutoBuilder_QueryData_Rule_Builder()
-            .ruleClass("")
-            .sources(ImmutableList.of())
-            .deps(ImmutableList.of())
-            .idlSources(ImmutableList.of())
-            .runtimeDeps(ImmutableList.of())
-            .resourceFiles(ImmutableList.of())
-            .manifest("")
-            .testApp("")
-            .instruments("")
-            .customPackage("")
-            .hdrs(ImmutableList.of())
-            .copts(ImmutableList.of())
-            .tags(ImmutableList.of())
-            .mainClass("")
-            .imports(ImmutableList.of())
-            .build();
 
     public Builder toBuilder() {
       return new AutoBuilder_QueryData_Rule_Builder(this);
     }
 
     public static Builder builder() {
-      return EMPTY.toBuilder();
+      return new AutoBuilder_QueryData_Rule_Builder();
     }
+
+    public static Builder builderForTests() {
+      return new AutoBuilder_QueryData_Rule_Builder()
+          .ruleClass("")
+          .sources(ImmutableList.of())
+          .deps(ImmutableList.of())
+          .idlSources(ImmutableList.of())
+          .runtimeDeps(ImmutableList.of())
+          .resourceFiles(ImmutableList.of())
+          .manifest(Optional.empty())
+          .testApp("")
+          .instruments("")
+          .customPackage("")
+          .hdrs(ImmutableList.of())
+          .copts(ImmutableList.of())
+          .tags(ImmutableList.of())
+          .mainClass("")
+          .imports(ImmutableList.of());
+    }
+
 
     @AutoBuilder
     public interface Builder {
+      Builder label(Label value);
 
       Builder ruleClass(String value);
 
-      Builder sources(ImmutableList<String> value);
+      Builder sources(ImmutableList<Label> value);
 
-      Builder deps(ImmutableList<String> value);
+      Builder deps(ImmutableList<Label> value);
 
-      Builder idlSources(ImmutableList<String> sources);
+      Builder idlSources(ImmutableList<Label> sources);
 
-      Builder runtimeDeps(ImmutableList<String> sources);
+      Builder runtimeDeps(ImmutableList<Label> sources);
 
-      Builder resourceFiles(ImmutableList<String> sources);
+      Builder resourceFiles(ImmutableList<Label> sources);
 
-      Builder manifest(String value);
+      Builder manifest(Optional<Label> value);
 
       Builder testApp(String value);
 
@@ -92,7 +98,7 @@ public class QueryData {
 
       Builder customPackage(String value);
 
-      Builder hdrs(ImmutableList<String> sources);
+      Builder hdrs(ImmutableList<Label> sources);
 
       Builder copts(ImmutableList<String> sources);
 
@@ -105,4 +111,6 @@ public class QueryData {
       Rule build();
     }
   }
+
+  public record SourceFile(Label label, ImmutableCollection<Label> subincliudes) {}
 }

--- a/querysync/java/com/google/idea/blaze/qsync/query/QuerySummary.java
+++ b/querysync/java/com/google/idea/blaze/qsync/query/QuerySummary.java
@@ -37,7 +37,6 @@ import com.google.devtools.build.lib.query2.proto.proto2api.Build;
 import com.google.devtools.build.lib.query2.proto.proto2api.Build.Target;
 import com.google.idea.blaze.common.Interners;
 import com.google.idea.blaze.common.Label;
-import com.google.idea.blaze.qsync.query.Query.SourceFile;
 import com.google.idea.blaze.qsync.query.Query.Summary;
 import java.io.BufferedInputStream;
 import java.io.File;
@@ -52,6 +51,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 /**
@@ -80,7 +80,7 @@ public abstract class QuerySummary {
    * <p>Whenever changing the logic in this class such that the Query.Summary proto contents will be
    * different for the same input, this version should be incremented.
    */
-  @VisibleForTesting public static final int PROTO_VERSION = 11;
+  @VisibleForTesting public static final int PROTO_VERSION = 12;
 
   public static final QuerySummary EMPTY =
       create(Query.Summary.newBuilder().setVersion(PROTO_VERSION).build());
@@ -167,25 +167,26 @@ public abstract class QuerySummary {
     }
 
     private Query.StoredRule ruleToStoredRule(QueryData.Rule r) {
-      final var value =
-          Query.StoredRule.newBuilder()
-              .setRuleClass(index(r.ruleClass()))
-              .addAllSources(index(r.sources()))
-              .addAllDeps(index(r.deps()))
-              .addAllIdlSources(index(r.idlSources()))
-              .addAllRuntimeDeps(index(r.runtimeDeps()))
-              .addAllResourceFiles(index(r.resourceFiles()))
-              .setManifest(index(r.manifest()))
-              .setTestApp(index(r.testApp()))
-              .setInstruments(index(r.instruments()))
-              .setCustomPackage(index(r.customPackage()))
-              .addAllHdrs(index(r.hdrs()))
-              .addAllCopts(index(r.copts()))
-              .addAllTags(index(r.tags()))
-              .setMainClass(index(r.mainClass()))
-              .addAllImports(index(r.imports()))
-              .build();
-      return value;
+      Query.StoredRule.Builder builder = Query.StoredRule.newBuilder()
+          .setLabel(indexLabel(r.label()))
+          .setRuleClass(index(r.ruleClass()))
+          .addAllSources(indexLabels(r.sources()))
+          .addAllDeps(indexLabels(r.deps()))
+          .addAllIdlSources(indexLabels(r.idlSources()))
+          .addAllRuntimeDeps(indexLabels(r.runtimeDeps()))
+          .addAllResourceFiles(indexLabels(r.resourceFiles()))
+          .setTestApp(index(r.testApp()))
+          .setInstruments(index(r.instruments()))
+          .setCustomPackage(index(r.customPackage()))
+          .addAllHdrs(indexLabels(r.hdrs()))
+          .addAllCopts(index(r.copts()))
+          .addAllTags(index(r.tags()))
+          .setMainClass(index(r.mainClass()))
+          .addAllImports(index(r.imports()));
+      if (r.manifest().isPresent()) {
+        builder.setManifest(indexLabel(r.manifest().get()));
+      }
+      return builder.build();
     }
 
     private Integer addStringAndGetIndex(String s) {
@@ -197,6 +198,27 @@ public abstract class QuerySummary {
       return strings.computeIfAbsent(s, this::addStringAndGetIndex);
     }
 
+    public Query.StoredLabel indexLabel(Label l) {
+      return Query.StoredLabel.newBuilder()
+        .setWorkspace(index(l.getWorkspaceName()))
+        .setBuildPackage(index(l.getPackage().toString()))
+        .setName(index(l.getName().toString()))
+        .build();
+    }
+
+    public List<Query.StoredLabel> indexLabels(Collection<Label> labels) {
+      return labels.stream()
+        .map(this::indexLabel)
+        .collect(toImmutableList());
+    }
+
+    public List<Query.StoredLabel> indexStringsAsLabels(Collection<String> labels) {
+      return labels.stream()
+        .map(Label::of)
+        .map(this::indexLabel)
+        .collect(toImmutableList());
+    }
+
     public List<Integer> index(Collection<String> ss) {
       return ss.stream()
           .map(s -> strings.computeIfAbsent(s, this::addStringAndGetIndex))
@@ -205,6 +227,13 @@ public abstract class QuerySummary {
 
     public List<String> list() {
       return ImmutableList.copyOf(list);
+    }
+
+    public Query.StoredSourceFile sourceFileToStoredSourceFile(QueryData.SourceFile it) {
+      return Query.StoredSourceFile.newBuilder()
+        .setLabel(indexLabel(it.label()))
+        .addAllSubinclude(indexLabels(it.subincliudes()))
+        .build();
     }
   }
 
@@ -217,31 +246,48 @@ public abstract class QuerySummary {
     }
 
     private QueryData.Rule storedRuleToRule(Query.StoredRule r) {
-      return QueryData.Rule.builder()
-          .ruleClass(lookup(r.getRuleClass()))
-          .sources(lookup(r.getSourcesList()))
-          .deps(lookup(r.getDepsList()))
-          .idlSources(lookup(r.getIdlSourcesList()))
-          .runtimeDeps(lookup(r.getRuntimeDepsList()))
-          .resourceFiles(lookup(r.getResourceFilesList()))
-          .manifest(lookup(r.getManifest()))
-          .testApp(lookup(r.getTestApp()))
-          .instruments(lookup(r.getInstruments()))
-          .customPackage(lookup(r.getCustomPackage()))
-          .hdrs(lookup(r.getHdrsList()))
-          .copts(lookup(r.getCoptsList()))
-          .tags(lookup(r.getTagsList()))
-          .mainClass(lookup(r.getMainClass()))
-          .imports(lookup(r.getImportsList()))
-          .build();
+      QueryData.Rule.Builder builder = QueryData.Rule.builder()
+          .label(lookupLabel(r.getLabel()))
+          .ruleClass(lookupString(r.getRuleClass()))
+          .sources(lookupLabels(r.getSourcesList()))
+          .deps(lookupLabels(r.getDepsList()))
+          .idlSources(lookupLabels(r.getIdlSourcesList()))
+          .runtimeDeps(lookupLabels(r.getRuntimeDepsList()))
+          .resourceFiles(lookupLabels(r.getResourceFilesList()))
+          .testApp(lookupString(r.getTestApp()))
+          .instruments(lookupString(r.getInstruments()))
+          .customPackage(lookupString(r.getCustomPackage()))
+          .hdrs(lookupLabels(r.getHdrsList()))
+          .copts(lookupStrings(r.getCoptsList()))
+          .tags(lookupStrings(r.getTagsList()))
+          .mainClass(lookupString(r.getMainClass()))
+          .imports(lookupStrings(r.getImportsList()));
+      if (r.hasManifest()) {
+        builder.manifest(Optional.of(lookupLabel(r.getManifest())));
+      } else {
+        builder.manifest(Optional.empty());
+      }
+      return builder.build();
     }
 
-    public String lookup(Integer s) {
+    private QueryData.SourceFile storedSourceFileToSourceFile(Query.StoredSourceFile s) {
+      return new QueryData.SourceFile(lookupLabel(s.getLabel()), lookupLabels(s.getSubincludeList()));
+    }
+
+    public String lookupString(Integer s) {
       return list.get(s);
     }
 
-    public ImmutableList<String> lookup(Collection<Integer> ss) {
+    public ImmutableList<String> lookupStrings(Collection<Integer> ss) {
       return ss.stream().map(list::get).collect(toImmutableList());
+    }
+
+    public Label lookupLabel(Query.StoredLabel l) {
+      return new Label(lookupString(l.getWorkspace()), lookupString(l.getBuildPackage()), lookupString(l.getName()));
+    }
+
+    public ImmutableList<Label> lookupLabels(Collection<Query.StoredLabel> ll) {
+      return ll.stream().map(this::lookupLabel).collect(toImmutableList());
     }
   }
 
@@ -252,22 +298,23 @@ public abstract class QuerySummary {
   public static QuerySummary create(QuerySpec.QueryStrategy queryStrategy, InputStream protoInputStream) throws IOException {
     // IMPORTANT: when changing the logic herein, you should also update PROTO_VERSION above.
     // Failure to do so is likely to result in problems during a partial sync.
-    Map<String, Query.SourceFile> sourceFileMap = Maps.newHashMap();
-    Map<Integer, Query.StoredRule> ruleMap = Maps.newHashMap();
+    Map<Label, Query.StoredSourceFile> sourceFileMap = Maps.newHashMap();
+    Map<Label, Query.StoredRule> ruleMap = Maps.newHashMap();
     Set<String> packagesWithErrors = Sets.newHashSet();
     StringIndexer indexer = new StringIndexer();
     Build.Target target;
     while ((target = Target.parseDelimitedFrom(protoInputStream)) != null) {
       switch (target.getType()) {
         case SOURCE_FILE:
-          Query.SourceFile sourceFile =
-              Query.SourceFile.newBuilder()
-                  .addAllSubinclude(intern(target.getSourceFile().getSubincludeList()))
+          Label sourceFileLabel = Label.of(target.getSourceFile().getName());
+          Query.StoredSourceFile sourceFile =
+              Query.StoredSourceFile.newBuilder()
+                .setLabel(indexer.indexLabel(sourceFileLabel))
+                .addAllSubinclude(indexer.indexStringsAsLabels(target.getSourceFile().getSubincludeList()))
                   .build();
-          String sourceFileName = intern(target.getSourceFile().getName());
-          sourceFileMap.put(sourceFileName, sourceFile);
+          sourceFileMap.put(sourceFileLabel, sourceFile);
           if (target.getSourceFile().getPackageContainsErrors()) {
-            packagesWithErrors.add(sourceFileName);
+            packagesWithErrors.add(intern(target.getSourceFile().getName()));
           }
           break;
         case RULE:
@@ -277,30 +324,34 @@ public abstract class QuerySummary {
           Query.StoredRule.Builder rule =
               Query.StoredRule.newBuilder()
                   .setRuleClass(indexer.index(target.getRule().getRuleClass()));
+          Label label = Label.of(target.getRule().getName());
+          rule.setLabel(indexer.indexLabel(label));
           for (Build.Attribute a : target.getRule().getAttributeList()) {
             String attributeName = intern(a.getName());
             if (SRCS_ATTRIBUTES.contains(attributeName)) {
-              rule.addAllSources(indexer.index(a.getStringListValueList()));
+              rule.addAllSources(indexer.indexStringsAsLabels(a.getStringListValueList()));
             } else if (attributeName.equals("hdrs")) {
-              rule.addAllHdrs(indexer.index(a.getStringListValueList()));
+              rule.addAllHdrs(indexer.indexStringsAsLabels(a.getStringListValueList()));
             } else if (attributeIsTrackedDependency(attributeName, target)) {
               if (a.hasStringValue()) {
-                rule.addDeps(indexer.index(a.getStringValue()));
+                rule.addDeps(indexer.indexLabel(Label.of(a.getStringValue())));
               } else {
-                rule.addAllDeps(indexer.index(a.getStringListValueList()));
+                rule.addAllDeps(indexer.indexStringsAsLabels(a.getStringListValueList()));
               }
             } else if (RUNTIME_DEP_ATTRIBUTES.contains(attributeName)) {
               if (a.hasStringValue()) {
-                rule.addRuntimeDeps(indexer.index(a.getStringValue()));
+                rule.addRuntimeDeps(indexer.indexLabel(Label.of(a.getStringValue())));
               } else {
-                rule.addAllRuntimeDeps(indexer.index(a.getStringListValueList()));
+                rule.addAllRuntimeDeps(indexer.indexStringsAsLabels(a.getStringListValueList()));
               }
             } else if (attributeName.equals("idl_srcs")) {
-              rule.addAllIdlSources(indexer.index(a.getStringListValueList()));
+              rule.addAllIdlSources(indexer.indexStringsAsLabels(a.getStringListValueList()));
             } else if (attributeName.equals("resource_files")) {
-              rule.addAllResourceFiles(indexer.index(a.getStringListValueList()));
+              rule.addAllResourceFiles(indexer.indexStringsAsLabels(a.getStringListValueList()));
             } else if (attributeName.equals("manifest")) {
-              rule.setManifest(indexer.index(a.getStringValue()));
+              if (!a.getStringValue().isEmpty()){
+                rule.setManifest(indexer.indexLabel(Label.of(a.getStringValue())));
+              }
             } else if (attributeName.equals("custom_package")) {
               rule.setCustomPackage(indexer.index((a.getStringValue())));
             } else if (attributeName.equals("copts")) {
@@ -319,7 +370,7 @@ public abstract class QuerySummary {
               rule.addAllImports(indexer.index(a.getStringListValueList()));
             }
           }
-          ruleMap.put(indexer.index(Label.of(target.getRule().getName()).toString()), rule.build());
+          ruleMap.put(label, rule.build());
           break;
         default:
           break;
@@ -329,8 +380,8 @@ public abstract class QuerySummary {
         Query.Summary.newBuilder()
             .setQueryStrategy(convertQueryStrategy(queryStrategy))
             .setVersion(PROTO_VERSION)
-            .putAllSourceFiles(sourceFileMap)
-            .putAllStoredRules(ruleMap)
+            .addAllSourceFiles(sourceFileMap.values())
+            .addAllStoredRules(ruleMap.values())
             .setStringStorage(Query.StringStorage.newBuilder().addAllIndexedStrings(indexer.list()))
             .addAllPackagesWithErrors(packagesWithErrors)
             .build());
@@ -383,9 +434,11 @@ public abstract class QuerySummary {
    * <p>This is a map of source target label to the {@link SourceFile} proto representing it.
    */
   @Memoized
-  public ImmutableMap<Label, SourceFile> getSourceFilesMap() {
-    return proto().getSourceFilesMap().entrySet().stream()
-        .collect(toImmutableMap(e -> Label.of(e.getKey()), Map.Entry::getValue));
+  public ImmutableMap<Label, QueryData.SourceFile> getSourceFilesMap() {
+    StringLookup lookup = new StringLookup(proto().getStringStorage().getIndexedStringsList());
+    return proto().getSourceFilesList().stream().map(lookup::storedSourceFileToSourceFile)
+      .collect(toImmutableMap(QueryData.SourceFile::label,
+                              Function.identity()));
   }
 
   /**
@@ -396,11 +449,12 @@ public abstract class QuerySummary {
   @Memoized
   public ImmutableMap<Label, QueryData.Rule> getRulesMap() {
     StringLookup lookup = new StringLookup(proto().getStringStorage().getIndexedStringsList());
-    return proto().getStoredRulesMap().entrySet().stream()
+    return proto().getStoredRulesList().stream()
+      .map(lookup::storedRuleToRule)
         .collect(
             toImmutableMap(
-                e -> Label.createLabelWithoutValidation(lookup.lookup(e.getKey())),
-                t -> lookup.storedRuleToRule(t.getValue())));
+                QueryData.Rule::label,
+                Function.identity()));
   }
 
   @Memoized
@@ -438,8 +492,7 @@ public abstract class QuerySummary {
                 flatteningToMultimap(
                     e -> e.getKey().toFilePath(),
                     e ->
-                        e.getValue().getSubincludeList().stream()
-                            .map(Label::of)
+                        e.getValue().subincliudes().stream()
                             .map(Label::toFilePath),
                     HashMultimap::create));
     return ImmutableMultimap.copyOf(Multimaps.invertFrom(includes, HashMultimap.create()));
@@ -476,28 +529,29 @@ public abstract class QuerySummary {
 
     Builder() {}
 
-    public Builder putAllSourceFiles(Map<Label, Query.SourceFile> sourceFileMap) {
-      builder.putAllSourceFiles(
-          sourceFileMap.entrySet().stream()
-              .collect(toImmutableMap(e -> intern(e.getKey().toString()), Map.Entry::getValue)));
+    public Builder putAllSourceFiles(Map<Label, QueryData.SourceFile> sourceFileMap) {
+      builder.addAllSourceFiles(
+        sourceFileMap.values().stream()
+          .map(indexer::sourceFileToStoredSourceFile)
+          .collect(toImmutableList()));
       return this;
     }
 
-    public Builder putSourceFiles(Label label, Query.SourceFile sourceFile) {
-      builder.putSourceFiles(intern(label.toString()), sourceFile);
+    public Builder putSourceFiles(QueryData.SourceFile sourceFile) {
+      builder.addSourceFiles(indexer.sourceFileToStoredSourceFile(sourceFile));
       return this;
     }
 
-    public Builder putAllRules(Map<Label, QueryData.Rule> rulesMap) {
-      builder.putAllStoredRules(
-          indexer.rulesToStoredRules(
-              rulesMap.entrySet().stream()
-                  .collect(toImmutableMap(e -> e.getKey().toString(), Map.Entry::getValue))));
+    public Builder putAllRules(Collection<QueryData.Rule> rules) {
+      builder.addAllStoredRules(
+        rules.stream()
+          .map(indexer::ruleToStoredRule)
+          .collect(toImmutableList()));
       return this;
     }
 
-    public Builder putRules(Label label, QueryData.Rule rule) {
-      builder.putStoredRules(indexer.index(label.toString()), indexer.ruleToStoredRule(rule));
+    public Builder putRules(QueryData.Rule rule) {
+      builder.addStoredRules(indexer.ruleToStoredRule(rule));
       return this;
     }
 

--- a/querysync/java/com/google/idea/blaze/qsync/query/querysummary.proto
+++ b/querysync/java/com/google/idea/blaze/qsync/query/querysummary.proto
@@ -10,20 +10,22 @@ option java_package = "com.google.idea.blaze.qsync.query";
  * Contains a summary of a {@code query} command output as needed by querysync.
  */
 message Summary {
-  map<string, SourceFile> source_files = 1;
-  reserved 2; // rules
+  reserved 1; // old source_files to be discarded.
+  reserved 2; // old rules to be discarded.
   int32 version = 3;
   repeated string packages_with_errors = 4;
   StringStorage string_storage = 5;
-  map<int32, StoredRule> stored_rules = 6;
+  reserved 6; // old stored_rules to be discarded.
 
   enum QueryStrategy {
     QUERY_STRATEGY_UNKNOWN = 0;
     QUERY_STRATEGY_PLAIN = 1;
     QUERY_STRATEGY_FILTERING_TO_KNOWN_AND_USED_TARGETS = 2;
   }
-
   QueryStrategy query_strategy = 7;
+
+  repeated StoredRule stored_rules = 8;
+  repeated StoredSourceFile source_files = 9;
 }
 
 /**
@@ -34,44 +36,31 @@ message StringStorage {
   repeated string indexed_strings = 1;
 }
 
-message SourceFile {
-  reserved 1;
-  // Subincludes of a source file, taken from blaze_query.SourceFile.subinclude
-  repeated string subinclude = 2;
+message StoredLabel {
+  int32 workspace = 1;
+  int32 buildPackage = 2;
+  int32 name = 3;
 }
 
-message Rule {
-  string rule_class = 1;
-  repeated string sources = 2;
-  repeated string deps = 3;
-  repeated string idl_sources = 4;
-  reserved 5;
-  repeated string runtime_deps = 6;
-  repeated string resource_files = 7;
-  string manifest = 8;
-  string test_app = 9;
-  string instruments = 10;
-  string custom_package = 11;
-  repeated string hdrs = 12;
-  repeated string copts = 13;
-  repeated string tags = 14;
-  string main_class = 15;
-  repeated string imports = 16;
+message StoredSourceFile {
+  StoredLabel label = 1;
+  // Subincludes of a source file, taken from blaze_query.SourceFile.subinclude
+  repeated StoredLabel subinclude = 2;
 }
 
 message StoredRule {
-  int32 rule_class = 1;
-  repeated int32 sources = 2;
-  repeated int32 deps = 3;
-  repeated int32 idl_sources = 4;
-  reserved 5;
-  repeated int32 runtime_deps = 6;
-  repeated int32 resource_files = 7;
-  int32 manifest = 8;
+  StoredLabel label = 1;
+  int32 rule_class = 2;
+  repeated StoredLabel sources = 3;
+  repeated StoredLabel deps = 4;
+  repeated StoredLabel idl_sources = 5;
+  repeated StoredLabel runtime_deps = 6;
+  repeated StoredLabel resource_files = 7;
+  StoredLabel manifest = 8;
   int32 test_app = 9;
   int32 instruments = 10;
   int32 custom_package = 11;
-  repeated int32 hdrs = 12;
+  repeated StoredLabel hdrs = 12;
   repeated int32 copts = 13;
   repeated int32 tags = 14;
   int32 main_class = 15;

--- a/querysync/javatests/com/google/idea/blaze/qsync/AffectedPackagesTest.java
+++ b/querysync/javatests/com/google/idea/blaze/qsync/AffectedPackagesTest.java
@@ -21,6 +21,7 @@ import static com.google.idea.blaze.qsync.query.QuerySummaryTestUtil.createProto
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.truth.Expect;
+import com.google.idea.blaze.common.Label;
 import com.google.idea.blaze.common.vcs.WorkspaceFileChange;
 import com.google.idea.blaze.common.vcs.WorkspaceFileChange.Operation;
 import com.google.idea.blaze.qsync.query.QuerySummary;
@@ -266,9 +267,9 @@ public class AffectedPackagesTest {
             new QuerySummaryTestBuilder()
                 .addPackages("//my/build/package1:rule", "//my/build/package2:rule")
                 .addSubincludes(
-                    ImmutableMultimap.<String, String>builder()
-                        .put("//my/build/package1:BUILD", "//my/build/package1:macro.bzl")
-                        .put("//my/build/package2:BUILD", "//my/build/package1:macro.bzl")
+                    ImmutableMultimap.<Label, Label>builder()
+                        .put(Label.of("//my/build/package1:BUILD"), Label.of("//my/build/package1:macro.bzl"))
+                        .put(Label.of("//my/build/package2:BUILD"), Label.of("//my/build/package1:macro.bzl"))
                         .build())
                 .build());
 
@@ -297,7 +298,7 @@ public class AffectedPackagesTest {
                 .addPackages("//my/build/package:rule")
                 .addSubincludes(
                     ImmutableMultimap.of(
-                        "//my/build/package:BUILD", "//other/build/package1:macro.bzl"))
+                        Label.of("//my/build/package:BUILD"), Label.of("//other/build/package1:macro.bzl")))
                 .build());
 
     AffectedPackages affected =

--- a/querysync/javatests/com/google/idea/blaze/qsync/BUILD
+++ b/querysync/javatests/com/google/idea/blaze/qsync/BUILD
@@ -70,6 +70,7 @@ java_test(
         "//querysync/java/com/google/idea/blaze/qsync/query",
         "//querysync/javatests/com/google/idea/blaze/qsync/query:QuerySummaryTestUtil",
         "//shared:vcs",
+        "//shared/java/com/google/idea/blaze/common",
         "//third_party/java/junit",
         "//third_party/java/truth",
         "@com_google_guava_guava//jar",

--- a/querysync/javatests/com/google/idea/blaze/qsync/TestDataSyncRunner.java
+++ b/querysync/javatests/com/google/idea/blaze/qsync/TestDataSyncRunner.java
@@ -100,7 +100,7 @@ public class TestDataSyncRunner {
         return QuerySummary.newBuilder()
                 .putAllPackagesWithErrors(querySummary.getPackagesWithErrors())
                 .putAllSourceFiles(querySummary.getSourceFilesMap())
-                .putAllRules(newRulesMap)
+                .putAllRules(newRulesMap.values())
                 .build();
     }
 }

--- a/querysync/javatests/com/google/idea/blaze/qsync/query/QuerySummaryTest.java
+++ b/querysync/javatests/com/google/idea/blaze/qsync/query/QuerySummaryTest.java
@@ -21,10 +21,10 @@ import static com.google.idea.blaze.qsync.query.QuerySummaryTestUtil.createProto
 import com.google.common.base.Preconditions;
 import com.google.common.truth.Truth8;
 import com.google.idea.blaze.common.Label;
-import com.google.idea.blaze.qsync.query.Query.SourceFile;
 import com.google.idea.blaze.qsync.testdata.TestData;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Optional;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -32,8 +32,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class QuerySummaryTest {
 
-  private String targetName(String buildTarget) {
-    return buildTarget.substring(buildTarget.indexOf(':') + 1);
+  private String targetName(Label buildTarget) {
+    return buildTarget.name();
   }
 
   @Test
@@ -132,9 +132,9 @@ public class QuerySummaryTest {
         QuerySummary.create(QuerySpec.QueryStrategy.PLAIN, TestData.BUILDINCLUDES_QUERY.getQueryOutputPath().toFile());
     Label buildLabel = Label.of(TestData.ROOT_PACKAGE + "/buildincludes:BUILD");
     assertThat(qs.getSourceFilesMap()).containsKey(buildLabel);
-    SourceFile buildSrc = qs.getSourceFilesMap().get(buildLabel);
-    assertThat(buildSrc.getSubincludeList())
-        .containsExactly(TestData.ROOT_PACKAGE + "/buildincludes:includes.bzl");
+    QueryData.SourceFile buildSrc = qs.getSourceFilesMap().get(buildLabel);
+    assertThat(buildSrc.subincliudes())
+        .containsExactly(Label.of(TestData.ROOT_PACKAGE + "/buildincludes:includes.bzl"));
     assertThat(qs.getReverseSubincludeMap())
         .containsExactly(
             TestData.ROOT.resolve("buildincludes/includes.bzl"),

--- a/querysync/javatests/com/google/idea/blaze/qsync/query/QuerySummaryTestBuilder.java
+++ b/querysync/javatests/com/google/idea/blaze/qsync/query/QuerySummaryTestBuilder.java
@@ -15,6 +15,7 @@
  */
 package com.google.idea.blaze.qsync.query;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.Arrays.stream;
@@ -26,7 +27,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.idea.blaze.common.Label;
-import com.google.idea.blaze.qsync.query.Query.SourceFile;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
@@ -36,7 +36,7 @@ public class QuerySummaryTestBuilder {
   private final ImmutableList.Builder<Label> packagesBuilder = ImmutableList.builder();
   private final ImmutableSet.Builder<Label> buildFilesWithErrorsBuilder = ImmutableSet.builder();
 
-  private final ImmutableMultimap.Builder<String, String> includesBuilder =
+  private final ImmutableMultimap.Builder<Label, Label> includesBuilder =
       ImmutableMultimap.builder();
 
   public QuerySummaryTestBuilder() {}
@@ -48,7 +48,7 @@ public class QuerySummaryTestBuilder {
   }
 
   @CanIgnoreReturnValue
-  public QuerySummaryTestBuilder addSubincludes(Multimap<String, String> subIncludes) {
+  public QuerySummaryTestBuilder addSubincludes(Multimap<Label, Label> subIncludes) {
     includesBuilder.putAll(subIncludes);
     return this;
   }
@@ -62,27 +62,22 @@ public class QuerySummaryTestBuilder {
   public Query.Summary build() {
     ImmutableList<Label> packages = packagesBuilder.build();
     ImmutableSet<Label> buildFilesWithErrors = buildFilesWithErrorsBuilder.build();
-    ImmutableMultimap<String, String> includes = includesBuilder.build();
+    ImmutableMultimap<Label, Label> includes = includesBuilder.build();
     Set<Label> sourceFiles =
         packages.stream()
             .map(Label::getPackage)
             .map(p -> Label.fromWorkspacePackageAndName(Label.ROOT_WORKSPACE, p, Path.of("BUILD")))
             .collect(toCollection(HashSet::new));
-    includes.keySet().stream().map(Label::of).forEach(sourceFiles::add);
+    sourceFiles.addAll(includes.keySet());
 
     QuerySummary.Builder builder = QuerySummary.newBuilder();
     builder.putAllRules(
-        packages.stream()
-            .filter(l -> !buildFilesWithErrors.contains(l.siblingWithName("BUILD")))
-            .collect(
-                toImmutableMap(
-                    l -> Label.of(l.toString()),
-                    l -> QueryData.Rule.builder().ruleClass("java_library").build())));
+      packages.stream()
+        .filter(l -> !buildFilesWithErrors.contains(l.siblingWithName("BUILD")))
+        .map(l -> QueryData.Rule.builderForTests().label(l).ruleClass("java_library").build())
+        .collect(toImmutableList()));
     builder.putAllSourceFiles(
-      sourceFiles.stream().collect(toImmutableMap(src -> src, src -> SourceFile.newBuilder()
-        .addAllSubinclude(includes.get(src.toString()))
-        .build()))
-    );
+      sourceFiles.stream().collect(toImmutableMap(src -> src, src -> new QueryData.SourceFile(src, includes.get(src)))));
 
     builder.putAllPackagesWithErrors(buildFilesWithErrors.stream().map(Label::getPackage).collect(toImmutableSet()));
 

--- a/shared/java/com/google/idea/blaze/common/Label.java
+++ b/shared/java/com/google/idea/blaze/common/Label.java
@@ -19,7 +19,6 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Interner;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -35,37 +34,23 @@ import java.util.List;
  * <p>Note that this class only supports labels in the current workspace, i.e. not labels of the
  * form {@code @repo//pkg/foo:abc}.
  */
-public class Label {
+public record Label(String workspace, String buildPackage, String name) {
 
   public final static String ROOT_WORKSPACE = "";
 
-  private static final Interner<Label> interner =
-      com.google.common.collect.Interners.newWeakInterner();
-
-  private final String label;
-
   public static Label of(String label) {
-    if (label.startsWith("@")) {
-      int doubleSlash = label.indexOf("//");
-      Preconditions.checkArgument(doubleSlash > 0, label);
-      int colon = label.indexOf(":");
-      Preconditions.checkArgument(colon > doubleSlash, label);
-      if (!label.startsWith("@@")) {
-        // Normalize `label` to either start with double-at or start with double-slash.
-        label = '@' + label;
-      }
-      if (label.startsWith("@@//")) {
-        label = label.substring(2);
-      }
-    } else {
-      Preconditions.checkArgument(label.startsWith("//"), label);
-      Preconditions.checkArgument(label.contains(":"), label);
-    }
-    return new Label(Interners.STRING.intern(label));
-  }
+    final var workspacePosition = label.startsWith("@") ? (label.startsWith("@@") ? 2 : 1) : 0;
+    final var workspaceEnd = label.indexOf("//", workspacePosition);
+    final var buildPackagePosition =  workspaceEnd + 2;
+    Preconditions.checkArgument(buildPackagePosition >= 2);
+    final var buildPackageEnd = label.indexOf(":", buildPackagePosition);
+    final var namePosition = buildPackageEnd + 1;
+    Preconditions.checkArgument(namePosition >= 1);
 
-  public static Label createLabelWithoutValidation(String label) {
-    return new Label(label);
+    final var workspace = label.substring(workspacePosition, workspaceEnd);
+    final var buildPackage = label.substring(buildPackagePosition, buildPackageEnd);
+    final var name = label.substring(namePosition);
+    return new Label(Interners.STRING.intern(workspace), Interners.STRING.intern(buildPackage), Interners.STRING.intern(name));
   }
 
   public static Label fromWorkspacePackageAndName(String workspace, Path packagePath, Path name) {
@@ -81,26 +66,16 @@ public class Label {
     return labels.stream().map(Label::of).collect(toImmutableList());
   }
 
-  private Label(String label) {
-    this.label = label;
-  }
-
   public Path getPackage() {
-    // this should be safe thanks to the asserts in the constructor.
-    return Path.of(label.substring(label.indexOf("//") + 2, label.indexOf(":")));
+    return Path.of(buildPackage);
   }
 
   public Path getName() {
-    // this should be safe thanks to the asserts in the constructor.
-    return Path.of(label.substring(label.indexOf(':') + 1));
+    return Path.of(name);
   }
 
   public String getWorkspaceName() {
-    if (label.startsWith("@@")) {
-      return label.substring(2, label.indexOf("//"));
-    } else {
-      return "";
-    }
+    return workspace;
   }
 
   public Label siblingWithName(String name) {
@@ -123,19 +98,15 @@ public class Label {
 
   @Override
   public String toString() {
-    return label;
-  }
-
-  @Override
-  public boolean equals(Object that) {
-    if (!(that instanceof Label)) {
-      return false;
+    final var result = new StringBuilder(5 + workspace.length() + buildPackage.length() + name.length());
+    if (!workspace.isEmpty()) {
+      result.append("@@");
+      result.append(workspace);
     }
-    return ((Label) that).label.equals(this.label);
-  }
-
-  @Override
-  public int hashCode() {
-    return label.hashCode();
+    result.append("//");
+    result.append(buildPackage);
+    result.append(":");
+    result.append(name);
+    return result.toString();
   }
 }


### PR DESCRIPTION
Cherry pick AOSP commit [fc03bee23b88e04806ed4eacc8b521f9a25b7880](https://cs.android.com/android-studio/platform/tools/adt/idea/+/fc03bee23b88e04806ed4eacc8b521f9a25b7880).

1. Finish transitioning query sync phase storage to indexed strings
2. Break labels up into workspace, package and name. This is to make
   unique strings shorter and faster to compare.
3. Use `Label`s in internal data structures instead of strings to avoid
   frequent parsing string parsing and conversion to labels.

Bug: 362727747
Test: existing unit tests
Change-Id: I149f751c0498c13e61208e7314b8a2be636eedcc

AOSP: fc03bee23b88e04806ed4eacc8b521f9a25b7880
