### PR TITLE
Add a managed project view file for query sync

### DIFF
--- a/.managed.bazelproject
+++ b/.managed.bazelproject
@@ -1,0 +1,27 @@
+directories:
+  .
+  -aswb/testdata
+  -clwb/tests/projects
+  -examples
+
+derive_targets_from_directories: true
+
+use_query_sync: true
+
+workspace_type: intellij_plugin
+
+additional_languages:
+  kotlin
+
+test_sources:
+  */tests/unittests*
+  */tests/integrationtests*
+
+build_flags:
+  # Choose one target ij product:
+  # --define=ij_product=intellij-oss-under-dev
+  # --define=ij_product=intellij-ue-oss-under-dev
+  # --define=ij_product=clion-oss-under-dev
+
+  # Setup disk cache, can improve build times:
+  # --disk_cache=/tmp/bazel_cache

--- a/clwb/clwb.bazelproject
+++ b/clwb/clwb.bazelproject
@@ -20,3 +20,5 @@ test_sources:
 
 additional_languages:
   kotlin
+
+use_query_sync: false

--- a/ijwb/ijwb.bazelproject
+++ b/ijwb/ijwb.bazelproject
@@ -23,4 +23,4 @@ test_sources:
 additional_languages:
   kotlin
 
-use_query_sync: true
+use_query_sync: false


### PR DESCRIPTION
This is the configuration I am currently using for query sync to develop either ijwb or clwb. Since this configuration can be used for both products I would suggest creating one managed project view file in the root of the project, but keep the product specific ones for aspect sync.
