### PR TITLE
[AOSP-pick] Separate BEP fetching and parsing

### DIFF
--- a/aswb/src/com/google/idea/blaze/android/run/deployinfo/BlazeApkDeployInfoProtoHelper.java
+++ b/aswb/src/com/google/idea/blaze/android/run/deployinfo/BlazeApkDeployInfoProtoHelper.java
@@ -49,8 +49,8 @@ public class BlazeApkDeployInfoProtoHelper {
       throws GetDeployInfoException {
     ImmutableList<OutputArtifact> outputArtifacts;
     ParsedBepOutput bepOutput;
-    try {
-      bepOutput = buildResultHelper.getBuildOutput(Optional.empty(), Interners.STRING);
+    try (final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {
+      bepOutput = buildResultHelper.getBuildOutput(bepStream, Interners.STRING);
       outputArtifacts = bepOutput.getDirectArtifactsForTarget(target, pathFilter).asList();
     } catch (GetArtifactsException e) {
       throw new GetDeployInfoException(e.getMessage());

--- a/aswb/src/com/google/idea/blaze/android/run/test/BlazeAndroidTestLaunchTask.java
+++ b/aswb/src/com/google/idea/blaze/android/run/test/BlazeAndroidTestLaunchTask.java
@@ -211,8 +211,10 @@ public class BlazeAndroidTestLaunchTask implements BlazeLaunchTask {
                         if (retVal != 0) {
                           context.setHasError();
                         } else {
-                          testResultsHolder.setTestResults(
-                              buildResultHelper.getTestResults(Optional.empty()));
+                          try (final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {
+                            testResultsHolder.setTestResults(
+                              buildResultHelper.getTestResults(bepStream));
+                          }
                         }
                         ListenableFuture<Void> unusedFuture =
                             FileCaches.refresh(

--- a/base/src/com/google/idea/blaze/base/buildview/BazelExecService.kt
+++ b/base/src/com/google/idea/blaze/base/buildview/BazelExecService.kt
@@ -175,7 +175,7 @@ class BazelExecService(private val project: Project) : Disposable {
     LOG.assertTrue(cmdBuilder.name == BlazeCommandName.BUILD)
 
     return executionScope(ctx) { provider ->
-      cmdBuilder.addBlazeFlags(provider.getBuildFlags())
+      cmdBuilder.addBlazeFlags(provider.buildFlags)
 
       val parseJob = parseEvents(ctx, provider)
 
@@ -185,11 +185,13 @@ class BazelExecService(private val project: Project) : Disposable {
       parseJob.cancelAndJoin()
 
       if (result.status == BuildResult.Status.FATAL_ERROR) {
-        BlazeBuildOutputs.noOutputs(result)
-      } else {
+        return@executionScope BlazeBuildOutputs.noOutputs(result)
+      }
+
+      provider.getBepStream(Optional.empty()).use { bepStream ->
         BlazeBuildOutputs.fromParsedBepOutput(
           result,
-          provider.getBuildOutput(Optional.empty(), Interners.STRING),
+          provider.getBuildOutput(bepStream, Interners.STRING),
         )
       }
     }

--- a/base/src/com/google/idea/blaze/base/command/CommandLineBlazeCommandRunner.java
+++ b/base/src/com/google/idea/blaze/base/command/CommandLineBlazeCommandRunner.java
@@ -94,7 +94,10 @@ public class CommandLineBlazeCommandRunner implements BlazeCommandRunner {
           Optional.ofNullable(context.getScope(SharedStringPoolScope.class))
               .map(SharedStringPoolScope::getStringInterner)
               .orElse(null);
-      ParsedBepOutput buildOutput = buildResultHelper.getBuildOutput(Optional.empty(), stringInterner);
+      ParsedBepOutput buildOutput;
+      try (final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {
+        buildOutput = buildResultHelper.getBuildOutput(bepStream, stringInterner);
+      }
       context.output(PrintOutput.log("BEP outputs retrieved (%s).", StringUtilRt.formatFileSize(buildOutput.getBepBytesConsumed())));
       return BlazeBuildOutputs.fromParsedBepOutput(buildResult, buildOutput);
     } catch (GetArtifactsException e) {
@@ -128,8 +131,8 @@ public class CommandLineBlazeCommandRunner implements BlazeCommandRunner {
       return BlazeTestResults.NO_RESULTS;
     }
     context.output(PrintOutput.log("Build command finished. Retrieving BEP outputs..."));
-    try {
-      return buildResultHelper.getTestResults(Optional.empty());
+    try(final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {
+      return buildResultHelper.getTestResults(bepStream);
     } catch (GetArtifactsException e) {
       context.output(PrintOutput.log("Failed to get build outputs: " + e.getMessage()));
       context.setHasError();

--- a/base/src/com/google/idea/blaze/base/command/buildresult/BuildEventProtocolOutputReader.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/BuildEventProtocolOutputReader.java
@@ -43,11 +43,6 @@ import javax.annotation.Nullable;
 public final class BuildEventProtocolOutputReader {
 
   private BuildEventProtocolOutputReader() {}
-  /** Returns all test results from a BEP-formatted {@link InputStream}. */
-  public static BlazeTestResults parseTestResults(InputStream inputStream)
-      throws BuildEventStreamException {
-    return parseTestResults(BuildEventStreamProvider.fromInputStream(inputStream));
-  }
   /**
    * Returns all test results from {@link BuildEventStreamProvider}.
    *

--- a/base/src/com/google/idea/blaze/base/command/buildresult/ParsedBepOutput.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/ParsedBepOutput.java
@@ -111,12 +111,6 @@ public final class ParsedBepOutput {
           ImmutableSet.of());
 
   /** Parses BEP events into {@link ParsedBepOutput} */
-  public static ParsedBepOutput parseBepArtifacts(InputStream bepStream)
-      throws BuildEventStreamException {
-    return parseBepArtifacts(BuildEventStreamProvider.fromInputStream(bepStream));
-  }
-
-  /** Parses BEP events into {@link ParsedBepOutput} */
   public static ParsedBepOutput parseBepArtifacts(BuildEventStreamProvider stream)
       throws BuildEventStreamException {
     return parseBepArtifacts(stream, null);

--- a/base/src/com/google/idea/blaze/base/run/testlogs/LocalBuildEventProtocolTestFinderStrategy.java
+++ b/base/src/com/google/idea/blaze/base/run/testlogs/LocalBuildEventProtocolTestFinderStrategy.java
@@ -34,7 +34,9 @@ public final class LocalBuildEventProtocolTestFinderStrategy
 
   @Override
   public BlazeTestResults findTestResults() throws GetArtifactsException {
-    return buildResultHelper.getTestResults(Optional.empty());
+    try (final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {
+      return buildResultHelper.getTestResults(bepStream);
+    }
   }
 
   @Override

--- a/base/tests/unittests/com/google/idea/blaze/base/command/buildresult/BuildEventProtocolOutputReaderTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/command/buildresult/BuildEventProtocolOutputReaderTest.java
@@ -113,7 +113,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
                 ImmutableList.of(outputGroup("name", ImmutableList.of("set-id")))));
 
     ImmutableSet<OutputArtifact> parsedFilenames =
-        ParsedBepOutput.parseBepArtifacts(asInputStream(events))
+        ParsedBepOutput.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)))
             .getAllOutputArtifacts(path -> true);
 
     assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
@@ -137,7 +137,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
                 ImmutableList.of(outputGroup("name", ImmutableList.of("set-id")))));
 
     ImmutableSet<OutputArtifact> parsedFilenames =
-        ParsedBepOutput.parseBepArtifacts(asInputStream(events)).getAllOutputArtifacts(filter);
+        ParsedBepOutput.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events))).getAllOutputArtifacts(filter);
 
     assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
         .containsExactly(new File("/usr/local/lib/File.py"));
@@ -150,7 +150,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
             .setCompleted(BuildEventStreamProtos.TargetComplete.getDefaultInstance());
 
     ImmutableSet<OutputArtifact> parsedFilenames =
-        ParsedBepOutput.parseBepArtifacts(asInputStream(targetFinishedEvent))
+        ParsedBepOutput.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(targetFinishedEvent)))
             .getAllOutputArtifacts(path -> true);
 
     assertThat(parsedFilenames).isEmpty();
@@ -177,7 +177,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
                 ImmutableList.of(outputGroup("name", ImmutableList.of("set-id")))));
 
     ImmutableSet<OutputArtifact> parsedFilenames =
-        ParsedBepOutput.parseBepArtifacts(asInputStream(events))
+        ParsedBepOutput.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)))
             .getAllOutputArtifacts(path -> true);
 
     assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
@@ -222,7 +222,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
             .collect(toImmutableList());
 
     ImmutableSet<OutputArtifact> parsedFilenames =
-        ParsedBepOutput.parseBepArtifacts(asInputStream(events))
+        ParsedBepOutput.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)))
             .getAllOutputArtifacts(path -> true);
 
     assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
