### PR TITLE
Add catch2 test support in CLion

### DIFF
--- a/clwb/src/com/google/idea/blaze/clwb/radler/RadCatchTestContextProvider.kt
+++ b/clwb/src/com/google/idea/blaze/clwb/radler/RadCatchTestContextProvider.kt
@@ -18,14 +18,11 @@ package com.google.idea.blaze.clwb.radler
 import com.jetbrains.rider.model.RadTestElementModel
 import com.jetbrains.rider.model.RadTestFramework
 
-class RadGoogleTestContextProvider : RadTestContextProvider() {
+class RadCatchTestContextProvider : RadTestContextProvider() {
 
-  override val testFramework: RadTestFramework = RadTestFramework.GTest
+  override val testFramework: RadTestFramework = RadTestFramework.Catch
 
-  override fun createTestFilter(test: RadTestElementModel): String {
-    val suite = test.suites?.firstOrNull() ?: "*"
-    val name = test.test ?: "*"
-
-    return "$suite.$name"
+  override fun createTestFilter(test: RadTestElementModel): String? {
+    return test.test
   }
 }

--- a/clwb/src/com/google/idea/blaze/clwb/radler/RadTestContextProvider.kt
+++ b/clwb/src/com/google/idea/blaze/clwb/radler/RadTestContextProvider.kt
@@ -67,7 +67,7 @@ private fun findTargets(context: ConfigurationContext): ListenableFuture<Collect
 
   return SourceToTargetFinder.findTargetInfoFuture(
     context.project,
-    File(virtualFile.path),
+    virtualFile.toNioPath().toFile(),
     Optional.of(RuleType.TEST),
   ) ?: Futures.immediateFuture(emptyList())
 }
@@ -81,7 +81,7 @@ private fun chooseTargetForFile(context: ConfigurationContext, targets: Collecti
   return TestTargetHeuristic.chooseTestTargetForSourceFile(
     context.project,
     psiFile,
-    File(virtualFile.path),
+    virtualFile.toNioPath().toFile(),
     ccTargets,
     null,
   )

--- a/clwb/src/com/google/idea/blaze/clwb/radler/RadTestContextProvider.kt
+++ b/clwb/src/com/google/idea/blaze/clwb/radler/RadTestContextProvider.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2024 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.clwb.radler
+
+import com.google.common.util.concurrent.Futures
+import com.google.common.util.concurrent.ListenableFuture
+import com.google.idea.blaze.base.dependencies.TargetInfo
+import com.google.idea.blaze.base.model.primitives.RuleType
+import com.google.idea.blaze.base.run.ExecutorType
+import com.google.idea.blaze.base.run.SourceToTargetFinder
+import com.google.idea.blaze.base.run.TestTargetHeuristic
+import com.google.idea.blaze.base.run.producers.RunConfigurationContext
+import com.google.idea.blaze.base.run.producers.TestContext
+import com.google.idea.blaze.base.run.producers.TestContextProvider
+import com.google.idea.blaze.base.util.pluginProjectScope
+import com.google.idea.blaze.cpp.CppBlazeRules.RuleTypes
+import com.intellij.execution.actions.ConfigurationContext
+import com.intellij.util.asSafely
+import com.jetbrains.cidr.radler.testing.RadTestPsiElement
+import com.jetbrains.rider.model.RadTestElementModel
+import com.jetbrains.rider.model.RadTestFramework
+import kotlinx.coroutines.async
+import kotlinx.coroutines.guava.asListenableFuture
+import kotlinx.coroutines.guava.await
+import java.io.File
+import java.util.*
+
+abstract class RadTestContextProvider : TestContextProvider {
+
+  override fun getTestContext(context: ConfigurationContext): RunConfigurationContext? {
+    val psiElement = context.psiLocation.asSafely<RadTestPsiElement>() ?: return null
+
+    if (psiElement.test.framework != testFramework) {
+      return null
+    }
+
+    val target = pluginProjectScope(context.project).async {
+      chooseTargetForFile(context, findTargets(context).await())
+    }.asListenableFuture()
+
+    return TestContext.builder(psiElement, ExecutorType.DEBUG_SUPPORTED_TYPES)
+      .setTarget(target)
+      .setTestFilter(createTestFilter(psiElement.test))
+      .build()
+  }
+
+  protected abstract val testFramework: RadTestFramework
+
+  protected abstract fun createTestFilter(test: RadTestElementModel): String?
+}
+
+private fun findTargets(context: ConfigurationContext): ListenableFuture<Collection<TargetInfo>> {
+  val virtualFile = context.location?.virtualFile ?: return Futures.immediateFuture(emptyList())
+
+  return SourceToTargetFinder.findTargetInfoFuture(
+    context.project,
+    File(virtualFile.path),
+    Optional.of(RuleType.TEST),
+  ) ?: Futures.immediateFuture(emptyList())
+}
+
+private fun chooseTargetForFile(context: ConfigurationContext, targets: Collection<TargetInfo>): TargetInfo? {
+  val psiFile = context.psiLocation?.containingFile ?: return null
+  val virtualFile = psiFile.virtualFile ?: return null
+
+  val ccTargets = targets.filter { it -> it.kind == RuleTypes.CC_TEST.kind }
+
+  return TestTargetHeuristic.chooseTestTargetForSourceFile(
+    context.project,
+    psiFile,
+    File(virtualFile.path),
+    ccTargets,
+    null,
+  )
+}

--- a/clwb/src/com/google/idea/blaze/clwb/radler/optional-plugin.xml
+++ b/clwb/src/com/google/idea/blaze/clwb/radler/optional-plugin.xml
@@ -16,6 +16,7 @@
 <idea-plugin>
   <extensions defaultExtensionNs="com.google.idea.blaze">
     <TestContextProvider implementation="com.google.idea.blaze.clwb.radler.RadGoogleTestContextProvider"/>
+    <TestContextProvider implementation="com.google.idea.blaze.clwb.radler.RadCatchTestContextProvider"/>
     <BinaryContextProvider implementation="com.google.idea.blaze.clwb.radler.RadBinaryContextProvider"/>
   </extensions>
 </idea-plugin>


### PR DESCRIPTION
Adds a test context provider for catch2 tests based on the work done for google tests. I also tried to provide a context provider for boost tests, however they don't play nicely with our current test infrastructure in the plugin. 