### PR TITLE
Adds support for the run button on main functions in nova 

### DIFF
--- a/clwb/src/com/google/idea/blaze/clwb/radler/RadBinaryContextProvider.kt
+++ b/clwb/src/com/google/idea/blaze/clwb/radler/RadBinaryContextProvider.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.idea.blaze.clwb.radler
 
 import com.google.idea.blaze.base.dependencies.TargetInfo
@@ -42,7 +57,7 @@ private fun findTargets(context: ConfigurationContext): Collection<TargetInfo> {
 
   val targets = SourceToTargetFinder.findTargetsForSourceFile(
     context.project,
-    File(virtualFile.path),
+    virtualFile.toNioPath().toFile(),
     Optional.of(RuleType.BINARY),
   ) ?: return emptyList()
 

--- a/clwb/src/com/google/idea/blaze/clwb/radler/RadBinaryContextProvider.kt
+++ b/clwb/src/com/google/idea/blaze/clwb/radler/RadBinaryContextProvider.kt
@@ -1,0 +1,50 @@
+package com.google.idea.blaze.clwb.radler
+
+import com.google.idea.blaze.base.dependencies.TargetInfo
+import com.google.idea.blaze.base.model.primitives.RuleType
+import com.google.idea.blaze.base.run.SourceToTargetFinder
+import com.google.idea.blaze.base.run.producers.BinaryContextProvider
+import com.google.idea.blaze.base.run.producers.BinaryContextProvider.BinaryRunContext
+import com.google.idea.blaze.cpp.CppBlazeRules.RuleTypes
+import com.intellij.execution.actions.ConfigurationContext
+import com.intellij.psi.PsiElement
+import com.intellij.psi.impl.source.tree.LeafElement
+import com.jetbrains.cidr.radler.protocol.RadSymbolsHost
+import java.io.File
+import java.util.*
+
+/**
+ * This run configuration provider creates configurations for the gutter icon created by the
+ * [com.jetbrains.cidr.cpp.runFile.nova.CppFileNovaRunLineMarkerProvider], since the actual gutter icon provider for
+ * radler requires a [com.jetbrains.cidr.execution.CidrTargetRunConfigurationProducer] and it would not be feasible to
+ * implement one here.
+ */
+class RadBinaryContextProvider : BinaryContextProvider {
+
+  override fun getRunContext(context: ConfigurationContext): BinaryRunContext? {
+    if (!isMain(context.psiLocation)) return null
+
+    val target = findTargets(context).firstOrNull() ?: return null
+
+    return BinaryRunContext.create(context.psiLocation, target)
+  }
+}
+
+private fun isMain(element: PsiElement?): Boolean {
+  if (element !is LeafElement) return false
+
+  val symbolsHost = RadSymbolsHost.getInstance(element.project)
+  return symbolsHost.isEntryPointOffset(element.containingFile.viewProvider.virtualFile, element.startOffset)
+}
+
+private fun findTargets(context: ConfigurationContext): Collection<TargetInfo> {
+  val virtualFile = context.location?.virtualFile ?: return emptyList()
+
+  val targets = SourceToTargetFinder.findTargetsForSourceFile(
+    context.project,
+    File(virtualFile.path),
+    Optional.of(RuleType.BINARY),
+  ) ?: return emptyList()
+
+  return targets.filter { it -> it.kind == RuleTypes.CC_BINARY.kind }
+}

--- a/clwb/src/com/google/idea/blaze/clwb/radler/optional-plugin.xml
+++ b/clwb/src/com/google/idea/blaze/clwb/radler/optional-plugin.xml
@@ -16,5 +16,6 @@
 <idea-plugin>
   <extensions defaultExtensionNs="com.google.idea.blaze">
     <TestContextProvider implementation="com.google.idea.blaze.clwb.radler.RadGoogleTestContextProvider"/>
+    <BinaryContextProvider implementation="com.google.idea.blaze.clwb.radler.RadBinaryContextProvider"/>
   </extensions>
 </idea-plugin>

--- a/clwb/src/com/google/idea/blaze/clwb/run/producers/NonBlazeProducerSuppressor.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/producers/NonBlazeProducerSuppressor.java
@@ -33,10 +33,7 @@ public class NonBlazeProducerSuppressor implements StartupActivity.DumbAware {
 
           // Gutter icons in CMake files.
           "com.jetbrains.cidr.cpp.execution.CMakeTargetRunConfigurationProducer",
-          "com.jetbrains.cidr.cpp.execution.debugger.CMakeRunConfigurationProducer",
-
-          // Gutter icons that sometimes appear in `cpp` files with a `main` function.
-          "com.jetbrains.cidr.cpp.runfile.CppFileTargetRunConfigurationProducer"
+          "com.jetbrains.cidr.cpp.execution.debugger.CMakeRunConfigurationProducer"
       );
 
   @Override


### PR DESCRIPTION
Builds up on the work of #7062 and adds support for binary run configurations in CLion. Double run button in nova will be fixed in 251.
