### PR TITLE
[AOSP-pick] Rename properties that specify aspect file

### DIFF
--- a/base/src/com/google/idea/blaze/base/qsync/BazelDependencyBuilder.java
+++ b/base/src/com/google/idea/blaze/base/qsync/BazelDependencyBuilder.java
@@ -254,7 +254,7 @@ public class BazelDependencyBuilder implements DependencyBuilder {
   }
 
   protected Path getBundledAspectPath(String dir, String filename) {
-    String aspectPath = System.getProperty(String.format("blaze.idea.%s.file", filename));
+    String aspectPath = System.getProperty(String.format("qsync.aspect.%s.file", filename));
     if (aspectPath != null) {
       return Path.of(aspectPath);
     }

--- a/clwb/test_defs.bzl
+++ b/clwb/test_defs.bzl
@@ -39,8 +39,8 @@ def clwb_integration_test(name, project, srcs, deps = []):
             "-Didea.suppressed.plugins.set.classic=org.jetbrains.plugins.clion.radler,intellij.rider.cpp.debugger,intellij.rider.plugins.clion.radler.cwm",
             "-Didea.suppressed.plugins.set.selector=classic",
             # define the path to the query sync aspects
-            "-Dblaze.idea.build_dependencies.bzl.file=aspect/build_dependencies.bzl",
-            "-Dblaze.idea.build_dependencies_deps.bzl.file=aspect/build_dependencies_deps.bzl",
+            "-Dqsync.aspect.build_dependencies.bzl.file=aspect/build_dependencies.bzl",
+            "-Dqsync.aspect.build_dependencies_deps.bzl.file=aspect/build_dependencies_deps.bzl",
         ],
         deps = deps + [
             ":clwb_lib",


### PR DESCRIPTION
Cherry pick AOSP commit [acc58667d8d5a37593bb0b161a4df0628694e9cd](https://cs.android.com/android-studio/platform/tools/adt/idea/+/acc58667d8d5a37593bb0b161a4df0628694e9cd).

locations in order to ignore any user configured values after a
workaround was suggested.

Bug: 379999838
Test: n/a
Change-Id: I4a00df094ad044c28802a83511a199624142e10f

AOSP: acc58667d8d5a37593bb0b161a4df0628694e9cd
