### PR TITLE
[AOSP-pick] Separate BEP parsing and data

### DIFF
--- a/base/src/com/google/idea/blaze/base/command/buildresult/BuildResultHelperBep.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/BuildResultHelperBep.java
@@ -15,7 +15,7 @@
  */
 package com.google.idea.blaze.base.command.buildresult;
 
-import static com.google.idea.blaze.base.command.buildresult.bepparser.ParsedBepOutput.parseBepArtifacts;
+import static com.google.idea.blaze.base.command.buildresult.bepparser.BepParser.parseBepArtifacts;
 
 import com.google.idea.blaze.base.command.buildresult.bepparser.BuildEventStreamProvider;
 import com.intellij.openapi.diagnostic.Logger;

--- a/base/src/com/google/idea/blaze/base/command/buildresult/BuildResultParser.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/BuildResultParser.java
@@ -16,6 +16,7 @@
 package com.google.idea.blaze.base.command.buildresult;
 
 import com.google.common.collect.Interner;
+import com.google.idea.blaze.base.command.buildresult.bepparser.BepParser;
 import com.google.idea.blaze.base.command.buildresult.bepparser.BuildEventStreamProvider;
 import com.google.idea.blaze.base.command.buildresult.bepparser.ParsedBepOutput;
 import com.google.idea.blaze.base.run.testlogs.BlazeTestResults;