@@ -259,7 +259,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
             .collect(toImmutableList());
 
     ImmutableSet<OutputArtifact> parsedFilenames =
-        ParsedBepOutput.parseBepArtifacts(asInputStream(events))
+        ParsedBepOutput.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)))
             .getAllOutputArtifacts(path -> true);
 
     assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
@@ -291,7 +291,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
             .collect(toImmutableList());
 
     ImmutableSet<OutputArtifact> parsedFilenames =
-        ParsedBepOutput.parseBepArtifacts(asInputStream(events))
+        ParsedBepOutput.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)))
             .getDirectArtifactsForTarget(Label.create("//some:target"), path -> true);
 
     assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
@@ -331,7 +331,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
             .collect(toImmutableList());
 
     ImmutableSet<OutputArtifact> parsedFilenames =
-        ParsedBepOutput.parseBepArtifacts(asInputStream(events))
+        ParsedBepOutput.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)))
             .getDirectArtifactsForTarget(Label.create("//some:target"), path -> true);
 
     assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
@@ -377,7 +377,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
             .collect(toImmutableList());
 
     ImmutableList<OutputArtifact> parsedFilenames =
-        ParsedBepOutput.parseBepArtifacts(asInputStream(events))
+        ParsedBepOutput.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)))
             .getOutputGroupArtifacts("group-name", path -> true);
 
     assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
