### PR TITLE
[AOSP-pick] Handle output groups explicitly in deployment

### DIFF
--- a/base/src/com/google/idea/blaze/base/sync/aspects/BlazeBuildOutputs.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/BlazeBuildOutputs.java
@@ -17,6 +17,7 @@ package com.google.idea.blaze.base.sync.aspects;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -102,12 +103,17 @@ public class BlazeBuildOutputs {
   }
 
   /** Returns the output artifacts generated for target with given label. */
-  public ImmutableSet<OutputArtifact> artifactsForTarget(String label) {
-    return perTargetArtifacts.get(label);
+  public ImmutableSet<OutputArtifact> artifactsForTarget(String label, String outputGroup) {
+    // TODO: solodkyy - This is slow although it is invoked at most two times.
+    return artifacts.values().stream()
+      .filter(a -> a.outputGroups.contains(outputGroup) && a.topLevelTargets.contains(label))
+      .map(a -> a.artifact)
+      .collect(toImmutableSet());
   }
 
   @VisibleForTesting
   public ImmutableList<OutputArtifact> getOutputGroupArtifacts(String outputGroup) {
+    // TODO: solodkyy - This is slow although it is invoked at most two times.
     return artifacts.values().stream()
         .filter(a -> a.outputGroups.contains(outputGroup))
         .map(a -> a.artifact)


### PR DESCRIPTION
Cherry pick AOSP commit [7f3f6a874e415d342ebd7b81fb01a1e64041d88f](https://cs.android.com/android-studio/platform/tools/adt/idea/+/7f3f6a874e415d342ebd7b81fb01a1e64041d88f).

STAT (diff to AOSP): 0 insertions(+), 0 deletion(-)

Bug: 385469770
Bug: 385546508
Test: existing
Change-Id: Id077b2cee98a4186e81e7222ae0ea65d5b310036

AOSP: 7f3f6a874e415d342ebd7b81fb01a1e64041d88f
