### PR TITLE
handling for debugging python test targets with transitions

### DIFF
--- a/aspect/python_info.bzl
+++ b/aspect/python_info.bzl
@@ -1,37 +1,32 @@
 # TEMPLATE-INCLUDE-BEGIN
-###if( $isPythonEnabled == "true" && $bazel8OrAbove == "true" )
-##load("@rules_python//python:defs.bzl", "PyInfo")
+###if( $isPythonEnabled == "true" )
+##load("@rules_python//python:defs.bzl", RulesPyInfo = "PyInfo")
 ###end
 # TEMPLATE-INCLUDE-END
 
 def py_info_in_target(target):
-# TEMPLATE-IGNORE-BEGIN
-    return PyInfo in target
-# TEMPLATE-IGNORE-END
-
 # TEMPLATE-INCLUDE-BEGIN
-##  #if( $isPythonEnabled == "true" )
-##  return PyInfo in target
-##  #else
-##  return None
-##  #end
+###if( $isPythonEnabled == "true" )
+##  if RulesPyInfo in target:
+##    return True
+###if( $bazel8OrAbove != "true")
+##  if PyInfo in target:
+##    return True
+###end
+###end
 # TEMPLATE-INCLUDE-END
+  return False
 
 def get_py_info(target):
-# TEMPLATE-IGNORE-BEGIN
-    if PyInfo in target:
-        return target[PyInfo]
-    else:
-        return None
-# TEMPLATE-IGNORE-END
-
 # TEMPLATE-INCLUDE-BEGIN
-##  #if( $isPythonEnabled == "true" )
+###if( $isPythonEnabled == "true" )
+##  if RulesPyInfo in target:
+##    return target[RulesPyInfo]
+###if( $bazel8OrAbove != "true")
 ##  if PyInfo in target:
-##      return target[PyInfo]
-##  else:
-##      return None
-##  #else
-##  return None
-##  #end
+##    return target[PyInfo]
+###end
+###end
 # TEMPLATE-INCLUDE-END
+  return None
+

--- a/aspect/python_info.bzl
+++ b/aspect/python_info.bzl
@@ -5,28 +5,39 @@
 # TEMPLATE-INCLUDE-END
 
 def py_info_in_target(target):
+# TEMPLATE-IGNORE-BEGIN
+    return PyInfo in target
+# TEMPLATE-IGNORE-END
+
 # TEMPLATE-INCLUDE-BEGIN
 ###if( $isPythonEnabled == "true" )
 ##  if RulesPyInfo in target:
 ##    return True
+###end
 ###if( $bazel8OrAbove != "true")
 ##  if PyInfo in target:
 ##    return True
 ###end
-###end
+##  return False
 # TEMPLATE-INCLUDE-END
-  return False
 
 def get_py_info(target):
+# TEMPLATE-IGNORE-BEGIN
+    if PyInfo in target:
+        return target[PyInfo]
+    else:
+        return None
+# TEMPLATE-IGNORE-END
+
 # TEMPLATE-INCLUDE-BEGIN
 ###if( $isPythonEnabled == "true" )
 ##  if RulesPyInfo in target:
 ##    return target[RulesPyInfo]
+###end
 ###if( $bazel8OrAbove != "true")
 ##  if PyInfo in target:
 ##    return target[PyInfo]
 ###end
-###end
+##  return None
 # TEMPLATE-INCLUDE-END
-  return None
 

--- a/base/src/com/google/idea/blaze/base/run/testmap/TargetInfoComparator.java
+++ b/base/src/com/google/idea/blaze/base/run/testmap/TargetInfoComparator.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.run.testmap;
+
+import com.google.idea.blaze.base.dependencies.TargetInfo;
+import com.google.idea.blaze.base.model.primitives.Kind;
+import java.util.Comparator;
+
+public class TargetInfoComparator implements Comparator<TargetInfo> {
+
+  /**
+   * Sorts the {@link TargetInfo} objects such that there is a preference to those without the
+   * underscore on the name and for those that do actually resolve to a {@link Kind}.
+   */
+
+  @Override
+  public int compare(TargetInfo o1, TargetInfo o2) {
+    Kind kind1 = o1.getKind();
+    Kind kind2 = o2.getKind();
+
+    if ((null == kind1) != (null == kind2)) {
+      return (null == kind1) ? 1 : -1;
+    }
+
+    String targetNameStr1 = o1.getLabel().targetName().toString();
+    String targetNameStr2 = o2.getLabel().targetName().toString();
+
+    boolean targetNameLeadingUnderscore1 = targetNameStr1.startsWith("_");
+    boolean targetNameLeadingUnderscore2 = targetNameStr2.startsWith("_");
+
+    if (targetNameLeadingUnderscore1 != targetNameLeadingUnderscore2) {
+      return targetNameLeadingUnderscore1 ? 1 : -1;
+    }
+
+    return targetNameStr1.compareTo(targetNameStr2);
+  }
+
+}

