### PR TITLE
[AOSP-pick] Replace output group name filter

### DIFF
--- a/aswb/src/com/google/idea/blaze/android/libraries/RenderJarCache.java
+++ b/aswb/src/com/google/idea/blaze/android/libraries/RenderJarCache.java
@@ -142,7 +142,7 @@ public class RenderJarCache {
     ImmutableList<OutputArtifactWithoutDigest> renderJars =
         buildOutput
             .getOutputGroupArtifacts(
-                RenderResolveOutputGroupProvider.RESOLVE_OUTPUT_GROUP::contains)
+                RenderResolveOutputGroupProvider.RESOLVE_OUTPUT_GROUP)
             .stream()
             .collect(ImmutableList.toImmutableList());
     if (renderJars.isEmpty()) {

--- a/aswb/src/com/google/idea/blaze/android/sync/aspects/strategy/RenderResolveOutputGroupProvider.java
+++ b/aswb/src/com/google/idea/blaze/android/sync/aspects/strategy/RenderResolveOutputGroupProvider.java
@@ -25,8 +25,7 @@ import com.intellij.openapi.util.SystemInfo;
 
 /** Adds output group required by {@link RenderJarClassFileFinder} when it is enabled. */
 public class RenderResolveOutputGroupProvider implements OutputGroupsProvider {
-  public static final ImmutableSet<String> RESOLVE_OUTPUT_GROUP =
-      ImmutableSet.of("intellij-render-resolve-android");
+  public static final String RESOLVE_OUTPUT_GROUP = "intellij-render-resolve-android";
 
   /**
    * Experiment to toggle render jar generation during syncs. By default, render jars should be
@@ -45,7 +44,7 @@ public class RenderResolveOutputGroupProvider implements OutputGroupsProvider {
       return ImmutableSet.of();
     }
 
-    return RESOLVE_OUTPUT_GROUP;
+    return ImmutableSet.of(RESOLVE_OUTPUT_GROUP);
   }
 
   /** Returns a set of {@link OutputGroup} for which render jars should be built. */

--- a/base/src/com/google/idea/blaze/base/qsync/BazelAppInspectorBuilder.java
+++ b/base/src/com/google/idea/blaze/base/qsync/BazelAppInspectorBuilder.java
@@ -80,7 +80,7 @@ public class BazelAppInspectorBuilder implements AppInspectorBuilder {
 
   private AppInspectorInfo createAppInspectorInfo(BlazeBuildOutputs blazeBuildOutputs) {
     ImmutableList<OutputArtifact> appInspectorJars =
-        blazeBuildOutputs.getOutputGroupArtifacts(s -> s.contains("default"));
+        blazeBuildOutputs.getOutputGroupArtifacts("default");
 
     return AppInspectorInfo.create(appInspectorJars, blazeBuildOutputs.buildResult.exitCode);
   }

--- a/base/src/com/google/idea/blaze/base/qsync/BazelRenderJarBuilder.java
+++ b/base/src/com/google/idea/blaze/base/qsync/BazelRenderJarBuilder.java
@@ -18,8 +18,9 @@ package com.google.idea.blaze.base.qsync;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.io.ByteSource;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.io.CharSource;
+import com.google.common.io.MoreFiles;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -177,7 +178,7 @@ public class BazelRenderJarBuilder implements RenderJarBuilder {
 
   private RenderJarInfo createRenderJarInfo(BlazeBuildOutputs blazeBuildOutputs) {
     ImmutableList<OutputArtifact> renderJars =
-      blazeBuildOutputs.getOutputGroupArtifacts(s -> s.contains("render_jars"));
+      blazeBuildOutputs.getOutputGroupArtifacts("render_jars");
     // TODO(b/283283123): Update the aspect to only return the render jar of the required target.
     // TODO(b/283280194): To setup fqcn -> target and target -> render jar mappings that would
     // increase the count of render jars but help with the performance by reducing the size of the

--- a/base/src/com/google/idea/blaze/base/qsync/GroupedOutputArtifacts.java
+++ b/base/src/com/google/idea/blaze/base/qsync/GroupedOutputArtifacts.java
@@ -18,6 +18,7 @@ package com.google.idea.blaze.base.qsync;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableSet;
 import com.google.idea.blaze.base.sync.aspects.BlazeBuildOutputs;
 import com.google.idea.blaze.common.artifact.OutputArtifact;
 import com.google.idea.blaze.qsync.deps.OutputGroup;
@@ -41,7 +42,7 @@ public class GroupedOutputArtifacts {
     ImmutableListMultimap.Builder<OutputGroup, OutputArtifact> builder = builder();
     for (OutputGroup group : outputGroups) {
       ImmutableList<OutputArtifact> artifacts =
-        buildOutputs.getOutputGroupArtifacts(group.outputGroupName()::equals);
+        buildOutputs.getOutputGroupArtifacts(group.outputGroupName());
       builder.putAll(group, artifacts);
     }
     return builder.build();

--- a/base/src/com/google/idea/blaze/base/sync/aspects/BlazeBuildOutputs.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/BlazeBuildOutputs.java
@@ -107,12 +107,20 @@ public class BlazeBuildOutputs {
   }
 
   @VisibleForTesting
-  public ImmutableList<OutputArtifact> getOutputGroupArtifacts(
-      Predicate<String> outputGroupFilter) {
+  public ImmutableList<OutputArtifact> getOutputGroupArtifacts(String outputGroup) {
     return artifacts.values().stream()
-        .filter(a -> a.outputGroups.stream().anyMatch(outputGroupFilter))
+        .filter(a -> a.outputGroups.contains(outputGroup))
         .map(a -> a.artifact)
         .collect(toImmutableList());
+  }
+
+  @VisibleForTesting
+  public ImmutableList<OutputArtifact> getOutputGroupArtifactsLegacySyncOnly(
+    Predicate<String> outputGroupFilter) {
+    return artifacts.values().stream()
+      .filter(a -> a.outputGroups.stream().anyMatch(outputGroupFilter))
+      .map(a -> a.artifact)
+      .collect(toImmutableList());
   }
 
   public ImmutableSet<String> getTargetsWithErrors() {

--- a/base/src/com/google/idea/blaze/base/sync/aspects/BlazeIdeInterfaceAspectsImpl.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/BlazeIdeInterfaceAspectsImpl.java
@@ -187,7 +187,7 @@ public class BlazeIdeInterfaceAspectsImpl implements BlazeIdeInterface {
   private static ImmutableSet<OutputArtifact> getTrackedOutputs(
       BlazeBuildOutputs buildOutput, Predicate<String> outputGroupFilter) {
     Predicate<String> pathFilter = AspectStrategy.ASPECT_OUTPUT_FILE_PREDICATE.negate();
-    return buildOutput.getOutputGroupArtifacts(outputGroupFilter).stream()
+    return buildOutput.getOutputGroupArtifactsLegacySyncOnly(outputGroupFilter).stream()
         .filter(a -> pathFilter.test(a.getBazelOutRelativePath()))
         .collect(toImmutableSet());
   }
@@ -216,7 +216,7 @@ public class BlazeIdeInterfaceAspectsImpl implements BlazeIdeInterface {
     Collection<OutputArtifact> files =
         buildResult
             .getBuildResult()
-            .getOutputGroupArtifacts(group -> group.startsWith(OutputGroup.INFO.prefix))
+            .getOutputGroupArtifactsLegacySyncOnly(group -> group.startsWith(OutputGroup.INFO.prefix))
             .stream()
             .filter(f -> ideInfoPredicate.test(f.getBazelOutRelativePath()))
             .distinct()
@@ -308,7 +308,7 @@ public class BlazeIdeInterfaceAspectsImpl implements BlazeIdeInterface {
           ImmutableList<OutputArtifact> resolveOutputs =
               buildResult
                   .getBuildResult()
-                  .getOutputGroupArtifacts(group -> group.startsWith(OutputGroup.RESOLVE.prefix));
+                  .getOutputGroupArtifactsLegacySyncOnly(group -> group.startsWith(OutputGroup.RESOLVE.prefix));
           prefetchGenfiles(context, resolveOutputs);
         });
     return state;


### PR DESCRIPTION
Cherry pick AOSP commit [c47d961501bca50da2e2c5bfd4129f214cc69a46](https://cs.android.com/android-studio/platform/tools/adt/idea/+/c47d961501bca50da2e2c5bfd4129f214cc69a46).

STAT: 0 insertions(+), 0 deletion(-)

with an explicit group name where possible. Query sync does not require
a more expensive output group name filtering applied to each artifact.

Separate legacy and query sync use cases and simplify support for the
query sync one.

Bug: 327638725
Test: n/a (existing)
Change-Id: If2b465a63ea3f7c65d425ad7b1ebca645f3e0556

AOSP: c47d961501bca50da2e2c5bfd4129f214cc69a46
