### PR TITLE
Fix CLion integration tests for EAP

### DIFF
--- a/intellij_platform_sdk/BUILD.clion251
+++ b/intellij_platform_sdk/BUILD.clion251
@@ -54,6 +54,7 @@ java_import(
     jars = glob([
         "plugins/c-plugin/lib/*.jar",
         "plugins/cidr-base-plugin/lib/*.jar",
+        "plugins/cidr-base-plugin/lib/modules/*.jar",
         "plugins/cidr-debugger-plugin/lib/*.jar",
         "plugins/clion/lib/*.jar",
         "plugins/clion-test-google/lib/*.jar",


### PR DESCRIPTION
Update BUILD.clion251 to reflect layout changes in the latest EAP.