### PR TITLE
WIP - Unrecognized attribute regression with bazel 8 

### DIFF
--- a/base/src/com/google/idea/blaze/base/lang/buildfile/validation/BuiltInRuleAnnotator.java
+++ b/base/src/com/google/idea/blaze/base/lang/buildfile/validation/BuiltInRuleAnnotator.java
@@ -63,8 +63,6 @@ public class BuiltInRuleAnnotator extends BuildAnnotator {
       }
       AttributeDefinition attribute = rule.getAttribute(name);
       if (attribute == null) {
-        markError(
-            arg, String.format("Unrecognized attribute '%s' for rule type '%s'", name, ruleName));
         continue;
       }
       missingAttributes.remove(name);

--- a/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/validation/BuiltInRuleAnnotatorTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/validation/BuiltInRuleAnnotatorTest.java
@@ -284,24 +284,6 @@ public class BuiltInRuleAnnotatorTest extends BuildFileIntegrationTestCase {
     assertNoErrors(file);
   }
 
-  @Test
-  public void testNoMissingAttributeErrorsForOverriddenBuiltIns() {
-    specProvider.setRules(ImmutableMap.of(JAVA_TEST.getName(), JAVA_TEST));
-    BuildFile file =
-        createBuildFile(
-            new WorkspacePath("java/com/foo/BUILD"),
-            "java_test(name = 'test', srcs = [':src'], extra_arg = [])");
-    assertHasError(file, "Unrecognized attribute 'extra_arg' for rule type 'java_test'");
-
-    file =
-        createBuildFile(
-            new WorkspacePath("java/com/bar/BUILD"),
-            "def java_test(srcs=[], **kwargs, extra_arg=[]):",
-            "  native.java_test(srcs = srcs, **kwargs)",
-            "java_test(name = 'test', srcs = [':src'], extra_arg = [])");
-    assertNoErrors(file);
-  }
-
   private void setRules(String... ruleNames) {
     ImmutableMap.Builder<String, RuleDefinition> rules = ImmutableMap.builder();
     for (String name : ruleNames) {


### PR DESCRIPTION
Drop unrecognized attribute inspection. ~~I have never seen a real issue found by this inspection, let's just drop it?~~ Seems like a regression, maybe we can fix the regression, I would like to investigate a bit further.

<img width="607" alt="Screenshot 2025-01-23 at 11 14 21 AM" src="https://github.com/user-attachments/assets/6473d614-7187-48f8-baaf-04058a269589" />
