### PR TITLE
Fixes for the PTY terminal on Windows

### DIFF
--- a/base/src/com/google/idea/blaze/base/buildview/BazelExecService.kt
+++ b/base/src/com/google/idea/blaze/base/buildview/BazelExecService.kt
@@ -35,17 +35,10 @@ import kotlin.io.path.pathString
 private val LOG: Logger = Logger.getInstance(BazelExecService::class.java)
 
 @Service(Service.Level.PROJECT)
-class BazelExecService(private val project: Project) : Disposable {
+class BazelExecService(private val project: Project, private val scope: CoroutineScope) {
   companion object {
     @JvmStatic
     fun instance(project: Project): BazelExecService = project.service()
-  }
-
-  // #api223 use the injected scope
-  private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-
-  override fun dispose() {
-    scope.cancel()
   }
 
   private fun assertNonBlocking() {

--- a/base/src/com/google/idea/blaze/base/buildview/BazelExecService.kt
+++ b/base/src/com/google/idea/blaze/base/buildview/BazelExecService.kt
@@ -79,7 +79,6 @@ class BazelExecService(private val project: Project, private val scope: Coroutin
       .withExePath(cmd.binaryPath)
       .withParameters(cmd.toArgumentList())
       .apply { setWorkDirectory(root.pathString) } // required for backwards compatability
-      .withRedirectErrorStream(true)
 
     var handler: OSProcessHandler? = null
     val exitCode = try {


### PR DESCRIPTION
Fix for no pty output on windows. Also addresses the missing \r after printing the command to the terminal. And some api-comapt clean up. 