@@ -418,7 +418,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
             .collect(toImmutableList());
 
     ImmutableList<OutputArtifact> parsedFilenames =
-        ParsedBepOutput.parseBepArtifacts(asInputStream(events))
+        ParsedBepOutput.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)))
             .getOutputGroupArtifacts("group-1", path -> true);
 
     assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
@@ -454,7 +454,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
             .collect(toImmutableList());
 
     ImmutableMap<String, BepArtifactData> outputData =
-        ParsedBepOutput.parseBepArtifacts(asInputStream(events)).getFullArtifactData();
+        ParsedBepOutput.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events))).getFullArtifactData();
     ImmutableList<OutputArtifact> outputs =
         outputData.values().stream().map(d -> d.artifact).collect(toImmutableList());
 
@@ -482,7 +482,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
     BuildEvent.Builder event = testResultEvent(label.toString(), status, filePaths);
 
     BlazeTestResults results =
-        BuildEventProtocolOutputReader.parseTestResults(asInputStream(event));
+        BuildEventProtocolOutputReader.parseTestResults(BuildEventStreamProvider.fromInputStream(asInputStream(event)));
 
     assertThat(results.perTargetResults.keySet()).containsExactly(label);
     assertThat(results.perTargetResults.get(label)).hasSize(1);
@@ -503,7 +503,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
             targetConfiguredEvent(label.toString(), "sh_test rule"),
             testResultEvent(label.toString(), status, filePaths));
 
-    BlazeTestResults results = BuildEventProtocolOutputReader.parseTestResults(events);
+    BlazeTestResults results = BuildEventProtocolOutputReader.parseTestResults(BuildEventStreamProvider.fromInputStream(events));
 
     assertThat(results.perTargetResults.keySet()).containsExactly(label);
     assertThat(results.perTargetResults.get(label)).hasSize(1);
