### PR TITLE
[AOSP-pick] Make run configurations configurable

### DIFF
--- a/aswb/src/com/google/idea/blaze/android/run/binary/BlazeAndroidBinaryRunConfigurationHandlerProvider.java
+++ b/aswb/src/com/google/idea/blaze/android/run/binary/BlazeAndroidBinaryRunConfigurationHandlerProvider.java
@@ -32,6 +32,11 @@ public class BlazeAndroidBinaryRunConfigurationHandlerProvider
   }
 
   @Override
+  public String getDisplayLabel() {
+    return "Android Binary";
+  }
+
+  @Override
   public boolean canHandleKind(TargetState state, @Nullable Kind kind) {
     return kind == AndroidBlazeRules.RuleTypes.ANDROID_BINARY.getKind();
   }

--- a/aswb/src/com/google/idea/blaze/android/run/test/BlazeAndroidTestRunConfigurationHandlerProvider.java
+++ b/aswb/src/com/google/idea/blaze/android/run/test/BlazeAndroidTestRunConfigurationHandlerProvider.java
@@ -32,6 +32,11 @@ public class BlazeAndroidTestRunConfigurationHandlerProvider
   }
 
   @Override
+  public String getDisplayLabel() {
+    return "Android Test";
+  }
+
+  @Override
   public boolean canHandleKind(TargetState state, @Nullable Kind kind) {
     return kind != null
         && kind.isOneOf(

--- a/base/src/com/google/idea/blaze/base/run/BlazeCommandRunConfiguration.java
+++ b/base/src/com/google/idea/blaze/base/run/BlazeCommandRunConfiguration.java
@@ -44,6 +44,7 @@ import com.google.idea.blaze.base.settings.Blaze;
 import com.google.idea.blaze.base.settings.BlazeImportSettings.ProjectType;
 import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
 import com.google.idea.blaze.base.ui.UiUtil;
+import com.google.idea.common.experiments.BoolExperiment;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.Executor;
 import com.intellij.execution.RunManagerEx;
@@ -61,15 +62,19 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.options.SettingsEditor;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.ComboBox;
 import com.intellij.openapi.util.InvalidDataException;
 import com.intellij.openapi.util.WriteExternalException;
 import com.intellij.ui.components.JBCheckBox;
 import com.intellij.ui.components.JBLabel;
 import com.intellij.util.ui.UIUtil;
 import java.util.List;
+import java.util.Objects;
 import javax.annotation.Nullable;
 import javax.swing.Box;
+import javax.swing.DefaultComboBoxModel;
 import javax.swing.JComponent;
+import javax.swing.JLabel;
 import org.jdom.Element;
 
 /** A run configuration which executes Blaze commands. */
@@ -78,6 +83,12 @@ public class BlazeCommandRunConfiguration
     implements BlazeRunConfiguration,
         ModuleRunProfile,
         RunConfigurationWithSuppressedDefaultDebugAction {
+
+  private static final BoolExperiment handlerSelectionLaxMode =
+    new BoolExperiment("aswb.run.config.handler.lax.editing", false);
+
+  private static final BoolExperiment handlerSelectionAutoFixMode =
+    new BoolExperiment("aswb.run.config.handler.auto.fix", true);
 
   private static final Logger logger = Logger.getInstance(BlazeCommandRunConfiguration.class);
 
@@ -175,9 +186,9 @@ public class BlazeCommandRunConfiguration
 
   public BlazeCommandRunConfiguration(Project project, ConfigurationFactory factory, String name) {
     super(project, factory, name);
-    // start with whatever fallback is present
+    // start with whatever fallback is present for unknown state. The user may need to fix it.
     handlerProvider =
-        BlazeCommandRunConfigurationHandlerProvider.findHandlerProvider(TargetState.KNOWN, null);
+        BlazeCommandRunConfigurationHandlerProvider.findHandlerProvider(TargetState.PENDING, null);
     handler = handlerProvider.createHandler(this);
     try {
       handler.getState().readExternal(blazeElementState);
@@ -262,9 +273,10 @@ public class BlazeCommandRunConfiguration
   }
 
   private TargetState getTargetState() {
-    return targetPatterns.isEmpty() && pendingContext != null
-        ? TargetState.PENDING
-        : TargetState.KNOWN;
+    return (targetPatterns.isEmpty() && pendingContext != null) ||
+           (getTargetKind() == null && (handlerProvider == null || handlerProvider.canHandleKind(TargetState.PENDING, null)))
+           ? TargetState.PENDING
+           : TargetState.KNOWN;
   }
 
   private void updateHandlerIfDifferentProvider(
@@ -336,27 +348,66 @@ public class BlazeCommandRunConfiguration
     Label label = (Label) targets.get(0);
     ListenableFuture<TargetInfo> future = TargetFinder.findTargetInfoFuture(getProject(), label);
     if (future.isDone()) {
-      updateTargetKindFromSingleTarget(FuturesUtil.getIgnoringErrors(future));
-    } else {
+      updateTargetKindFromTargetInfoFuture(future, label, null);
+    }
+    else {
       updateTargetKindFromSingleTarget(null);
       future.addListener(
-          () -> {
-            updateTargetKindFromSingleTarget(FuturesUtil.getIgnoringErrors(future));
-            if (asyncCallback != null) {
-              asyncCallback.run();
-            }
-          },
+        () -> {
+          updateTargetKindFromTargetInfoFuture(future, label, asyncCallback);
+        },
           MoreExecutors.directExecutor());
     }
   }
 
-  private void updateTargetKindFromSingleTarget(@Nullable TargetInfo target) {
-    updateTargetKind(target == null ? null : target.kindString);
+  private void updateTargetKindFromTargetInfoFuture(ListenableFuture<TargetInfo> future, Label label, Runnable asyncCallback) {
+    TargetInfo targetInfo = FuturesUtil.getIgnoringErrors(future);
+    if (targetInfo == null) {
+      Throwable throwable = getFutureFailure(future);
+      if (throwable != null) {
+        logger.warn(
+          String.format("Failed to retrieve target info for run config %s target %s. Error: %s", this, label, throwable),
+          throwable);
+      }
+    }
+    else {
+      if (!Objects.equals(getTargetKind(), targetInfo.getKind())) {
+        logger.info(
+          String.format("Run configuration %s target %s kind updated to %s", this, targetInfo.getLabel(), targetInfo.getKind()));
+      }
+    }
+    if (updateTargetKindFromSingleTarget(targetInfo)) {
+      if (asyncCallback != null) {
+        asyncCallback.run();
+      }
+    }
   }
 
-  private void updateTargetKind(@Nullable String kind) {
+  private static Throwable getFutureFailure(ListenableFuture<TargetInfo> future) {
+    Throwable throwable = null;
+    try {
+      future.get();
+    } catch (Throwable t) {
+      throwable = t;
+    }
+    return throwable;
+  }
+
+  private boolean updateTargetKindFromSingleTarget(@Nullable TargetInfo target) {
+    return updateTargetKind(target == null ? null : target.kindString);
+  }
+
+  private boolean updateTargetKind(@Nullable String kind) {
+    TargetState targetStateWas = getTargetState();
+    if (Objects.equals(targetKindString, kind)) {
+      return false;
+    }
     targetKindString = kind;
-    updateHandler();
+    if (targetStateWas == TargetState.PENDING) {
+      // Let users choose if already determined.
+      updateHandler();
+    }
+    return true;
   }
 
   /**
@@ -427,15 +478,18 @@ public class BlazeCommandRunConfiguration
                           "You must specify a %s target expression.", Blaze.buildSystemName(getProject())));
         }
       }
-      if (!pattern.startsWith("//") && !pattern.startsWith("@")) {
+      if (!pattern.startsWith("//") && !pattern.startsWith("@") && !pattern.startsWith("-//") && !pattern.startsWith("-@")) {
         throw new RuntimeConfigurationError(
-            "You must specify the full target expression, starting with // or @");
+            "You must specify the full target expression, starting with '//' or '@' or '-' for a negative one");
       }
 
       String error = TargetExpression.validate(pattern);
       if (error != null) {
         throw new RuntimeConfigurationError(error);
       }
+    }
+    if (handlerProvider.canHandleKind(TargetState.PENDING, null)) {
+      throw new RuntimeConfigurationError("Android Studio handler must be selected");
     }
   }
 
@@ -579,8 +633,9 @@ public class BlazeCommandRunConfiguration
   static class BlazeCommandRunConfigurationSettingsEditor
       extends SettingsEditor<BlazeCommandRunConfiguration> {
 
-    private BlazeCommandRunConfigurationHandlerProvider handlerProvider;
-    private BlazeCommandRunConfigurationHandler handler;
+    private String handlersLoadedForKind ;
+    private BlazeCommandRunConfigurationHandlerProvider editorHandlerProvider;
+    private BlazeCommandRunConfigurationHandler editorHandler;
     private RunConfigurationStateEditor handlerStateEditor;
     private JComponent handlerStateComponent;
     private Element elementState;
@@ -591,6 +646,15 @@ public class BlazeCommandRunConfiguration
     private final JBLabel targetExpressionLabel;
     private final ConsoleOutputFileSettingsUi<BlazeCommandRunConfiguration> outputFileUi;
     private final TargetExpressionListUi targetsUi;
+    private final JLabel handlerLabel;
+    private final ComboBox<ProviderItem> handlerCombo;
+
+    public record ProviderItem(BlazeCommandRunConfigurationHandlerProvider provider) {
+      @Override
+      public String toString() {
+        return provider.getDisplayLabel();
+      }
+    }
 
     BlazeCommandRunConfigurationSettingsEditor(BlazeCommandRunConfiguration config) {
       Project project = config.getProject();
@@ -599,13 +663,25 @@ public class BlazeCommandRunConfiguration
       targetExpressionLabel = new JBLabel(UIUtil.ComponentStyle.LARGE);
       keepInSyncCheckBox = new JBCheckBox("Keep in sync with source XML");
       outputFileUi = new ConsoleOutputFileSettingsUi<>();
-      editorWithoutSyncCheckBox = UiUtil.createBox(targetExpressionLabel, targetsUi);
+      handlerLabel = new JLabel("Android Studio handler");
+      handlerCombo =
+        new ComboBox<>(new DefaultComboBoxModel<>(BlazeCommandRunConfigurationHandlerProvider.findHandlerProviders().stream().map(
+          ProviderItem::new).toArray(ProviderItem[]::new)));
+      handlerCombo.setEditable(false);
+
+      editorWithoutSyncCheckBox = UiUtil.createBox(targetExpressionLabel, targetsUi, handlerLabel, handlerCombo);
       editor =
           UiUtil.createBox(
               editorWithoutSyncCheckBox, outputFileUi.getComponent(), keepInSyncCheckBox);
       updateEditor(config);
-      updateHandlerEditor(config);
+      updateHandlerEditor(config, config.handlerProvider);
       keepInSyncCheckBox.addItemListener(e -> updateEnabledStatus());
+      handlerCombo.addActionListener(e -> {
+        if (handlerCombo.getSelectedItem() instanceof ProviderItem providerItem) {
+          updateHandlerProviderToConfig(config,
+                                        BlazeCommandRunConfigurationHandlerProvider.getHandlerProvider(providerItem.provider().getId()));
+        }
+      });
     }
 
     private void updateEditor(BlazeCommandRunConfiguration config) {
@@ -613,7 +689,7 @@ public class BlazeCommandRunConfiguration
           String.format(
               "Target expression (%s handled by %s):",
               config.getTargetKindName(), config.handler.getHandlerName()));
-      keepInSyncCheckBox.setVisible(config.keepInSync != null);
+      keepInSyncCheckBox.setVisible(true/*config.keepInSync != null*/);
       if (config.keepInSync != null) {
         keepInSyncCheckBox.setSelected(config.keepInSync);
       }
@@ -630,23 +706,27 @@ public class BlazeCommandRunConfiguration
       }
       targetsUi.setEnabled(enabled);
       outputFileUi.setComponentEnabled(enabled);
+      handlerCombo.setEnabled(enabled);
     }
 
-    private void updateHandlerEditor(BlazeCommandRunConfiguration config) {
-      handlerProvider = config.handlerProvider;
-      handler = handlerProvider.createHandler(config);
+    private void updateHandlerEditor(BlazeCommandRunConfiguration config, BlazeCommandRunConfigurationHandlerProvider newProvider) {
+      editorHandlerProvider = newProvider;
+      editorHandler = editorHandlerProvider.createHandler(config);
       try {
-        handler.getState().readExternal(config.blazeElementState);
+        editorHandler.getState().readExternal(config.blazeElementState);
       } catch (InvalidDataException e) {
         logger.error(e);
       }
-      handlerStateEditor = handler.getState().getEditor(config.getProject());
+      handlerStateEditor = editorHandler.getState().getEditor(config.getProject());
 
       if (handlerStateComponent != null) {
         editorWithoutSyncCheckBox.remove(handlerStateComponent);
       }
       handlerStateComponent = handlerStateEditor.createComponent();
       editorWithoutSyncCheckBox.add(handlerStateComponent);
+      if (!Objects.equals(handlerCombo.getSelectedItem(), new ProviderItem(newProvider))) {
+        handlerCombo.setSelectedItem(new ProviderItem(newProvider));
+      }
     }
 
     @Override
@@ -657,9 +737,10 @@ public class BlazeCommandRunConfiguration
     @Override
     protected void resetEditorFrom(BlazeCommandRunConfiguration config) {
       elementState = config.blazeElementState.clone();
+      handlerCombo.setSelectedItem(new ProviderItem(config.handlerProvider));
       updateEditor(config);
-      if (config.handlerProvider != handlerProvider) {
-        updateHandlerEditor(config);
+      if (config.handlerProvider != editorHandlerProvider) {
+        updateHandlerEditor(config, config.handlerProvider);
       }
       targetsUi.setTargetExpressions(config.targetPatterns);
       outputFileUi.resetEditorFrom(config);
@@ -669,16 +750,16 @@ public class BlazeCommandRunConfiguration
     @Override
     protected void applyEditorTo(BlazeCommandRunConfiguration config) {
       outputFileUi.applyEditorTo(config);
-      handlerStateEditor.applyEditorTo(handler.getState());
+      handlerStateEditor.applyEditorTo(editorHandler.getState());
       try {
-        handler.getState().writeExternal(elementState);
+        editorHandler.getState().writeExternal(elementState);
       } catch (WriteExternalException e) {
         logger.error(e);
       }
       config.keepInSync = keepInSyncCheckBox.isVisible() ? keepInSyncCheckBox.isSelected() : null;
 
       // now set the config's state, based on the editor's (possibly out of date) handler
-      config.updateHandlerIfDifferentProvider(handlerProvider);
+      config.updateHandlerIfDifferentProvider(editorHandlerProvider);
       config.blazeElementState = elementState.clone();
       try {
         config.handler.getState().readExternal(config.blazeElementState);
@@ -689,13 +770,84 @@ public class BlazeCommandRunConfiguration
       // finally, update the handler
       config.targetPatterns = targetsUi.getTargetExpressions();
       config.updateTargetKindAsync(
-          () -> ApplicationManager.getApplication().invokeLater(this::fireEditorStateChanged));
+          () -> {
+            ApplicationManager.getApplication().invokeLater(() -> {
+              if (!Objects.equals(handlersLoadedForKind, config.targetKindString)) {
+                handlersLoadedForKind = config.targetKindString;
+                updateHandlerListAndAutoSelect(config, true);
+              }
+              if (editorHandlerProvider != config.handlerProvider) {
+                updateHandlerEditor(config, config.handlerProvider);
+              }
+              fireEditorStateChanged();
+            });
+          });
+      updateHandlerListAndAutoSelect(config, false);
+      if (editorHandlerProvider != config.handlerProvider) {
+        updateHandlerEditor(config, config.handlerProvider);
+      }
       updateEditor(config);
-      if (config.handlerProvider != handlerProvider) {
-        updateHandlerEditor(config);
+      if (config.handlerProvider != editorHandlerProvider) {
+        updateHandlerEditor(config, config.handlerProvider);
         handlerStateEditor.resetEditorFrom(config.handler.getState());
       } else {
         handlerStateEditor.applyEditorTo(config.handler.getState());
+      }
+    }
+
+    private void updateHandlerListAndAutoSelect(BlazeCommandRunConfiguration config, boolean autoSelect) {
+      final var handlers =
+        ((handlerSelectionLaxMode.getValue() || config.getTargetKind() == null)
+         ? BlazeCommandRunConfigurationHandlerProvider.findHandlerProviders()
+         : BlazeCommandRunConfigurationHandlerProvider.findHandlerProviders(config.getTargetState(), config.getTargetKind()))
+          .stream().map(ProviderItem::new)
+          .collect(toImmutableList());
+      final var currentHandlers = ImmutableList.<ProviderItem>builder();
+      for (var i = 0; i < handlerCombo.getModel().getSize(); i++) {
+        currentHandlers.add(handlerCombo.getModel().getElementAt(i));
+      }
+      var selected = handlerCombo.getSelectedItem();
+      if (!Objects.equals(currentHandlers.build(), handlers)) {
+        handlerCombo.setModel(new DefaultComboBoxModel<>(handlers.toArray(ProviderItem[]::new)));
+        if (autoSelect && handlerSelectionAutoFixMode.getValue()) {
+          final var newBestSelection = Iterables.getFirst(
+            BlazeCommandRunConfigurationHandlerProvider.findHandlerProviders(config.getTargetState(), config.getTargetKind()), null);
+          if (newBestSelection != null && selected != newBestSelection) {
+            // Note, we only auto-update the configuration in the UI. At the runtime the configuration updates its handler only if it is in
+            // the pending state, i.e. the handler is unknown or intentionally set to pending.
+            selected = newBestSelection;
+            logger.info(String.format("Auto-updating %s run configuration handler to %s", config, newBestSelection));
+          }
+        }
+      }
+      if (!handlers.contains(selected)) {
+        selected = Iterables.getFirst(handlers, null);
+      }
+      if (!Objects.equals(handlerCombo.getSelectedItem(), selected)) {
+        handlerCombo.setSelectedItem(selected);
+      }
+    }
+
+    private void updateHandlerProviderToConfig(BlazeCommandRunConfiguration config, BlazeCommandRunConfigurationHandlerProvider provider) {
+      try {
+        try {
+          handlerStateEditor.applyEditorTo(editorHandler.getState());
+          editorHandler.getState().writeExternal(elementState);
+        }
+        catch (Throwable t) {
+          logger.error("Attempt to preserve state crashed", t);
+        }
+        updateHandlerEditor(config, provider);
+        try {
+          editorHandler.getState().readExternal(elementState);
+        }
+        catch (Throwable t) {
+          logger.error("Attempt to preserve state crashed", t);
+        }
+        handlerStateEditor.resetEditorFrom(editorHandler.getState());
+      }
+      catch (Throwable t){
+        logger.error("Cannot configure handler provider", t);
       }
     }
   }

--- a/base/src/com/google/idea/blaze/base/run/confighandler/BlazeCommandGenericRunConfigurationHandlerProvider.java
+++ b/base/src/com/google/idea/blaze/base/run/confighandler/BlazeCommandGenericRunConfigurationHandlerProvider.java
@@ -32,6 +32,11 @@ public class BlazeCommandGenericRunConfigurationHandlerProvider
   }
 
   @Override
+  public String getDisplayLabel() {
+    return "Generic Command";
+  }
+
+  @Override
   public boolean canHandleKind(TargetState state, @Nullable Kind kind) {
     return !state.equals(TargetState.PENDING);
   }

--- a/base/src/com/google/idea/blaze/base/run/confighandler/PendingTargetRunConfigurationHandler.java
+++ b/base/src/com/google/idea/blaze/base/run/confighandler/PendingTargetRunConfigurationHandler.java
@@ -38,7 +38,7 @@ import com.intellij.execution.runners.ProgramRunner;
 import com.intellij.openapi.application.ApplicationManager;
 import javax.annotation.Nullable;
 
-class PendingTargetRunConfigurationHandler implements BlazeCommandRunConfigurationHandler {
+public class PendingTargetRunConfigurationHandler implements BlazeCommandRunConfigurationHandler {
 
   private final BuildSystemName buildSystemName;
   private final BlazeCommandRunConfigurationCommonState state;

--- a/base/src/com/google/idea/blaze/base/run/confighandler/PendingTargetRunConfigurationHandlerProvider.java
+++ b/base/src/com/google/idea/blaze/base/run/confighandler/PendingTargetRunConfigurationHandlerProvider.java
@@ -19,8 +19,13 @@ import com.google.idea.blaze.base.model.primitives.Kind;
 import com.google.idea.blaze.base.run.BlazeCommandRunConfiguration;
 import javax.annotation.Nullable;
 
-class PendingTargetRunConfigurationHandlerProvider
+public class PendingTargetRunConfigurationHandlerProvider
     implements BlazeCommandRunConfigurationHandlerProvider {
+
+  @Override
+  public String getDisplayLabel() {
+    return "(select)";
+  }
 
   @Override
   public boolean canHandleKind(TargetState state, @Nullable Kind kind) {

--- a/base/tests/integrationtests/com/google/idea/blaze/base/run/BlazeCommandRunConfigurationGenericHandlerIntegrationTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/run/BlazeCommandRunConfigurationGenericHandlerIntegrationTest.java
@@ -26,6 +26,8 @@ import com.google.idea.blaze.base.model.MockBlazeProjectDataManager;
 import com.google.idea.blaze.base.model.primitives.TargetExpression;
 import com.google.idea.blaze.base.run.BlazeCommandRunConfiguration.BlazeCommandRunConfigurationSettingsEditor;
 import com.google.idea.blaze.base.run.confighandler.BlazeCommandGenericRunConfigurationHandler;
+import com.google.idea.blaze.base.run.confighandler.PendingTargetRunConfigurationHandler;
+import com.google.idea.blaze.base.run.confighandler.PendingTargetRunConfigurationHandlerProvider;
 import com.google.idea.blaze.base.run.state.BlazeCommandRunConfigurationCommonState;
 import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
 import com.intellij.openapi.options.ConfigurationException;
@@ -59,23 +61,23 @@ public class BlazeCommandRunConfigurationGenericHandlerIntegrationTest
   }
 
   @Test
-  public void testNewConfigurationHasGenericHandler() {
+  public void testNewConfigurationHasPendingHandler() {
     assertThat(configuration.getHandler())
-        .isInstanceOf(BlazeCommandGenericRunConfigurationHandler.class);
+        .isInstanceOf(PendingTargetRunConfigurationHandler.class);
   }
 
   @Test
-  public void testSetTargetNullMakesGenericHandler() {
+  public void testSetTargetNullMakesPendingHandler() {
     configuration.setTarget(null);
     assertThat(configuration.getHandler())
-        .isInstanceOf(BlazeCommandGenericRunConfigurationHandler.class);
+        .isInstanceOf(PendingTargetRunConfigurationHandler.class);
   }
 
   @Test
-  public void testTargetExpressionMakesGenericHandler() {
+  public void testTargetExpressionMakesPendingHandler() {
     configuration.setTarget(TargetExpression.fromStringSafe("//..."));
     assertThat(configuration.getHandler())
-        .isInstanceOf(BlazeCommandGenericRunConfigurationHandler.class);
+        .isInstanceOf(PendingTargetRunConfigurationHandler.class);
   }
 
   @Test
@@ -99,7 +101,7 @@ public class BlazeCommandRunConfigurationGenericHandlerIntegrationTest
 
     assertThat(readConfiguration.getTargets()).containsExactly(targetExpression);
     assertThat(readConfiguration.getHandler())
-        .isInstanceOf(BlazeCommandGenericRunConfigurationHandler.class);
+        .isInstanceOf(PendingTargetRunConfigurationHandler.class);
 
     BlazeCommandRunConfigurationCommonState readState =
         (BlazeCommandRunConfigurationCommonState) readConfiguration.getHandler().getState();
@@ -122,7 +124,7 @@ public class BlazeCommandRunConfigurationGenericHandlerIntegrationTest
 
     assertThat(readConfiguration.getTargets()).isEqualTo(configuration.getTargets());
     assertThat(readConfiguration.getHandler())
-        .isInstanceOf(BlazeCommandGenericRunConfigurationHandler.class);
+        .isInstanceOf(PendingTargetRunConfigurationHandler.class);
   }
 
   @Test
@@ -147,7 +149,7 @@ public class BlazeCommandRunConfigurationGenericHandlerIntegrationTest
 
     assertThat(readConfiguration.getTargets()).containsExactly(targetExpression);
     assertThat(readConfiguration.getHandler())
-        .isInstanceOf(BlazeCommandGenericRunConfigurationHandler.class);
+        .isInstanceOf(PendingTargetRunConfigurationHandler.class);
 
     BlazeCommandRunConfigurationCommonState readState =
         (BlazeCommandRunConfigurationCommonState) readConfiguration.getHandler().getState();
@@ -174,7 +176,7 @@ public class BlazeCommandRunConfigurationGenericHandlerIntegrationTest
     configuration.setTarget(null);
     assertThat(configuration.getTargets()).isEmpty();
     assertThat(configuration.getHandler())
-        .isInstanceOf(BlazeCommandGenericRunConfigurationHandler.class);
+        .isInstanceOf(PendingTargetRunConfigurationHandler.class);
     BlazeCommandRunConfigurationCommonState state =
         (BlazeCommandRunConfigurationCommonState) configuration.getHandler().getState();
 
@@ -197,7 +199,7 @@ public class BlazeCommandRunConfigurationGenericHandlerIntegrationTest
 
     assertThat(readConfiguration.getTargets()).isEmpty();
     assertThat(configuration.getHandler())
-        .isInstanceOf(BlazeCommandGenericRunConfigurationHandler.class);
+        .isInstanceOf(PendingTargetRunConfigurationHandler.class);
 
     readState = (BlazeCommandRunConfigurationCommonState) readConfiguration.getHandler().getState();
     assertThat(readState.getCommandState().getCommand())

--- a/base/tests/integrationtests/com/google/idea/blaze/base/run/BlazeCommandRunConfigurationRunManagerImplTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/run/BlazeCommandRunConfigurationRunManagerImplTest.java
@@ -137,6 +137,7 @@ public class BlazeCommandRunConfigurationRunManagerImplTest extends BlazeIntegra
     final XMLOutputter xmlOutputter = new XMLOutputter(Format.getCompactFormat());
     final BlazeCommandRunConfigurationSettingsEditor editor =
         new BlazeCommandRunConfigurationSettingsEditor(configuration);
+    configuration.setKeepInSync(false); // Except keep in sync: null is translated to false;
     configuration.setTarget(Label.create("//package:rule"));
 
     final Element initialElement = runManager.getState();

--- a/base/tests/utils/unit/com/google/idea/blaze/base/run/MockBlazeCommandRunConfigurationHandlerProvider.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/run/MockBlazeCommandRunConfigurationHandlerProvider.java
@@ -36,6 +36,11 @@ import org.jdom.Element;
 public class MockBlazeCommandRunConfigurationHandlerProvider
     implements BlazeCommandRunConfigurationHandlerProvider {
   @Override
+  public String getDisplayLabel() {
+    return "Mock";
+  }
+
+  @Override
   public boolean canHandleKind(TargetState state, @Nullable Kind kind) {
     return true;
   }

--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrRunConfigurationHandlerProvider.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrRunConfigurationHandlerProvider.java
@@ -26,6 +26,11 @@ public class BlazeCidrRunConfigurationHandlerProvider
     implements BlazeCommandRunConfigurationHandlerProvider {
 
   @Override
+  public String getDisplayLabel() {
+    return "CC Compatible (Binary or Test)";
+  }
+
+  @Override
   public boolean canHandleKind(TargetState state, @Nullable Kind kind) {
     return RunConfigurationUtils.canUseClionHandler(kind);
   }

--- a/golang/src/com/google/idea/blaze/golang/run/BlazeGoRunConfigurationHandlerProvider.java
+++ b/golang/src/com/google/idea/blaze/golang/run/BlazeGoRunConfigurationHandlerProvider.java
@@ -28,6 +28,11 @@ public class BlazeGoRunConfigurationHandlerProvider
     implements BlazeCommandRunConfigurationHandlerProvider {
 
   @Override
+  public String getDisplayLabel() {
+    return "Go (Binary or Test)";
+  }
+
+  @Override
   public boolean canHandleKind(TargetState state, @Nullable Kind kind) {
     return kind != null
         && kind.hasLanguage(LanguageClass.GO)

--- a/java/src/com/google/idea/blaze/java/run/BlazeJavaRunConfigurationHandlerProvider.java
+++ b/java/src/com/google/idea/blaze/java/run/BlazeJavaRunConfigurationHandlerProvider.java
@@ -35,6 +35,11 @@ public class BlazeJavaRunConfigurationHandlerProvider
   }
 
   @Override
+  public String getDisplayLabel() {
+    return "JVM Compatible (Binary or Test)";
+  }
+
+  @Override
   public boolean canHandleKind(TargetState state, @Nullable Kind kind) {
     return supportsKind(kind);
   }

--- a/java/tests/unittests/com/google/idea/blaze/java/run/BlazeJavaRunProfileStateTest.java
+++ b/java/tests/unittests/com/google/idea/blaze/java/run/BlazeJavaRunProfileStateTest.java
@@ -44,6 +44,7 @@ import com.google.idea.blaze.base.run.BlazeCommandRunConfigurationType;
 import com.google.idea.blaze.base.run.ExecutorType;
 import com.google.idea.blaze.base.run.confighandler.BlazeCommandGenericRunConfigurationHandlerProvider;
 import com.google.idea.blaze.base.run.confighandler.BlazeCommandRunConfigurationHandlerProvider;
+import com.google.idea.blaze.base.run.confighandler.PendingTargetRunConfigurationHandlerProvider;
 import com.google.idea.blaze.base.run.state.BlazeCommandRunConfigurationCommonState;
 import com.google.idea.blaze.base.run.targetfinder.TargetFinder;
 import com.google.idea.blaze.base.scope.BlazeContext;
@@ -115,6 +116,8 @@ public class BlazeJavaRunProfileStateTest extends BlazeTestCase {
         registerExtensionPoint(
             BlazeCommandRunConfigurationHandlerProvider.EP_NAME,
             BlazeCommandRunConfigurationHandlerProvider.class);
+    handlerProviderEp.registerExtension(
+      new PendingTargetRunConfigurationHandlerProvider(), testDisposable);
     handlerProviderEp.registerExtension(
         new BlazeJavaRunConfigurationHandlerProvider(), testDisposable);
     handlerProviderEp.registerExtension(

--- a/python/src/com/google/idea/blaze/python/run/BlazePyRunConfigurationHandlerProvider.java
+++ b/python/src/com/google/idea/blaze/python/run/BlazePyRunConfigurationHandlerProvider.java
@@ -26,6 +26,11 @@ public class BlazePyRunConfigurationHandlerProvider
     implements BlazeCommandRunConfigurationHandlerProvider {
 
   @Override
+  public String getDisplayLabel() {
+    return "Python";
+  }
+
+  @Override
   public boolean canHandleKind(TargetState state, @Nullable Kind kind) {
     return PyDebugUtils.canUsePyDebugger(kind);
   }


### PR DESCRIPTION
Cherry pick AOSP commit [990fdde7dae9cb0964c3e8339c3e8d6698b45e7e](https://cs.android.com/android-studio/platform/tools/adt/idea/+/990fdde7dae9cb0964c3e8339c3e8d6698b45e7e).

Let users control the IDE.

1. Allow breaking links between XML files and run configurations. It
   often happens that one need to modify an imported configuration.
   If syncing is disabled it won't be auto-updated by the sync unless
   the link is re-enabled by the user.

2. Do not auto-detect the configuration handler every time the set of
   selected build targets change. This may look like being helpful but
   it is not obvious to users. Instead, the IDE should warn users about
   incompatible run configuration handlers.

   This will also prevent the IDE from corrupting run configurations
   imported from XML files.

3. Keep auto-detecting the handler when the build targets are set for
   the first time since run configuration syncing depends on this
   behavior.

4. Allow users to choose the run configuration handler manually. It is
   absolutely fine to just `build` and Android binary target and it is
   also fine to attempt to deploy any other target. Most will fail but
   some may be compatible rules.

5. In the future, add a button to detect the handler automatically,
   which if needed can query blaze/depserver for the target kind if
   unknown.

NOTE: This does not fix the issues itself and those run configurations
      that failed to be imported correctly won't bew imported correctly
      afterwards, however this change allows users to fix run
      configurations themselves.

Bug: 382099213
Test: n/a (unfortunately)
Change-Id: I979a3cf9f32a0425b2732ee105212aef9985a0ab

AOSP: 990fdde7dae9cb0964c3e8339c3e8d6698b45e7e
