### PR TITLE
Allow to boost `.ijwb` over BSP and .idea folder. (#7201)

### DIFF
--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -413,6 +413,9 @@
                  description="By default Bazel plugin takes control and opens project if .ijwb folder is present. This property can be used to disable this behavior to allow to open .idea or other project models if they are exists."
                  key="bazel.project.auto.open.if.present"/>
     <registryKey defaultValue="false"
+                 description="Google plugin is not exclusive anymore, and we need to give a chance to BSP to chime in. Otherwise neither will import the project if .idea folder is present. This property can be used to give a priority to .ijwb or alike over .idea *and* BSP."
+                 key="bazel.project.prefer.google.plugin"/>
+    <registryKey defaultValue="false"
                  description="The Bazel Plugin sometimes uses the --query_file option to pass the query via a file. By default, the file is deleted immediately after the query execution is finished. Set this flag to true to avoid file deletion"
                  key="bazel.sync.keep.query.files"/>
     <registryKey defaultValue="false"
@@ -422,7 +425,7 @@
                  description="Causes the plugin to read external workspace data, enabling features such as code completion for external targets. This may incur the cost of an additional 'bazel mod' call, which could cause issues with older versions or setups."
                  key="bazel.read.external.workspace.data"/>
     <registryKey defaultValue="true"
-                 description="Enable basic syntax highliting in Query Sync's 'Analysis Disabled' mode"
+                 description="Enable basic syntax highlighting in Query Sync's 'Analysis Disabled' mode"
                  key="bazel.qsync.enable.basic.highlighting.in.non.analysis.mode"/>
     <editorNotificationProvider implementation="com.google.idea.blaze.base.wizard2.BazelNotificationProvider"/>
   </extensions>

--- a/base/src/com/google/idea/blaze/base/project/AutoImportProjectOpenProcessor.java
+++ b/base/src/com/google/idea/blaze/base/project/AutoImportProjectOpenProcessor.java
@@ -21,7 +21,9 @@ import com.google.idea.blaze.base.wizard2.WorkspaceTypeData;
 import com.intellij.ide.SaveAndSyncHandler;
 import com.intellij.ide.impl.OpenProjectTask;
 import com.intellij.ide.impl.ProjectUtil;
+import com.intellij.ide.plugins.PluginManagerCore;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.project.ex.ProjectManagerEx;
@@ -78,7 +80,8 @@ public class AutoImportProjectOpenProcessor extends ProjectOpenProcessor {
 
   @Override
   public boolean isStrongProjectInfoHolder() {
-    return false;
+      return !PluginManagerCore.isPluginInstalled(PluginId.getId("org.jetbrains.bazel")) ||
+              Registry.is("bazel.project.prefer.google.plugin");
   }
 
   @Override


### PR DESCRIPTION
* Allow to boost `.ijwb` over BSP and .idea folder.

* Smarter default in case BSP not installed

* Google plugin has no priority by default and used if JetBrains Bazel is not installed. If BSP is there then registry key value is used.

fixes #7200

(cherry picked from commit d407faba3e52e32a929aa9581f4412f474b01a96)

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

