### PR TITLE
[AOSP-pick] Delete currently unused fields

### DIFF
--- a/base/src/com/google/idea/blaze/base/qsync/BazelDependencyBuilder.java
+++ b/base/src/com/google/idea/blaze/base/qsync/BazelDependencyBuilder.java
@@ -318,18 +318,10 @@ public class BazelDependencyBuilder implements DependencyBuilder {
       context.output(
         PrintOutput.log(String.format("Fetched and parsed artifact info files in %d ms", elapsed)));
     }
-    Optional<VcsState> vcsState = Optional.empty();
-    if (vcsHandler.isPresent()) {
-      try {
-        vcsState = vcsHandler.get().vcsStateForWorkspaceStatus(blazeBuildOutputs.workspaceStatus);
-      } catch (BuildException e) {
-        context.handleExceptionAsWarning("Failed to get VCS state", e);
-      }
-    }
     DependencyBuildContext buildContext =
         DependencyBuildContext.create(
             // getOnlyElement should be safe since we never shard querysync builds:
-            getOnlyElement(blazeBuildOutputs.getBuildIds()), buildTime, vcsState);
+            getOnlyElement(blazeBuildOutputs.getBuildIds()), buildTime);
 
     return OutputInfo.create(
         allArtifacts,

--- a/base/src/com/google/idea/blaze/base/sync/aspects/BlazeBuildOutputs.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/BlazeBuildOutputs.java
@@ -40,7 +40,7 @@ public class BlazeBuildOutputs {
 
   public static BlazeBuildOutputs noOutputs(BuildResult buildResult) {
     return new BlazeBuildOutputs(
-      buildResult, ImmutableMap.of(), ImmutableMap.of(), ImmutableSet.of(), 0L, ImmutableMap.of());
+      buildResult, ImmutableMap.of(), ImmutableMap.of(), ImmutableSet.of(), 0L);
   }
 
   @VisibleForTesting
@@ -50,8 +50,7 @@ public class BlazeBuildOutputs {
         ImmutableMap.of(),
         ImmutableMap.of(buildId, buildResult),
         ImmutableSet.of(),
-        0L,
-        ImmutableMap.of());
+        0L);
   }
 
   public static BlazeBuildOutputs fromParsedBepOutput(
@@ -67,8 +66,7 @@ public class BlazeBuildOutputs {
             : parsedOutput.getFullArtifactData(),
         buildIdWithResult,
         parsedOutput.getTargetsWithErrors(),
-        parsedOutput.getBepBytesConsumed(),
-        parsedOutput.getWorkspaceStatus());
+        parsedOutput.getBepBytesConsumed());
   }
 
   public final BuildResult buildResult;
