### PR TITLE
improved query expression around transitions

### DIFF
--- a/querysync/java/com/google/idea/blaze/qsync/BlazeQueryParser.java
+++ b/querysync/java/com/google/idea/blaze/qsync/BlazeQueryParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 The Bazel Authors. All rights reserved.
+ * Copyright 2022-2025 The Bazel Authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,13 +42,6 @@ import java.util.Set;
  * yields a {@link BuildGraphData} instance derived from it. Instances of this class are single use.
  */
 public class BlazeQueryParser {
-
-  /**
-   * When a rule has a transition applied to it then it will present with this
-   * prefix on it.
-   */
-
-  private final static String RULE_NAME_PREFIX_TRANSITION = "_transition_";
 
   // Rules that will need to be built, whether the target is included in the
   // project or not.
@@ -113,17 +106,6 @@ public class BlazeQueryParser {
                                  RuleVisitor visitor) {
       for (String kind : kinds) {
         builder.put(kind, visitor);
-
-        // When the `bazel query` executes over Rules which have transitions applied to them, the
-        // returned list of data contains rules which have Rule names with `_` prefixed but with
-        // the original Kind and _also_ original Rule names with the Kind prefixed with
-        // `_transition_`. An example is when a specific pinned Python version is used, a
-        // transition is employed to enforce the vesion. In this case we see a rule `_my_rule` with
-        // kind `py_test` and a rule `my_rule` with kind `_transition_py_test`. Without
-        // accommodating for this, the `_transition_py_test` one would be ignored and so the
-        // downstream logic here would be working with the wrong Rule name.
-
-        builder.put(RULE_NAME_PREFIX_TRANSITION + kind, visitor);
       }
     }
   }
@@ -131,7 +113,7 @@ public class BlazeQueryParser {
   /**
    * Returns the list of all rule classes directly supported by the current query sync configuration.
    *
-   * <p>This information is only supposed ot be used to refine the Bazel query that query sync issues.
+   * <p>This information is only supposed to be used to refine the Bazel query that query sync issues.
    */
   public static ImmutableSet<String> getAllSupportedRuleClasses() {
     return new RuleVisitors().myVisitorsByRuleClass.keySet();


### PR DESCRIPTION
A prior PR ([7198](https://github.com/bazelbuild/intellij/pull/7198)) introduced ability for Bazel queries to handle Rules that have transitions applied to them. This change introduced a modified Bazel query used in the plugin. This commit will optimize the query so it is more compact and (most likely) performs slightly better.

# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: [7196](https://github.com/bazelbuild/intellij/issues/7196) was the original issue, this is an improvement related to a [comment](https://github.com/bazelbuild/intellij/pull/7198/files#r1953560330) on the PR [7198](https://github.com/bazelbuild/intellij/pull/7198) from @anguslees.

# Description of this change

The Bazel query issued by IJ previously contained the following;

```
kind("source file|android_library|_transition_android_library|android_binary|_transition_android_binary|android_local_test|_transition_android_local_test|android_instrumentation_test|_transition_android_instrumentation_test|kt_android_library_helper|_transition_kt_android_library_helper|java_library|_transition_java_library|java_binary|_transition_java_binary|kt_jvm_library|_transition_kt_jvm_library|kt_jvm_binary|_transition_kt_jvm_binary|kt_jvm_library_helper|_transition_kt_jvm_library_helper|kt_native_library|_transition_kt_native_library|java_test|_transition_java_test|java_proto_library|_transition_java_proto_library|java_lite_proto_library|_transition_java_lite_proto_library|java_mutable_proto_library|_transition_java_mutable_proto_library|_java_grpc_library|_transition__java_grpc_library|_kotlin_library|_transition__kotlin_library|_java_lite_grpc_library|_transition__java_lite_grpc_library|_iml_module_|_transition__iml_module_|cc_library|_transition_cc_library|cc_binary|_transition_cc_binary|cc_shared_library|_transition_cc_shared_library|cc_test|_transition_cc_test|proto_library|_transition_proto_library|py_library|_transition_py_library|py_binary|_transition_py_binary|py_test|_transition_py_test", $base) 
```

...and now it contains...

```
kind("source file|(_transition_)?(_iml_module_|_java_grpc_library|_java_lite_grpc_library|_kotlin_library|android_binary|android_instrumentation_test|android_library|android_local_test|cc_binary|cc_library|cc_shared_library|cc_test|java_binary|java_library|java_lite_proto_library|java_mutable_proto_library|java_proto_library|java_test|kt_android_library_helper|kt_jvm_binary|kt_jvm_library|kt_jvm_library_helper|kt_native_library|proto_library|py_binary|py_library|py_test)", $base)
```

Note the section `(_transition_)?(....)` replaces the repeated pattern in the earlier query.

See the [original issue](https://github.com/bazelbuild/intellij/issues/7196) for guidance on how to test and a minimal test project.