### PR TITLE
fix(qsync): Hightlighting level is always updated after 'enable analy…

### DIFF
--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -712,6 +712,7 @@
     <ArtifactFetcher implementation="com.google.idea.blaze.base.qsync.cache.FileApiArtifactFetcher"/>
     <QuerySyncListenerProvider implementation="com.google.idea.blaze.base.qsync.ProjectUpdater$Provider" />
     <QuerySyncListenerProvider implementation="com.google.idea.blaze.base.qsync.ProjectStatsLogger$Provider" />
+    <QuerySyncListenerProvider implementation="com.google.idea.blaze.base.qsync.QuerySyncHighlightingResetListener$Provider"/>
   </extensions>
 
   <projectListeners>

--- a/base/src/com/google/idea/blaze/base/qsync/QuerySyncHighlightingResetListener.java
+++ b/base/src/com/google/idea/blaze/base/qsync/QuerySyncHighlightingResetListener.java
@@ -1,0 +1,41 @@
+package com.google.idea.blaze.base.qsync;
+
+import com.google.idea.blaze.common.Context;
+import com.google.idea.blaze.qsync.QuerySyncProjectListener;
+import com.google.idea.blaze.qsync.QuerySyncProjectSnapshot;
+import com.intellij.codeInsight.daemon.impl.analysis.FileHighlightingSettingListener;
+import com.intellij.codeInsight.daemon.impl.analysis.HighlightingSettingsPerFile;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiManager;
+
+public class QuerySyncHighlightingResetListener implements QuerySyncProjectListener {
+
+    private final Project project;
+
+    QuerySyncHighlightingResetListener(Project project) {
+        this.project = project;
+    }
+
+    @Override
+    public void onNewProjectSnapshot(Context<?> context, QuerySyncProjectSnapshot instance) {
+        for (VirtualFile virtualFile : FileEditorManager.getInstance(project).getOpenFiles()) {
+            var psiFile = PsiManager.getInstance(project).findFile(virtualFile);
+            if (psiFile != null) {
+                var newHighlighting = HighlightingSettingsPerFile.getInstance(project).getHighlightingSettingForRoot(psiFile);
+                project.getMessageBus()
+                        .syncPublisher(FileHighlightingSettingListener.SETTING_CHANGE)
+                        .settingChanged(psiFile, newHighlighting);
+            }
+        }
+    }
+
+    public static class Provider implements QuerySyncProjectListenerProvider {
+        @Override
+        public QuerySyncProjectListener createListener(QuerySyncProject querySyncProject) {
+            return new QuerySyncHighlightingResetListener(querySyncProject.getIdeProject());
+        }
+    }
+}
+

--- a/base/src/com/google/idea/blaze/base/qsync/QuerySyncHighlightingSettingProvider.java
+++ b/base/src/com/google/idea/blaze/base/qsync/QuerySyncHighlightingSettingProvider.java
@@ -4,6 +4,7 @@ import com.google.idea.blaze.base.settings.Blaze;
 import com.google.idea.blaze.base.settings.BlazeImportSettings;
 import com.intellij.codeInsight.daemon.impl.analysis.DefaultHighlightingSettingProvider;
 import com.intellij.codeInsight.daemon.impl.analysis.FileHighlightingSetting;
+import com.intellij.codeInsight.daemon.impl.analysis.HighlightLevelUtil;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiManager;
@@ -13,10 +14,13 @@ import org.jetbrains.annotations.Nullable;
 public class QuerySyncHighlightingSettingProvider extends DefaultHighlightingSettingProvider {
     @Override
     public @Nullable FileHighlightingSetting getDefaultSetting(@NotNull Project project, @NotNull VirtualFile file) {
+
         var psiFile = PsiManager.getInstance(project).findFile(file);
         if (Blaze.getProjectType(psiFile.getProject()) == BlazeImportSettings.ProjectType.QUERY_SYNC) {
             if(!QuerySyncManager.getInstance(psiFile.getProject()).isReadyForAnalysis(psiFile)){
                 return FileHighlightingSetting.ESSENTIAL;
+            } else {
+                return FileHighlightingSetting.FORCE_HIGHLIGHTING;
             }
         }
         return null;


### PR DESCRIPTION
…sis'

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