@@ -525,7 +525,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
             targetCompletedEvent(label.toString(), "sh_test rule"),
             testResultEvent(label.toString(), status, filePaths));
 
-    BlazeTestResults results = BuildEventProtocolOutputReader.parseTestResults(events);
+    BlazeTestResults results = BuildEventProtocolOutputReader.parseTestResults(BuildEventStreamProvider.fromInputStream(events));
 
     assertThat(results.perTargetResults.keySet()).containsExactly(label);
     assertThat(results.perTargetResults.get(label)).hasSize(1);
@@ -548,7 +548,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
             targetCompletedEvent(label.toString(), "sh_test rule"),
             testResultEvent(label.toString(), status, filePaths));
 
-    BlazeTestResults results = BuildEventProtocolOutputReader.parseTestResults(events);
+    BlazeTestResults results = BuildEventProtocolOutputReader.parseTestResults(BuildEventStreamProvider.fromInputStream(events));
 
     assertThat(results.perTargetResults.keySet()).containsExactly(label);
     assertThat(results.perTargetResults.get(label)).hasSize(1);
@@ -571,7 +571,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
     BuildEvent.Builder event = testResultEvent(label.toString(), status, filePaths);
 
     BlazeTestResults results =
-        BuildEventProtocolOutputReader.parseTestResults(asInputStream(event));
+        BuildEventProtocolOutputReader.parseTestResults(BuildEventStreamProvider.fromInputStream(asInputStream(event)));
 
     BlazeTestResult result = results.perTargetResults.get(label).iterator().next();
     assertThat(getOutputXmlFiles(result))
@@ -597,7 +597,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
                 ImmutableList.of("/usr/local/tmp/_cache/shard2_of_2.xml")));
 
     BlazeTestResults results =
-        BuildEventProtocolOutputReader.parseTestResults(asInputStream(events));
+        BuildEventProtocolOutputReader.parseTestResults(BuildEventStreamProvider.fromInputStream(asInputStream(events)));
 
     ImmutableCollection<BlazeTestResult> targetResults = results.perTargetResults.get(label);
     assertThat(targetResults).hasSize(2);
@@ -628,7 +628,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
             ImmutableList.of("/usr/local/tmp/_cache/second_result.xml"));
 
     BlazeTestResults results =
-        BuildEventProtocolOutputReader.parseTestResults(asInputStream(test1, test2));
+        BuildEventProtocolOutputReader.parseTestResults(BuildEventStreamProvider.fromInputStream(asInputStream(test1, test2)));
 
     assertThat(results.perTargetResults).hasSize(2);
     assertThat(results.perTargetResults.get(Label.create("//java/com/google:Test1"))).hasSize(1);

--- a/base/tests/unittests/com/google/idea/blaze/base/run/testlogs/LocalBuildEventProtocolTestFinderStrategyTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/run/testlogs/LocalBuildEventProtocolTestFinderStrategyTest.java
@@ -23,47 +23,36 @@ import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos;
 import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.BuildEventId.TestResultId;
 import com.google.idea.blaze.base.BlazeTestCase;
 import com.google.idea.blaze.base.command.buildresult.BuildEventProtocolOutputReader;
+import com.google.idea.blaze.base.command.buildresult.BuildEventStreamProvider;
 import com.google.idea.blaze.base.command.buildresult.BuildEventStreamProvider.BuildEventStreamException;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtifactsException;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelperBep;
