### PR TITLE
make label parsing more resilient

### DIFF
--- a/base/src/com/google/idea/blaze/base/dependencies/TargetInfo.java
+++ b/base/src/com/google/idea/blaze/base/dependencies/TargetInfo.java
@@ -22,6 +22,7 @@ import com.google.idea.blaze.base.model.primitives.Kind;
 import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.model.primitives.RuleType;
 import com.google.idea.blaze.common.BuildTarget;
+import com.intellij.openapi.diagnostic.Logger;
 import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
@@ -32,6 +33,9 @@ import javax.annotation.Nullable;
  * output, and the per-target data provided by a global dependency index.
  */
 public class TargetInfo {
+
+  private static final Logger LOG = Logger.getInstance(TargetInfo.class);
+
   public final Label label;
   public final String kindString;
   @Nullable public final TestSize testSize;
@@ -169,5 +173,17 @@ public class TargetInfo {
   public static TargetInfo fromBuildTarget(BuildTarget buildTarget) {
     return TargetInfo.builder(Label.create(buildTarget.label().toString()), buildTarget.kind())
         .build();
+  }
+
+  public static @Nullable TargetInfo tryFromBuildTarget(BuildTarget buildTarget) {
+    final var label = buildTarget.label().toString();
+    final var error = Label.validate(label);
+
+    if (error != null) {
+      LOG.warn(String.format("invalid label '%s': %s'", label, error));
+      return null;
+    }
+
+    return TargetInfo.builder(Label.create(buildTarget.label().toString()), buildTarget.kind()).build();
   }
 }

--- a/base/src/com/google/idea/blaze/base/qsync/QuerySyncProjectData.java
+++ b/base/src/com/google/idea/blaze/base/qsync/QuerySyncProjectData.java
@@ -37,6 +37,7 @@ import com.google.idea.blaze.qsync.project.QuerySyncLanguage;
 import com.intellij.openapi.diagnostic.Logger;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.Optional;
 import org.jetbrains.annotations.Nullable;
 
@@ -102,7 +103,8 @@ public class QuerySyncProjectData implements BlazeProjectData {
   public ImmutableList<TargetInfo> targets() {
     if (blazeProject.isPresent()) {
       return blazeProject.get().getTargetMap().values().stream()
-          .map(TargetInfo::fromBuildTarget)
+          .map(TargetInfo::tryFromBuildTarget)
+          .filter(Objects::nonNull)
           .collect(ImmutableList.toImmutableList());
     }
     return ImmutableList.of();


### PR DESCRIPTION
In some cases query sync might return some labels that cannot be validated later on. The actual fix would be to fix query sync to exclude these invalid labels; this just addresses the symptom.

