### PR TITLE
clion: fix non-passed env vars for gdbserverless debugging

### DIFF
--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrLauncher.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrLauncher.java
@@ -189,10 +189,7 @@ public final class BlazeCidrLauncher extends CidrLauncher {
 
     final GeneralCommandLine commandLine = new GeneralCommandLine(command.toList());
 
-    EnvironmentVariablesData envState = handlerState.getEnvVarsState().getData();
-    commandLine.withParentEnvironmentType(
-        envState.isPassParentEnvs() ? ParentEnvironmentType.SYSTEM : ParentEnvironmentType.NONE);
-    commandLine.getEnvironment().putAll(envState.getEnvs());
+    updateCommandlineWithEnvironmentData(commandLine);
 
     return new ScopedBlazeProcessHandler(
         project,
@@ -214,6 +211,13 @@ public final class BlazeCidrLauncher extends CidrLauncher {
             return ImmutableList.of(new LineProcessingProcessAdapter(outputStream));
           }
         });
+  }
+
+  private void updateCommandlineWithEnvironmentData(GeneralCommandLine commandLine) {
+    EnvironmentVariablesData envState = handlerState.getEnvVarsState().getData();
+    commandLine.withParentEnvironmentType(
+        envState.isPassParentEnvs() ? ParentEnvironmentType.SYSTEM : ParentEnvironmentType.NONE);
+    commandLine.getEnvironment().putAll(envState.getEnvs());
   }
 
   @Override
@@ -246,6 +250,9 @@ public final class BlazeCidrLauncher extends CidrLauncher {
 
       commandLine.addParameters(handlerState.getExeFlagsState().getFlagsForExternalProcesses());
       commandLine.addParameters(handlerState.getTestArgs());
+
+      // otherwise is handled in createProcess
+      updateCommandlineWithEnvironmentData(commandLine);
 
       if (CppBlazeRules.RuleTypes.CC_TEST.getKind().equals(configuration.getTargetKind())) {
         convertBlazeTestFilterToExecutableFlag().ifPresent(commandLine::addParameters);


### PR DESCRIPTION
it wasn't checked back in the days that the change did not break the flow on mac/windows/linux with gdbserver disabled

fixes #7166

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #7166

# Description of this change