-import com.google.idea.blaze.base.io.InputStreamProvider;
-import com.google.idea.blaze.base.io.MockInputStreamProvider;
 import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.testFramework.rules.TempDirectory;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.Mockito;
 
 /** Unit tests for {@link LocalBuildEventProtocolTestFinderStrategy}. */
 @RunWith(JUnit4.class)
 public class LocalBuildEventProtocolTestFinderStrategyTest extends BlazeTestCase {
 
-  private MockInputStreamProvider inputStreamProvider;
-  private final Set<File> deletedFiles = new HashSet<>();
-
-  @After
-  public void clearState() {
-    deletedFiles.clear();
-  }
-
-  @Override
-  protected void initTest(Container applicationServices, Container projectServices) {
-    inputStreamProvider = new MockInputStreamProvider();
-    applicationServices.register(InputStreamProvider.class, inputStreamProvider);
-  }
+  @Rule
+  public TempDirectory tempDirectory = new TempDirectory();
 
   @Test
   public void testFinder_fileDeletedAfterCleanup() throws GetArtifactsException {
-    File file = createMockFile("/tmp/bep_output.txt", new byte[0]);
+    File file = tempDirectory.newFile("tmp/bep_output.txt", new byte[0]);
 
     LocalBuildEventProtocolTestFinderStrategy testFinder =
         new LocalBuildEventProtocolTestFinderStrategy(new BuildResultHelperBep(file));
@@ -73,7 +62,7 @@ public class LocalBuildEventProtocolTestFinderStrategyTest extends BlazeTestCase
       testFinder.deleteTemporaryOutputFiles();
     }
 
-    assertThat(deletedFiles).contains(file);
+    assertThat(file.exists()).isFalse();
   }
 
   @Test
@@ -90,29 +79,16 @@ public class LocalBuildEventProtocolTestFinderStrategyTest extends BlazeTestCase
             BuildEventStreamProtos.TestStatus.INCOMPLETE,
             ImmutableList.of("/usr/local/tmp/_cache/second_result.xml"));
     File bepOutputFile =
-        createMockFile("/tmp/bep_output.txt", asByteArray(ImmutableList.of(test1, test2)));
+        tempDirectory.newFile("tmp/bep_output.txt", asByteArray(ImmutableList.of(test1, test2)));
     LocalBuildEventProtocolTestFinderStrategy strategy =
         new LocalBuildEventProtocolTestFinderStrategy(new BuildResultHelperBep(bepOutputFile));
 
-    InputStream inputStream = inputStreamProvider.forFile(bepOutputFile);
-    BlazeTestResults results = BuildEventProtocolOutputReader.parseTestResults(inputStream);
+    BlazeTestResults results = BuildEventProtocolOutputReader.parseTestResults(BuildEventStreamProvider.fromInputStream(
+      Files.newInputStream(bepOutputFile.toPath())));
     BlazeTestResults finderStrategyResults = strategy.findTestResults();
 
     assertThat(finderStrategyResults.perTargetResults.entries())
         .containsExactlyElementsIn(results.perTargetResults.entries());
-  }
-
-  private File createMockFile(String path, byte[] contents) {
-    File org = new File(path);
-    File spy = Mockito.spy(org);
-    inputStreamProvider.addFile(path, contents);
-    Mockito.when(spy.delete())
-        .then(
-            invocationOnMock -> {
-              deletedFiles.add(spy);
-              return true;
-            });
-    return spy;
   }
 
   private static byte[] asByteArray(Iterable<BuildEventStreamProtos.BuildEvent.Builder> events)

--- a/base/tests/utils/unit/com/google/idea/blaze/base/bazel/BepUtils.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/bazel/BepUtils.java
@@ -31,6 +31,7 @@ import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.Con
 import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.NamedSetOfFiles;
 import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.OutputGroup;
 import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.TargetComplete;
+import com.google.idea.blaze.base.command.buildresult.BuildEventStreamProvider;
 import com.google.idea.blaze.base.command.buildresult.BuildEventStreamProvider.BuildEventStreamException;
 import com.google.idea.blaze.base.command.buildresult.ParsedBepOutput;
 import java.io.ByteArrayInputStream;
@@ -127,6 +128,6 @@ public final class BepUtils {
 
   public static ParsedBepOutput parsedBep(List<BuildEvent> events)
       throws IOException, BuildEventStreamException {
-    return ParsedBepOutput.parseBepArtifacts(asInputStream(events));
+    return ParsedBepOutput.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)));
   }
 }

