### PR TITLE
Add import project action to project drop down

### DIFF
--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -22,6 +22,7 @@
         <add-to-group group-id="FileOpenGroup" anchor="first"/>
         <add-to-group group-id="WelcomeScreen.QuickStart" anchor="before"
             relative-to-action="Vcs.VcsClone"/>
+        <add-to-group group-id="ProjectWidget.Actions" anchor="last"/>
       </action>
     <action id="MakeBlazeProject"
       class="com.google.idea.blaze.base.actions.BlazeMakeProjectAction"


### PR DESCRIPTION
I am always looking for the "import bazel project" action in this drop down, until I remember it is under file. Thus, I would like to suggest to also add it there.

![image](https://github.com/user-attachments/assets/8654e420-5b5f-408e-b092-d6b4166eabee)

