### PR TITLE
[AOSP-pick] Rename sync… to requestSync…

### DIFF
--- a/aswb/src/com/google/idea/blaze/android/projectsystem/BlazeProjectSystemSyncManager.java
+++ b/aswb/src/com/google/idea/blaze/android/projectsystem/BlazeProjectSystemSyncManager.java
@@ -58,7 +58,7 @@ public class BlazeProjectSystemSyncManager implements ProjectSystemSyncManager {
   }
 
   @Override
-  public ListenableFuture<SyncResult> syncProject(ProjectSystemSyncManager.SyncReason reason) {
+  public ListenableFuture<SyncResult> requestSyncProject(ProjectSystemSyncManager.SyncReason reason) {
     SettableFuture<ProjectSystemSyncManager.SyncResult> syncResult = SettableFuture.create();
 
     if (BlazeSyncStatus.getInstance(project).syncInProgress()) {


### PR DESCRIPTION
Cherry pick AOSP commit [5aceb86f37066f0fbc388e4dda8505fa75dd4b41](https://cs.android.com/android-studio/platform/tools/adt/idea/+/5aceb86f37066f0fbc388e4dda8505fa75dd4b41).

This method does not perform the sync, but schedules
a sync request until it is possible.

Once experimental feature of 'Auto sync' disabling implemented,
this will be a convenient moment to skip such sync request in favor
of showing a notification.

Bug: N/A
Test: N/A
Change-Id: If01f8ac2ba234bbb20701cbfc07c1da34f6c9eb1

AOSP: 5aceb86f37066f0fbc388e4dda8505fa75dd4b41
