### PR TITLE
[AOSP-pick] [querysync] Do not scan Bazel system directories for BUILD files

### DIFF
--- a/base/src/com/google/idea/blaze/base/qsync/ProjectLoader.java
+++ b/base/src/com/google/idea/blaze/base/qsync/ProjectLoader.java
@@ -126,12 +126,14 @@ public class ProjectLoader {
             .collect(ImmutableSet.toImmutableSet());
 
     ProjectDefinition latestProjectDef =
-        ProjectDefinition.create(
-            importRoots.rootPaths(),
-            importRoots.excludePaths(),
-            LanguageClasses.toQuerySync(workspaceLanguageSettings.getActiveLanguages()),
-            testSourceGlobs,
-            importRoots.systemExcludes());
+        ProjectDefinition.builder()
+            .setProjectIncludes(importRoots.rootPaths())
+            .setProjectExcludes(importRoots.excludePaths())
+            .setLanguageClasses(
+                LanguageClasses.toQuerySync(workspaceLanguageSettings.getActiveLanguages()))
+            .setTestSources(testSourceGlobs)
+            .setSystemExcludes(importRoots.systemExcludes())
+            .build();
 
     Path snapshotFilePath = getSnapshotFilePath(importSettings);
 

--- a/base/src/com/google/idea/blaze/base/qsync/QuerySyncProject.java
+++ b/base/src/com/google/idea/blaze/base/qsync/QuerySyncProject.java
@@ -484,12 +484,14 @@ public class QuerySyncProject {
             .map(Glob::toString)
             .collect(ImmutableSet.toImmutableSet());
     ProjectDefinition projectDefinition =
-        ProjectDefinition.create(
-            importRoots.rootPaths(),
-            importRoots.excludePaths(),
-            LanguageClasses.toQuerySync(workspaceLanguageSettings.getActiveLanguages()),
-            testSourceGlobs,
-            importRoots.systemExcludes());
+        ProjectDefinition.builder()
+            .setProjectIncludes(importRoots.rootPaths())
+            .setProjectExcludes(importRoots.excludePaths())
+            .setLanguageClasses(
+                LanguageClasses.toQuerySync(workspaceLanguageSettings.getActiveLanguages()))
+            .setTestSources(testSourceGlobs)
+            .setSystemExcludes(importRoots.systemExcludes())
+            .build();
 
     return this.projectDefinition.equals(projectDefinition);
   }

--- a/querysync/java/com/google/idea/blaze/qsync/project/PostQuerySyncData.java
+++ b/querysync/java/com/google/idea/blaze/qsync/project/PostQuerySyncData.java
@@ -37,13 +37,7 @@ public abstract class PostQuerySyncData {
   @VisibleForTesting
   public static final PostQuerySyncData EMPTY =
       builder()
-          .setProjectDefinition(
-              ProjectDefinition.create(
-                  /* includes= */ ImmutableSet.of(),
-                  /* excludes= */ ImmutableSet.of(),
-                  /* languageClasses= */ ImmutableSet.of(),
-                  /* testSources= */ ImmutableSet.of(),
-                  /* systemExcludes= */ ImmutableSet.of()))
+          .setProjectDefinition(ProjectDefinition.EMPTY)
           .setVcsState(Optional.empty())
           .setBazelVersion(Optional.empty())
           .setQuerySummary(QuerySummary.EMPTY)

--- a/querysync/java/com/google/idea/blaze/qsync/project/SnapshotDeserializer.java
+++ b/querysync/java/com/google/idea/blaze/qsync/project/SnapshotDeserializer.java
@@ -70,12 +70,16 @@ public class SnapshotDeserializer {
 
   private void visitProjectDefinition(SnapshotProto.ProjectDefinition proto) {
     snapshot.setProjectDefinition(
-        ProjectDefinition.create(
-            proto.getIncludePathsList().stream().map(Path::of).collect(toImmutableSet()),
-            proto.getExcludePathsList().stream().map(Path::of).collect(toImmutableSet()),
-            QuerySyncLanguage.fromProtoList(proto.getLanguageClassesList()),
-            ImmutableSet.copyOf(proto.getTestSourcesList()),
-            ImmutableSet.copyOf(proto.getSystemExcludesList())));
+        ProjectDefinition.builder()
+            .setProjectIncludes(
+                proto.getIncludePathsList().stream().map(Path::of).collect(toImmutableSet()))
+            .setProjectExcludes(
+                proto.getExcludePathsList().stream().map(Path::of).collect(toImmutableSet()))
+            .setLanguageClasses(QuerySyncLanguage.fromProtoList(proto.getLanguageClassesList()))
+            .setTestSources(ImmutableSet.copyOf(proto.getTestSourcesList()))
+            .setSystemExcludes(
+                proto.getSystemExcludesList().stream().map(Path::of).collect(toImmutableSet()))
+            .build());
   }
 
   private void visitVcsState(SnapshotProto.VcsState proto) {

--- a/querysync/java/com/google/idea/blaze/qsync/project/snapshot.proto
+++ b/querysync/java/com/google/idea/blaze/qsync/project/snapshot.proto
@@ -22,6 +22,7 @@ message ProjectDefinition {
   repeated string exclude_paths = 2;
   repeated LanguageClass language_classes = 3;
   repeated string test_sources = 4;
+  // TODO(b/382333575): improve excluding system folders
   repeated string system_excludes = 5;
 }
 

--- a/querysync/javatests/com/google/idea/blaze/qsync/GraphToProjectConverters.java
+++ b/querysync/javatests/com/google/idea/blaze/qsync/GraphToProjectConverters.java
@@ -43,7 +43,7 @@ abstract class GraphToProjectConverters {
 
   public abstract ImmutableSet<String> testSources();
 
-  public abstract ImmutableSet<String> systemExcludes();
+  public abstract ImmutableSet<Path> systemExcludes();
 
   static Builder builder() {
     return new AutoValue_GraphToProjectConverters.Builder()
@@ -70,7 +70,7 @@ abstract class GraphToProjectConverters {
 
     abstract Builder setTestSources(ImmutableSet<String> value);
 
-    abstract Builder setSystemExcludes(ImmutableSet<String> value);
+    abstract Builder setSystemExcludes(ImmutableSet<Path> value);
 
     abstract GraphToProjectConverters autoBuild();
 
@@ -80,12 +80,13 @@ abstract class GraphToProjectConverters {
           info.packageReader(),
           info.fileExistenceCheck(),
           NOOP_CONTEXT,
-          ProjectDefinition.create(
-              info.projectIncludes(),
-              info.projectExcludes(),
-              info.languageClasses(),
-              info.testSources(),
-              info.systemExcludes()),
+          ProjectDefinition.builder()
+              .setProjectIncludes(info.projectIncludes())
+              .setProjectExcludes(info.projectExcludes())
+              .setLanguageClasses(info.languageClasses())
+              .setTestSources(info.testSources())
+              .setSystemExcludes(info.systemExcludes())
+              .build(),
           newDirectExecutorService());
     }
   }

--- a/querysync/javatests/com/google/idea/blaze/qsync/ProjectRefresherTest.java
+++ b/querysync/javatests/com/google/idea/blaze/qsync/ProjectRefresherTest.java
@@ -184,12 +184,10 @@ public class ProjectRefresherTest {
                                 Operation.MODIFY, Path.of("package/path/BUILD"))),
                         Optional.empty())))
             .setProjectDefinition(
-                ProjectDefinition.create(
-                    ImmutableSet.of(Path.of("package")),
-                    ImmutableSet.of(),
-                    ImmutableSet.of(QuerySyncLanguage.JAVA),
-                    ImmutableSet.of(),
-                    ImmutableSet.of()))
+                ProjectDefinition.builder()
+                    .setProjectIncludes(ImmutableSet.of(Path.of("package")))
+                    .setLanguageClasses(ImmutableSet.of(QuerySyncLanguage.JAVA))
+                    .build())
             .setBazelVersion(Optional.of("1.0.0"))
             .build();
 
