### PR TITLE
Use toolchains_aspects to propagate aspects to toolchains

### DIFF
--- a/aspect/intellij_info.bzl
+++ b/aspect/intellij_info.bzl
@@ -4,12 +4,17 @@ load(
     ":intellij_info_impl.bzl",
     "intellij_info_aspect_impl",
     "make_intellij_info_aspect",
+    "is_valid_aspect_target",
 )
 
 EXTRA_DEPS = [
     "embed",  # From go rules (bazel only)
     "_cc_toolchain",  # From rules_cc (bazel only)
     "_kt_toolchain",  # From rules_kotlin (bazel only)
+]
+
+TOOLCHAIN_TYPE_DEPS = [
+    "@@bazel_tools//tools/cpp:toolchain_type",  # For rules_cc
 ]
 
 def tool_label(tool_name):
@@ -50,8 +55,21 @@ def get_py_launcher(target, ctx):
         return str(attr._launcher.label)
     return None
 
+def _collect_targets_from_toolchains(ctx, toolchain_types):
+    """Returns a list of targets for the given toolchain types."""
+    result = []
+    for toolchain_type in toolchain_types:
+        if toolchain_type in ctx.rule.toolchains:
+            if is_valid_aspect_target(ctx.rule.toolchains[toolchain_type]):
+                result.append(ctx.rule.toolchains[toolchain_type])
+    return result
+    
 semantics = struct(
     tool_label = tool_label,
+    toolchains_propagation  = struct(
+        toolchain_types = TOOLCHAIN_TYPE_DEPS,
+        collect_toolchain_deps = _collect_targets_from_toolchains,
+    ),
     extra_deps = EXTRA_DEPS,
     extra_required_aspect_providers = [],
     go = struct(
@@ -68,4 +86,4 @@ semantics = struct(
 def _aspect_impl(target, ctx):
     return intellij_info_aspect_impl(target, ctx, semantics)
 
-intellij_info_aspect = make_intellij_info_aspect(_aspect_impl, semantics)
+intellij_info_aspect = make_intellij_info_aspect(_aspect_impl, semantics, toolchains_aspects = TOOLCHAIN_TYPE_DEPS,)


### PR DESCRIPTION
with bazel @ head `_cc_toolchain` attribute is removed and we should modify the aspect to propagate to the toolchain via the toolchain type not the attribute name.

The feature for aspect to toolchains propagation is only available at Bazel 8, so we would need to version the aspect based on the user Bazel version if we want to merge this.