### PR TITLE
xcode: query xcode parameters from provider based on attributes

### DIFF
--- a/aspect/BUILD
+++ b/aspect/BUILD
@@ -17,6 +17,7 @@ filegroup(
         "intellij_info_impl.bzl",
         "java_classpath.bzl",
         "make_variables.bzl",
+        "xcode_query.bzl",
         ":BUILD.bazel",
         "//aspect/tools:CreateAar",
         "//aspect/tools:JarFilter_deploy.jar",
@@ -51,6 +52,7 @@ filegroup(
         "intellij_info_impl_bundled.bzl",
         "java_classpath.bzl",
         "make_variables.bzl",
+        "xcode_query.bzl",
         ":BUILD.bazel",
     ],
     visibility = ["//visibility:public"],
@@ -117,9 +119,9 @@ genrule(
 
 genrule(
     name = "create_workspace_file",
-    outs = ["WORKSPACE"],
     srcs = [],
-    cmd = r"""echo 'workspace(name = "intellij_aspect")' > $@"""
+    outs = ["WORKSPACE"],
+    cmd = r"""echo 'workspace(name = "intellij_aspect")' > $@""",
 )
 
 define_flag_hack()

--- a/aspect/xcode_query.bzl
+++ b/aspect/xcode_query.bzl
@@ -1,0 +1,22 @@
+provider_attrs = ["xcode_version", "default_macos_sdk_version"]
+
+def all_items_are_true(items):
+    for item in items:
+        if item == False:
+            return False
+
+    return True
+
+def hasattrs(obj, attrs):
+    return all_items_are_true([hasattr(obj, attr) for attr in attrs])
+
+def format(target):
+    all_providers = providers(target)
+    for key in all_providers:
+        provider = all_providers[key]
+
+        if hasattrs(provider, provider_attrs):
+            attrs = [getattr(provider, attr) for attr in provider_attrs]
+            return "{} {}".format(attrs[0], attrs[1])
+
+    return ""

--- a/base/src/com/google/idea/blaze/base/sync/aspects/strategy/AspectRepositoryProvider.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/strategy/AspectRepositoryProvider.java
@@ -24,7 +24,7 @@ public interface AspectRepositoryProvider {
     return Optional.ofNullable(project.getProjectFilePath()).map((it) -> Paths.get(it).getParent().resolve("aspect").toFile());
   }
 
-  private static Optional<File> findAspectDirectory() {
+  static Optional<File> findAspectDirectory() {
     return EP_NAME.getExtensionsIfPointIsRegistered().stream()
         .map(AspectRepositoryProvider::aspectDirectory)
         .filter(Optional::isPresent)

--- a/cpp/src/com/google/idea/blaze/cpp/XcodeCompilerSettingsProviderImpl.java
+++ b/cpp/src/com/google/idea/blaze/cpp/XcodeCompilerSettingsProviderImpl.java
@@ -30,6 +30,7 @@ import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.settings.Blaze;
+import com.google.idea.blaze.base.sync.aspects.strategy.AspectRepositoryProvider;
 import com.google.idea.blaze.cpp.XcodeCompilerSettingsProvider.XcodeCompilerSettingsException.IssueKind;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.io.FileUtil;
@@ -44,17 +45,13 @@ import java.util.Optional;
 
 
 public class XcodeCompilerSettingsProviderImpl implements XcodeCompilerSettingsProvider {
-
-  private static final String QUERY_XCODE_VERSION_STARLARK_EXPR = "`{} {}`.format(providers(target)[`XcodeProperties`].xcode_version, providers(target)[`XcodeProperties`].default_macos_sdk_version) if providers(target) and `XcodeProperties` in providers(target) else ``".replace(
-      '`', '"');
-
   // This only exists because it's impossible to escape a `deps()` query expression correctly in a Java string.
   private static final String[] QUERY_XCODE_VERSION_SCRIPT_LINES = new String[]{
       "#!/bin/bash",
       "__BAZEL_BIN__ cquery \\",
       " 'deps(\"@bazel_tools//tools/osx:current_xcode_config\")' \\",
       " --output=starlark \\",
-      " --starlark:expr='" + QUERY_XCODE_VERSION_STARLARK_EXPR + "'",
+      " --starlark:file='" + AspectRepositoryProvider.findAspectDirectory().orElseThrow() + "/xcode_query.bzl'",
   };
 
   @Override


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

Bazel 8 introduced new provider located in apple_common module, which is not available in cquery context, so the implementation was updated to just find a provider with required attributes to make implementation also work for bazel 7 and older

fixes #6604