### PR TITLE
Do not use curses with the old sync view

### DIFF
--- a/base/src/com/google/idea/blaze/base/buildview/BazelExecService.kt
+++ b/base/src/com/google/idea/blaze/base/buildview/BazelExecService.kt
@@ -66,7 +66,12 @@ class BazelExecService(private val project: Project) : Disposable {
   }
 
   private suspend fun execute(ctx: BlazeContext, cmdBuilder: BlazeCommand.Builder): Int {
-    val cmd = cmdBuilder.apply { addBlazeFlags("--curses=yes") }.build()
+    // the old sync view does not use a PTY based terminal
+    if (BuildViewMigration.present(ctx)) {
+      cmdBuilder.addBlazeFlags("--curses=yes")
+    }
+
+    val cmd = cmdBuilder.build()
     val root = cmd.effectiveWorkspaceRoot.orElseGet { WorkspaceRoot.fromProject(project).path() }
     val size = BuildViewScope.of(ctx)?.consoleSize ?: PtyConsoleView.DEFAULT_SIZE
 
@@ -183,4 +188,3 @@ class BazelExecService(private val project: Project) : Disposable {
     }
   }
 }
-

--- a/base/src/com/google/idea/blaze/base/toolwindow/ConsoleView.java
+++ b/base/src/com/google/idea/blaze/base/toolwindow/ConsoleView.java
@@ -237,6 +237,10 @@ final class ConsoleView implements Disposable {
   }
 
   private void println(String text, OutputType outputType) {
+    if (outputType == OutputType.PROCESS) {
+      text = text.stripTrailing();
+    }
+
     ansiEscapeDecoder.escapeText(
         text,
         outputType == OutputType.ERROR ? ProcessOutputTypes.STDERR : ProcessOutputTypes.STDOUT,


### PR DESCRIPTION
In #7001 I accidentally also enabled curses when using the old sync view. This PR adds the appropriate checks to disable curses when using the old sync view.