--- a/base/tests/utils/unit/com/google/idea/blaze/base/bazel/FakeBlazeCommandRunner.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/bazel/FakeBlazeCommandRunner.java
@@ -52,9 +52,12 @@ public class FakeBlazeCommandRunner implements BlazeCommandRunner {
 
   public FakeBlazeCommandRunner() {
     this(
-        buildResultHelper ->
-            BlazeBuildOutputs.fromParsedBepOutput(
-                BuildResult.SUCCESS, buildResultHelper.getBuildOutput(Optional.empty(), Interners.STRING)));
+        buildResultHelper -> {
+          try (final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {
+            return BlazeBuildOutputs.fromParsedBepOutput(
+              BuildResult.SUCCESS, buildResultHelper.getBuildOutput(bepStream, Interners.STRING));
+          }
+        });
   }
 
   public FakeBlazeCommandRunner(BuildFunction buildFunction) {

--- a/base/tests/utils/unit/com/google/idea/blaze/base/bazel/FakeBuildResultHelperBep.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/bazel/FakeBuildResultHelperBep.java
@@ -17,6 +17,8 @@ package com.google.idea.blaze.base.bazel;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Interner;
+import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos;
+import com.google.idea.blaze.base.command.buildresult.BuildEventStreamProvider;
 import com.google.idea.blaze.base.command.buildresult.BuildFlags;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
 import com.google.idea.blaze.base.command.buildresult.ParsedBepOutput;
@@ -49,8 +51,36 @@ public final class FakeBuildResultHelperBep implements BuildResultHelper {
     return ImmutableList.of();
   }
 
+
   @Override
-  public ParsedBepOutput getBuildOutput(Optional<String> completedBuildId, Interner<String> stringInterner)
+  public BuildEventStreamProvider getBepStream(Optional<String> completionBuildId)
+    throws GetArtifactsException {
+    return new BuildEventStreamProvider() {
+      @Override
+      public Object getId() {
+        return Optional.empty();
+      }
+
+      @Nullable
+      @Override
+      public BuildEventStreamProtos.BuildEvent getNext() throws BuildEventStreamException {
+        return null;
+      }
+
+      @Override
+      public long getBytesConsumed() {
+        return 0;
+      }
+
+      @Override
+      public void close() {
+
+      }
+    };
+  }
+
+  @Override
+  public ParsedBepOutput getBuildOutput(BuildEventStreamProvider bepStream, Interner<String> stringInterner)
       throws GetArtifactsException {
     if (parsedBepOutput == null) {
       throw new GetArtifactsException("Could not get artifacts from null bep");
@@ -60,12 +90,12 @@ public final class FakeBuildResultHelperBep implements BuildResultHelper {
   }
 
   @Override
-  public BlazeTestResults getTestResults(Optional<String> completedBuildId) {
+  public BlazeTestResults getTestResults(BuildEventStreamProvider bepStream) {
     return BlazeTestResults.NO_RESULTS;
   }
 
   @Override
-  public BuildFlags getBlazeFlags(Optional<String> completedBuildId) throws GetFlagsException {
+  public BuildFlags getBlazeFlags(BuildEventStreamProvider bepStream) throws GetFlagsException {
     return new BuildFlags(startupOptions.build(), cmdlineOptions.build());
   }
 

--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrRunConfigurationRunner.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrRunConfigurationRunner.java
@@ -166,10 +166,10 @@ public class BlazeCidrRunConfigurationRunner implements BlazeCommandRunConfigura
         throw new ExecutionException(e);
       }
       List<File> candidateFiles;
-      try {
+      try (final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {
         candidateFiles =
             LocalFileArtifact.getLocalFiles(
-                    buildResultHelper.getBuildOutput(Optional.empty(), Interners.STRING)
+                    buildResultHelper.getBuildOutput(bepStream, Interners.STRING)
                         .getDirectArtifactsForTarget(target, file -> true))
                 .stream()
                 .filter(File::canExecute)

--- a/golang/src/com/google/idea/blaze/golang/run/BlazeGoRunConfigurationRunner.java
+++ b/golang/src/com/google/idea/blaze/golang/run/BlazeGoRunConfigurationRunner.java
@@ -368,10 +368,10 @@ public class BlazeGoRunConfigurationRunner implements BlazeCommandRunConfigurati
         return parseScriptPathFile(workspaceRoot, blazeInfo.getExecutionRoot(), scriptPath.get());
       } else {
         List<File> candidateFiles;
-        try {
+        try (final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {
           candidateFiles =
               LocalFileArtifact.getLocalFiles(
-                      buildResultHelper.getBuildOutput(Optional.empty(), Interners.STRING)
+                      buildResultHelper.getBuildOutput(bepStream, Interners.STRING)
                           .getDirectArtifactsForTarget(label, file -> true))
                   .stream()
                   .filter(File::canExecute)

--- a/java/src/com/google/idea/blaze/java/run/hotswap/ClassFileManifestBuilder.java
+++ b/java/src/com/google/idea/blaze/java/run/hotswap/ClassFileManifestBuilder.java
@@ -132,10 +132,10 @@ public class ClassFileManifestBuilder {
         throw new ExecutionException(e);
       }
       ImmutableList<File> jars;
-      try {
+      try(final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {
         jars =
             LocalFileArtifact.getLocalFiles(
-                buildResultHelper.getBuildOutput(Optional.empty(), Interners.STRING)
+                buildResultHelper.getBuildOutput(bepStream, Interners.STRING)
                   .getOutputGroupArtifacts(JavaClasspathAspectStrategy.OUTPUT_GROUP, file -> true))
                 .stream()
                 .filter(f -> f.getName().endsWith(".jar"))

--- a/python/src/com/google/idea/blaze/python/run/BlazePyRunConfigurationRunner.java
+++ b/python/src/com/google/idea/blaze/python/run/BlazePyRunConfigurationRunner.java
@@ -341,10 +341,10 @@ public class BlazePyRunConfigurationRunner implements BlazeCommandRunConfigurati
         throw new ExecutionException(e);
       }
       List<File> candidateFiles;
-      try {
+      try(final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {
         candidateFiles =
             LocalFileArtifact.getLocalFiles(
-                buildResultHelper.getBuildOutput(Optional.empty(), Interners.STRING)
+                buildResultHelper.getBuildOutput(bepStream, Interners.STRING)
                   .getDirectArtifactsForTarget(target, file -> true).asList())
                 .stream()
                 .filter(File::canExecute)

--- a/scala/src/com/google/idea/blaze/scala/run/producers/GenerateDeployableJarTaskProvider.java
+++ b/scala/src/com/google/idea/blaze/scala/run/producers/GenerateDeployableJarTaskProvider.java
@@ -187,11 +187,14 @@ class GenerateDeployableJarTaskProvider
         throw new ExecutionException(e);
       }
 
-      List<File> outputs =
-          LocalFileArtifact.getLocalFiles(
-              buildResultHelper.getBuildOutput(Optional.empty(), Interners.STRING)
-                  .getDirectArtifactsForTarget(
-                      target.withTargetName(target.targetName() + "_deploy.jar"), file -> true));
+      List<File> outputs;
+      try (final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {
+        outputs = LocalFileArtifact.getLocalFiles(
+            buildResultHelper.getBuildOutput(bepStream, Interners.STRING)
+                .getDirectArtifactsForTarget(
+                    target.withTargetName(target.targetName() + "_deploy.jar"), file -> true));
+      }
+
       if (outputs.isEmpty()) {
         throw new ExecutionException(
             String.format("Failed to find deployable jar when building %s", target));


### PR DESCRIPTION
Cherry pick AOSP commit [47436ebddcad73d6a5d4bf1d8ab8a8ccbe1c2235](https://cs.android.com/android-studio/platform/tools/adt/idea/+/47436ebddcad73d6a5d4bf1d8ab8a8ccbe1c2235).

Separate BEP fetching and parsing

This is to enable independent changes to both processes.

1. Introduce a `BuildResultHelper.getBepStream()` method that knows
   how to get a BEP stream. Each `BuildResultHelper` gets its own
   implementation.

2. Re-implement other methods like `getBuildOutput()` to operate on
   externally supplied `BuildEventStreamProvider`. These methods should
   not eventually depend on a specific implementation of
   `BuildResultHelper` and will be moved out soon.

3. Update tests accordingly.

Bug: n/a
Test: existing
Change-Id: I48f6cf5d19889e60c6795c1b097243cd7006c686

AOSP: 47436ebddcad73d6a5d4bf1d8ab8a8ccbe1c2235
