### PR TITLE
[AOSP-pick] Remove 2 options of query sync settings

### DIFF
--- a/base/src/com/google/idea/blaze/base/qsync/UnsyncedFileEditorNotificationProvider.java
+++ b/base/src/com/google/idea/blaze/base/qsync/UnsyncedFileEditorNotificationProvider.java
@@ -100,15 +100,6 @@ public class UnsyncedFileEditorNotificationProvider implements EditorNotificatio
         .createActionLabel("Sync now", IncrementalSyncProjectAction.ID)
         .addHyperlinkListener(
             event -> EditorNotifications.getInstance(project).updateAllNotifications());
-    panel.createActionLabel(
-        "Enable automatic syncing",
-        () -> {
-          QuerySyncSettings.getInstance().enableSyncOnFileChanges(true);
-          showAutoSyncNotification(project);
-          IncrementalSyncProjectAction.doIncrementalSync(
-              UnsyncedFileEditorNotificationProvider.class, project, null);
-          EditorNotifications.getInstance(project).updateAllNotifications();
-        });
     return panel;
   }
 

--- a/base/src/com/google/idea/blaze/base/qsync/settings/QuerySyncConfigurable.java
+++ b/base/src/com/google/idea/blaze/base/qsync/settings/QuerySyncConfigurable.java
@@ -136,16 +136,6 @@ class QuerySyncConfigurable extends BoundSearchableConfigurable implements Confi
                         "Display detailed dependency text in the editor",
                         settings::showDetailedInformationInEditor,
                         settings::enableShowDetailedInformationInEditor);
-                    addCheckBox(
-                        ip,
-                        "Include working set when building dependencies",
-                        settings::buildWorkingSet,
-                        settings::enableBuildWorkingSet);
-                    addCheckBox(
-                        ip,
-                        "Automatically sync project on file changes",
-                        settings::syncOnFileChanges,
-                        settings::enableSyncOnFileChanges);
                     return Unit.INSTANCE;
                   });
           return Unit.INSTANCE;

--- a/base/src/com/google/idea/blaze/base/qsync/settings/QuerySyncSettings.java
+++ b/base/src/com/google/idea/blaze/base/qsync/settings/QuerySyncSettings.java
@@ -85,7 +85,8 @@ public class QuerySyncSettings implements PersistentStateComponent<QuerySyncSett
   }
 
   public boolean buildWorkingSet() {
-    return state.buildWorkingSet;
+    // Force to disable it as it's not a stable feature
+    return false;
   }
 
   public void enableSyncOnFileChanges(boolean syncOnFileChanges) {
@@ -93,7 +94,8 @@ public class QuerySyncSettings implements PersistentStateComponent<QuerySyncSett
   }
 
   public boolean syncOnFileChanges() {
-    return state.syncOnFileChanges;
+    // Force to disable it as it's not a stable feature
+    return false;
   }
 
   @Override


### PR DESCRIPTION
Cherry pick AOSP commit [39d8b044d86236f31598799a368b787a7ad8f64f](https://cs.android.com/android-studio/platform/tools/adt/idea/+/39d8b044d86236f31598799a368b787a7ad8f64f).

1. remove them from ui
2. set the value as false to disable them temporarily
3. remove enable auto sync option in banner

Bug: b/382306540
Test: manually
Change-Id: I16dbb5e14c7617454e7ced5268b65fd39c750a9b

AOSP: 39d8b044d86236f31598799a368b787a7ad8f64f
