### PR TITLE
Store the package and name of a Label as strings rather than paths, to avoid occurrence of backslashes on Windows

### DIFF
--- a/querysync/java/com/google/idea/blaze/qsync/project/BuildGraphData.java
+++ b/querysync/java/com/google/idea/blaze/qsync/project/BuildGraphData.java
@@ -94,7 +94,8 @@ public abstract class BuildGraphData {
       final var probe = path != null ? path : Path.of("");
       final var probeNameCount = path != null ? path.getNameCount() : 0;
       if (packages().contains(probe)) {
-        return Optional.of(Label.of("//" + probe.toString() + ":" + file.subpath(probeNameCount, file.getNameCount()).toString()));
+        var label = Label.fromWorkspacePackageAndName("", probe, file.subpath(probeNameCount, file.getNameCount()));
+        return Optional.of(label);
       }
     } while (path != null);
     return Optional.empty();

--- a/querysync/java/com/google/idea/blaze/qsync/query/QuerySummary.java
+++ b/querysync/java/com/google/idea/blaze/qsync/query/QuerySummary.java
@@ -202,8 +202,8 @@ public abstract class QuerySummary {
     public Query.StoredLabel indexLabel(Label l) {
       return Query.StoredLabel.newBuilder()
         .setWorkspace(index(l.getWorkspaceName()))
-        .setBuildPackage(index(l.getPackage().toString()))
-        .setName(index(l.getName().toString()))
+        .setBuildPackage(index(l.buildPackage()))
+        .setName(index(l.name()))
         .build();
     }
 

--- a/shared/java/com/google/idea/blaze/common/Label.java
+++ b/shared/java/com/google/idea/blaze/common/Label.java
@@ -69,7 +69,7 @@ public record Label(String workspace, String buildPackage, String name) {
     StringBuilder res = new StringBuilder();
     p.iterator().forEachRemaining(part -> res.append(part).append("/"));
     // Remove the trailing slash
-    return res.substring(0, res.length() - 1);
+    return res.isEmpty()? "" : res.substring(0, res.length() - 1);
   }
 
   public static Label fromWorkspacePackageAndName(String workspace, Path packagePath, String name) {

--- a/shared/java/com/google/idea/blaze/common/TargetTree.java
+++ b/shared/java/com/google/idea/blaze/common/TargetTree.java
@@ -237,7 +237,7 @@ public class TargetTree extends AbstractCollection<Label> {
 
     @CanIgnoreReturnValue
     public Builder add(Label target) {
-      return add(target.getPackage().iterator(), target.getName().toString());
+      return add(target.getPackage().iterator(), target.name());
     }
 
     @CanIgnoreReturnValue

--- a/shared/javatests/com/google/idea/blaze/common/LabelTest.java
+++ b/shared/javatests/com/google/idea/blaze/common/LabelTest.java
@@ -95,6 +95,11 @@ public class LabelTest {
   }
 
   @Test
+  public void testNew_backslashes() {
+    assertThrows(IllegalArgumentException.class, () -> Label.of("//package\\path:rule"));
+  }
+
+  @Test
   public void testNew_noName() {
     assertThrows(IllegalArgumentException.class, () -> Label.of("//package/path"));
   }


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #7258 

# Description of this change

