### PR TITLE
[AOSP-pick] Fix _proto deps that are supposed to be proto_deps

### DIFF
--- a/querysync/java/com/google/idea/blaze/qsync/query/BUILD
+++ b/querysync/java/com/google/idea/blaze/qsync/query/BUILD
@@ -23,9 +23,9 @@ java_library(
     srcs = glob(["*.java"]),
     deps = [
         ":querysummary_java_proto",
+        "//proto:proto_deps",
         "//shared",
         "//shared:proto",
-        "//third_party/bazel/src/main/protobuf:build_java_proto",
         "//third_party/java/auto_value",
         "@com_google_guava_guava//jar",
         "@error_prone_annotations//jar",


### PR DESCRIPTION
Cherry pick AOSP commit [606614a93ac85d38cadab53c31536ae273c9b155](https://cs.android.com/android-studio/platform/tools/adt/idea/+/606614a93ac85d38cadab53c31536ae273c9b155).

This is to prevent upcoming changes break at runtime.

Bug: 383454198
Test: n/a
Change-Id: I4f79d39eab41d412f0d67ed34660d5c711d7bed4

AOSP: 606614a93ac85d38cadab53c31536ae273c9b155
