### PR TITLE
[AOSP-pick] [FL-22733] Notify the user about missing Android SDK or required Android platforms.

### DIFF
--- a/aswb/tests/unittests/com/google/idea/blaze/android/rendering/BlazeRenderErrorContributorTest.java
+++ b/aswb/tests/unittests/com/google/idea/blaze/android/rendering/BlazeRenderErrorContributorTest.java
@@ -20,10 +20,12 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.android.tools.idea.rendering.EnvironmentContextFactory;
 import com.android.tools.idea.rendering.RenderErrorContributor;
 import com.android.tools.idea.rendering.RenderErrorModelFactory;
 import com.android.tools.idea.rendering.RenderIssueCollectionConsumer;
 import com.android.tools.idea.rendering.RenderResults;
+import com.android.tools.idea.rendering.StudioEnvironmentContextFactory;
 import com.android.tools.idea.rendering.errors.ui.RenderErrorModel;
 import com.android.tools.rendering.RenderResult;
 import com.google.common.collect.ImmutableCollection;
@@ -109,8 +111,8 @@ public class BlazeRenderErrorContributorTest extends BlazeTestCase {
     projectServices.register(BuildReferenceManager.class, new MockBuildReferenceManager(project));
     projectServices.register(TransitiveDependencyMap.class, new TransitiveDependencyMap(project));
     projectServices.register(ProjectScopeBuilder.class, new ProjectScopeBuilderImpl(project));
-    projectServices.register(
-        AndroidResourceModuleRegistry.class, new AndroidResourceModuleRegistry());
+    projectServices.register(AndroidResourceModuleRegistry.class, new AndroidResourceModuleRegistry());
+    projectServices.register(EnvironmentContextFactory.class, new StudioEnvironmentContextFactory());
 
     ExtensionPointImpl<Kind.Provider> kindProvider =
         registerExtensionPoint(Kind.Provider.EP_NAME, Kind.Provider.class);


### PR DESCRIPTION
Cherry pick AOSP commit [b4da8ebad9e52b2090b6116d8289888c78786b78](https://cs.android.com/android-studio/platform/tools/adt/idea/+/b4da8ebad9e52b2090b6116d8289888c78786b78).

The following scenarios are covered with the changes:
* No Android SDK is installed at all: we offer a fix to install SDK into the default location
* Some platforms are missing (for example, we have SDK with platform 34, but the project requires 35): we offer to download the platform in this case
* Project has an SDK in local.properties different from the one used by IDE (default or from ANDROID_HOME): in this case we rewrite local.properties and show a notification to the user
One more important thing: the way we detect Android projects was altered, also in IDEA.
Before the changes, we were looking for a top-level folder app with the AndroidManifest.xml, which is not always the case (especially with our wizard projects we typically have composeApp, not just app, folder).
After the changes, we are looking for any folder with the specific AndroidManifest.xml path (both in main and androidMain). This will allow opening more projects in IDEA initially when no local.properties file is present.

Merge-request: IJ-MR-149228
Merged-by: Ilia Bogdanovich <ilia.bogdanovich@jetbrains.com>

GitOrigin-RevId: 6f8e9c3bcb51e1ff2812abf1b69b73db10c09ea0
(cherry picked from commit 2dec242f247f181da7855d0b6d6713b2cd3ac523)
Change-Id: I10a44780957e2f8b991e70416d0e7b24f70dbf10

AOSP: b4da8ebad9e52b2090b6116d8289888c78786b78