@@ -38,7 +39,7 @@ public final class BuildResultParser {
     BuildEventStreamProvider bepStream, Interner<String> stringInterner)
     throws BuildResultHelper.GetArtifactsException {
     try {
-      return ParsedBepOutput.parseBepArtifacts(bepStream, stringInterner);
+      return BepParser.parseBepArtifacts(bepStream, stringInterner);
     } catch (BuildEventStreamProvider.BuildEventStreamException e) {
       BuildResultHelper.logger.error(e);
       throw new BuildResultHelper.GetArtifactsException(String.format(

--- a/base/src/com/google/idea/blaze/base/command/buildresult/bepparser/BepParser.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/bepparser/BepParser.java
@@ -1,0 +1,309 @@
+package com.google.idea.blaze.base.command.buildresult.bepparser;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.Interner;
+import com.google.common.collect.Interners;
+import com.google.common.collect.Queues;
+import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos;
+import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.WorkspaceStatus.Item;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.idea.blaze.common.artifact.OutputArtifact;
+import com.google.idea.common.experiments.BoolExperiment;
+import com.google.idea.common.experiments.IntExperiment;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.components.Service;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.Semaphore;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+
+public final class BepParser {
+  private static final BoolExperiment parallelBepPoolingEnabled =
+    new BoolExperiment("bep.parsing.pooling.enabled", true);
+  // Maximum number of concurrent BEP parsing operations to allow.
+  // For large projects, BEP parsing of a single shard can consume several hundred Mb of memory
+  private static final IntExperiment maxThreads =
+    new IntExperiment("bep.parsing.concurrency.limit", 5);
+
+  private BepParser() {}
+
+  /** Parses BEP events into {@link ParsedBepOutput} */
+  public static ParsedBepOutput parseBepArtifacts(BuildEventStreamProvider stream)
+    throws BuildEventStreamProvider.BuildEventStreamException {
+    return parseBepArtifacts(stream, null);
+  }
+
+  /**
+   * Parses BEP events into {@link ParsedBepOutput}. String references in {@link BuildEventStreamProtos.NamedSetOfFiles}
+   * are interned to conserve memory.
+   *
+   * <p>BEP protos often contain many duplicate strings both within a single stream and across
+   * shards running in parallel, so a {@link Interner} is used to share references.
+   */
+  public static ParsedBepOutput parseBepArtifacts(
+      BuildEventStreamProvider stream, @Nullable Interner<String> interner)
+    throws BuildEventStreamProvider.BuildEventStreamException {
+    final var semaphore = ApplicationManager.getApplication().getService(BepParserSemaphore.class);
+    semaphore.start();
+    try {
+      if (interner == null) {
+        interner = Interners.newStrongInterner();
+      }
+
+      BuildEventStreamProtos.BuildEvent event;
+      Map<String, String> configIdToMnemonic = new HashMap<>();
+      Set<String> topLevelFileSets = new HashSet<>();
+      Map<String, FileSetBuilder> fileSets = new LinkedHashMap<>();
+      ImmutableSetMultimap.Builder<String, String> targetToFileSets = ImmutableSetMultimap.builder();
+      ImmutableSet.Builder<String> targetsWithErrors = ImmutableSet.builder();
+      String localExecRoot = null;
+      String buildId = null;
+      long startTimeMillis = 0L;
+      int buildResult = 0;
+      boolean emptyBuildEventStream = true;
+      ImmutableMap<String, String> workspaceStatus = ImmutableMap.of();
+
+      while ((event = stream.getNext()) != null) {
+        emptyBuildEventStream = false;
+        switch (event.getId().getIdCase()) {
+          case WORKSPACE:
+            localExecRoot = event.getWorkspaceInfo().getLocalExecRoot();
+            continue;
+          case WORKSPACE_STATUS:
+            workspaceStatus =
+                event.getWorkspaceStatus().getItemList().stream().collect(toImmutableMap(Item::getKey, Item::getValue));
+            continue;
+          case CONFIGURATION:
+            configIdToMnemonic.put(
+              event.getId().getConfiguration().getId(), event.getConfiguration().getMnemonic());
+            continue;
+          case NAMED_SET:
+            BuildEventStreamProtos.NamedSetOfFiles namedSet = internNamedSet(event.getNamedSetOfFiles(), interner);
+            fileSets.compute(
+              event.getId().getNamedSet().getId(),
+              (k, v) ->
+                v != null ? v.setNamedSet(namedSet) : new FileSetBuilder().setNamedSet(namedSet));
+            continue;
+          case ACTION_COMPLETED:
+            Preconditions.checkState(event.hasAction());
+            if (!event.getAction().getSuccess()) {
+              targetsWithErrors.add(event.getId().getActionCompleted().getLabel());
+            }
+            break;
+          case TARGET_COMPLETED:
+            String label = event.getId().getTargetCompleted().getLabel();
+            String configId = event.getId().getTargetCompleted().getConfiguration().getId();
+
+            event
+              .getCompleted()
+              .getOutputGroupList()
+              .forEach(
+                o -> {
+                  List<String> sets = getFileSets(o);
+                  targetToFileSets.putAll(label, sets);
+                  topLevelFileSets.addAll(sets);
+                  for (String id : sets) {
+                    fileSets.compute(
+                      id,
+                      (k, v) -> {
+                        FileSetBuilder builder = (v != null) ? v : new FileSetBuilder();
+                        return builder
+                          .setConfigId(configId)
+                          .addOutputGroups(ImmutableSet.of(o.getName()))
+                          .addTargets(ImmutableSet.of(label));
+                      });
+                  }
+                });
+            continue;
+          case STARTED:
+            buildId = Strings.emptyToNull(event.getStarted().getUuid());
+            startTimeMillis = event.getStarted().getStartTimeMillis();
+            continue;
+          case BUILD_FINISHED:
+            buildResult = event.getFinished().getExitCode().getCode();
+            continue;
+          default: // continue
+        }
+      }
+      // If stream is empty, it means that service failed to retrieve any blaze build event from build
+      // event stream. This should not happen if a build start correctly.
+      if (emptyBuildEventStream) {
+        throw new BuildEventStreamProvider.BuildEventStreamException("No build events found");
+      }
+      ImmutableMap<String, ParsedBepOutput.FileSet> filesMap =
+        fillInTransitiveFileSetData(
+          fileSets, topLevelFileSets, configIdToMnemonic, startTimeMillis);
+      return new ParsedBepOutput(
+        buildId,
+        localExecRoot,
+        workspaceStatus,
+        filesMap,
+        targetToFileSets.build(),
+        startTimeMillis,
+        buildResult,
+        stream.getBytesConsumed(),
+        targetsWithErrors.build());
+    }
+    finally {
+      semaphore.end();
+    }
+  }
+
+  private static List<String> getFileSets(BuildEventStreamProtos.OutputGroup group) {
+    return group.getFileSetsList().stream()
+        .map(BuildEventStreamProtos.BuildEventId.NamedSetOfFilesId::getId)
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Only top-level targets have configuration mnemonic, producing target, and output group data
+   * explicitly provided in BEP. This method fills in that data for the transitive closure.
+   */
+  private static ImmutableMap<String, ParsedBepOutput.FileSet> fillInTransitiveFileSetData(
+      Map<String, FileSetBuilder> fileSets,
+      Set<String> topLevelFileSets,
+      Map<String, String> configIdToMnemonic,
+      long startTimeMillis) {
+    Queue<String> toVisit = Queues.newArrayDeque(topLevelFileSets);
+    Set<String> visited = new HashSet<>(topLevelFileSets);
+    while (!toVisit.isEmpty()) {
+      String setId = toVisit.remove();
+      FileSetBuilder fileSet = fileSets.get(setId);
+      if (fileSet.namedSet == null) {
+        continue;
+      }
+      fileSet.namedSet.getFileSetsList().stream()
+          .map(BuildEventStreamProtos.BuildEventId.NamedSetOfFilesId::getId)
+          .filter(s -> !visited.contains(s))
+          .forEach(
+              child -> {
+                fileSets.get(child).updateFromParent(fileSet);
+                toVisit.add(child);
+                visited.add(child);
+              });
+    }
+    return fileSets.entrySet().stream()
+        .filter(e -> e.getValue().isValid(configIdToMnemonic))
+        .collect(
+            toImmutableMap(
+              Map.Entry::getKey, e -> e.getValue().build(configIdToMnemonic, startTimeMillis)));
+  }
+
+  private static ImmutableList<OutputArtifact> parseFiles(
+    BuildEventStreamProtos.NamedSetOfFiles namedSet, String config, long startTimeMillis) {
+    return namedSet.getFilesList().stream()
+        .map(f -> OutputArtifactParser.parseArtifact(f, config, startTimeMillis))
+        .filter(Objects::nonNull)
+        .collect(toImmutableList());
+  }
+
+  /** Returns a copy of a {@link BuildEventStreamProtos.NamedSetOfFiles} with interned string references. */
+  private static BuildEventStreamProtos.NamedSetOfFiles internNamedSet(
+    BuildEventStreamProtos.NamedSetOfFiles namedSet, Interner<String> interner) {
+    return namedSet.toBuilder()
+        .clearFiles()
+        .addAllFiles(
+            namedSet.getFilesList().stream()
+                .map(
+                    file -> {
+                      BuildEventStreamProtos.File.Builder builder =
+                          file.toBuilder()
+                              .setUri(interner.intern(file.getUri()))
+                              .setName(interner.intern(file.getName()))
+                              .clearPathPrefix()
+                              .addAllPathPrefix(
+                                  file.getPathPrefixList().stream()
+                                      .map(interner::intern)
+                                      .collect(Collectors.toUnmodifiableList()));
+                      return builder.build();
+                    })
+                .collect(Collectors.toUnmodifiableList()))
+        .build();
+  }
+
+  @Service(Service.Level.APP)
+  public static final class BepParserSemaphore {
+
+    public Semaphore parallelParsingSemaphore = parallelBepPoolingEnabled.getValue() ? new Semaphore(maxThreads.getValue()) : null;
+
+    public void start() throws BuildEventStreamProvider.BuildEventStreamException {
+      if (parallelParsingSemaphore != null) {
+        try {
+          parallelParsingSemaphore.acquire();
+        }
+        catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new BuildEventStreamProvider.BuildEventStreamException("Failed to acquire a parser semphore permit", e);
+        }
+      }
+    }
+
+    public void end() {
+      if (parallelParsingSemaphore != null) {
+        parallelParsingSemaphore.release();
+      }
+    }
+  }
+
+  private static class FileSetBuilder {
+    @Nullable BuildEventStreamProtos.NamedSetOfFiles namedSet;
+    @Nullable String configId;
+    final Set<String> outputGroups = new HashSet<>();
+    final Set<String> targets = new HashSet<>();
+
+    @CanIgnoreReturnValue
+    FileSetBuilder updateFromParent(FileSetBuilder parent) {
+      configId = parent.configId;
+      outputGroups.addAll(parent.outputGroups);
+      targets.addAll(parent.targets);
+      return this;
+    }
+
+    @CanIgnoreReturnValue
+    FileSetBuilder setNamedSet(BuildEventStreamProtos.NamedSetOfFiles namedSet) {
+      this.namedSet = namedSet;
+      return this;
+    }
+
+    @CanIgnoreReturnValue
+    FileSetBuilder setConfigId(String configId) {
+      this.configId = configId;
+      return this;
+    }
+
+    @CanIgnoreReturnValue
+    FileSetBuilder addOutputGroups(Set<String> outputGroups) {
+      this.outputGroups.addAll(outputGroups);
+      return this;
+    }
+
+    @CanIgnoreReturnValue
+    FileSetBuilder addTargets(Set<String> targets) {
+      this.targets.addAll(targets);
+      return this;
+    }
+
+    boolean isValid(Map<String, String> configIdToMnemonic) {
+      return namedSet != null && configId != null && configIdToMnemonic.get(configId) != null;
+    }
+
+    ParsedBepOutput.FileSet build(Map<String, String> configIdToMnemonic, long startTimeMillis) {
+      return new ParsedBepOutput.FileSet(parseFiles(namedSet, configIdToMnemonic.get(configId), startTimeMillis), outputGroups, targets);
+    }
+  }
+}

--- a/base/src/com/google/idea/blaze/base/command/buildresult/bepparser/ParsedBepOutput.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/bepparser/ParsedBepOutput.java
@@ -16,83 +16,25 @@
 package com.google.idea.blaze.base.command.buildresult.bepparser;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.stream.Collectors.groupingBy;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
-import com.google.common.collect.Interner;
-import com.google.common.collect.Interners;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Queues;
 import com.google.common.collect.SetMultimap;
-import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.BuildEvent;
-import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.BuildEventId.NamedSetOfFilesId;
-import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.File;
-import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.NamedSetOfFiles;
-import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.OutputGroup;
-import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.WorkspaceStatus.Item;
-import com.google.errorprone.annotations.CanIgnoreReturnValue;
-import com.google.idea.blaze.base.command.buildresult.bepparser.BuildEventStreamProvider.BuildEventStreamException;
 import com.google.idea.blaze.common.artifact.OutputArtifact;
-import com.google.idea.common.experiments.BoolExperiment;
-import com.google.idea.common.experiments.IntExperiment;
-import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.components.Service;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Objects;
-import java.util.Queue;
 import java.util.Set;
-import java.util.concurrent.Semaphore;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
 /** A data class representing blaze's build event protocol (BEP) output for a build. */
 public final class ParsedBepOutput {
-  private static final BoolExperiment parallelBepPoolingEnabled =
-    new BoolExperiment("bep.parsing.pooling.enabled", true);
-
-  // Maximum number of concurrent BEP parsing operations to allow.
-  // For large projects, BEP parsing of a single shard can consume several hundred Mb of memory
-  private static final IntExperiment maxThreads =
-    new IntExperiment("bep.parsing.concurrency.limit", 5);
-
-  @Service(Service.Level.APP)
-  public static final class BepParserSemaphore {
-
-    public Semaphore parallelParsingSemaphore = parallelBepPoolingEnabled.getValue() ? new Semaphore(maxThreads.getValue()) : null;
-
-    public void start() throws BuildEventStreamException {
-      if (parallelParsingSemaphore != null) {
-        try {
-          parallelParsingSemaphore.acquire();
-        }
-        catch (InterruptedException e) {
-          Thread.currentThread().interrupt();
-          throw new BuildEventStreamException("Failed to acquire a parser semphore permit", e);
-        }
-      }
-    }
-
-    public void end() {
-      if (parallelParsingSemaphore != null) {
-        parallelParsingSemaphore.release();
-      }
-    }
-  }
 
   @VisibleForTesting
   public static final ParsedBepOutput EMPTY =
@@ -106,168 +48,6 @@ public final class ParsedBepOutput {
           0,
           0,
           ImmutableSet.of());
-
-  /** Parses BEP events into {@link ParsedBepOutput} */
-  public static ParsedBepOutput parseBepArtifacts(BuildEventStreamProvider stream)
-      throws BuildEventStreamException {
-    return parseBepArtifacts(stream, null);
-  }
-
-  /**
-   * Parses BEP events into {@link ParsedBepOutput}. String references in {@link NamedSetOfFiles}
-   * are interned to conserve memory.
-   *
-   * <p>BEP protos often contain many duplicate strings both within a single stream and across
-   * shards running in parallel, so a {@link Interner} is used to share references.
-   */
-  public static ParsedBepOutput parseBepArtifacts(
-      BuildEventStreamProvider stream, @Nullable Interner<String> interner)
-      throws BuildEventStreamException {
-    final var semaphore = ApplicationManager.getApplication().getService(BepParserSemaphore.class);
-    semaphore.start();
-    try {
-      if (interner == null) {
-        interner = Interners.newStrongInterner();
-      }
-
-      BuildEvent event;
-      Map<String, String> configIdToMnemonic = new HashMap<>();
-      Set<String> topLevelFileSets = new HashSet<>();
-      Map<String, FileSet.Builder> fileSets = new LinkedHashMap<>();
-      ImmutableSetMultimap.Builder<String, String> targetToFileSets = ImmutableSetMultimap.builder();
-      ImmutableSet.Builder<String> targetsWithErrors = ImmutableSet.builder();
-      String localExecRoot = null;
-      String buildId = null;
-      ImmutableMap<String, String> workspaceStatus = ImmutableMap.of();
-      long startTimeMillis = 0L;
-      int buildResult = 0;
-      boolean emptyBuildEventStream = true;
-
-      while ((event = stream.getNext()) != null) {
-        emptyBuildEventStream = false;
-        switch (event.getId().getIdCase()) {
-          case WORKSPACE:
-            localExecRoot = event.getWorkspaceInfo().getLocalExecRoot();
-            continue;
-          case WORKSPACE_STATUS:
-            workspaceStatus =
-              event.getWorkspaceStatus().getItemList().stream().collect(toImmutableMap(Item::getKey, Item::getValue));
-            continue;
-          case CONFIGURATION:
-            configIdToMnemonic.put(
-              event.getId().getConfiguration().getId(), event.getConfiguration().getMnemonic());
-            continue;
-          case NAMED_SET:
-            NamedSetOfFiles namedSet = internNamedSet(event.getNamedSetOfFiles(), interner);
-            fileSets.compute(
-              event.getId().getNamedSet().getId(),
-              (k, v) ->
-                v != null ? v.setNamedSet(namedSet) : FileSet.builder().setNamedSet(namedSet));
-            continue;
-          case ACTION_COMPLETED:
-            Preconditions.checkState(event.hasAction());
-            if (!event.getAction().getSuccess()) {
-              targetsWithErrors.add(event.getId().getActionCompleted().getLabel());
-            }
-            break;
-          case TARGET_COMPLETED:
-            String label = event.getId().getTargetCompleted().getLabel();
-            String configId = event.getId().getTargetCompleted().getConfiguration().getId();
-
-            event
-              .getCompleted()
-              .getOutputGroupList()
-              .forEach(
-                o -> {
-                  List<String> sets = getFileSets(o);
-                  targetToFileSets.putAll(label, sets);
-                  topLevelFileSets.addAll(sets);
-                  for (String id : sets) {
-                    fileSets.compute(
-                      id,
-                      (k, v) -> {
-                        FileSet.Builder builder = (v != null) ? v : FileSet.builder();
-                        return builder
-                          .setConfigId(configId)
-                          .addOutputGroups(ImmutableSet.of(o.getName()))
-                          .addTargets(ImmutableSet.of(label));
-                      });
-                  }
-                });
-            continue;
-          case STARTED:
-            buildId = Strings.emptyToNull(event.getStarted().getUuid());
-            startTimeMillis = event.getStarted().getStartTimeMillis();
-            continue;
-          case BUILD_FINISHED:
-            buildResult = event.getFinished().getExitCode().getCode();
-            continue;
-          default: // continue
-        }
-      }
-      // If stream is empty, it means that service failed to retrieve any blaze build event from build
-      // event stream. This should not happen if a build start correctly.
-      if (emptyBuildEventStream) {
-        throw new BuildEventStreamException("No build events found");
-      }
-      ImmutableMap<String, FileSet> filesMap =
-        fillInTransitiveFileSetData(
-          fileSets, topLevelFileSets, configIdToMnemonic, startTimeMillis);
-      return new ParsedBepOutput(
-        buildId,
-        localExecRoot,
-        workspaceStatus,
-        filesMap,
-        targetToFileSets.build(),
-        startTimeMillis,
-        buildResult,
-        stream.getBytesConsumed(),
-        targetsWithErrors.build());
-    }
-    finally {
-      semaphore.end();
-    }
-  }
-
-  private static List<String> getFileSets(OutputGroup group) {
-    return group.getFileSetsList().stream()
-        .map(NamedSetOfFilesId::getId)
-        .collect(Collectors.toList());
-  }
-
-  /**
-   * Only top-level targets have configuration mnemonic, producing target, and output group data
-   * explicitly provided in BEP. This method fills in that data for the transitive closure.
-   */
-  private static ImmutableMap<String, FileSet> fillInTransitiveFileSetData(
-      Map<String, FileSet.Builder> fileSets,
-      Set<String> topLevelFileSets,
-      Map<String, String> configIdToMnemonic,
-      long startTimeMillis) {
-    Queue<String> toVisit = Queues.newArrayDeque(topLevelFileSets);
-    Set<String> visited = new HashSet<>(topLevelFileSets);
-    while (!toVisit.isEmpty()) {
-      String setId = toVisit.remove();
-      FileSet.Builder fileSet = fileSets.get(setId);
-      if (fileSet.namedSet == null) {
-        continue;
-      }
-      fileSet.namedSet.getFileSetsList().stream()
-          .map(NamedSetOfFilesId::getId)
-          .filter(s -> !visited.contains(s))
-          .forEach(
-              child -> {
-                fileSets.get(child).updateFromParent(fileSet);
-                toVisit.add(child);
-                visited.add(child);
-              });
-    }
-    return fileSets.entrySet().stream()
-        .filter(e -> e.getValue().isValid(configIdToMnemonic))
-        .collect(
-            toImmutableMap(
-                Entry::getKey, e -> e.getValue().build(configIdToMnemonic, startTimeMillis)));
-  }
 
   @Nullable public final String buildId;
 
@@ -288,7 +68,7 @@ public final class ParsedBepOutput {
   private final long bepBytesConsumed;
   private final ImmutableSet<String> targetsWithErrors;
 
-  private ParsedBepOutput(
+  ParsedBepOutput(
     @Nullable String buildId,
     @Nullable String localExecRoot,
     ImmutableMap<String, String> workspaceStatus,
@@ -385,108 +165,22 @@ public final class ParsedBepOutput {
     return targetsWithErrors;
   }
 
-  private static ImmutableList<OutputArtifact> parseFiles(
-      NamedSetOfFiles namedSet, String config, long startTimeMillis) {
-    return namedSet.getFilesList().stream()
-        .map(f -> OutputArtifactParser.parseArtifact(f, config, startTimeMillis))
-        .filter(Objects::nonNull)
-        .collect(toImmutableList());
-  }
-
-  private static class FileSet {
+  static class FileSet {
     private final ImmutableList<OutputArtifact> parsedOutputs;
     private final ImmutableSet<String> outputGroups;
     private final ImmutableSet<String> targets;
 
     FileSet(
-        NamedSetOfFiles namedSet,
-        String configuration,
-        long startTimeMillis,
+      ImmutableList<OutputArtifact> parsedOutputs,
         Set<String> outputGroups,
         Set<String> targets) {
-      this.parsedOutputs = parseFiles(namedSet, configuration, startTimeMillis);
+      this.parsedOutputs = parsedOutputs;
       this.outputGroups = ImmutableSet.copyOf(outputGroups);
       this.targets = ImmutableSet.copyOf(targets);
-    }
-
-    static Builder builder() {
-      return new Builder();
     }
 
     private Stream<BepArtifactData> toPerArtifactData() {
       return parsedOutputs.stream().map(a -> new BepArtifactData(a, outputGroups, targets));
     }
-
-    private static class Builder {
-      @Nullable NamedSetOfFiles namedSet;
-      @Nullable String configId;
-      final Set<String> outputGroups = new HashSet<>();
-      final Set<String> targets = new HashSet<>();
-
-      @CanIgnoreReturnValue
-      Builder updateFromParent(Builder parent) {
-        configId = parent.configId;
-        outputGroups.addAll(parent.outputGroups);
-        targets.addAll(parent.targets);
-        return this;
-      }
-
-      @CanIgnoreReturnValue
-      Builder setNamedSet(NamedSetOfFiles namedSet) {
-        this.namedSet = namedSet;
-        return this;
-      }
-
-      @CanIgnoreReturnValue
-      Builder setConfigId(String configId) {
-        this.configId = configId;
-        return this;
-      }
-
-      @CanIgnoreReturnValue
-      Builder addOutputGroups(Set<String> outputGroups) {
-        this.outputGroups.addAll(outputGroups);
-        return this;
-      }
-
-      @CanIgnoreReturnValue
-      Builder addTargets(Set<String> targets) {
-        this.targets.addAll(targets);
-        return this;
-      }
-
-      boolean isValid(Map<String, String> configIdToMnemonic) {
-        return namedSet != null && configId != null && configIdToMnemonic.get(configId) != null;
-      }
-
-      FileSet build(Map<String, String> configIdToMnemonic, long startTimeMillis) {
-        return new FileSet(
-            namedSet, configIdToMnemonic.get(configId), startTimeMillis, outputGroups, targets);
-      }
-    }
-  }
-
-  /** Returns a copy of a {@link NamedSetOfFiles} with interned string references. */
-  private static NamedSetOfFiles internNamedSet(
-      NamedSetOfFiles namedSet, Interner<String> interner) {
-    return namedSet.toBuilder()
-        .clearFiles()
-        .addAllFiles(
-            namedSet.getFilesList().stream()
-                .map(
-                    file -> {
-                      File.Builder builder =
-                          file.toBuilder()
-                              .setUri(interner.intern(file.getUri()))
-                              .setName(interner.intern(file.getName()))
-                              .clearPathPrefix()
-                              .addAllPathPrefix(
-                                  file.getPathPrefixList().stream()
-                                      .map(interner::intern)
-                                      .collect(Collectors.toUnmodifiableList()));
-                      return builder.build();
-                    })
-                .collect(Collectors.toUnmodifiableList()))
-        .build();
   }
 }

--- a/base/tests/unittests/com/google/idea/blaze/base/command/buildresult/BuildEventProtocolOutputReaderTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/command/buildresult/BuildEventProtocolOutputReaderTest.java
@@ -40,9 +40,9 @@ import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.Tar
 import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.TestResult;
 import com.google.idea.blaze.base.BlazeTestCase;
 import com.google.idea.blaze.base.command.buildresult.bepparser.BepArtifactData;
+import com.google.idea.blaze.base.command.buildresult.bepparser.BepParser;
 import com.google.idea.blaze.base.command.buildresult.bepparser.BuildEventStreamProvider;
 import com.google.idea.blaze.base.command.buildresult.bepparser.OutputArtifactParser;
-import com.google.idea.blaze.base.command.buildresult.bepparser.ParsedBepOutput;
 import com.google.idea.blaze.base.model.primitives.GenericBlazeRules;
 import com.google.idea.blaze.base.model.primitives.GenericBlazeRules.RuleTypes;
 import com.google.idea.blaze.base.model.primitives.Kind;
@@ -117,7 +117,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
                 ImmutableList.of(outputGroup("name", ImmutableList.of("set-id")))));
 
     ImmutableSet<OutputArtifact> parsedFilenames =
-        ParsedBepOutput.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)))
+        BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)))
             .getAllOutputArtifacts(path -> true);
 
     assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
