### PR TITLE
cleanup: remove non-existing allow.macros.for.run.configurations key

### DIFF
--- a/base/tests/utils/unit/com/google/idea/blaze/base/BlazeTestCase.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/BlazeTestCase.java
@@ -33,7 +33,6 @@ import com.intellij.openapi.extensions.impl.ExtensionsAreaImpl;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.SystemInfo;
-import com.intellij.openapi.util.registry.Registry;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -95,7 +94,6 @@ public class BlazeTestCase {
 
   @Before
   public final void setup() {
-    Registry.get("allow.macros.for.run.configurations").setValue(false);
     testDisposable = new RootDisposable();
     MockApplication application = TestUtils.createMockApplication(testDisposable);
     MockProject mockProject = TestUtils.mockProject(application.getPicoContainer(), testDisposable);


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

