### PR TITLE
[AOSP-pick] Continue separating BEP fetching and parsing

### DIFF
--- a/aswb/src/com/google/idea/blaze/android/run/deployinfo/BlazeApkDeployInfoProtoHelper.java
+++ b/aswb/src/com/google/idea/blaze/android/run/deployinfo/BlazeApkDeployInfoProtoHelper.java
@@ -21,6 +21,7 @@ import com.google.devtools.build.lib.rules.android.deployinfo.AndroidDeployInfoO
 import com.google.devtools.build.lib.rules.android.deployinfo.AndroidDeployInfoOuterClass.Artifact;
 import com.google.idea.blaze.android.manifest.ManifestParser.ParsedManifest;
 import com.google.idea.blaze.android.manifest.ParsedManifestService;
+import com.google.idea.blaze.base.command.buildresult.BuildResultParser;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtifactsException;
 import com.google.idea.blaze.base.command.buildresult.LocalFileArtifact;
@@ -45,12 +46,12 @@ import java.util.stream.Stream;
  */
 public class BlazeApkDeployInfoProtoHelper {
   public AndroidDeployInfo readDeployInfoProtoForTarget(
-      Label target, BuildResultHelper buildResultHelper, Predicate<String> pathFilter)
+    Label target, BuildResultHelper buildResultHelper, Predicate<String> pathFilter)
       throws GetDeployInfoException {
     ImmutableList<OutputArtifact> outputArtifacts;
     ParsedBepOutput bepOutput;
     try (final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {
-      bepOutput = buildResultHelper.getBuildOutput(bepStream, Interners.STRING);
+      bepOutput = BuildResultParser.getBuildOutput(bepStream, Interners.STRING);
       outputArtifacts = bepOutput.getDirectArtifactsForTarget(target, pathFilter).asList();
     } catch (GetArtifactsException e) {
       throw new GetDeployInfoException(e.getMessage());

--- a/aswb/src/com/google/idea/blaze/android/run/test/BlazeAndroidTestLaunchTask.java
+++ b/aswb/src/com/google/idea/blaze/android/run/test/BlazeAndroidTestLaunchTask.java
@@ -25,6 +25,7 @@ import com.google.idea.blaze.base.async.process.LineProcessingOutputStream;
 import com.google.idea.blaze.base.command.BlazeCommand;
 import com.google.idea.blaze.base.command.BlazeCommandName;
 import com.google.idea.blaze.base.command.BlazeFlags;
+import com.google.idea.blaze.base.command.buildresult.BuildResultParser;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtifactsException;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelperBep;
@@ -213,7 +214,7 @@ public class BlazeAndroidTestLaunchTask implements BlazeLaunchTask {
                         } else {
                           try (final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {
                             testResultsHolder.setTestResults(
-                              buildResultHelper.getTestResults(bepStream));
+                              BuildResultParser.getTestResults(bepStream));
                           }
                         }
                         ListenableFuture<Void> unusedFuture =

--- a/base/src/com/google/idea/blaze/base/buildview/BazelExecService.kt
+++ b/base/src/com/google/idea/blaze/base/buildview/BazelExecService.kt
@@ -5,6 +5,7 @@ import com.google.idea.blaze.base.buildview.events.BuildEventParser
 import com.google.idea.blaze.base.command.BlazeCommand
 import com.google.idea.blaze.base.command.BlazeCommandName
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelperBep
+import com.google.idea.blaze.base.command.buildresult.BuildResultParser
 import com.google.idea.blaze.base.model.primitives.WorkspaceRoot
 import com.google.idea.blaze.base.scope.BlazeContext
 import com.google.idea.blaze.base.sync.aspects.BlazeBuildOutputs
@@ -191,7 +192,7 @@ class BazelExecService(private val project: Project) : Disposable {
       provider.getBepStream(Optional.empty()).use { bepStream ->
         BlazeBuildOutputs.fromParsedBepOutput(
           result,
-          provider.getBuildOutput(bepStream, Interners.STRING),
+          BuildResultParser.getBuildOutput(bepStream, Interners.STRING),
         )
       }
     }

--- a/base/src/com/google/idea/blaze/base/command/CommandLineBlazeCommandRunner.java
+++ b/base/src/com/google/idea/blaze/base/command/CommandLineBlazeCommandRunner.java
@@ -23,6 +23,7 @@ import com.google.idea.blaze.base.async.process.LineProcessingOutputStream;
 import com.google.idea.blaze.base.async.process.PrintOutputLineProcessor;
 import com.google.idea.blaze.base.bazel.BazelExitCodeException;
 import com.google.idea.blaze.base.bazel.BazelExitCodeException.ThrowOption;
+import com.google.idea.blaze.base.command.buildresult.BuildResultParser;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtifactsException;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelperBep;
@@ -96,7 +97,7 @@ public class CommandLineBlazeCommandRunner implements BlazeCommandRunner {
               .orElse(null);
       ParsedBepOutput buildOutput;
       try (final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {
-        buildOutput = buildResultHelper.getBuildOutput(bepStream, stringInterner);
+        buildOutput = BuildResultParser.getBuildOutput(bepStream, stringInterner);
       }
       context.output(PrintOutput.log("BEP outputs retrieved (%s).", StringUtilRt.formatFileSize(buildOutput.getBepBytesConsumed())));
       return BlazeBuildOutputs.fromParsedBepOutput(buildResult, buildOutput);
@@ -132,7 +133,7 @@ public class CommandLineBlazeCommandRunner implements BlazeCommandRunner {
     }
     context.output(PrintOutput.log("Build command finished. Retrieving BEP outputs..."));
     try(final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {
-      return buildResultHelper.getTestResults(bepStream);
+      return BuildResultParser.getTestResults(bepStream);
     } catch (GetArtifactsException e) {
       context.output(PrintOutput.log("Failed to get build outputs: " + e.getMessage()));
       context.setHasError();

--- a/base/src/com/google/idea/blaze/base/command/buildresult/BepArtifactData.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/BepArtifactData.java
@@ -25,7 +25,6 @@ import com.google.idea.blaze.common.artifact.OutputArtifact;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 /** All the relevant output data for a single {@link OutputArtifact}. */

--- a/base/src/com/google/idea/blaze/base/command/buildresult/BuildResultHelper.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/BuildResultHelper.java
@@ -15,11 +15,10 @@
  */
 package com.google.idea.blaze.base.command.buildresult;
 
-import com.google.common.collect.Interner;
 import com.google.errorprone.annotations.MustBeClosed;
-import com.google.idea.blaze.base.run.testlogs.BlazeTestResults;
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.exception.BuildException;
+import com.intellij.openapi.diagnostic.Logger;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Optional;
@@ -27,6 +26,7 @@ import java.util.function.Consumer;
 
 /** Assists in getting build artifacts from a build operation. */
 public interface BuildResultHelper extends AutoCloseable {
+  static final Logger logger = Logger.getInstance(BuildResultHelper.class);
 
   /**
    * Returns the build flags necessary for the build result helper to work.
@@ -42,31 +42,8 @@ public interface BuildResultHelper extends AutoCloseable {
   @MustBeClosed
   BuildEventStreamProvider getBepStream(Optional<String> completionBuildId) throws GetArtifactsException;
 
-  /**
-   * Parses the BEP stream and returns the corresponding {@link ParsedBepOutput}. May only be
-   * called once on a given stream.
-   *
-   * <p>As BEP retrieval can be memory-intensive for large projects, implementations of
-   * getBuildOutput may restrict parallelism for cases in which many builds are executed in parallel
-   * (e.g. remote builds).
-   */
-  ParsedBepOutput getBuildOutput(
-    BuildEventStreamProvider bepStream, Interner<String> stringInterner)
-      throws GetArtifactsException;
-
-  /**
-   * Parses BEP stream and returns the corresponding {@link BlazeTestResults}. May
-   * only be called once on a given stream.
-   */
-  BlazeTestResults getTestResults(BuildEventStreamProvider bepStream) throws GetArtifactsException;
-
   /** Deletes the local BEP output file associated with the test results */
   default void deleteTemporaryOutputFiles() {}
-
-  /**
-   * Parses the BEP stream and  collects all build flags used. Return all flags that pass filters
-   */
-  BuildFlags getBlazeFlags(BuildEventStreamProvider bepStream) throws GetFlagsException;
 
   /**
    * Parses the BEP output data to collect message on stdout.

--- a/base/src/com/google/idea/blaze/base/command/buildresult/BuildResultHelperBep.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/BuildResultHelperBep.java
@@ -15,6 +15,8 @@
  */
 package com.google.idea.blaze.base.command.buildresult;
 
+import static com.google.idea.blaze.base.command.buildresult.ParsedBepOutput.parseBepArtifacts;
+
 import com.google.common.collect.Interner;
 import com.google.idea.blaze.base.command.buildresult.BuildEventStreamProvider.BuildEventStreamException;
 import com.google.idea.blaze.base.run.testlogs.BlazeTestResults;
@@ -65,39 +67,9 @@ public class BuildResultHelperBep implements BuildResultHelper {
   }
 
   @Override
-  public ParsedBepOutput getBuildOutput(BuildEventStreamProvider bepStream, Interner<String> stringInterner)
-      throws GetArtifactsException {
-    try {
-      return ParsedBepOutput.parseBepArtifacts(bepStream, stringInterner);
-    } catch (BuildEventStreamException e) {
-      logger.error(e);
-      throw new GetArtifactsException(e.getMessage());
-    }
-  }
-
-  @Override
-  public BlazeTestResults getTestResults(BuildEventStreamProvider bepStream) {
-    try  {
-      return BuildEventProtocolOutputReader.parseTestResults(bepStream);
-    } catch (BuildEventStreamException e) {
-      logger.warn(e);
-      return BlazeTestResults.NO_RESULTS;
-    }
-  }
-
-  @Override
   public void deleteTemporaryOutputFiles() {
     if (!outputFile.delete()) {
       logger.warn("Could not delete BEP output file: " + outputFile);
-    }
-  }
-
-  @Override
-  public BuildFlags getBlazeFlags(BuildEventStreamProvider bepStream) throws GetFlagsException {
-    try {
-      return BuildFlags.parseBep(bepStream);
-    } catch (BuildEventStreamException e) {
-      throw new GetFlagsException(e);
     }
   }
 

--- a/base/src/com/google/idea/blaze/base/command/buildresult/BuildResultParser.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/BuildResultParser.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2024 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.command.buildresult;
+
+import com.google.common.collect.Interner;
+import com.google.idea.blaze.base.run.testlogs.BlazeTestResults;
+
+/**
+ * A utility class that knows how to collect data from {@link BuildEventStreamProvider} in a use case specific way.
+ */
+public final class BuildResultParser {
+  private BuildResultParser() { }
+
+  /**
+   * Parses the BEP stream and returns the corresponding {@link ParsedBepOutput}. May only be
+   * called once on a given stream.
+   *
+   * <p>As BEP retrieval can be memory-intensive for large projects, implementations of
+   * getBuildOutput may restrict parallelism for cases in which many builds are executed in parallel
+   * (e.g. remote builds).
+   */
+  public static ParsedBepOutput getBuildOutput(
+    BuildEventStreamProvider bepStream, Interner<String> stringInterner)
+    throws BuildResultHelper.GetArtifactsException {
+    try {
+      return ParsedBepOutput.parseBepArtifacts(bepStream, stringInterner);
+    } catch (BuildEventStreamProvider.BuildEventStreamException e) {
+      BuildResultHelper.logger.error(e);
+      throw new BuildResultHelper.GetArtifactsException(String.format(
+        "Failed to parse bep for build id: %s: %s", bepStream.getId(), e.getMessage()));
+    }
+  }
+
+  /**
+   * Parses BEP stream and returns the corresponding {@link BlazeTestResults}. May
+   * only be called once on a given stream.
+   */
+  public static BlazeTestResults getTestResults(BuildEventStreamProvider bepStream) throws BuildResultHelper.GetArtifactsException {
+    try  {
+      return BuildEventProtocolOutputReader.parseTestResults(bepStream);
+    } catch (BuildEventStreamProvider.BuildEventStreamException e) {
+      BuildResultHelper.logger.warn(e);
+      throw new BuildResultHelper.GetArtifactsException(
+        String.format("Failed to parse bep for build id: %s", bepStream.getId()), e);
+    }
+  }
+
+  /**
+   * Parses the BEP stream and  collects all build flags used. Return all flags that pass filters
+   */
+  public static BuildFlags getBlazeFlags(BuildEventStreamProvider bepStream) throws BuildResultHelper.GetFlagsException {
+    try {
+      return BuildFlags.parseBep(bepStream);
+    } catch (BuildEventStreamProvider.BuildEventStreamException e) {
+      throw new BuildResultHelper.GetFlagsException(
+        String.format("Failed to parse bep for build id: %s", bepStream.getId()), e);
+    }
+  }
+}

--- a/base/src/com/google/idea/blaze/base/command/buildresult/ParsedBepOutput.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/ParsedBepOutput.java
@@ -47,7 +47,6 @@ import com.google.idea.common.experiments.BoolExperiment;
 import com.google.idea.common.experiments.IntExperiment;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.Service;
-import java.io.InputStream;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;

--- a/base/src/com/google/idea/blaze/base/run/testlogs/LocalBuildEventProtocolTestFinderStrategy.java
+++ b/base/src/com/google/idea/blaze/base/run/testlogs/LocalBuildEventProtocolTestFinderStrategy.java
@@ -15,6 +15,7 @@
  */
 package com.google.idea.blaze.base.run.testlogs;
 
+import com.google.idea.blaze.base.command.buildresult.BuildResultParser;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtifactsException;
 import java.util.Optional;
@@ -35,7 +36,7 @@ public final class LocalBuildEventProtocolTestFinderStrategy
   @Override
   public BlazeTestResults findTestResults() throws GetArtifactsException {
     try (final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {
-      return buildResultHelper.getTestResults(bepStream);
+      return BuildResultParser.getTestResults(bepStream);
     }
   }
 

--- a/base/tests/utils/unit/com/google/idea/blaze/base/bazel/FakeBlazeCommandRunner.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/bazel/FakeBlazeCommandRunner.java
@@ -18,6 +18,7 @@ package com.google.idea.blaze.base.bazel;
 import com.google.errorprone.annotations.MustBeClosed;
 import com.google.idea.blaze.base.command.BlazeCommand;
 import com.google.idea.blaze.base.command.BlazeCommandRunner;
+import com.google.idea.blaze.base.command.buildresult.BuildResultParser;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtifactsException;
 import com.google.idea.blaze.base.command.info.BlazeInfoException;
@@ -55,7 +56,7 @@ public class FakeBlazeCommandRunner implements BlazeCommandRunner {
         buildResultHelper -> {
           try (final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {
             return BlazeBuildOutputs.fromParsedBepOutput(
-              BuildResult.SUCCESS, buildResultHelper.getBuildOutput(bepStream, Interners.STRING));
+              BuildResult.SUCCESS, BuildResultParser.getBuildOutput(bepStream, Interners.STRING));
           }
         });
   }

--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrRunConfigurationRunner.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrRunConfigurationRunner.java
@@ -22,6 +22,7 @@ import com.google.idea.blaze.base.command.BlazeInvocationContext;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtifactsException;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelperProvider;
+import com.google.idea.blaze.base.command.buildresult.BuildResultParser;
 import com.google.idea.blaze.base.command.buildresult.LocalFileArtifact;
 import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.model.primitives.TargetExpression;
@@ -169,7 +170,7 @@ public class BlazeCidrRunConfigurationRunner implements BlazeCommandRunConfigura
       try (final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {
         candidateFiles =
             LocalFileArtifact.getLocalFiles(
-                    buildResultHelper.getBuildOutput(bepStream, Interners.STRING)
+                    BuildResultParser.getBuildOutput(bepStream, Interners.STRING)
                         .getDirectArtifactsForTarget(target, file -> true))
                 .stream()
                 .filter(File::canExecute)

--- a/golang/src/com/google/idea/blaze/golang/run/BlazeGoRunConfigurationRunner.java
+++ b/golang/src/com/google/idea/blaze/golang/run/BlazeGoRunConfigurationRunner.java
@@ -34,6 +34,7 @@ import com.google.idea.blaze.base.command.BlazeInvocationContext;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtifactsException;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelperProvider;
+import com.google.idea.blaze.base.command.buildresult.BuildResultParser;
 import com.google.idea.blaze.base.command.buildresult.LocalFileArtifact;
 import com.google.idea.blaze.base.command.info.BlazeInfo;
 import com.google.idea.blaze.base.io.FileOperationProvider;
@@ -371,7 +372,7 @@ public class BlazeGoRunConfigurationRunner implements BlazeCommandRunConfigurati
         try (final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {
           candidateFiles =
               LocalFileArtifact.getLocalFiles(
-                      buildResultHelper.getBuildOutput(bepStream, Interners.STRING)
+                      BuildResultParser.getBuildOutput(bepStream, Interners.STRING)
                           .getDirectArtifactsForTarget(label, file -> true))
                   .stream()
                   .filter(File::canExecute)

--- a/java/src/com/google/idea/blaze/java/fastbuild/FastBuildServiceImpl.java
+++ b/java/src/com/google/idea/blaze/java/fastbuild/FastBuildServiceImpl.java
@@ -37,6 +37,7 @@ import com.google.idea.blaze.base.command.BlazeInvocationContext;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtifactsException;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelperProvider;
+import com.google.idea.blaze.base.command.buildresult.BuildResultParser;
 import com.google.idea.blaze.base.command.buildresult.LocalFileArtifact;
 import com.google.idea.blaze.base.command.info.BlazeInfo;
 import com.google.idea.blaze.base.command.info.BlazeInfoRunner;
@@ -326,7 +327,7 @@ final class FastBuildServiceImpl implements FastBuildService, ProjectComponent {
     try (final var bepStream = resultHelper.getBepStream(Optional.empty())) {
       ImmutableList<File> deployJarArtifacts =
           LocalFileArtifact.getLocalFiles(
-              resultHelper.getBuildOutput(bepStream, Interners.STRING)
+              BuildResultParser.getBuildOutput(bepStream, Interners.STRING)
                   .getDirectArtifactsForTarget(
                       deployJarStrategy.deployJarOwnerLabel(label, blazeVersionData), jarPredicate));
       checkState(deployJarArtifacts.size() == 1);
@@ -340,7 +341,7 @@ final class FastBuildServiceImpl implements FastBuildService, ProjectComponent {
       Predicate<String> filePredicate =
           file -> aspectStrategy.getAspectOutputFilePredicate().test(file);
       ideInfoFiles = LocalFileArtifact.getLocalFiles(
-          resultHelper.getBuildOutput(bepStream, Interners.STRING)
+          BuildResultParser.getBuildOutput(bepStream, Interners.STRING)
               .getOutputGroupArtifacts(
                   aspectStrategy.getAspectOutputGroup(), filePredicate));
     } catch (GetArtifactsException e) {

--- a/java/src/com/google/idea/blaze/java/run/hotswap/ClassFileManifestBuilder.java
+++ b/java/src/com/google/idea/blaze/java/run/hotswap/ClassFileManifestBuilder.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.idea.blaze.base.command.BlazeCommandName;
 import com.google.idea.blaze.base.command.BlazeInvocationContext;
+import com.google.idea.blaze.base.command.buildresult.BuildResultParser;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtifactsException;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelperProvider;
@@ -135,7 +136,7 @@ public class ClassFileManifestBuilder {
       try(final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {
         jars =
             LocalFileArtifact.getLocalFiles(
-                buildResultHelper.getBuildOutput(bepStream, Interners.STRING)
+                BuildResultParser.getBuildOutput(bepStream, Interners.STRING)
                   .getOutputGroupArtifacts(JavaClasspathAspectStrategy.OUTPUT_GROUP, file -> true))
                 .stream()
                 .filter(f -> f.getName().endsWith(".jar"))

--- a/python/src/com/google/idea/blaze/python/run/BlazePyRunConfigurationRunner.java
+++ b/python/src/com/google/idea/blaze/python/run/BlazePyRunConfigurationRunner.java
@@ -23,6 +23,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.idea.blaze.base.command.BlazeCommandName;
 import com.google.idea.blaze.base.command.BlazeFlags;
 import com.google.idea.blaze.base.command.BlazeInvocationContext;
+import com.google.idea.blaze.base.command.buildresult.BuildResultParser;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtifactsException;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelperProvider;
@@ -344,7 +345,7 @@ public class BlazePyRunConfigurationRunner implements BlazeCommandRunConfigurati
       try(final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {
         candidateFiles =
             LocalFileArtifact.getLocalFiles(
-                buildResultHelper.getBuildOutput(bepStream, Interners.STRING)
+                BuildResultParser.getBuildOutput(bepStream, Interners.STRING)
                   .getDirectArtifactsForTarget(target, file -> true).asList())
                 .stream()
                 .filter(File::canExecute)

--- a/scala/src/com/google/idea/blaze/scala/run/producers/GenerateDeployableJarTaskProvider.java
+++ b/scala/src/com/google/idea/blaze/scala/run/producers/GenerateDeployableJarTaskProvider.java
@@ -27,6 +27,7 @@ import com.google.idea.blaze.base.command.BlazeInvocationContext;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtifactsException;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelperProvider;
+import com.google.idea.blaze.base.command.buildresult.BuildResultParser;
 import com.google.idea.blaze.base.command.buildresult.LocalFileArtifact;
 import com.google.idea.blaze.base.console.BlazeConsoleLineProcessorProvider;
 import com.google.idea.blaze.base.issueparser.BlazeIssueParser;
@@ -190,7 +191,7 @@ class GenerateDeployableJarTaskProvider
       List<File> outputs;
       try (final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {
         outputs = LocalFileArtifact.getLocalFiles(
-            buildResultHelper.getBuildOutput(bepStream, Interners.STRING)
+            BuildResultParser.getBuildOutput(bepStream, Interners.STRING)
                 .getDirectArtifactsForTarget(
                     target.withTargetName(target.targetName() + "_deploy.jar"), file -> true));
       }


### PR DESCRIPTION
Cherry pick AOSP commit [04942f41fd1bc7b11d9906c4ebeeea388fa9f3e4](https://cs.android.com/android-studio/platform/tools/adt/idea/+/04942f41fd1bc7b11d9906c4ebeeea388fa9f3e4).

This is to enable independent changes to both processes.

Replace almost identical copies of `getBuildOutput()` and similar
methods in `BuildResultHelper` implementations with `BuildResultParser`
utility methods.

Prefer exceptions to empty results where failures were reported
differently.

Bug: n/a
Test: existing
Change-Id: I23fbd78c8798795ba9a758ece35e4a0b8e2efeaf

AOSP: 04942f41fd1bc7b11d9906c4ebeeea388fa9f3e4
