### PR TITLE
If we edit project view and not triggered Sync, on project reopening …

### DIFF
--- a/base/src/com/google/idea/blaze/base/sync/BlazeSyncStartupActivity.java
+++ b/base/src/com/google/idea/blaze/base/sync/BlazeSyncStartupActivity.java
@@ -38,16 +38,18 @@ public class BlazeSyncStartupActivity implements StartupActivity.DumbAware {
     if (importSettings == null) {
       return;
     }
-    if (Blaze.getUpToDateProjectTypeBeforeSync(project) == ProjectType.QUERY_SYNC) {
+    ProjectType initialProjectType = importSettings.getProjectType();
+    ProjectType currentProjectType = Blaze.getUpToDateProjectTypeBeforeSync(project);
+    if (currentProjectType == ProjectType.QUERY_SYNC) {
       // When query sync is not enabled hasProjectData triggers the load
       QuerySyncManager.getInstance(project)
           .onStartup(QuerySyncActionStatsScope.create(getClass(), null));
-      return;
-    }
-    if (hasProjectData(project, importSettings)) {
-      BlazeSyncManager.getInstance(project).requestProjectSync(startupSyncParams());
     } else {
-      BlazeSyncManager.getInstance(project).incrementalProjectSync(SYNC_REASON);
+      if (initialProjectType == currentProjectType && hasProjectData(project, importSettings)) {
+        BlazeSyncManager.getInstance(project).requestProjectSync(startupSyncParams());
+      } else {
+        BlazeSyncManager.getInstance(project).incrementalProjectSync(SYNC_REASON);
+      }
     }
   }
 


### PR DESCRIPTION
…the wrong load project data load will be attempted to be attempted to load.

One more case for https://github.com/bazelbuild/intellij/pull/7088

# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

