### PR TITLE
Fix aspect_template reference in java_classpath aspect

### DIFF
--- a/aspect/java_classpath.bzl
+++ b/aspect/java_classpath.bzl
@@ -1,6 +1,6 @@
 """An aspect which extracts the runtime classpath from a java target."""
 
-load("@intellij_aspect_template//:java_info.bzl", "get_java_info", "java_info_in_target")
+load(":java_info.bzl", "get_java_info", "java_info_in_target")
 
 def _runtime_classpath_impl(target, ctx):
     """The top level aspect implementation function.

--- a/base/src/com/google/idea/blaze/base/sync/aspects/storage/AspectStorageService.kt
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/storage/AspectStorageService.kt
@@ -53,8 +53,8 @@ class AspectStorageService(private val project: Project, private val scope: Coro
    * Register a [AspectWriter] to provide aspect files.
    */
   @Throws(SyncFailedException::class)
-  fun prepare(parentCtx: BlazeContext) {
-    val parentScope = parentCtx.getScope(ToolWindowScope::class.java)
+  fun prepare(parentCtx: BlazeContext?) {
+    val parentScope = parentCtx?.getScope(ToolWindowScope::class.java)
 
     Scope.push(parentCtx) { ctx ->
 

--- a/java/src/com/google/idea/blaze/java/run/hotswap/ClassFileManifestBuilder.java
+++ b/java/src/com/google/idea/blaze/java/run/hotswap/ClassFileManifestBuilder.java
@@ -31,7 +31,9 @@ import com.google.idea.blaze.base.run.BlazeBeforeRunCommandHelper;
 import com.google.idea.blaze.base.run.BlazeCommandRunConfiguration;
 import com.google.idea.blaze.base.run.ExecutorType;
 import com.google.idea.blaze.base.run.confighandler.BlazeCommandRunConfigurationRunner;
+import com.google.idea.blaze.base.sync.SyncScope.SyncFailedException;
 import com.google.idea.blaze.base.sync.aspects.BuildResult;
+import com.google.idea.blaze.base.sync.aspects.storage.AspectStorageService;
 import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
 import com.google.idea.blaze.base.util.SaveUtil;
 import com.google.idea.blaze.common.Interners;
@@ -98,6 +100,12 @@ public class ClassFileManifestBuilder {
         JavaClasspathAspectStrategy.findStrategy(versionData);
     if (aspectStrategy == null) {
       return null;
+    }
+
+    try {
+      AspectStorageService.of(project).prepare(null);
+    } catch (SyncFailedException e) {
+      throw new ExecutionException("could not prepare aspects", e);
     }
 
     SaveUtil.saveAllFiles();


### PR DESCRIPTION
# Discussion thread for this change

Issue number: #7260

# Description of this change

One intellij_aspect_template reference was left in java_classpath.bzl causing it to fail at runtime. Also, just to make sure the aspects are present, call AspectStorageService.prepare before using them.