@@ -219,12 +217,10 @@ public class ProjectRefresherTest {
                             new WorkspaceFileChange(Operation.ADD, Path.of("package/path/BUILD"))),
                         Optional.empty())))
             .setProjectDefinition(
-                ProjectDefinition.create(
-                    ImmutableSet.of(Path.of("package")),
-                    ImmutableSet.of(),
-                    ImmutableSet.of(QuerySyncLanguage.JAVA),
-                    ImmutableSet.of(),
-                    ImmutableSet.of()))
+                ProjectDefinition.builder()
+                    .setProjectIncludes(ImmutableSet.of(Path.of("package")))
+                    .setLanguageClasses(ImmutableSet.of(QuerySyncLanguage.JAVA))
+                    .build())
             .build();
 
     RefreshOperation update =
@@ -256,12 +252,10 @@ public class ProjectRefresherTest {
                                 Operation.DELETE, Path.of("package/path/BUILD"))),
                         Optional.empty())))
             .setProjectDefinition(
-                ProjectDefinition.create(
-                    ImmutableSet.of(Path.of("package")),
-                    ImmutableSet.of(),
-                    ImmutableSet.of(QuerySyncLanguage.JAVA),
-                    ImmutableSet.of(),
-                    ImmutableSet.of()))
+                ProjectDefinition.builder()
+                    .setProjectIncludes(ImmutableSet.of(Path.of("package")))
+                    .setLanguageClasses(ImmutableSet.of(QuerySyncLanguage.JAVA))
+                    .build())
             .build();
 
     RefreshOperation update =
