### PR TITLE
Revert "Hide `FileGitHubIssueAction` as Github is no longer used to track issues against ASwB (#7277)"

### DIFF
--- a/base/src/com/google/idea/blaze/base/actions/FileGitHubIssueAction.java
+++ b/base/src/com/google/idea/blaze/base/actions/FileGitHubIssueAction.java
@@ -53,10 +53,8 @@ public final class FileGitHubIssueAction extends BlazeProjectAction {
 
   private static final String BASE_URL = "https://github.com/bazelbuild/intellij/issues/new";
 
-  // TODO(b/383187717): Enable this action after modifying it to open bugs under
-  // Android Public Tracker > App Development > Android Studio instead of github.
   private static final BoolExperiment enabled =
-      new BoolExperiment("github.issue.filing.enabled", false);
+      new BoolExperiment("github.issue.filing.enabled", true);
 
   /**
    * A rough heuristic to detect if the machine is a Google-corp machine by executing 'glogin


### PR DESCRIPTION
This reverts commit 68cfd5f0ddc5da1406b45c1a1a29171876f6030f (#7277).