@@ -141,7 +141,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
                 ImmutableList.of(outputGroup("name", ImmutableList.of("set-id")))));
 
     ImmutableSet<OutputArtifact> parsedFilenames =
-        ParsedBepOutput.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events))).getAllOutputArtifacts(filter);
+        BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events))).getAllOutputArtifacts(filter);
 
     assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
         .containsExactly(new File("/usr/local/lib/File.py"));
@@ -154,7 +154,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
             .setCompleted(BuildEventStreamProtos.TargetComplete.getDefaultInstance());
 
     ImmutableSet<OutputArtifact> parsedFilenames =
-        ParsedBepOutput.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(targetFinishedEvent)))
+        BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(targetFinishedEvent)))
             .getAllOutputArtifacts(path -> true);
 
     assertThat(parsedFilenames).isEmpty();
@@ -181,7 +181,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
                 ImmutableList.of(outputGroup("name", ImmutableList.of("set-id")))));
 
     ImmutableSet<OutputArtifact> parsedFilenames =
-        ParsedBepOutput.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)))
+        BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)))
             .getAllOutputArtifacts(path -> true);
 
     assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
@@ -226,7 +226,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
             .collect(toImmutableList());
 
     ImmutableSet<OutputArtifact> parsedFilenames =
-        ParsedBepOutput.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)))
+        BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)))
             .getAllOutputArtifacts(path -> true);
 
     assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
