### PR TITLE
[AOSP-pick] Begin extracting IDE_JAVA aspect interface

### DIFF
--- a/aspect/build_dependencies.bzl
+++ b/aspect/build_dependencies.bzl
@@ -7,6 +7,7 @@ load(
     "ANDROID_IDE_INFO",
     "ZIP_TOOL_LABEL",
     _ide_cc_not_validated = "IDE_CC",
+    _ide_java_not_validated = "IDE_JAVA",
     _ide_kotlin_not_validated = "IDE_KOTLIN",
 )
 
@@ -19,7 +20,13 @@ PROTO_RULE_KINDS = [
     "kt_proto_library_helper",
 ]
 
-def _rule_function(rule):
+def _rule_function(
+        rule):  # @unused
+    return []
+
+def _target_rule_function(
+        target,  # @unused
+        rule):  # @unused
     return []
 
 def _unique(values):
@@ -33,6 +40,14 @@ def _validate_ide(unvalidated, template):
         elif type(getattr(unvalidated, a)) != type(getattr(template, a)):
             fail("attribute type mismatch: ", a, type(getattr(unvalidated, a)), type(getattr(template, a)))
     return struct(**{a: getattr(unvalidated, a) for a in dir(template) if a not in dir(struct())})
+
+IDE_JAVA = _validate_ide(
+    _ide_java_not_validated,
+    template = struct(
+        srcs_attributes = [],  # Additional srcs like attributes.
+        get_java_info = _target_rule_function,  # A function that takes a rule and returns a JavaInfo like structure (or the provider itself).
+    ),
+)
 
 IDE_KOTLIN = _validate_ide(
     _ide_kotlin_not_validated,
@@ -56,8 +71,7 @@ IDE_CC = _validate_ide(
     ),
 )
 
-JAVA_SRC_ATTRS = ["srcs", "java_srcs", "java_test_srcs"]
-JVM_SRC_ATTRS = _unique(JAVA_SRC_ATTRS + IDE_KOTLIN.srcs_attributes)
+JVM_SRC_ATTRS = _unique(["srcs"] + IDE_JAVA.srcs_attributes + IDE_KOTLIN.srcs_attributes)
 
 def _package_dependencies_impl(target, ctx):
     java_info_file = _write_java_target_info(target, ctx)
@@ -469,6 +483,8 @@ def _collect_own_java_artifacts(
     own_srcjar_files = []
     resource_package = ""
 
+    java_info = IDE_JAVA.get_java_info(target, ctx.rule)
+
     if must_build_main_artifacts:
         # For rules that we do not follow dependencies of (either because they don't
         # have further dependencies with JavaInfo or do so in attributes we don't care)
@@ -477,11 +493,11 @@ def _collect_own_java_artifacts(
         # This is done primarily for rules like proto, whose toolchain classes
         # are collected via attribute traversal, but still requires jars for any
         # proto deps of the underlying proto_library.
-        if JavaInfo in target:
+        if java_info:
             if can_follow_dependencies:
-                own_jar_depsets.append(target[JavaInfo].compile_jars)
+                own_jar_depsets.append(java_info.compile_jars)
             else:
-                own_jar_depsets.append(target[JavaInfo].transitive_compile_time_jars)
+                own_jar_depsets.append(java_info.transitive_compile_time_jars)
 
         if declares_android_resources(target, ctx):
             ide_aar = _get_ide_aar_file(target, ctx)
@@ -523,8 +539,8 @@ def _collect_own_java_artifacts(
 
         # Add generated java_outputs (e.g. from annotation processing)
         generated_class_jars = []
-        if JavaInfo in target:
-            for java_output in target[JavaInfo].java_outputs:
+        if java_info:
+            for java_output in java_info.java_outputs:
                 # Prefer source jars if they exist and are requested:
                 if use_generated_srcjars and java_output.generated_source_jar:
                     own_gensrc_files.append(java_output.generated_source_jar)

--- a/aspect/build_dependencies_deps.bzl
+++ b/aspect/build_dependencies_deps.bzl
@@ -10,6 +10,23 @@ ZIP_TOOL_LABEL = "@@bazel_tools//tools/zip:zipper"
 
 ANDROID_IDE_INFO = None
 
+# JAVA
+
+def _get_java_info(target, rule):
+    if not JavaInfo in target:
+        return None
+    p = target[JavaInfo]
+    return struct(
+        compile_jars = p.compile_jars,
+        transitive_compile_time_jars = p.transitive_compile_time_jars,
+        java_outputs = p.java_outputs,
+    )
+
+IDE_JAVA = struct(
+    srcs_attributes = ["java_srcs", "java_test_srcs"],
+    get_java_info = _get_java_info,
+)
+
 # KOTLIN
 
 def _get_dependency_attribute(rule, attr):


### PR DESCRIPTION
Cherry pick AOSP commit [489884f04a1e4be2d3df6b6758989c26ac0c1654](https://cs.android.com/android-studio/platform/tools/adt/idea/+/489884f04a1e4be2d3df6b6758989c26ac0c1654).

1. Include `srcs` like attributes
2. Wrap `JavaInfo` provider

Bug: 379999838
Test: n/a
Change-Id: Ie9205f5fee2203c5aa3b1e80f2e1fd9171fbe645

AOSP: 489884f04a1e4be2d3df6b6758989c26ac0c1654
