### PR TITLE
[AOSP-pick] Hide `FileGitHubIssueAction` as Github is no longer used to track issues against ASwB

### DIFF
--- a/base/src/com/google/idea/blaze/base/actions/FileGitHubIssueAction.java
+++ b/base/src/com/google/idea/blaze/base/actions/FileGitHubIssueAction.java
@@ -53,8 +53,10 @@ public final class FileGitHubIssueAction extends BlazeProjectAction {
 
   private static final String BASE_URL = "https://github.com/bazelbuild/intellij/issues/new";
 
+  // TODO(b/383187717): Enable this action after modifying it to open bugs under
+  // Android Public Tracker > App Development > Android Studio instead of github.
   private static final BoolExperiment enabled =
-      new BoolExperiment("github.issue.filing.enabled", true);
+      new BoolExperiment("github.issue.filing.enabled", false);
 
   /**
    * A rough heuristic to detect if the machine is a Google-corp machine by executing 'glogin


### PR DESCRIPTION
Cherry pick AOSP commit [52393dd1e45b4c52a3b07f0dbc4af138e29dbe06](https://cs.android.com/android-studio/platform/tools/adt/idea/+/52393dd1e45b4c52a3b07f0dbc4af138e29dbe06).

Change-Id: Iabf6fbad1821c23aebd64dcbf93b52c0f9df50f0
Tests: manual
Bug: 349186243

AOSP: 52393dd1e45b4c52a3b07f0dbc4af138e29dbe06