@@ -263,7 +263,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
             .collect(toImmutableList());
 
     ImmutableSet<OutputArtifact> parsedFilenames =
-        ParsedBepOutput.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)))
+        BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)))
             .getAllOutputArtifacts(path -> true);
 
     assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
@@ -295,7 +295,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
             .collect(toImmutableList());
 
     ImmutableSet<OutputArtifact> parsedFilenames =
-        ParsedBepOutput.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)))
+        BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)))
             .getDirectArtifactsForTarget("//some:target", path -> true);
 
     assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
@@ -335,7 +335,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
             .collect(toImmutableList());
 
     ImmutableSet<OutputArtifact> parsedFilenames =
-        ParsedBepOutput.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)))
+        BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)))
             .getDirectArtifactsForTarget("//some:target", path -> true);
 
     assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
@@ -381,7 +381,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
             .collect(toImmutableList());
 
     ImmutableList<OutputArtifact> parsedFilenames =
-        ParsedBepOutput.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)))
+        BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)))
             .getOutputGroupArtifacts("group-name", path -> true);
 
     assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
@@ -422,7 +422,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
             .collect(toImmutableList());
 
     ImmutableList<OutputArtifact> parsedFilenames =
-        ParsedBepOutput.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)))
+        BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)))
             .getOutputGroupArtifacts("group-1", path -> true);
 
     assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
