### PR TITLE
Basic qsync support in CLion for linux

### DIFF
--- a/aspect/build_dependencies.bzl
+++ b/aspect/build_dependencies.bzl
@@ -84,7 +84,7 @@ def _package_dependencies_impl(target, ctx):
         qsync_aars = dep_info.aars.to_list() if dep_info.aars else [],
         qsync_gensrcs = dep_info.gensrcs.to_list() if dep_info.gensrcs else [],
         cc_headers = dep_info.cc_headers.to_list() if dep_info.cc_headers else [],
-        cc_info_file = cc_info_file + [dep_info.cc_toolchain_info.file] if dep_info.cc_toolchain_info else [],
+        cc_info_file = cc_info_file + ([dep_info.cc_toolchain_info.file] if dep_info.cc_toolchain_info else []),
     )]
 
 def _write_java_target_info(target, ctx, custom_prefix = ""):

--- a/aspect/build_dependencies.bzl
+++ b/aspect/build_dependencies.bzl
@@ -213,12 +213,16 @@ def merge_dependencies_info(target, ctx, java_dep_info, cc_dep_info, cc_toolchai
 
     if cc_dep_info and cc_toolchain_dep_info:
         test_mode_cc_src_deps = depset(transitive = [cc_dep_info.test_mode_cc_src_deps, cc_toolchain_dep_info.test_mode_cc_src_deps])
+        cc_toolchain_info = cc_toolchain_dep_info.cc_toolchain_info
     elif cc_dep_info:
         test_mode_cc_src_deps = cc_dep_info.test_mode_cc_src_deps
+        cc_toolchain_info = cc_dep_info.cc_toolchain_info
     elif cc_toolchain_dep_info:
         test_mode_cc_src_deps = cc_toolchain_dep_info.test_mode_cc_src_deps
+        cc_toolchain_info = cc_toolchain_dep_info.cc_toolchain_info
     else:
         test_mode_cc_src_deps = None
+        cc_toolchain_info = None
 
     merged = create_dependencies_info(
         label = target.label,
@@ -229,7 +233,7 @@ def merge_dependencies_info(target, ctx, java_dep_info, cc_dep_info, cc_toolchai
         expand_sources = java_dep_info.expand_sources if java_dep_info else None,
         cc_compilation_info = cc_dep_info.cc_compilation_info if cc_dep_info else None,
         cc_headers = cc_dep_info.cc_headers if cc_dep_info else None,
-        cc_toolchain_info = cc_toolchain_dep_info.cc_toolchain_info if cc_toolchain_dep_info else None,
+        cc_toolchain_info = cc_toolchain_info,
         test_mode_own_files = java_dep_info.test_mode_own_files if java_dep_info else None,
         test_mode_cc_src_deps = test_mode_cc_src_deps,
     )

--- a/clwb/BUILD
+++ b/clwb/BUILD
@@ -201,6 +201,12 @@ clwb_integration_test(
     srcs = ["tests/integrationtests/com/google/idea/blaze/clwb/ExternalIncludesTest.java"],
 )
 
+clwb_integration_test(
+    name = "query_sync_integration_test",
+    project = "simple",
+    srcs = ["tests/integrationtests/com/google/idea/blaze/clwb/QuerySyncTest.java"],
+)
+
 test_suite(
     name = "integration_tests",
     tests = [
@@ -208,5 +214,6 @@ test_suite(
         ":simple_integration_test",
         ":virtual_includes_integration_test",
         ":external_includes_integration_test",
+        ":query_sync_integration_test",
     ],
 )

--- a/clwb/test_defs.bzl
+++ b/clwb/test_defs.bzl
@@ -38,6 +38,9 @@ def clwb_integration_test(name, project, srcs, deps = []):
             # suppressed plugin sets for classic, radler is currently disabled for tests
             "-Didea.suppressed.plugins.set.classic=org.jetbrains.plugins.clion.radler,intellij.rider.cpp.debugger,intellij.rider.plugins.clion.radler.cwm",
             "-Didea.suppressed.plugins.set.selector=classic",
+            # define the path to the query sync aspects
+            "-Dblaze.idea.build_dependencies.bzl.file=aspect/build_dependencies.bzl",
+            "-Dblaze.idea.build_dependencies_deps.bzl.file=aspect/build_dependencies_deps.bzl",
         ],
         deps = deps + [
             ":clwb_lib",

--- a/clwb/tests/integrationtests/com/google/idea/blaze/clwb/QuerySyncTest.java
+++ b/clwb/tests/integrationtests/com/google/idea/blaze/clwb/QuerySyncTest.java
@@ -1,0 +1,55 @@
+package com.google.idea.blaze.clwb;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.idea.blaze.clwb.base.Assertions.assertContainsHeader;
+
+import com.google.idea.blaze.clwb.base.BazelVersionRule;
+import com.google.idea.blaze.clwb.base.ClwbIntegrationTestCase;
+import com.google.idea.blaze.clwb.base.OSRule;
+import com.intellij.util.system.OS;
+import java.util.concurrent.ExecutionException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class QuerySyncTest extends ClwbIntegrationTestCase {
+
+  // currently query sync only works on linux, TODO: fix mac and windows
+  @Rule
+  public final OSRule osRule = new OSRule(OS.Linux);
+
+  // query sync requires bazel 6+
+  @Rule
+  public final BazelVersionRule bazelRule = new BazelVersionRule(6, 0);
+
+  @Test
+  public void testClwb() throws Exception {
+    final var success = runQuerySync();
+    assertThat(success).isTrue();
+
+    checkAnalysis();
+    checkCompiler();
+  }
+
+  private void checkAnalysis() throws ExecutionException {
+    final var success = enableAnalysisFor(findProjectFile("main/hello-world.cc"));
+    assertThat(success).isTrue();
+  }
+
+  private void checkCompiler() {
+    final var compilerSettings = findFileCompilerSettings("main/hello-world.cc");
+
+    // TODO: query sync selects the wrong compiler
+    // if (SystemInfo.isMac) {
+    //   assertThat(compilerSettings.getCompilerKind()).isEqualTo(ClangCompilerKind.INSTANCE);
+    // } else if (SystemInfo.isLinux) {
+    //   assertThat(compilerSettings.getCompilerKind()).isEqualTo(GCCCompilerKind.INSTANCE);
+    // } else if (SystemInfo.isWindows) {
+    //   assertThat(compilerSettings.getCompilerKind()).isEqualTo(MSVCCompilerKind.INSTANCE);
+    // }
+
+    assertContainsHeader("iostream", compilerSettings);
+  }
+}

--- a/clwb/tests/integrationtests/com/google/idea/blaze/clwb/QuerySyncTest.java
+++ b/clwb/tests/integrationtests/com/google/idea/blaze/clwb/QuerySyncTest.java
@@ -41,7 +41,7 @@ public class QuerySyncTest extends ClwbIntegrationTestCase {
   private void checkCompiler() {
     final var compilerSettings = findFileCompilerSettings("main/hello-world.cc");
 
-    // TODO: query sync selects the wrong compiler
+    // TODO: query sync always uses clang : https://github.com/bazelbuild/intellij/issues/7177
     // if (SystemInfo.isMac) {
     //   assertThat(compilerSettings.getCompilerKind()).isEqualTo(ClangCompilerKind.INSTANCE);
     // } else if (SystemInfo.isLinux) {

--- a/cpp/src/com/google/idea/blaze/cpp/qsync/CcProjectModelUpdateOperation.java
+++ b/cpp/src/com/google/idea/blaze/cpp/qsync/CcProjectModelUpdateOperation.java
@@ -172,8 +172,8 @@ public class CcProjectModelUpdateOperation implements Disposable {
 
   /** Pre-commits the project update. Should be called from a background thread. */
   public void preCommit() {
-    modifiableOcWorkspace.preCommit();
     processCompilerSettings();
+    modifiableOcWorkspace.preCommit();
   }
 
   /** Commits the project update. Must be called from the write thread. */


### PR DESCRIPTION
This PR provides basic support for qsync in CLion, but only for linux with gcc so far. Issues addressed:

- cc_info_file and cc_toolchain_info propagation in the aspect
- project model setup in CLion

Also adds a simple integration test that imports the project using query sync.