### PR TITLE
Followup: query xcode parameters from provider based on attributes

### DIFF
--- a/aspect/BUILD
+++ b/aspect/BUILD
@@ -15,6 +15,7 @@ filegroup(
         "intellij_info_impl.bzl",
         "java_classpath.bzl",
         "make_variables.bzl",
+        "xcode_query.bzl",
         ":BUILD.bazel",
         "//aspect/tools:CreateAar",
         "//aspect/tools:JarFilter_deploy.jar",
@@ -46,6 +47,7 @@ aspect_library(
         "java_classpath.bzl",
         "make_variables.bzl",
         ":BUILD.bazel",
+        "xcode_query.bzl", # maybe move this to a dedicated library, but let's keep this here for now
     ],
     namespace = "aspect/default",
     visibility = ["//visibility:public"],

--- a/aspect/xcode_query.bzl
+++ b/aspect/xcode_query.bzl
@@ -1,0 +1,22 @@
+provider_attrs = ["xcode_version", "default_macos_sdk_version"]
+
+def all_items_are_true(items):
+    for item in items:
+        if item == False:
+            return False
+
+    return True
+
+def hasattrs(obj, attrs):
+    return all_items_are_true([hasattr(obj, attr) for attr in attrs])
+
+def format(target):
+    all_providers = providers(target)
+    for key in all_providers:
+        provider = all_providers[key]
+
+        if hasattrs(provider, provider_attrs):
+            attrs = [getattr(provider, attr) for attr in provider_attrs]
+            return "{} {}".format(attrs[0], attrs[1])
+
+    return ""

--- a/clwb/tests/integrationtests/com/google/idea/blaze/clwb/SimpleTest.java
+++ b/clwb/tests/integrationtests/com/google/idea/blaze/clwb/SimpleTest.java
@@ -61,7 +61,7 @@ public class SimpleTest extends ClwbIntegrationTestCase {
 
     final var scriptLines = Files.readAllLines(compilerSettings.getCompilerExecutable().toPath());
 
-    assertContainsPattern("export DEVELOPER_DIR=/.*/Xcode.app/Contents/Developer", scriptLines);
-    assertContainsPattern("export SDKROOT=/.*/Xcode.app/Contents/Developer/.*", scriptLines);
+    assertContainsPattern("export DEVELOPER_DIR=/.*/Xcode.*.app/Contents/Developer", scriptLines);
+    assertContainsPattern("export SDKROOT=/.*/Xcode.*.app/Contents/Developer/.*", scriptLines);
   }
 }

--- a/clwb/tests/integrationtests/com/google/idea/blaze/clwb/base/Assertions.java
+++ b/clwb/tests/integrationtests/com/google/idea/blaze/clwb/base/Assertions.java
@@ -9,6 +9,7 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.jetbrains.cidr.lang.workspace.OCCompilerSettings;
 import com.jetbrains.cidr.lang.workspace.headerRoots.HeadersSearchRoot;
+import java.util.List;
 import java.util.regex.Pattern;
 
 public class Assertions {
@@ -73,5 +74,13 @@ public class Assertions {
     }
 
     return assertWithMessage("symbol is not defined: " + symbol).that((String) null);
+  }
+
+  public static void assertContainsPattern(String regex, List<String> list) {
+    final var pattern = Pattern.compile(regex);
+    final var message = String.format("%s not found in:\n%s", regex, StringUtil.join(list, "\n"));
+    final var match = list.stream().anyMatch(it -> pattern.matcher(it).matches());
+
+    assertWithMessage(message).that(match).isTrue();
   }
 }

--- a/cpp/src/com/google/idea/blaze/cpp/XcodeCompilerSettingsProviderImpl.java
+++ b/cpp/src/com/google/idea/blaze/cpp/XcodeCompilerSettingsProviderImpl.java
@@ -30,6 +30,7 @@ import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.settings.Blaze;
+import com.google.idea.blaze.base.sync.aspects.strategy.AspectRepositoryProvider;
 import com.google.idea.blaze.cpp.XcodeCompilerSettingsProvider.XcodeCompilerSettingsException.IssueKind;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.io.FileUtil;
@@ -44,17 +45,13 @@ import java.util.Optional;
 
 
 public class XcodeCompilerSettingsProviderImpl implements XcodeCompilerSettingsProvider {
-
-  private static final String QUERY_XCODE_VERSION_STARLARK_EXPR = "`{} {}`.format(providers(target)[`XcodeProperties`].xcode_version, providers(target)[`XcodeProperties`].default_macos_sdk_version) if providers(target) and `XcodeProperties` in providers(target) else ``".replace(
-      '`', '"');
-
   // This only exists because it's impossible to escape a `deps()` query expression correctly in a Java string.
   private static final String[] QUERY_XCODE_VERSION_SCRIPT_LINES = new String[]{
       "#!/bin/bash",
       "__BAZEL_BIN__ cquery \\",
       " 'deps(\"@bazel_tools//tools/osx:current_xcode_config\")' \\",
       " --output=starlark \\",
-      " --starlark:expr='" + QUERY_XCODE_VERSION_STARLARK_EXPR + "'",
+      " --starlark:file='" + AspectRepositoryProvider.findAspectDirectory().orElseThrow() + "/xcode_query.bzl'",
   };
 
   @Override


### PR DESCRIPTION
Followup for #7193 after #7202 was merged.

Bazel 8 introduced new provider located in apple_common module,
which is not available in cquery context, so the implementation
was updated to just find a provider with required attributes to
make implementation also work for bazel 7 and older.