@@ -76,8 +74,6 @@ public class BlazeBuildOutputs {
   private final ImmutableMap<String, BuildResult> buildShardResults;
   private final ImmutableSet<String> targetsWithErrors;
   public final long bepBytesConsumed;
-
-  public final ImmutableMap<String, String> workspaceStatus;
 
   /**
    * {@link BepArtifactData} by {@link OutputArtifact#getBazelOutRelativePath()} for all artifacts from a
@@ -93,14 +89,12 @@ public class BlazeBuildOutputs {
     Map<String, BepArtifactData> artifacts,
       ImmutableMap<String, BuildResult> buildShardResults,
     ImmutableSet<String> targetsWithErrors,
-    long bepBytesConsumed,
-    ImmutableMap<String, String> workspaceStatus) {
+    long bepBytesConsumed) {
     this.buildResult = buildResult;
     this.artifacts = ImmutableMap.copyOf(artifacts);
     this.buildShardResults = buildShardResults;
     this.targetsWithErrors = targetsWithErrors;
     this.bepBytesConsumed = bepBytesConsumed;
-    this.workspaceStatus = workspaceStatus;
 
     ImmutableSetMultimap.Builder<String, OutputArtifact> perTarget = ImmutableSetMultimap.builder();
     artifacts.values().forEach(a -> a.topLevelTargets.forEach(t -> perTarget.put(t, a.artifact)));
@@ -171,8 +165,7 @@ public class BlazeBuildOutputs {
                 // On duplicate buildIds, preserve most recent result
                 toImmutableMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1)),
       Sets.union(targetsWithErrors, nextOutputs.targetsWithErrors).immutableCopy(),
-      bepBytesConsumed + nextOutputs.bepBytesConsumed,
-      workspaceStatus);
+      bepBytesConsumed + nextOutputs.bepBytesConsumed);
   }
 
   public ImmutableList<String> getBuildIds() {

--- a/querysync/java/com/google/idea/blaze/qsync/deps/ArtifactTrackerStateDeserializer.java
+++ b/querysync/java/com/google/idea/blaze/qsync/deps/ArtifactTrackerStateDeserializer.java
@@ -71,16 +71,11 @@ public class ArtifactTrackerStateDeserializer {
   }
 
   private void visitBuildContext(ArtifactTrackerProto.BuildContext buildContext) {
-    Optional<VcsState> vcsState = Optional.empty();
-    if (buildContext.hasVcsState()) {
-      vcsState = Optional.of(SnapshotDeserializer.convertVcsState(buildContext.getVcsState()));
-    }
     buildContexts.put(
         buildContext.getBuildId(),
         DependencyBuildContext.create(
             buildContext.getBuildId(),
-            Instant.ofEpochMilli(buildContext.getStartTimeMillis()),
-            vcsState));
+            Instant.ofEpochMilli(buildContext.getStartTimeMillis())));
   }
 
   private void visitTargetBuildInfo(Map.Entry<String, ArtifactTrackerProto.TargetBuildInfo> entry) {

--- a/querysync/java/com/google/idea/blaze/qsync/deps/ArtifactTrackerStateSerializer.java
+++ b/querysync/java/com/google/idea/blaze/qsync/deps/ArtifactTrackerStateSerializer.java
@@ -77,9 +77,6 @@ public class ArtifactTrackerStateSerializer {
               .addBuildContextsBuilder()
               .setStartTimeMillis(buildContext.startTime().toEpochMilli())
               .setBuildId(buildContext.buildId());
-      buildContext
-          .vcsState()
-          .ifPresent(vcs -> SnapshotSerializer.visitVcsState(vcs, builder.getVcsStateBuilder()));
     }
   }
 

--- a/querysync/java/com/google/idea/blaze/qsync/deps/DependencyBuildContext.java
+++ b/querysync/java/com/google/idea/blaze/qsync/deps/DependencyBuildContext.java
@@ -27,7 +27,7 @@ import java.util.Optional;
 @AutoValue
 public abstract class DependencyBuildContext {
 
-  public static final DependencyBuildContext NONE = create("", Instant.EPOCH, Optional.empty());
+  public static final DependencyBuildContext NONE = create("", Instant.EPOCH);
 
   /** The bazel build ID. */
   public abstract String buildId();
@@ -38,14 +38,8 @@ public abstract class DependencyBuildContext {
    */
   public abstract Instant startTime();
 
-  /**
-   * The state of the VCS from the build that produced this output. May be absent if the bazel
-   * instance or VCS state do not support this.
-   */
-  public abstract Optional<VcsState> vcsState();
-
   public static DependencyBuildContext create(
-      String buildId, Instant startTime, Optional<VcsState> vcsState) {
-    return new AutoValue_DependencyBuildContext(buildId, startTime, vcsState);
+      String buildId, Instant startTime) {
+    return new AutoValue_DependencyBuildContext(buildId, startTime);
   }
 }

--- a/querysync/java/com/google/idea/blaze/qsync/deps/artifact_tracker_state.proto
+++ b/querysync/java/com/google/idea/blaze/qsync/deps/artifact_tracker_state.proto
@@ -91,7 +91,7 @@ message JavaArtifacts {
 message BuildContext {
   string build_id = 1;
   int64 start_time_millis = 2;
-  VcsState vcs_state = 3;
+  reserved 3;
 }
 
 message CcCompilationInfo {

--- a/querysync/javatests/com/google/idea/blaze/qsync/deps/ArtifactDirectoryBuilderTest.java
+++ b/querysync/javatests/com/google/idea/blaze/qsync/deps/ArtifactDirectoryBuilderTest.java
@@ -43,7 +43,7 @@ public class ArtifactDirectoryBuilderTest {
             BuildArtifact.create(
                 "digest", Path.of("build-out/path/to/artifact"), Label.of("//path/to:target")),
             DependencyBuildContext.create(
-                "build-id", Instant.EPOCH.plusSeconds(1), Optional.empty()));
+                "build-id", Instant.EPOCH.plusSeconds(1)));
 
     assertThat(added).hasValue(ProjectPath.projectRelative("artifactDir/path/to/artifact"));
 
@@ -82,7 +82,7 @@ public class ArtifactDirectoryBuilderTest {
         Path.of("path/to/artifact"),
         BuildArtifact.create(
             "digest1", Path.of("build-out/path/to/artifact"), Label.of("//path/to:target")),
-        DependencyBuildContext.create("build-id", Instant.EPOCH.plusSeconds(1), Optional.empty()));
+        DependencyBuildContext.create("build-id", Instant.EPOCH.plusSeconds(1)));
 
     Optional<ProjectPath> added =
         adb.addIfNewer(
@@ -90,7 +90,7 @@ public class ArtifactDirectoryBuilderTest {
             BuildArtifact.create(
                 "digest2", Path.of("build-out/path/to/newartifact"), Label.of("//path/to:target")),
             DependencyBuildContext.create(
-                "build-id", Instant.EPOCH.plusSeconds(2), Optional.empty()));
+                "build-id", Instant.EPOCH.plusSeconds(2)));
 
     assertThat(added).hasValue(ProjectPath.projectRelative("artifactDir/path/to/artifact"));
 
