### PR TITLE
cleanup: remove non-existing key

### DIFF
--- a/base/tests/unittests/com/google/idea/blaze/base/sync/workspace/ExecutionRootPathResolverTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/sync/workspace/ExecutionRootPathResolverTest.java
@@ -138,7 +138,6 @@ public class ExecutionRootPathResolverTest extends BlazeTestCase {
   @Override
   protected void initTest(Container applicationServices, Container projectServices) {
     Registry.get("bazel.sync.resolve.virtual.includes").setValue(true);
-    Registry.get("bazel.sync.collect.virtual.includes.hints").setValue(false);
 
     pathResolver =
         new ExecutionRootPathResolver(

--- a/cpp/tests/unittests/com/google/idea/blaze/cpp/BlazeCompilerSettingsTest.java
+++ b/cpp/tests/unittests/com/google/idea/blaze/cpp/BlazeCompilerSettingsTest.java
@@ -56,7 +56,6 @@ public class BlazeCompilerSettingsTest extends BlazeTestCase {
     applicationServices.register(ExperimentService.class, new MockExperimentService());
 
     Registry.get("bazel.sync.resolve.virtual.includes").setValue(true);
-    Registry.get("bazel.sync.collect.virtual.includes.hints").setValue(true);
 
     applicationServices.register(QuerySyncSettings.class, new QuerySyncSettings());
 


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

Cleanup for a registry key removed a while ago.