### PR TITLE
Fix reading of _kt_toolchain attribute

### DIFF
--- a/aspect/intellij_info_impl.bzl
+++ b/aspect/intellij_info_impl.bzl
@@ -1127,7 +1127,7 @@ def collect_kotlin_toolchain_info(target, ide_info, ide_info_file, output_groups
     ide_info["kt_toolchain_ide_info"] = struct(
         language_version = kt.language_version,
     )
-    update_sync_output_groups(output_groups, "intellij-info-kotlin", depset([ide_info_file]))
+    update_sync_output_groups(output_groups, "intellij-info-kt", depset([ide_info_file]))
     return True
 
 def _is_proto_library_wrapper(target, ctx):

--- a/kotlin/src/com/google/idea/blaze/kotlin/KotlinBlazeRules.java
+++ b/kotlin/src/com/google/idea/blaze/kotlin/KotlinBlazeRules.java
@@ -31,6 +31,8 @@ public final class KotlinBlazeRules implements Kind.Provider {
 
   /** Kotlin-specific blaze rule types. */
   public enum RuleTypes {
+    KT_TOOLCHAIN("_kt_toolchain", LanguageClass.KOTLIN, RuleType.UNKNOWN),
+    KT_TOOLCHAIN_ALIAS("_kt_toolchain_alias", LanguageClass.KOTLIN, RuleType.UNKNOWN),
     KT_JVM_TOOLCHAIN("kt_jvm_toolchain", LanguageClass.KOTLIN, RuleType.UNKNOWN),
     // TODO(b/157683101): remove once https://youtrack.jetbrains.com/issue/KT-24309 is fixed
     KT_JVM_LIBRARY_HELPER("kt_jvm_library_helper", LanguageClass.KOTLIN, RuleType.LIBRARY),


### PR DESCRIPTION

# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: https://github.com/bazelbuild/intellij/issues/7114

# Description of this change

Fixes https://github.com/bazelbuild/intellij/issues/7114.

rules_kotlin has moved to using a special _kt_toolchain attribute, but it looks like the plugin is unable to properly read them. This commit fixes the output group `intellij-info-kt` (instead of `intellij-info-kotlin`) and adds rule kinds so that the plugin recognizes the toolchain.