@@ -118,7 +118,7 @@ public class ArtifactDirectoryBuilderTest {
         Path.of("path/to/artifact"),
         BuildArtifact.create(
             "digest1", Path.of("build-out/path/to/artifact"), Label.of("//path/to:target")),
-        DependencyBuildContext.create("build-id", Instant.EPOCH.plusSeconds(2), Optional.empty()));
+        DependencyBuildContext.create("build-id", Instant.EPOCH.plusSeconds(2)));
 
     Optional<ProjectPath> added =
         adb.addIfNewer(
@@ -126,7 +126,7 @@ public class ArtifactDirectoryBuilderTest {
             BuildArtifact.create(
                 "digest2", Path.of("build-out/path/to/newartifact"), Label.of("//path/to:target")),
             DependencyBuildContext.create(
-                "build-id", Instant.EPOCH.plusSeconds(1), Optional.empty()));
+                "build-id", Instant.EPOCH.plusSeconds(1)));
 
     assertThat(added).isEmpty();
 
@@ -153,7 +153,7 @@ public class ArtifactDirectoryBuilderTest {
         Path.of("path/to/artifact"),
         BuildArtifact.create(
             "digest1", Path.of("build-out/path/to/artifact"), Label.of("//path/to:target")),
-        DependencyBuildContext.create("build-id", Instant.EPOCH.plusSeconds(1), Optional.empty()));
+        DependencyBuildContext.create("build-id", Instant.EPOCH.plusSeconds(1)));
 
     ProjectProto.ArtifactDirectories.Builder protoBuilder =
         TextFormat.parse(

--- a/querysync/javatests/com/google/idea/blaze/qsync/deps/ArtifactTrackerStateSerializationTest.java
+++ b/querysync/javatests/com/google/idea/blaze/qsync/deps/ArtifactTrackerStateSerializationTest.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.idea.blaze.common.Label;
-import com.google.idea.blaze.common.vcs.VcsState;
 import com.google.idea.blaze.qsync.artifacts.BuildArtifact;
 import com.google.idea.blaze.qsync.java.ArtifactTrackerProto.ArtifactTrackerState;
 import com.google.idea.blaze.qsync.java.JavaArtifactMetadata;
@@ -34,7 +33,6 @@ import com.google.idea.blaze.qsync.project.ProjectPath;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Map;
-import java.util.Optional;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -71,8 +69,7 @@ public class ArtifactTrackerStateSerializationTest {
     DependencyBuildContext buildContext =
         DependencyBuildContext.create(
             "abc-def",
-            Instant.ofEpochMilli(1000),
-            Optional.of(new VcsState("workspaceId", "12345", ImmutableSet.of(), Optional.empty())));
+            Instant.ofEpochMilli(1000));
     ImmutableMap<Label, TargetBuildInfo> depsMap =
         ImmutableMap.of(
             Label.of("//my/package:target"),
@@ -110,8 +107,7 @@ public class ArtifactTrackerStateSerializationTest {
     DependencyBuildContext buildContext =
         DependencyBuildContext.create(
             "abc-def",
-            Instant.ofEpochMilli(1000),
-            Optional.of(new VcsState("workspaceId", "12345", ImmutableSet.of(), Optional.empty())));
+            Instant.ofEpochMilli(1000));
     ImmutableMap<Label, TargetBuildInfo> depsMap =
         ImmutableMap.of(
             Label.of("//my/package:target"),
@@ -172,8 +168,7 @@ public class ArtifactTrackerStateSerializationTest {
     DependencyBuildContext buildContext =
         DependencyBuildContext.create(
             "abc-def",
-            Instant.ofEpochMilli(1000),
-            Optional.of(new VcsState("workspaceId", "12345", ImmutableSet.of(), Optional.empty())));
+            Instant.ofEpochMilli(1000));
     TargetBuildInfo.Builder targetInfo =
         TargetBuildInfo.forJavaTarget(
             JavaArtifactInfo.empty(Label.of("//my/package:target")).toBuilder()

--- a/querysync/javatests/com/google/idea/blaze/qsync/java/AddProjectGenSrcsTest.java
+++ b/querysync/javatests/com/google/idea/blaze/qsync/java/AddProjectGenSrcsTest.java
@@ -47,7 +47,6 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.Map;
-import java.util.Optional;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -155,7 +154,7 @@ public class AddProjectGenSrcsTest {
                             .withMetadata(new JavaSourcePackage("com.org"))))
                 .build(),
             DependencyBuildContext.create(
-                "abc-def", Instant.now().minusSeconds(60), Optional.empty()));
+                "abc-def", Instant.now().minusSeconds(60)));
 
     Label genSrc2Label = testData.getAssumedOnlyLabel().siblingWithName("genSrc2");
     TargetBuildInfo genSrc2 =