--- a/base/tests/unittests/com/google/idea/blaze/base/run/testmap/TargetInfoComparatorTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/run/testmap/TargetInfoComparatorTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2024 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.run.testmap;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.idea.blaze.base.BlazeTestCase;
+import com.google.idea.blaze.base.dependencies.TargetInfo;
+import com.google.idea.blaze.base.model.primitives.GenericBlazeRules;
+import com.google.idea.blaze.base.model.primitives.Kind;
+import com.google.idea.blaze.base.model.primitives.Label;
+import com.intellij.openapi.extensions.impl.ExtensionPointImpl;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TargetInfoComparatorTest extends BlazeTestCase {
+
+  private TargetInfoComparator comparator = new TargetInfoComparator();
+
+  @Override
+  protected void initTest(Container applicationServices, Container projectServices) {
+    super.initTest(applicationServices, projectServices);
+    ExtensionPointImpl<Kind.Provider> kindProvider =
+        registerExtensionPoint(Kind.Provider.EP_NAME, Kind.Provider.class);
+    kindProvider.registerExtension(new GenericBlazeRules());
+    applicationServices.register(Kind.ApplicationState.class, new Kind.ApplicationState());
+  }
+
+  /**
+   * <p>In this case the `zzz` kindString will not resolve to a known instance of
+   * {@link com.google.idea.blaze.base.model.primitives.Kind} and so it will come last.</p>
+   */
+
+  @Test
+  public void testNoKind() {
+    List<TargetInfo> targetInfos = List.of(
+        TargetInfo.builder(Label.create("//project:aaa"), "zzz").build(),
+        TargetInfo.builder(Label.create("//project:bbb"), "sh_test").build()
+    );
+
+    List<TargetInfo> sortedTargetInfos = targetInfos
+        .stream()
+        .sorted(comparator)
+        .collect(Collectors.toUnmodifiableList());
+
+    // expecting that the first one will be the one that has the Kind.
+    assertThat(sortedTargetInfos.get(0).getLabel()).isEqualTo(Label.create("//project:bbb"));
+    assertThat(sortedTargetInfos.get(1).getLabel()).isEqualTo(Label.create("//project:aaa"));
+  }
+
+  /**
+   * <p>In this case the `_transition_` will be stopped on the `_transition_py_test` and so
+   * both {@link TargetInfo}s will be having the
+   * {@link com.google.idea.blaze.base.model.primitives.Kind} of `py_test`. This means that the
+   * sorting will make the `_aaa` last as it starts with an underscore.</p>
+   */
+  @Test
+  public void testUnderscoreOnLabelTargetName() {
+    List<TargetInfo> targetInfos = List.of(
+        TargetInfo.builder(Label.create("//project:_aaa"), "sh_test").build(),
+        TargetInfo.builder(Label.create("//project:bbb"), "_transition_sh_test").build()
+    );
+
+    List<TargetInfo> sortedTargetInfos = targetInfos
+        .stream()
+        .sorted(comparator)
+        .collect(Collectors.toUnmodifiableList());
+
+    // expecting that the first one will be the one that has the Kind.
+    assertThat(sortedTargetInfos.get(0).getLabel()).isEqualTo(Label.create("//project:bbb"));
+    assertThat(sortedTargetInfos.get(1).getLabel()).isEqualTo(Label.create("//project:_aaa"));
+  }
+
+  /**
+   * <p>As there is no missing {@link com.google.idea.blaze.base.model.primitives.Kind}
+   * nor an underscore-prefixed </p>
+   */
+  @Test
+  public void testByLabelName() {
+    List<TargetInfo> targetInfos = List.of(
+        TargetInfo.builder(Label.create("//project:ddd"), "sh_test").build(),
+        TargetInfo.builder(Label.create("//project:aaa"), "sh_test").build()
+    );
+
+    List<TargetInfo> sortedTargetInfos = targetInfos
+        .stream()
+        .sorted(comparator)
+        .collect(Collectors.toUnmodifiableList());
+
+    // expecting that the first one will be the one that has the Kind.
+    assertThat(sortedTargetInfos.get(0).getLabel()).isEqualTo(Label.create("//project:aaa"));
+    assertThat(sortedTargetInfos.get(1).getLabel()).isEqualTo(Label.create("//project:ddd"));
+  }
+
+}