@@ -458,7 +458,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
             .collect(toImmutableList());
 
     ImmutableMap<String, BepArtifactData> outputData =
-        ParsedBepOutput.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events))).getFullArtifactData();
+        BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events))).getFullArtifactData();
     ImmutableList<OutputArtifact> outputs =
         outputData.values().stream().map(d -> d.artifact).collect(toImmutableList());
 

--- a/base/tests/utils/unit/com/google/idea/blaze/base/bazel/BepUtils.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/bazel/BepUtils.java
@@ -30,6 +30,7 @@ import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.Con
 import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.NamedSetOfFiles;
 import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.OutputGroup;
 import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.TargetComplete;
+import com.google.idea.blaze.base.command.buildresult.bepparser.BepParser;
 import com.google.idea.blaze.base.command.buildresult.bepparser.BuildEventStreamProvider;
 import com.google.idea.blaze.base.command.buildresult.bepparser.BuildEventStreamProvider.BuildEventStreamException;
 import com.google.idea.blaze.base.command.buildresult.bepparser.ParsedBepOutput;
@@ -126,6 +127,6 @@ public final class BepUtils {
 
   public static ParsedBepOutput parsedBep(List<BuildEvent> events)
       throws IOException, BuildEventStreamException {
-    return ParsedBepOutput.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)));
+    return BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)));
   }
 }


### PR DESCRIPTION
Cherry pick AOSP commit [300518bc59dc4d72c797a07bbd786d779b5d68ac](https://cs.android.com/android-studio/platform/tools/adt/idea/+/300518bc59dc4d72c797a07bbd786d779b5d68ac).

This is a step towards having a simpler and faster implementation for
the needs of the query sync that does not support sharding.

Bug: 327638725
Test: n/a (existing)
Change-Id: I6a67096c23e18f433abaf24f74461cbe6f29638a

AOSP: 300518bc59dc4d72c797a07bbd786d779b5d68ac