@@ -169,7 +168,7 @@ public class AddProjectGenSrcsTest {
                                 genSrc2Label)
                             .withMetadata(new JavaSourcePackage("com.org"))))
                 .build(),
-            DependencyBuildContext.create("abc-def", Instant.now(), Optional.empty()));
+            DependencyBuildContext.create("abc-def", Instant.now()));
 
     ArtifactTracker.State artifactState =
         ArtifactTracker.State.create(
@@ -242,7 +241,7 @@ public class AddProjectGenSrcsTest {
                             .withMetadata(new JavaSourcePackage("com.org"))))
                 .build(),
             DependencyBuildContext.create(
-                "abc-def", Instant.now().minusSeconds(60), Optional.empty()));
+                "abc-def", Instant.now().minusSeconds(60)));
 
     Label genSrc2Label = testData.getAssumedOnlyLabel().siblingWithName("genSrc2");
     TargetBuildInfo genSrc2 =
@@ -256,7 +255,7 @@ public class AddProjectGenSrcsTest {
                                 genSrc2Label)
                             .withMetadata(new JavaSourcePackage("com.org"))))
                 .build(),
-            DependencyBuildContext.create("abc-def", Instant.now(), Optional.empty()));
+            DependencyBuildContext.create("abc-def", Instant.now()));
 
     ArtifactTracker.State artifactState =
         ArtifactTracker.State.create(


### PR DESCRIPTION
Cherry pick AOSP commit [59eef1099056ea319a15d6afc36cd5b4ede11365](https://cs.android.com/android-studio/platform/tools/adt/idea/+/59eef1099056ea319a15d6afc36cd5b4ede11365).

as it complicates build output handling simplification.

VCS state in the artifact tracker is currently unused.

Bug: n/a
Test: n/a
Change-Id: If4d8d94538168024ef30fa327d7763049adce3d8

AOSP: 59eef1099056ea319a15d6afc36cd5b4ede11365
