### PR TITLE
[AOSP-pick] Do not instantiate empty labels

### DIFF
--- a/querysync/java/com/google/idea/blaze/qsync/query/QuerySummary.java
+++ b/querysync/java/com/google/idea/blaze/qsync/query/QuerySummary.java
@@ -335,13 +335,17 @@ public abstract class QuerySummary {
               rule.addAllHdrs(indexer.indexStringsAsLabels(a.getStringListValueList()));
             } else if (attributeIsTrackedDependency(attributeName, target)) {
               if (a.hasStringValue()) {
-                rule.addDeps(indexer.indexLabel(Label.of(a.getStringValue())));
+                if (!a.getStringValue().isEmpty()) {
+                  rule.addDeps(indexer.indexLabel(Label.of(a.getStringValue())));
+                }
               } else {
                 rule.addAllDeps(indexer.indexStringsAsLabels(a.getStringListValueList()));
               }
             } else if (RUNTIME_DEP_ATTRIBUTES.contains(attributeName)) {
               if (a.hasStringValue()) {
-                rule.addRuntimeDeps(indexer.indexLabel(Label.of(a.getStringValue())));
+                if (!a.getStringValue().isEmpty()) {
+                  rule.addRuntimeDeps(indexer.indexLabel(Label.of(a.getStringValue())));
+                }
               } else {
                 rule.addAllRuntimeDeps(indexer.indexStringsAsLabels(a.getStringListValueList()));
               }

--- a/shared/java/com/google/idea/blaze/common/Label.java
+++ b/shared/java/com/google/idea/blaze/common/Label.java
@@ -39,13 +39,14 @@ public record Label(String workspace, String buildPackage, String name) {
   public final static String ROOT_WORKSPACE = "";
 
   public static Label of(String label) {
+    Preconditions.checkArgument(!label.isBlank(), "Empty label");
     final var workspacePosition = label.startsWith("@") ? (label.startsWith("@@") ? 2 : 1) : 0;
     final var workspaceEnd = label.indexOf("//", workspacePosition);
     final var buildPackagePosition =  workspaceEnd + 2;
-    Preconditions.checkArgument(buildPackagePosition >= 2);
+    Preconditions.checkArgument(buildPackagePosition >= 2, "Invalid label: " + label);
     final var buildPackageEnd = label.indexOf(":", buildPackagePosition);
     final var namePosition = buildPackageEnd + 1;
-    Preconditions.checkArgument(namePosition >= 1);
+    Preconditions.checkArgument(namePosition >= 1, "Invalid label: " + label);
 
     final var workspace = label.substring(workspacePosition, workspaceEnd);
     final var buildPackage = label.substring(buildPackagePosition, buildPackageEnd);

--- a/shared/javatests/com/google/idea/blaze/common/LabelTest.java
+++ b/shared/javatests/com/google/idea/blaze/common/LabelTest.java
@@ -85,6 +85,11 @@ public class LabelTest {
   }
 
   @Test
+  public void testNew_empty() {
+    assertThrows(IllegalArgumentException.class, () -> Label.of(""));
+  }
+
+  @Test
   public void testNew_badPackage() {
     assertThrows(IllegalArgumentException.class, () -> Label.of("package/path:rule"));
   }


### PR DESCRIPTION
Cherry pick AOSP commit [ac4b2a16dcabf514cc200d6a5b802cb170ab7482](https://cs.android.com/android-studio/platform/tools/adt/idea/+/ac4b2a16dcabf514cc200d6a5b802cb170ab7482).

Skip empty attributes as empty labels cannot be created.

Bug: 380927265
Test: n/a (To be added separately as it requires some preparation)
Change-Id: I3f43f9ae18d6953129fa2c65f14844e3472f9352

AOSP: ac4b2a16dcabf514cc200d6a5b802cb170ab7482
