### PR TITLE
[AOSP-pick] Make artifact prefix path public

### DIFF
--- a/aswb/tests/unittests/com/google/idea/blaze/android/filecache/LocalArtifactCacheTest.java
+++ b/aswb/tests/unittests/com/google/idea/blaze/android/filecache/LocalArtifactCacheTest.java
@@ -114,7 +114,7 @@ public class LocalArtifactCacheTest {
     String execRoot = workspaceRoot.directory().getAbsolutePath();
     String mnemonic = "k8-opt";
     return new LocalFileOutputArtifactWithoutDigest(
-      new File(execRoot + "/blaze-out" + mnemonic + "/" + path), Path.of("blaze-out", mnemonic, path), mnemonic);
+      new File(execRoot + "/blaze-out" + mnemonic + "/" + path), Path.of("blaze-out", mnemonic, path), 1, mnemonic);
   }
 
   @Test

--- a/aswb/tests/unittests/com/google/idea/blaze/android/libraries/UnpackedAarsTest.java
+++ b/aswb/tests/unittests/com/google/idea/blaze/android/libraries/UnpackedAarsTest.java
@@ -192,6 +192,11 @@ public class UnpackedAarsTest extends BlazeTestCase {
       return artifactPath;
     }
 
+    @Override
+    public int getArtifactPathPrefixLength() {
+      return 0;
+    }
+
     @Nullable
     @Override
     public ArtifactState toArtifactState() {

--- a/base/src/com/google/idea/blaze/base/command/buildresult/LocalFileOutputArtifact.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/LocalFileOutputArtifact.java
@@ -27,8 +27,8 @@ public class LocalFileOutputArtifact extends LocalFileOutputArtifactWithoutDiges
   private final String digest;
 
   public LocalFileOutputArtifact(
-    File file, Path artifactPath, String configurationMnemonic, String digest) {
-    super(file, artifactPath, configurationMnemonic);
+    File file, Path artifactPath, int prefixLength, String configurationMnemonic, String digest) {
+    super(file, artifactPath, prefixLength, configurationMnemonic);
     this.digest = digest;
   }
 

--- a/base/src/com/google/idea/blaze/base/command/buildresult/LocalFileOutputArtifactWithoutDigest.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/LocalFileOutputArtifactWithoutDigest.java
@@ -35,12 +35,14 @@ public class LocalFileOutputArtifactWithoutDigest
 
   private final File file;
   private final Path artifactPath;
+  private final int prefixLength;
   private final String configurationMnemonic;
 
   public LocalFileOutputArtifactWithoutDigest(
-    File file, Path artifactPath, String configurationMnemonic) {
+    File file, Path artifactPath, int prefixLength, String configurationMnemonic) {
     this.file = file;
     this.artifactPath = artifactPath;
+    this.prefixLength = prefixLength;
     this.configurationMnemonic = configurationMnemonic;
   }
 
@@ -63,6 +65,11 @@ public class LocalFileOutputArtifactWithoutDigest
   @Override
   public Path getArtifactPath() {
     return artifactPath;
+  }
+
+  @Override
+  public int getArtifactPathPrefixLength() {
+    return prefixLength;
   }
 
   @Override

--- a/base/src/com/google/idea/blaze/base/command/buildresult/LocalFileParser.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/LocalFileParser.java
@@ -41,6 +41,7 @@ public class LocalFileParser implements OutputArtifactParser {
       return new LocalFileOutputArtifact(
         f,
         OutputArtifactParser.bazelFileToArtifactPath(file),
+        file.getPathPrefixCount(),
         configurationMnemonic,
         file.getDigest());
     }

--- a/base/src/com/google/idea/blaze/base/command/buildresult/RemoteOutputArtifact.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/RemoteOutputArtifact.java
@@ -54,6 +54,7 @@ public interface RemoteOutputArtifact
   default ProjectData.OutputArtifact toProto() {
     return ProjectData.OutputArtifact.newBuilder()
         .setArtifactPath(getArtifactPath().toString())
+        .setPrefixLengthPlusOne(getArtifactPathPrefixLength() + 1)
         .setId(getHashId())
         .setSyncStartTimeMillis(getSyncTimeMillis())
         .setFileLength(getLength())

--- a/base/src/com/google/idea/blaze/base/ideinfo/ArtifactLocation.java
+++ b/base/src/com/google/idea/blaze/base/ideinfo/ArtifactLocation.java
@@ -56,7 +56,7 @@ public final class ArtifactLocation
         .build();
   }
 
-  private String getRootExecutionPathFragment() {
+  public String getRootExecutionPathFragment() {
     return rootExecutionPathFragment;
   }
 

--- a/base/src/com/google/idea/blaze/base/sync/workspace/ArtifactLocationDecoderImpl.java
+++ b/base/src/com/google/idea/blaze/base/sync/workspace/ArtifactLocationDecoderImpl.java
@@ -141,6 +141,8 @@ public final class ArtifactLocationDecoderImpl implements ArtifactLocationDecode
       return new SourceArtifact(decode(location));
     }
     String configMnemonic = execRootPath.substring(ix1 + 1, ix2);
-    return new LocalFileOutputArtifactWithoutDigest(decode(location), Path.of(execRootPath), configMnemonic);
+    return new LocalFileOutputArtifactWithoutDigest(
+      decode(location), Path.of(execRootPath),
+      Path.of(location.getRootExecutionPathFragment()).getNameCount(), configMnemonic);
   }
 }