--- a/querysync/javatests/com/google/idea/blaze/qsync/query/QuerySpecTest.java
+++ b/querysync/javatests/com/google/idea/blaze/qsync/query/QuerySpecTest.java
@@ -19,6 +19,8 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.idea.blaze.qsync.BlazeQueryParser;
 import java.nio.file.Path;
+import java.util.stream.Stream;
+import java.util.stream.Collectors;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -86,6 +88,22 @@ public class QuerySpecTest {
 
   @Test
   public void testGetQueryExpression_experimental_includes_and_excludes() {
+
+    // There are a number of Kinds that are expected to be queried for. It is also
+    // necessary to include the same Kinds with the prefix `_transition_` as well because it
+    // could be that any given rule is subject to a transition.
+
+    String kindsExpression = Stream.of(
+        "android_library", "android_binary", "android_local_test",
+        "android_instrumentation_test", "kt_android_library_helper", "java_library", "java_binary",
+        "kt_jvm_library", "kt_jvm_binary", "kt_jvm_library_helper", "kt_native_library", "java_test",
+        "java_proto_library", "java_lite_proto_library", "java_mutable_proto_library",
+        "_java_grpc_library", "_kotlin_library", "_java_lite_grpc_library", "_iml_module_",
+        "cc_library", "cc_binary", "cc_shared_library", "cc_test", "proto_library", "py_library",
+        "py_binary", "py_test")
+        .flatMap(k -> Stream.of(k, "_transition_" + k))
+        .collect(Collectors.joining("|"));
+
     QuerySpec qs =
       QuerySpec.builder(QuerySpec.QueryStrategy.FILTERING_TO_KNOWN_AND_USED_TARGETS)
         .workspaceRoot(Path.of("/workspace/"))
@@ -98,7 +116,7 @@ public class QuerySpecTest {
     assertThat(qs.getQueryExpression())
       .hasValue(
         "let base = //some/included/path/...:* + //another/included/path/...:* - //some/included/path/excluded/...:* - //another/included/path/excluded/...:*\n" +
-        " in let known = kind(\"source file|android_library|android_binary|android_local_test|android_instrumentation_test|kt_android_library_helper|java_library|java_binary|kt_jvm_library|kt_jvm_binary|kt_jvm_library_helper|kt_native_library|java_test|java_proto_library|java_lite_proto_library|java_mutable_proto_library|_java_grpc_library|_kotlin_library|_java_lite_grpc_library|_iml_module_|cc_library|cc_binary|cc_shared_library|cc_test|proto_library|py_library|py_binary|py_test\", $base) \n" +
+        " in let known = kind(\"source file|" + kindsExpression + "\", $base) \n" +
         " in let unknown = $base except $known \n" +
         " in $known union ($base intersect allpaths($known, $unknown)) \n");
   }


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: [7196](https://github.com/bazelbuild/intellij/issues/7196)

# Description of this change

- The change will recognize Kinds with a `_transition_` prefix as being the Kind with with `_transition_` prefix stripped.
- The selection of the Target to map to from a source file will avoid, where possible, any with a `_` prefix.
- The Python templated aspect logic will allow the `rules_python` `PyInfo` provider to be considered with Bazel < 8. I am unsure of all the wider ramifications of this so it may require some discussion. I think internal Bazel rules were dropped on Bazel 5 so perhaps it is a reasonable assumption that the user would be using `rules_python` if they are using Python at all?