@@ -289,12 +283,10 @@ public class ProjectRefresherTest {
             .setVcsState(
                 Optional.of(new VcsState("workspaceId", "1", workingSet, Optional.empty())))
             .setProjectDefinition(
-                ProjectDefinition.create(
-                    ImmutableSet.of(Path.of("package")),
-                    ImmutableSet.of(),
-                    ImmutableSet.of(QuerySyncLanguage.JAVA),
-                    ImmutableSet.of(),
-                    ImmutableSet.of()))
+                ProjectDefinition.builder()
+                    .setProjectIncludes(ImmutableSet.of(Path.of("package")))
+                    .setLanguageClasses(ImmutableSet.of(QuerySyncLanguage.JAVA))
+                    .build())
             .build();
 
     RefreshOperation update =
@@ -324,12 +316,10 @@ public class ProjectRefresherTest {
             .setVcsState(
                 Optional.of(new VcsState("workspaceId", "1", workingSet, Optional.empty())))
             .setProjectDefinition(
-                ProjectDefinition.create(
-                    ImmutableSet.of(Path.of("package")),
-                    ImmutableSet.of(),
-                    ImmutableSet.of(QuerySyncLanguage.JAVA),
-                    ImmutableSet.of(),
-                    ImmutableSet.of()))
+                ProjectDefinition.builder()
+                    .setProjectIncludes(ImmutableSet.of(Path.of("package")))
+                    .setLanguageClasses(ImmutableSet.of(QuerySyncLanguage.JAVA))
+                    .build())
             .build();
 
     RefreshOperation update =
@@ -359,12 +349,10 @@ public class ProjectRefresherTest {
                                 Operation.MODIFY, Path.of("package/path/BUILD"))),
                         Optional.empty())))
             .setProjectDefinition(
-                ProjectDefinition.create(
-                    ImmutableSet.of(Path.of("package")),
-                    ImmutableSet.of(),
-                    ImmutableSet.of(QuerySyncLanguage.JAVA),
-                    ImmutableSet.of(),
-                    ImmutableSet.of()))
+                ProjectDefinition.builder()
+                    .setProjectIncludes(ImmutableSet.of(Path.of("package")))
+                    .setLanguageClasses(ImmutableSet.of(QuerySyncLanguage.JAVA))
+                    .build())
             .build();
 
     RefreshOperation update =

