### PR TITLE
Add cfg exec to java runtime required by aspects

### DIFF
--- a/aspect/intellij_info_impl.bzl
+++ b/aspect/intellij_info_impl.bzl
@@ -1374,6 +1374,7 @@ def make_intellij_info_aspect(aspect_impl, semantics, **kwargs):
         ),
         "_java_runtime": attr.label(
             default = "@bazel_tools//tools/jdk:current_java_runtime",
+            cfg = "exec",
         ),
     }
 


### PR DESCRIPTION
If the configuration is not defined for the java runtime, this can cause toolchain resolution issues at runtime.
