### PR TITLE
Keep bazel from automatically enabling curses with the old sync view

### DIFF
--- a/base/src/com/google/idea/blaze/base/buildview/BazelExecService.kt
+++ b/base/src/com/google/idea/blaze/base/buildview/BazelExecService.kt
@@ -69,6 +69,8 @@ class BazelExecService(private val project: Project) : Disposable {
     // the old sync view does not use a PTY based terminal
     if (BuildViewMigration.present(ctx)) {
       cmdBuilder.addBlazeFlags("--curses=yes")
+    } else {
+      cmdBuilder.addBlazeFlags("--curses=no")
     }
 
     val cmd = cmdBuilder.build()


### PR DESCRIPTION
Since Bazel is invoked using the PtyCommandLine it seems to automatically enable curses. Therefore, to prevent this when using the old sync view this PR adds the explicit --curses=no option.