--- a/querysync/javatests/com/google/idea/blaze/qsync/TestDataSyncRunner.java
+++ b/querysync/javatests/com/google/idea/blaze/qsync/TestDataSyncRunner.java
@@ -53,12 +53,9 @@ public class TestDataSyncRunner {
 
   public QuerySyncProjectSnapshot sync(TestData testProject) throws IOException, BuildException {
     ProjectDefinition projectDefinition =
-        ProjectDefinition.create(
-            /* includes= */ ImmutableSet.copyOf(testProject.getRelativeSourcePaths()),
-            /* excludes= */ ImmutableSet.of(),
-            /* languageClasses= */ ImmutableSet.of(),
-            /* testSources= */ ImmutableSet.of(),
-            /* systemExcludes= */ ImmutableSet.of());
+        ProjectDefinition.builder()
+        .setProjectIncludes(ImmutableSet.copyOf(testProject.getRelativeSourcePaths()))
+        .build();
     QuerySummary querySummary = adaptQuerySummaryDueToABazelBug(getQuerySummary(testProject));
     PostQuerySyncData pqsd =
         PostQuerySyncData.builder()

--- a/querysync/javatests/com/google/idea/blaze/qsync/project/ProjectDefinitionTest.java
+++ b/querysync/javatests/com/google/idea/blaze/qsync/project/ProjectDefinitionTest.java
@@ -29,12 +29,9 @@ public class ProjectDefinitionTest {
   @Test
   public void testGetIncludingContentRoot_returnsContentRoot() {
     ProjectDefinition projectDefinition =
-        ProjectDefinition.create(
-            ImmutableSet.of(Path.of("contentroot1"), Path.of("contentroot2")),
-            ImmutableSet.of(),
-            ImmutableSet.of(),
-            ImmutableSet.of(),
-            ImmutableSet.of());
+        ProjectDefinition.builder()
+            .setProjectIncludes(ImmutableSet.of(Path.of("contentroot1"), Path.of("contentroot2")))
+            .build();
     assertThat(projectDefinition.getIncludingContentRoot(Path.of("contentroot1/some/path")))
         .hasValue(Path.of("contentroot1"));
     assertThat(projectDefinition.getIncludingContentRoot(Path.of("contentroot2")))
@@ -44,12 +41,9 @@ public class ProjectDefinitionTest {
   @Test
   public void testGetIncludingContentRoot_externalPath_returnsEmpty() {
     ProjectDefinition projectDefinition =
-        ProjectDefinition.create(
-            ImmutableSet.of(Path.of("contentroot1"), Path.of("contentroot2")),
-            ImmutableSet.of(),
-            ImmutableSet.of(),
-            ImmutableSet.of(),
-            ImmutableSet.of());
+        ProjectDefinition.builder()
+            .setProjectIncludes(ImmutableSet.of(Path.of("contentroot1"), Path.of("contentroot2")))
+            .build();
     assertThat(projectDefinition.getIncludingContentRoot(Path.of("anotherRoot/some/path")))
         .isEmpty();
   }
@@ -57,12 +51,10 @@ public class ProjectDefinitionTest {
   @Test
   public void testGetIncludingContentRoot_excludedPath_returnsEmpty() {
     ProjectDefinition projectDefinition =
-        ProjectDefinition.create(
-            ImmutableSet.of(Path.of("contentroot1"), Path.of("contentroot2")),
-            ImmutableSet.of(Path.of("contentroot1/excluded")),
-            ImmutableSet.of(),
-            ImmutableSet.of(),
-            ImmutableSet.of());
+        ProjectDefinition.builder()
+        .setProjectIncludes(ImmutableSet.of(Path.of("contentroot1"), Path.of("contentroot2")))
+        .setProjectExcludes(ImmutableSet.of(Path.of("contentroot1/excluded")))
+        .build();
     assertThat(projectDefinition.getIncludingContentRoot(Path.of("contentroot1/excluded/path")))
         .isEmpty();
   }

--- a/querysync/javatests/com/google/idea/blaze/qsync/project/SnapshotSerializationTest.java
+++ b/querysync/javatests/com/google/idea/blaze/qsync/project/SnapshotSerializationTest.java
@@ -42,12 +42,13 @@ public class SnapshotSerializationTest {
     PostQuerySyncData original =
         PostQuerySyncData.builder()
             .setProjectDefinition(
-                ProjectDefinition.create(
-                    ImmutableSet.of(Path.of("project/path")),
-                    ImmutableSet.of(Path.of("project/path/excluded")),
-                    ImmutableSet.of(QuerySyncLanguage.JAVA),
-                    ImmutableSet.of("javatests/*"),
-                    ImmutableSet.of()))
+                ProjectDefinition
+                    .builder()
+                    .setProjectIncludes(ImmutableSet.of(Path.of("project/path")))
+                    .setProjectExcludes(ImmutableSet.of(Path.of("project/path/excluded")))
+                    .setLanguageClasses(ImmutableSet.of(QuerySyncLanguage.JAVA))
+                    .setTestSources(ImmutableSet.of("javatests/*"))
+                    .build())
             .setVcsState(
                 Optional.of(
                     new VcsState(
@@ -74,9 +75,7 @@ public class SnapshotSerializationTest {
   public void testSerialization_withVcsState_including_workspaceSnapshot() throws IOException {
     PostQuerySyncData original =
         PostQuerySyncData.builder()
-            .setProjectDefinition(
-                ProjectDefinition.create(
-                    ImmutableSet.of(), ImmutableSet.of(), ImmutableSet.of(), ImmutableSet.of(), ImmutableSet.of()))
+            .setProjectDefinition(ProjectDefinition.EMPTY)
             .setVcsState(
                 Optional.of(
                     new VcsState(
@@ -101,12 +100,13 @@ public class SnapshotSerializationTest {
     PostQuerySyncData original =
         PostQuerySyncData.builder()
             .setProjectDefinition(
-                ProjectDefinition.create(
-                    ImmutableSet.of(Path.of("project/path")),
-                    ImmutableSet.of(Path.of("project/path/excluded")),
-                    ImmutableSet.of(QuerySyncLanguage.JAVA),
-                    ImmutableSet.of("javatests/*"),
-                    ImmutableSet.of()))
+                ProjectDefinition
+                    .builder()
+                    .setProjectIncludes(ImmutableSet.of(Path.of("project/path")))
+                    .setProjectExcludes(ImmutableSet.of(Path.of("project/path/excluded")))
+                    .setLanguageClasses(ImmutableSet.of(QuerySyncLanguage.JAVA))
+                    .setTestSources(ImmutableSet.of("javatests/*"))
+                    .build())
             .setVcsState(Optional.empty())
             .setQuerySummary(QuerySummaryTestUtil.createProtoForPackages("//project/path:path"))
             .build();
@@ -125,12 +125,13 @@ public class SnapshotSerializationTest {
     PostQuerySyncData original =
         PostQuerySyncData.builder()
             .setProjectDefinition(
-                ProjectDefinition.create(
-                    ImmutableSet.of(Path.of("project/path")),
-                    ImmutableSet.of(Path.of("project/path/excluded")),
-                    ImmutableSet.of(QuerySyncLanguage.JAVA),
-                    ImmutableSet.of("javatests/*"),
-                    ImmutableSet.of()))
+                ProjectDefinition
+                    .builder()
+                    .setProjectIncludes(ImmutableSet.of(Path.of("project/path")))
+                    .setProjectExcludes(ImmutableSet.of(Path.of("project/path/excluded")))
+                    .setLanguageClasses(ImmutableSet.of(QuerySyncLanguage.JAVA))
+                    .setTestSources(ImmutableSet.of("javatests/*"))
+                    .build())
             .setVcsState(Optional.empty())
             .setQuerySummary(QuerySummaryTestUtil.createProtoForPackages("//project/path:path"))
             .build();

--- a/querysync/javatests/com/google/idea/blaze/qsync/testdata/ProjectProtos.java
+++ b/querysync/javatests/com/google/idea/blaze/qsync/testdata/ProjectProtos.java
@@ -46,12 +46,10 @@ public class ProjectProtos {
             EMPTY_PACKAGE_READER,
             Predicates.alwaysTrue(),
             NOOP_CONTEXT,
-            ProjectDefinition.create(
-                ImmutableSet.of(workspaceImportDirectory),
-                ImmutableSet.of(),
-                ImmutableSet.of(QuerySyncLanguage.JAVA),
-                ImmutableSet.of(),
-                ImmutableSet.of()),
+            ProjectDefinition.builder()
+                .setProjectIncludes(ImmutableSet.of(workspaceImportDirectory))
+                .setLanguageClasses(ImmutableSet.of(QuerySyncLanguage.JAVA))
+                .build(),
             newDirectExecutorService());
     return converter.createProject(BuildGraphs.forTestProject(project));
   }


### PR DESCRIPTION
Cherry pick AOSP commit [f57818820af2d29c97334904bc4b643511b4d711](https://cs.android.com/android-studio/platform/tools/adt/idea/+/f57818820af2d29c97334904bc4b643511b4d711).

these folders should be excluded and scanning them for BUILD files slows down the initial import step

Change-Id: Id2587b18ee38a7d4f99b7b9b8b88e7584e261a8f
Bug: 309706901
Tests: presubmits

AOSP: f57818820af2d29c97334904bc4b643511b4d711