--- a/base/tests/utils/unit/com/google/idea/blaze/base/sync/FakeRemoteOutputArtifact.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/sync/FakeRemoteOutputArtifact.java
@@ -29,8 +29,10 @@ import org.jetbrains.annotations.Nullable;
 public class FakeRemoteOutputArtifact implements RemoteOutputArtifact {
   private final File file;
   private final Path artifactPath;
+  private final int artifactPathPrefixLength;
 
-  public FakeRemoteOutputArtifact(File file, Path artifactPath) {
+  public FakeRemoteOutputArtifact(File file, Path artifactPath, int artifactPathPrefixLength) {
+    this.artifactPathPrefixLength = artifactPathPrefixLength;
     if (!file.toPath().endsWith(artifactPath)) {
       throw new IllegalArgumentException(file + "must end with " + artifactPath);
     }
@@ -56,6 +58,11 @@ public class FakeRemoteOutputArtifact implements RemoteOutputArtifact {
   @Override
   public Path getArtifactPath() {
     return artifactPath;
+  }
+
+  @Override
+  public int getArtifactPathPrefixLength() {
+    return artifactPathPrefixLength;
   }
 
   @Nullable

--- a/base/tests/utils/unit/com/google/idea/blaze/base/sync/workspace/MockArtifactLocationDecoder.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/sync/workspace/MockArtifactLocationDecoder.java
@@ -55,10 +55,12 @@ public class MockArtifactLocationDecoder implements ArtifactLocationDecoder {
     }
 
     File file = decode(artifact);
+    int artifactPathPrefixLength = Path.of(artifact.getRootExecutionPathFragment()).getNameCount();
     if (isRemote && file.exists()) {
-      return new FakeRemoteOutputArtifact(file, workspaceRoot.toPath().relativize(file.toPath()));
+      return new FakeRemoteOutputArtifact(file, workspaceRoot.toPath().relativize(file.toPath()), artifactPathPrefixLength);
     }
     return new LocalFileOutputArtifactWithoutDigest(
-        decode(artifact), Path.of(artifact.getExecutionRootRelativePath()), artifact.getExecutionRootRelativePath());
+      decode(artifact), Path.of(artifact.getExecutionRootRelativePath()), artifactPathPrefixLength,
+      artifact.getExecutionRootRelativePath());
   }
 }

--- a/proto/project_data.proto
+++ b/proto/project_data.proto
@@ -162,6 +162,8 @@ message OutputArtifact {
   // The artifact path as returned by Bazel/s File.path (i.e. includes prefixes like bazel-out if present and maybe an absolute path).
   // Components of this path should not be inspected individually (except the file name).
   string artifact_path = 6;
+  // The length of the artifact prefix like `bazel-out/k8/bin`.
+  int32 prefix_length_plus_one = 7; // +1 to differentiate from the default.
 }
 
 message AndroidResourceModule {

--- a/shared/java/com/google/idea/blaze/common/artifact/OutputArtifactInfo.java
+++ b/shared/java/com/google/idea/blaze/common/artifact/OutputArtifactInfo.java
@@ -43,6 +43,11 @@ public interface OutputArtifactInfo {
   Path getArtifactPath();
 
   /**
+   * The length of a prefix path if any, i.e. the length of a prefix like `basel-out/k8/bin` is 3.
+   */
+  int getArtifactPathPrefixLength();
+
+  /**
    * The blaze-out-relative path.
    *
    * <p><b>Do not use</b> as it is quirky due to compatibility with old code. See: {@link #artifactPathToBazelOutRelativePath(Path)}

--- a/shared/javatests/com/google/idea/blaze/common/artifact/TestOutputArtifact.java
+++ b/shared/javatests/com/google/idea/blaze/common/artifact/TestOutputArtifact.java
@@ -29,6 +29,7 @@ public abstract class TestOutputArtifact implements OutputArtifact {
           .setLength(0)
           .setDigest("digest")
           .setArtifactPath(Path.of("path/file"))
+          .setArtifactPathPrefixLength(0)
           .setConfigurationMnemonic("mnemonic")
           .build();
 
@@ -55,6 +56,9 @@ public abstract class TestOutputArtifact implements OutputArtifact {
   public abstract Path getArtifactPath();
 
   @Override
+  public abstract int getArtifactPathPrefixLength();
+
+  @Override
   public abstract String getConfigurationMnemonic();
 
   @Nullable
@@ -73,6 +77,8 @@ public abstract class TestOutputArtifact implements OutputArtifact {
     public abstract Builder setDigest(String value);
 
     public abstract Builder setArtifactPath(Path value);
+
+    public abstract Builder setArtifactPathPrefixLength(int value);
 
     public abstract Builder setConfigurationMnemonic(String value);
 


### PR DESCRIPTION
Cherry pick AOSP commit [2ff0d9f3048d8b0d8ad4bf498a5e058d034d16fb](https://cs.android.com/android-studio/platform/tools/adt/idea/+/2ff0d9f3048d8b0d8ad4bf498a5e058d034d16fb).

A path to an artifact in Bazel consists of a prefix and the artifact
name constituting together the artifact path.

Expose the prefix to consumers to consumers in addition to the full
artifact path.

Prefixes and artifact names are needed to construct runfiles like
directory structures.

Bug: n/a
Test: n/a
Change-Id: Ie79b0f6dc4a456262d6bca93893b0886ca9ebabb

AOSP: 2ff0d9f3048d8b0d8ad4bf498a5e058d034d16fb
