### PR TITLE
[AOSP-pick] Extract BuildOutputs interface

### DIFF
--- a/base/src/com/google/idea/blaze/base/buildview/BazelExecService.kt
+++ b/base/src/com/google/idea/blaze/base/buildview/BazelExecService.kt
@@ -170,7 +170,7 @@ class BazelExecService(private val project: Project, private val scope: Coroutin
     }
   }
 
-  fun build(ctx: BlazeContext, cmdBuilder: BlazeCommand.Builder): BlazeBuildOutputs {
+  fun build(ctx: BlazeContext, cmdBuilder: BlazeCommand.Builder): BlazeBuildOutputs.Legacy {
     assertNonBlocking()
     LOG.assertTrue(cmdBuilder.name == BlazeCommandName.BUILD)
 
@@ -185,11 +185,11 @@ class BazelExecService(private val project: Project, private val scope: Coroutin
       parseJob.cancelAndJoin()
 
       if (result.status == BuildResult.Status.FATAL_ERROR) {
-        return@executionScope BlazeBuildOutputs.noOutputs(result)
+        return@executionScope BlazeBuildOutputs.noOutputsForLegacy(result)
       }
 
       provider.getBepStream(Optional.empty()).use { bepStream ->
-        BlazeBuildOutputs.fromParsedBepOutput(
+        BlazeBuildOutputs.fromParsedBepOutputForLegacy(
           result,
           BuildResultParser.getBuildOutput(bepStream, Interners.STRING),
         )

--- a/base/src/com/google/idea/blaze/base/command/BlazeCommandRunner.java
+++ b/base/src/com/google/idea/blaze/base/command/BlazeCommandRunner.java
@@ -44,6 +44,18 @@ public interface BlazeCommandRunner {
       throws BuildException;
 
   /**
+   * Runs a blaze build command, parses the build results into a {@link BlazeBuildOutputs} object
+   * using the given {@link BuildResultHelper}.
+   */
+  BlazeBuildOutputs.Legacy runLegacy(
+    Project project,
+    BlazeCommand.Builder blazeCommandBuilder,
+    BuildResultHelper buildResultHelper,
+    BlazeContext context,
+    Map<String, String> envVars)
+    throws BuildException;
+
+  /**
    * Runs a blaze test command, parses the test results into a {@link BlazeTestResults} object using
    * the given {@link BuildResultHelper}.
    */

--- a/base/src/com/google/idea/blaze/base/command/CommandLineBlazeCommandRunner.java
+++ b/base/src/com/google/idea/blaze/base/command/CommandLineBlazeCommandRunner.java
@@ -66,7 +66,7 @@ import java.util.function.Function;
 public class CommandLineBlazeCommandRunner implements BlazeCommandRunner {
 
   @Override
-  public BlazeBuildOutputs run(
+  public BlazeBuildOutputs.Legacy runLegacy(
       Project project,
       BlazeCommand.Builder blazeCommandBuilder,
       BuildResultHelper buildResultHelper,
@@ -75,7 +75,7 @@ public class CommandLineBlazeCommandRunner implements BlazeCommandRunner {
     try {
       performGuardCheck(project, context);
     } catch (ExecutionDeniedException e) {
-      return BlazeBuildOutputs.noOutputs(BuildResult.FATAL_ERROR);
+      return BlazeBuildOutputs.noOutputsForLegacy(BuildResult.FATAL_ERROR);
     }
 
     BuildResult buildResult =
@@ -83,7 +83,7 @@ public class CommandLineBlazeCommandRunner implements BlazeCommandRunner {
     BuildDepsStatsScope.fromContext(context)
         .ifPresent(stats -> stats.setBazelExitCode(buildResult.exitCode));
     if (buildResult.status == Status.FATAL_ERROR) {
-      return BlazeBuildOutputs.noOutputs(buildResult);
+      return BlazeBuildOutputs.noOutputsForLegacy(buildResult);
     }
     if (buildResult.status == Status.BUILD_ERROR) {
       context.setHasError();
@@ -99,12 +99,18 @@ public class CommandLineBlazeCommandRunner implements BlazeCommandRunner {
         buildOutput = BuildResultParser.getBuildOutput(bepStream, stringInterner);
       }
       context.output(PrintOutput.log("BEP outputs retrieved (%s).", StringUtilRt.formatFileSize(buildOutput.getBepBytesConsumed())));
-      return BlazeBuildOutputs.fromParsedBepOutput(buildResult, buildOutput);
+      return BlazeBuildOutputs.fromParsedBepOutputForLegacy(buildResult, buildOutput);
     } catch (GetArtifactsException e) {
       context.output(PrintOutput.log("Failed to get build outputs: " + e.getMessage()));
       context.setHasError();
-      return BlazeBuildOutputs.noOutputs(buildResult);
+      return BlazeBuildOutputs.noOutputsForLegacy(buildResult);
     }
+  }
+
+  @Override
+  public BlazeBuildOutputs run(Project project, BlazeCommand.Builder blazeCommandBuilder,
+                               BuildResultHelper buildResultHelper, BlazeContext context, Map<String, String> envVars) throws BuildException {
+    return runLegacy(project, blazeCommandBuilder, buildResultHelper, context, envVars);
   }
 
   @Override

--- a/base/src/com/google/idea/blaze/base/command/buildresult/bepparser/BepParser.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/bepparser/BepParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.idea.blaze.base.command.buildresult.bepparser;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;

--- a/base/src/com/google/idea/blaze/base/logging/utils/BuildPhaseSyncStats.java
+++ b/base/src/com/google/idea/blaze/base/logging/utils/BuildPhaseSyncStats.java
@@ -46,11 +46,7 @@ public abstract class BuildPhaseSyncStats {
 
   public abstract ImmutableList<TimedEvent> timedEvents();
 
-  public abstract ImmutableList<String> buildIds();
-
   public abstract Duration totalTime();
-
-  public abstract long bepBytesConsumed();
 
   public abstract Optional<ShardStats> shardStats();
 
@@ -66,8 +62,6 @@ public abstract class BuildPhaseSyncStats {
         .setTargetsDerivedFromDirectories(false)
         .setBuildResult(BuildResult.FATAL_ERROR)
         .setTimedEvents(ImmutableList.of())
-        .setBepBytesConsumed(0L)
-        .setBuildIds(ImmutableList.of())
         .setTotalTime(Duration.ZERO);
   }
   /** Auto value builder for SyncStats. */
@@ -89,11 +83,7 @@ public abstract class BuildPhaseSyncStats {
 
     public abstract Builder setTimedEvents(ImmutableList<TimedEvent> timedEvents);
 
-    public abstract Builder setBuildIds(ImmutableList<String> buildIds);
-
     public abstract Builder setTotalTime(Duration totalTime);
-
-    public abstract Builder setBepBytesConsumed(long bytes);
 
     public abstract Builder setShardStats(ShardStats shardStats);
 

--- a/base/src/com/google/idea/blaze/base/qsync/BazelDependencyBuilder.java
+++ b/base/src/com/google/idea/blaze/base/qsync/BazelDependencyBuilder.java
@@ -316,13 +316,13 @@ public class BazelDependencyBuilder implements DependencyBuilder {
     DependencyBuildContext buildContext =
         DependencyBuildContext.create(
             // getOnlyElement should be safe since we never shard querysync builds:
-            getOnlyElement(blazeBuildOutputs.getBuildIds()), buildTime);
+            blazeBuildOutputs.buildId(), buildTime);
 
     return OutputInfo.create(
       allArtifacts,
       artifactInfoFilesBuilder.build(),
       ccInfoBuilder.build(),
-      blazeBuildOutputs.getTargetsWithErrors().stream()
+      blazeBuildOutputs.targetsWithErrors().stream()
             .map(Object::toString)
             .map(Label::of)
             .collect(toImmutableSet()),

--- a/base/src/com/google/idea/blaze/base/qsync/GroupedOutputArtifacts.java
+++ b/base/src/com/google/idea/blaze/base/qsync/GroupedOutputArtifacts.java
@@ -18,7 +18,6 @@ package com.google.idea.blaze.base.qsync;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
-import com.google.common.collect.ImmutableSet;
 import com.google.idea.blaze.base.sync.aspects.BlazeBuildOutputs;
 import com.google.idea.blaze.common.artifact.OutputArtifact;
 import com.google.idea.blaze.qsync.deps.OutputGroup;

--- a/base/src/com/google/idea/blaze/base/sync/BlazeSyncBuildResult.java
+++ b/base/src/com/google/idea/blaze/base/sync/BlazeSyncBuildResult.java
@@ -52,7 +52,7 @@ public abstract class BlazeSyncBuildResult {
   public abstract BlazeInfo getBlazeInfo();
 
   @Nullable
-  public abstract BlazeBuildOutputs getBuildResult();
+  public abstract BlazeBuildOutputs.Legacy getBuildResult();
 
   public abstract ImmutableList<BuildPhaseSyncStats> getBuildPhaseStats();
 
@@ -67,7 +67,7 @@ public abstract class BlazeSyncBuildResult {
   public abstract static class Builder {
     public abstract Builder setBlazeInfo(BlazeInfo info);
 
-    public abstract Builder setBuildResult(BlazeBuildOutputs buildResult);
+    public abstract Builder setBuildResult(BlazeBuildOutputs.Legacy buildResult);
 
     public abstract Builder setBuildPhaseStats(Iterable<BuildPhaseSyncStats> stats);
 

--- a/base/src/com/google/idea/blaze/base/sync/BuildPhaseSyncTask.java
+++ b/base/src/com/google/idea/blaze/base/sync/BuildPhaseSyncTask.java
@@ -257,14 +257,12 @@ public final class BuildPhaseSyncTask {
         .setShardStats(shardedTargets.shardStats())
         .setParallelBuilds(syncBuildInvoker.supportsParallelism());
 
-    BlazeBuildOutputs blazeBuildResult =
+    BlazeBuildOutputs.Legacy blazeBuildResult =
         getBlazeBuildResult(context, viewSet, shardedTargets, syncBuildInvoker, parallel);
     resultBuilder.setBuildResult(blazeBuildResult);
     buildStats
         .setBuildResult(blazeBuildResult.buildResult())
-        .setBuildIds(blazeBuildResult.getBuildIds())
-        .setBuildBinaryType(syncBuildInvoker.getType())
-        .setBepBytesConsumed(blazeBuildResult.bepBytesConsumed);
+        .setBuildBinaryType(syncBuildInvoker.getType());
 
     if (context.isCancelled()) {
       throw new SyncCanceledException();
@@ -427,7 +425,7 @@ public final class BuildPhaseSyncTask {
     return targets.build();
   }
 
-  private BlazeBuildOutputs getBlazeBuildResult(
+  private BlazeBuildOutputs.Legacy getBlazeBuildResult(
       BlazeContext parentContext,
       ProjectViewSet projectViewSet,
       ShardedTargetList shardedTargets,

--- a/base/src/com/google/idea/blaze/base/sync/aspects/BlazeBuildOutputs.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/BlazeBuildOutputs.java
@@ -18,6 +18,7 @@ package com.google.idea.blaze.base.sync.aspects;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.collect.Iterables.getOnlyElement;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -34,91 +35,180 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-/** The result of a (potentially sharded) blaze build. */
-public class BlazeBuildOutputs {
+/**
+ * The result of a Bazel build.
+ */
+public interface BlazeBuildOutputs {
 
-  public static BlazeBuildOutputs noOutputs(BuildResult buildResult) {
-    return new BlazeBuildOutputs(
+  ImmutableSet<OutputArtifact> getTargetArtifacts(String label, String outputGroup);
+
+  ImmutableList<OutputArtifact> getOutputGroupArtifacts(String outputGroup);
+
+  ImmutableSet<String> targetsWithErrors();
+
+  BuildResult buildResult();
+
+  String idForLogging();
+
+  String buildId();
+
+  /**
+   * @return true if the build outputs are empty.
+   */
+  boolean isEmpty();
+
+  /** The result of a (potentially sharded) blaze build.
+   *
+   *<p><em>NOTE</em>:The implementation supporting sharded builds is slow and memory hungry. It should only be used with the legacy sync.
+   **/
+  interface Legacy extends BlazeBuildOutputs {
+
+
+    /**
+     * {@link OutputArtifact} out of all {@link BepArtifactData} from a build
+     */
+    ImmutableSet<OutputArtifact> getAllOutputArtifacts();
+
+    /**
+     * {@link BepArtifactData} by {@link OutputArtifact#getBazelOutRelativePath()} for all artifacts from a
+     * build.
+     */
+    ImmutableMap<String, BepArtifactData> artifacts();
+
+    /**
+     * The artifacts transitively associated with each top-level target.
+     */
+    ImmutableSetMultimap<String, OutputArtifact> perTargetArtifacts();
+
+    ImmutableMap<String, BuildResult> buildShardResults();
+
+    ImmutableList<OutputArtifact> getOutputGroupArtifactsLegacySyncOnly(
+      Predicate<String> outputGroupFilter);
+
+    Legacy updateOutputs(Legacy nextOutputs);
+
+    ImmutableList<String> getBuildIds();
+
+    long bepBytesConsumed();
+
+    boolean allBuildsFailed();
+  }
+
+
+  static BlazeBuildOutputs noOutputs(BuildResult buildResult) {
+    return new BlazeBuildOutputsImpl(
+      buildResult, ImmutableMap.of(), ImmutableMap.of(), ImmutableSet.of(), 0L);
+  }
+
+  static BlazeBuildOutputs.Legacy noOutputsForLegacy(BuildResult buildResult) {
+    return new BlazeBuildOutputsImpl(
       buildResult, ImmutableMap.of(), ImmutableMap.of(), ImmutableSet.of(), 0L);
   }
 
   @VisibleForTesting
-  public static BlazeBuildOutputs noOutputs(String buildId, BuildResult buildResult) {
-    return new BlazeBuildOutputs(
-        buildResult,
-        ImmutableMap.of(),
-        ImmutableMap.of(buildId, buildResult),
-        ImmutableSet.of(),
-        0L);
+  static BlazeBuildOutputs noOutputsForTesting(String buildId, BuildResult buildResult) {
+    return new BlazeBuildOutputsImpl(
+      buildResult,
+      ImmutableMap.of(),
+      ImmutableMap.of(buildId, buildResult),
+      ImmutableSet.of(),
+      0L);
   }
 
-  public static BlazeBuildOutputs fromParsedBepOutput(
+
+  static BlazeBuildOutputs fromParsedBepOutput(
     BuildResult result, ParsedBepOutput parsedOutput) {
     ImmutableMap<String, BuildResult> buildIdWithResult =
-        parsedOutput.buildId != null
-            ? ImmutableMap.of(parsedOutput.buildId, result)
-            : ImmutableMap.of();
-    return new BlazeBuildOutputs(
-        result,
-        result.status == Status.FATAL_ERROR
-            ? ImmutableMap.of()
-            : parsedOutput.getFullArtifactData(),
-        buildIdWithResult,
-        parsedOutput.getTargetsWithErrors(),
-        parsedOutput.getBepBytesConsumed());
+      parsedOutput.buildId != null
+      ? ImmutableMap.of(parsedOutput.buildId, result)
+      : ImmutableMap.of();
+    return new BlazeBuildOutputsImpl(
+      result,
+      result.status == Status.FATAL_ERROR
+      ? ImmutableMap.of()
+      : parsedOutput.getFullArtifactData(),
+      buildIdWithResult,
+      parsedOutput.getTargetsWithErrors(),
+      parsedOutput.getBepBytesConsumed());
   }
 
-  private final BuildResult buildResult;
-  // Maps build id to the build result of individual shards
-  private final ImmutableMap<String, BuildResult> buildShardResults;
-  private final ImmutableSet<String> targetsWithErrors;
-  public final long bepBytesConsumed;
+  static BlazeBuildOutputs.Legacy fromParsedBepOutputForLegacy(
+    BuildResult result, ParsedBepOutput parsedOutput) {
+    ImmutableMap<String, BuildResult> buildIdWithResult =
+      parsedOutput.buildId != null
+      ? ImmutableMap.of(parsedOutput.buildId, result)
+      : ImmutableMap.of();
+    return new BlazeBuildOutputsImpl(
+      result,
+      result.status == Status.FATAL_ERROR
+      ? ImmutableMap.of()
+      : parsedOutput.getFullArtifactData(),
+      buildIdWithResult,
+      parsedOutput.getTargetsWithErrors(),
+      parsedOutput.getBepBytesConsumed());
+  }
 
   /**
-   * {@link BepArtifactData} by {@link OutputArtifact#getBazelOutRelativePath()} for all artifacts from a
-   * build.
+   * The result of a (potentially sharded) blaze build.
    */
-  private final ImmutableMap<String, BepArtifactData> artifacts;
+  class BlazeBuildOutputsImpl implements BlazeBuildOutputs, Legacy {
+    private final BuildResult buildResult;
+    // Maps build id to the build result of individual shards
+    private final ImmutableMap<String, BuildResult> buildShardResults;
+    private final ImmutableSet<String> targetsWithErrors;
+    public final long bepBytesConsumed;
 
-  /** The artifacts transitively associated with each top-level target. */
-  private final ImmutableSetMultimap<String, OutputArtifact> perTargetArtifacts;
+    /**
+     * {@link BepArtifactData} by {@link OutputArtifact#getBazelOutRelativePath()} for all artifacts from a
+     * build.
+     */
+    private final ImmutableMap<String, BepArtifactData> artifacts;
 
-  private BlazeBuildOutputs(
-    BuildResult buildResult,
-    Map<String, BepArtifactData> artifacts,
+    /**
+     * The artifacts transitively associated with each top-level target.
+     */
+    private final ImmutableSetMultimap<String, OutputArtifact> perTargetArtifacts;
+
+    private BlazeBuildOutputsImpl(
+      BuildResult buildResult,
+      Map<String, BepArtifactData> artifacts,
       ImmutableMap<String, BuildResult> buildShardResults,
-    ImmutableSet<String> targetsWithErrors,
-    long bepBytesConsumed) {
-    this.buildResult = buildResult;
-    this.artifacts = ImmutableMap.copyOf(artifacts);
-    this.buildShardResults = buildShardResults;
-    this.targetsWithErrors = targetsWithErrors;
-    this.bepBytesConsumed = bepBytesConsumed;
+      ImmutableSet<String> targetsWithErrors,
+      long bepBytesConsumed) {
+      this.buildResult = buildResult;
+      this.artifacts = ImmutableMap.copyOf(artifacts);
+      this.buildShardResults = buildShardResults;
+      this.targetsWithErrors = targetsWithErrors;
+      this.bepBytesConsumed = bepBytesConsumed;
 
-    ImmutableSetMultimap.Builder<String, OutputArtifact> perTarget = ImmutableSetMultimap.builder();
-    artifacts.values().forEach(a -> a.topLevelTargets.forEach(t -> perTarget.put(t, a.artifact)));
-    this.perTargetArtifacts = perTarget.build();
-  }
+      ImmutableSetMultimap.Builder<String, OutputArtifact> perTarget = ImmutableSetMultimap.builder();
+      artifacts.values().forEach(a -> a.topLevelTargets.forEach(t -> perTarget.put(t, a.artifact)));
+      this.perTargetArtifacts = perTarget.build();
+    }
 
-  /** Returns the output artifacts generated for target with given label. */
-  public ImmutableSet<OutputArtifact> artifactsForTarget(String label, String outputGroup) {
-    // TODO: solodkyy - This is slow although it is invoked at most two times.
-    return artifacts.values().stream()
-      .filter(a -> a.outputGroups.contains(outputGroup) && a.topLevelTargets.contains(label))
-      .map(a -> a.artifact)
-      .collect(toImmutableSet());
-  }
+    /** Returns the output artifacts generated for target with given label. */
+    @Override
+    public ImmutableSet<OutputArtifact> getTargetArtifacts(String label, String outputGroup) {
+      // TODO: solodkyy - This is slow although it is invoked at most two times.
+      return artifacts.values().stream()
+        .filter(a -> a.outputGroups.contains(outputGroup) && a.topLevelTargets.contains(label))
+        .map(a -> a.artifact)
+        .collect(toImmutableSet());
+    }
 
   /** Returns all output artifacts. */
-  public ImmutableSet<OutputArtifact> getAllArtifacts() {
+  @Override
+  public ImmutableSet<OutputArtifact> getAllOutputArtifacts() {
     return artifacts.values().stream()
         .map((it) -> it.artifact)
         .collect(ImmutableSet.toImmutableSet());
   }
 
   @VisibleForTesting
+  @Override
   public ImmutableList<OutputArtifact> getOutputGroupArtifacts(String outputGroup) {
     // TODO: solodkyy - This is slow although it is invoked at most two times.
     return artifacts.values().stream()
@@ -127,87 +217,127 @@ public class BlazeBuildOutputs {
         .collect(toImmutableList());
   }
 
-  @VisibleForTesting
-  public ImmutableList<OutputArtifact> getOutputGroupArtifactsLegacySyncOnly(
-    Predicate<String> outputGroupFilter) {
-    return artifacts.values().stream()
-      .filter(a -> a.outputGroups.stream().anyMatch(outputGroupFilter))
-      .map(a -> a.artifact)
-      .collect(toImmutableList());
-  }
-
-  public ImmutableSet<String> getTargetsWithErrors() {
-    return targetsWithErrors;
-  }
-
-  /** Merges this {@link BlazeBuildOutputs} with a newer set of outputs. */
-  public BlazeBuildOutputs updateOutputs(BlazeBuildOutputs nextOutputs) {
-
-    // first combine common artifacts
-    Map<String, BepArtifactData> combined = new LinkedHashMap<>(artifacts);
-    for (Map.Entry<String, BepArtifactData> e : nextOutputs.artifacts.entrySet()) {
-      BepArtifactData a = e.getValue();
-      combined.compute(e.getKey(), (k, v) -> v == null ? a : v.update(a));
+    @Override
+    public ImmutableMap<String, BepArtifactData> artifacts() {
+      return artifacts;
     }
 
-    // then iterate over targets, throwing away old data for rebuilt targets and updating output
-    // data accordingly
-    for (String target : perTargetArtifacts.keySet()) {
-      if (!nextOutputs.perTargetArtifacts.containsKey(target)) {
-        continue;
-      }
-      Set<OutputArtifact> oldOutputs = perTargetArtifacts.get(target);
-      Set<OutputArtifact> newOutputs = nextOutputs.perTargetArtifacts.get(target);
+    @Override
+    public ImmutableSetMultimap<String, OutputArtifact> perTargetArtifacts() {
+      return perTargetArtifacts;
+    }
 
-      // remove out of date target associations
-      for (OutputArtifact old : oldOutputs) {
-        if (newOutputs.contains(old)) {
+    @Override
+    public ImmutableMap<String, BuildResult> buildShardResults() {
+      return buildShardResults;
+    }
+
+    @VisibleForTesting
+    @Override
+    public ImmutableList<OutputArtifact> getOutputGroupArtifactsLegacySyncOnly(
+      Predicate<String> outputGroupFilter) {
+      return artifacts.values().stream()
+        .filter(a -> a.outputGroups.stream().anyMatch(outputGroupFilter))
+        .map(a -> a.artifact)
+        .collect(toImmutableList());
+    }
+
+    @Override
+    public ImmutableSet<String> targetsWithErrors() {
+      return targetsWithErrors;
+    }
+
+    /**
+     * Merges this {@link BlazeBuildOutputs} with a newer set of outputs.
+     */
+    @Override
+    public BlazeBuildOutputs.Legacy updateOutputs(BlazeBuildOutputs.Legacy nextOutputs) {
+
+      // first combine common artifacts
+      Map<String, BepArtifactData> combined = new LinkedHashMap<>(artifacts);
+      for (Map.Entry<String, BepArtifactData> e : nextOutputs.artifacts().entrySet()) {
+        BepArtifactData a = e.getValue();
+        combined.compute(e.getKey(), (k, v) -> v == null ? a : v.update(a));
+      }
+
+      // then iterate over targets, throwing away old data for rebuilt targets and updating output
+      // data accordingly
+      for (String target : perTargetArtifacts.keySet()) {
+        if (!nextOutputs.perTargetArtifacts().containsKey(target)) {
           continue;
         }
-        // no longer output by this target; need to update target associations
-        BepArtifactData data = combined.get(old.getBazelOutRelativePath());
-        if (data != null) {
-          data = data.removeTargetAssociation(target);
-        }
-        if (data == null) {
-          combined.remove(old.getBazelOutRelativePath());
-        } else {
-          combined.put(old.getBazelOutRelativePath(), data);
+        Set<OutputArtifact> oldOutputs = perTargetArtifacts.get(target);
+        Set<OutputArtifact> newOutputs = nextOutputs.perTargetArtifacts().get(target);
+
+        // remove out of date target associations
+        for (OutputArtifact old : oldOutputs) {
+          if (newOutputs.contains(old)) {
+            continue;
+          }
+          // no longer output by this target; need to update target associations
+          BepArtifactData data = combined.get(old.getBazelOutRelativePath());
+          if (data != null) {
+            data = data.removeTargetAssociation(target);
+          }
+          if (data == null) {
+            combined.remove(old.getBazelOutRelativePath());
+          }
+          else {
+            combined.put(old.getBazelOutRelativePath(), data);
+          }
         }
       }
-    }
-    return new BlazeBuildOutputs(
+      return new BlazeBuildOutputsImpl(
         BuildResult.combine(buildResult(), nextOutputs.buildResult()),
         combined,
         Stream.concat(
-                nextOutputs.buildShardResults.entrySet().stream(),
-                buildShardResults.entrySet().stream())
-            .collect(
-                // On duplicate buildIds, preserve most recent result
-                toImmutableMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1)),
-      Sets.union(targetsWithErrors, nextOutputs.targetsWithErrors).immutableCopy(),
-      bepBytesConsumed + nextOutputs.bepBytesConsumed);
-  }
+            nextOutputs.buildShardResults().entrySet().stream(),
+            buildShardResults.entrySet().stream())
+          .collect(
+            // On duplicate buildIds, preserve most recent result
+            toImmutableMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1)),
+        Sets.union(targetsWithErrors, nextOutputs.targetsWithErrors()).immutableCopy(),
+        bepBytesConsumed + nextOutputs.bepBytesConsumed());
+    }
 
-  public ImmutableList<String> getBuildIds() {
-    return buildShardResults.keySet().asList();
-  }
+    @Override
+    public ImmutableList<String> getBuildIds() {
+      return buildShardResults.keySet().asList();
+    }
 
-  /** Returns true if all component builds had fatal errors. */
-  public boolean allBuildsFailed() {
-    return !buildShardResults.isEmpty()
-        && buildShardResults.values().stream()
-            .allMatch(result -> result.status == Status.FATAL_ERROR);
-  }
+    @Override
+    public long bepBytesConsumed() {
+      return bepBytesConsumed;
+    }
 
-  public BuildResult buildResult() {
-    return buildResult;
-  }
+    /**
+     * Returns true if all component builds had fatal errors.
+     */
+    @Override
+    public boolean allBuildsFailed() {
+      return !buildShardResults.isEmpty()
+             && buildShardResults.values().stream()
+               .allMatch(result -> result.status == Status.FATAL_ERROR);
+    }
 
-  /**
-   * @return true if the build outputs are empty ().
-   */
-  public boolean isEmpty() {
-    return artifacts.isEmpty();
+    @Override
+    public BuildResult buildResult() {
+      return buildResult;
+    }
+
+    @Override
+    public String idForLogging() {
+      return getBuildIds().stream().collect(Collectors.joining(","));
+    }
+
+    @Override
+    public String buildId() {
+      return getOnlyElement(getBuildIds());
+    }
+
+    @Override
+    public boolean isEmpty() {
+      return artifacts.isEmpty();
+    }
   }
 }

--- a/base/src/com/google/idea/blaze/base/sync/aspects/BlazeIdeInterface.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/BlazeIdeInterface.java
@@ -60,7 +60,7 @@ public interface BlazeIdeInterface {
    *
    * @param outputGroups Set of {@link OutputGroup} to be generated in the build.
    */
-  BlazeBuildOutputs build(
+  BlazeBuildOutputs.Legacy build(
       Project project,
       BlazeContext context,
       WorkspaceRoot workspaceRoot,

--- a/base/src/com/google/idea/blaze/base/sync/aspects/BlazeIdeInterfaceAspectsImpl.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/BlazeIdeInterfaceAspectsImpl.java
@@ -178,14 +178,14 @@ public class BlazeIdeInterfaceAspectsImpl implements BlazeIdeInterface {
   }
 
   /** Returns the {@link OutputArtifact}s we want to track between syncs. */
-  private static ImmutableSet<OutputArtifact> getTrackedOutputs(BlazeBuildOutputs buildOutput) {
+  private static ImmutableSet<OutputArtifact> getTrackedOutputs(BlazeBuildOutputs.Legacy buildOutput) {
     // don't track intellij-info.txt outputs -- they're already tracked in
     // BlazeIdeInterfaceState
     return getTrackedOutputs(buildOutput, group -> true);
   }
 
   private static ImmutableSet<OutputArtifact> getTrackedOutputs(
-      BlazeBuildOutputs buildOutput, Predicate<String> outputGroupFilter) {
+      BlazeBuildOutputs.Legacy buildOutput, Predicate<String> outputGroupFilter) {
     Predicate<String> pathFilter = AspectStrategy.ASPECT_OUTPUT_FILE_PREDICATE.negate();
     return buildOutput.getOutputGroupArtifactsLegacySyncOnly(outputGroupFilter).stream()
         .filter(a -> pathFilter.test(a.getBazelOutRelativePath()))
@@ -588,7 +588,7 @@ public class BlazeIdeInterfaceAspectsImpl implements BlazeIdeInterface {
   }
 
   @Override
-  public BlazeBuildOutputs build(
+  public BlazeBuildOutputs.Legacy build(
       Project project,
       BlazeContext context,
       WorkspaceRoot workspaceRoot,
@@ -602,7 +602,7 @@ public class BlazeIdeInterfaceAspectsImpl implements BlazeIdeInterface {
       boolean invokeParallel) {
     AspectStrategy aspectStrategy = AspectStrategy.getInstance(blazeVersion);
 
-    final Ref<BlazeBuildOutputs> combinedResult = new Ref<>();
+    final Ref<BlazeBuildOutputs.Legacy> combinedResult = new Ref<>();
 
     // The build is a sync iff INFO output group is present
     boolean isSync = outputGroups.contains(OutputGroup.INFO);
@@ -651,7 +651,7 @@ public class BlazeIdeInterfaceAspectsImpl implements BlazeIdeInterface {
                   progressTracker.onBuildStarted(context);
 
                   try {
-                    BlazeBuildOutputs result =
+                    BlazeBuildOutputs.Legacy result =
                         runBuildForTargets(
                             project,
                             childContext,
@@ -690,14 +690,14 @@ public class BlazeIdeInterfaceAspectsImpl implements BlazeIdeInterface {
     if (combinedResult.isNull()
         || (!BuildPhaseSyncTask.continueSyncOnOom.getValue()
             && buildResult.status == Status.FATAL_ERROR)) {
-      return BlazeBuildOutputs.noOutputs(buildResult);
+      return BlazeBuildOutputs.noOutputsForLegacy(buildResult);
     }
     return combinedResult.get();
   }
 
   /* Prints summary only for failed shards */
   private void printShardFinishedSummary(
-      BlazeContext context, String taskName, BlazeBuildOutputs result, BuildInvoker invoker) {
+      BlazeContext context, String taskName, BlazeBuildOutputs.Legacy result, BuildInvoker invoker) {
     if (result.buildResult().status == Status.SUCCESS) {
       return;
     }
@@ -738,7 +738,7 @@ public class BlazeIdeInterfaceAspectsImpl implements BlazeIdeInterface {
   }
 
   /** Runs a blaze build for the given output groups. */
-  private static BlazeBuildOutputs runBuildForTargets(
+  private static BlazeBuildOutputs.Legacy runBuildForTargets(
       Project project,
       BlazeContext context,
       BuildInvoker invoker,

--- a/base/tests/utils/integration/com/google/idea/blaze/base/sync/BlazeSyncIntegrationTestCase.java
+++ b/base/tests/utils/integration/com/google/idea/blaze/base/sync/BlazeSyncIntegrationTestCase.java
@@ -341,7 +341,7 @@ public abstract class BlazeSyncIntegrationTestCase extends BlazeIntegrationTestC
     }
 
     @Override
-    public BlazeBuildOutputs build(
+    public BlazeBuildOutputs.Legacy build(
         Project project,
         BlazeContext context,
         WorkspaceRoot workspaceRoot,
@@ -353,7 +353,7 @@ public abstract class BlazeSyncIntegrationTestCase extends BlazeIntegrationTestC
         ImmutableSet<OutputGroup> outputGroups,
         BlazeInvocationContext blazeInvocationContext,
         boolean invokeParallel) {
-      return BlazeBuildOutputs.noOutputs(BuildResult.SUCCESS);
+      return BlazeBuildOutputs.noOutputsForLegacy(BuildResult.SUCCESS);
     }
   }
 

--- a/plugin_dev/src/com/google/idea/blaze/plugin/run/BlazeIntellijPluginDeployer.java
+++ b/plugin_dev/src/com/google/idea/blaze/plugin/run/BlazeIntellijPluginDeployer.java
@@ -78,8 +78,8 @@ class BlazeIntellijPluginDeployer {
     buildArtifactsMap.clear();
   }
 
-  void reportBuildComplete(BlazeBuildOutputs blazeBuildOutputs) throws GetArtifactsException {
-    ImmutableSet<OutputArtifact> buildArtifacts = blazeBuildOutputs.getAllArtifacts();
+  void reportBuildComplete(BlazeBuildOutputs.Legacy blazeBuildOutputs) throws GetArtifactsException {
+    ImmutableSet<OutputArtifact> buildArtifacts = blazeBuildOutputs.getAllOutputArtifacts();
     buildArtifactsMap.clear();
     buildArtifacts.forEach(a -> buildArtifactsMap.put(a.getBazelOutRelativePath(), a));
 

--- a/plugin_dev/src/com/google/idea/blaze/plugin/run/BuildPluginBeforeRunTaskProvider.java
+++ b/plugin_dev/src/com/google/idea/blaze/plugin/run/BuildPluginBeforeRunTaskProvider.java
@@ -225,10 +225,10 @@ public final class BuildPluginBeforeRunTaskProvider
                       return null;
                     }
                     SaveUtil.saveAllFiles();
-                    BlazeBuildOutputs outputs =
+                    BlazeBuildOutputs.Legacy outputs =
                         invoker
                             .getCommandRunner()
-                            .run(project, command, buildResultHelper, context, ImmutableMap.of());
+                            .runLegacy(project, command, buildResultHelper, context, ImmutableMap.of());
                     if (!outputs.buildResult().equals(BuildResult.SUCCESS)) {
                       context.setHasError();
                     }


### PR DESCRIPTION
Cherry pick AOSP commit [d6bbbf53d8b1da6b6ad70960d26130a883a3f821](https://cs.android.com/android-studio/platform/tools/adt/idea/+/d6bbbf53d8b1da6b6ad70960d26130a883a3f821).

and begin separating the legacy sync use case, which requires more
computation than the query sync one.

Bug: n/a
Test: n/a
Change-Id: I02a85f235260672fd436ae22b390641e0abbf2ee

AOSP: d6bbbf53d8b1da6b6ad70960d26130a883a3f821
