### PR TITLE
Add support for K2 mode

### DIFF
--- a/kotlin/src/META-INF/blaze-kotlin.xml
+++ b/kotlin/src/META-INF/blaze-kotlin.xml
@@ -19,6 +19,10 @@
     <TargetKindProvider implementation="com.google.idea.blaze.kotlin.KotlinBlazeRules"/>
   </extensions>
 
+  <extensions defaultExtensionNs="org.jetbrains.kotlin">
+    <supportsKotlinPluginMode supportsK2="true" />
+  </extensions>
+
   <extensionPoints>
     <extensionPoint qualifiedName="com.google.idea.blaze.KotlinPluginOptionsProvider" interface="com.google.idea.blaze.kotlin.sync.KotlinPluginOptionsProvider"/>
   </extensionPoints>


### PR DESCRIPTION
Addresses https://github.com/bazelbuild/intellij/issues/7121


# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: https://github.com/bazelbuild/intellij/issues/7121

# Description of this change

To support K2 mode, plugins need to explicitly opt-into it even if they don't use the Analysis APIs. https://kotlin.github.io/analysis-api/declaring-k2-compatibility.html

I built the plugin manually locally and verified with IDE with

```
bazel build //ijwb:ijwb_bazel_zip --define=ij_product=intellij-2024.2
```
After adding this and enabling K2 mode, the Kotlin plugin works
![image](https://github.com/user-attachments/assets/b2f516b2-be66-4bc4-9a35-f168d1f3feb0)