### PR TITLE
[AOSP-pick] Simplify handling of config mnemonics

### DIFF
--- a/aswb/tests/unittests/com/google/idea/blaze/android/filecache/LocalArtifactCacheTest.java
+++ b/aswb/tests/unittests/com/google/idea/blaze/android/filecache/LocalArtifactCacheTest.java
@@ -114,7 +114,7 @@ public class LocalArtifactCacheTest {
     String execRoot = workspaceRoot.directory().getAbsolutePath();
     String mnemonic = "k8-opt";
     return new LocalFileOutputArtifactWithoutDigest(
-      new File(execRoot + "/blaze-out" + mnemonic + "/" + path), Path.of("blaze-out", mnemonic, path), 1, mnemonic);
+      new File(execRoot + "/blaze-out" + mnemonic + "/" + path), Path.of("blaze-out", mnemonic, path), 1);
   }
 
   @Test

--- a/aswb/tests/unittests/com/google/idea/blaze/android/libraries/UnpackedAarsTest.java
+++ b/aswb/tests/unittests/com/google/idea/blaze/android/libraries/UnpackedAarsTest.java
@@ -183,11 +183,6 @@ public class UnpackedAarsTest extends BlazeTestCase {
     }
 
     @Override
-    public String getConfigurationMnemonic() {
-      return "";
-    }
-
-    @Override
     public Path getArtifactPath() {
       return artifactPath;
     }

--- a/base/src/com/google/idea/blaze/base/command/buildresult/BuildEventProtocolOutputReader.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/BuildEventProtocolOutputReader.java
@@ -143,7 +143,7 @@ public final class BuildEventProtocolOutputReader {
     if (mnemonic == null) {
       return parseLocalFile(file, fileFilter);
     }
-    OutputArtifact output = OutputArtifactParser.parseArtifact(file, mnemonic, startTimeMillis);
+    OutputArtifact output = OutputArtifactParser.parseArtifact(file, startTimeMillis);
     return output == null || !fileFilter.test(output.getBazelOutRelativePath()) ? null : output;
   }
 

--- a/base/src/com/google/idea/blaze/base/command/buildresult/LocalFileOutputArtifact.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/LocalFileOutputArtifact.java
@@ -27,8 +27,8 @@ public class LocalFileOutputArtifact extends LocalFileOutputArtifactWithoutDiges
   private final String digest;
 
   public LocalFileOutputArtifact(
-    File file, Path artifactPath, int prefixLength, String configurationMnemonic, String digest) {
-    super(file, artifactPath, prefixLength, configurationMnemonic);
+    File file, Path artifactPath, int prefixLength, String digest) {
+    super(file, artifactPath, prefixLength);
     this.digest = digest;
   }
 

--- a/base/src/com/google/idea/blaze/base/command/buildresult/LocalFileOutputArtifactWithoutDigest.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/LocalFileOutputArtifactWithoutDigest.java
@@ -36,14 +36,12 @@ public class LocalFileOutputArtifactWithoutDigest
   private final File file;
   private final Path artifactPath;
   private final int prefixLength;
-  private final String configurationMnemonic;
 
   public LocalFileOutputArtifactWithoutDigest(
-    File file, Path artifactPath, int prefixLength, String configurationMnemonic) {
+    File file, Path artifactPath, int prefixLength) {
     this.file = file;
     this.artifactPath = artifactPath;
     this.prefixLength = prefixLength;
-    this.configurationMnemonic = configurationMnemonic;
   }
 
   private long getLastModifiedTime() {
@@ -55,11 +53,6 @@ public class LocalFileOutputArtifactWithoutDigest
   public ArtifactState toArtifactState() {
     long lastModifiedTime = getLastModifiedTime();
     return lastModifiedTime == 0 ? null : new LocalFileState(getBazelOutRelativePath(), lastModifiedTime);
-  }
-
-  @Override
-  public String getConfigurationMnemonic() {
-    return configurationMnemonic;
   }
 
   @Override
@@ -106,7 +99,6 @@ public class LocalFileOutputArtifactWithoutDigest
     return MoreObjects.toStringHelper(this)
         .add("file", file.getPath())
         .add("artifactPath", artifactPath)
-        .add("configurationMnemonic", configurationMnemonic)
         .toString();
   }
 }

--- a/base/src/com/google/idea/blaze/base/command/buildresult/LocalFileParser.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/LocalFileParser.java
@@ -31,7 +31,7 @@ public class LocalFileParser implements OutputArtifactParser {
   @Override
   @Nullable
   public OutputArtifact parse(
-    BuildEventStreamProtos.File file, String configurationMnemonic, long syncStartTimeMillis) {
+    BuildEventStreamProtos.File file, long syncStartTimeMillis) {
     String uri = file.getUri();
     if (!uri.startsWith(URLUtil.FILE_PROTOCOL)) {
       return null;
@@ -42,7 +42,6 @@ public class LocalFileParser implements OutputArtifactParser {
         f,
         OutputArtifactParser.bazelFileToArtifactPath(file),
         file.getPathPrefixCount(),
-        configurationMnemonic,
         file.getDigest());
     }
     catch (URISyntaxException | IllegalArgumentException e) {

--- a/base/src/com/google/idea/blaze/base/command/buildresult/bepparser/BepParser.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/bepparser/BepParser.java
@@ -152,7 +152,6 @@ public final class BepParser {
       final Interner<String> interner = nullableInterner == null ? Interners.newStrongInterner() : nullableInterner;
 
       BuildEventStreamProtos.BuildEvent event;
-      Map<String, String> configIdToMnemonic = new HashMap<>();
       Map<String, BuildEventStreamProtos.NamedSetOfFiles> fileSets = new LinkedHashMap<>();
       final var data = new OutputGroupTargetConfigFileSetMap();
       ImmutableSet.Builder<String> targetsWithErrors = ImmutableSet.builder();
@@ -172,10 +171,6 @@ public final class BepParser {
           case WORKSPACE_STATUS:
             workspaceStatus =
                 event.getWorkspaceStatus().getItemList().stream().collect(toImmutableMap(Item::getKey, Item::getValue));
-            continue;
-          case CONFIGURATION:
-            configIdToMnemonic.put(
-              event.getId().getConfiguration().getId(), event.getConfiguration().getMnemonic());
             continue;
           case NAMED_SET:
             BuildEventStreamProtos.NamedSetOfFiles namedSet = internNamedSet(event.getNamedSetOfFiles(), interner);
@@ -213,7 +208,7 @@ public final class BepParser {
       }
       ImmutableMap<String, ParsedBepOutput.FileSet> filesMap =
         fillInTransitiveFileSetData(
-          fileSets, data, configIdToMnemonic, startTimeMillis);
+          fileSets, data, startTimeMillis);
       return new ParsedBepOutput(
         buildId,
         localExecRoot,
@@ -245,7 +240,6 @@ public final class BepParser {
   private static ImmutableMap<String, ParsedBepOutput.FileSet> fillInTransitiveFileSetData(
     Map<String, BuildEventStreamProtos.NamedSetOfFiles> namedFileSets,
       OutputGroupTargetConfigFileSetMap data,
-      Map<String, String> configIdToMnemonic,
       long startTimeMillis) {
     Map<String, FileSetBuilder> fileSets =
       ImmutableMap.copyOf(
@@ -279,16 +273,16 @@ public final class BepParser {
               });
     }
     return fileSets.entrySet().stream()
-        .filter(e -> e.getValue().isValid(configIdToMnemonic))
+        .filter(e -> e.getValue().isValid())
         .collect(
             toImmutableMap(
-              Map.Entry::getKey, e -> e.getValue().build(configIdToMnemonic, startTimeMillis)));
+              Map.Entry::getKey, e -> e.getValue().build(startTimeMillis)));
   }
 
   private static ImmutableList<OutputArtifact> parseFiles(
-    BuildEventStreamProtos.NamedSetOfFiles namedSet, String config, long startTimeMillis) {
+    BuildEventStreamProtos.NamedSetOfFiles namedSet, long startTimeMillis) {
     return namedSet.getFilesList().stream()
-        .map(f -> OutputArtifactParser.parseArtifact(f, config, startTimeMillis))
+        .map(f -> OutputArtifactParser.parseArtifact(f, startTimeMillis))
         .filter(Objects::nonNull)
         .collect(toImmutableList());
   }
@@ -379,12 +373,12 @@ public final class BepParser {
       return this;
     }
 
-    boolean isValid(Map<String, String> configIdToMnemonic) {
-      return namedSet != null && configId != null && configIdToMnemonic.get(configId) != null;
+    boolean isValid() {
+      return namedSet != null && configId != null;
     }
 
-    ParsedBepOutput.FileSet build(Map<String, String> configIdToMnemonic, long startTimeMillis) {
-      return new ParsedBepOutput.FileSet(parseFiles(namedSet, configIdToMnemonic.get(configId), startTimeMillis), outputGroups, targets);
+    ParsedBepOutput.FileSet build(long startTimeMillis) {
+      return new ParsedBepOutput.FileSet(parseFiles(namedSet, startTimeMillis), outputGroups, targets);
     }
   }
 }

--- a/base/src/com/google/idea/blaze/base/command/buildresult/bepparser/OutputArtifactParser.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/bepparser/OutputArtifactParser.java
@@ -32,17 +32,16 @@ public interface OutputArtifactParser {
 
   @Nullable
   static OutputArtifact parseArtifact(
-      BuildEventStreamProtos.File file, String configurationMnemonic, long syncStartTimeMillis) {
+      BuildEventStreamProtos.File file, long syncStartTimeMillis) {
     return Arrays.stream(EP_NAME.getExtensions())
-        .map(p -> p.parse(file, configurationMnemonic, syncStartTimeMillis))
+        .map(p -> p.parse(file, syncStartTimeMillis))
         .filter(Objects::nonNull)
         .findFirst()
         .orElse(null);
   }
 
   @Nullable
-  OutputArtifact parse(
-      BuildEventStreamProtos.File file, String configurationMnemonic, long syncStartTimeMillis);
+  OutputArtifact parse(BuildEventStreamProtos.File file, long syncStartTimeMillis);
 
   static Path bazelFileToArtifactPath(BuildEventStreamProtos.File file) {
     return Path.of(Joiner.on('/').join(file.getPathPrefixList()), file.getName());

--- a/base/src/com/google/idea/blaze/base/command/info/BlazeConfigurationHandler.java
+++ b/base/src/com/google/idea/blaze/base/command/info/BlazeConfigurationHandler.java
@@ -38,14 +38,14 @@ public class BlazeConfigurationHandler {
   }
 
   @Nullable
-  public String getConfigurationMnemonic(File artifact) {
+  private String getConfigurationMnemonic(File artifact) {
     if (!artifact.getPath().startsWith(blazeOutPath)) {
       return null;
     }
     return getConfigurationMnemonic(artifact.getPath().substring(blazeOutPath.length()));
   }
 
-  public static String getConfigurationMnemonic(String blazeOutRelativePath) {
+  private static String getConfigurationMnemonic(String blazeOutRelativePath) {
     int endIndex = blazeOutRelativePath.indexOf(File.separatorChar);
     return endIndex == -1 ? blazeOutRelativePath : blazeOutRelativePath.substring(0, endIndex);
   }

--- a/base/src/com/google/idea/blaze/base/model/RemoteOutputArtifacts.java
+++ b/base/src/com/google/idea/blaze/base/model/RemoteOutputArtifacts.java
@@ -193,7 +193,7 @@ public final class RemoteOutputArtifacts
   }
 
   private static String parseConfigurationMnemonic(RemoteOutputArtifact output) {
-    return BlazeConfigurationHandler.getConfigurationMnemonic(output.getBazelOutRelativePath());
+    return output.getConfigurationMnemonicForLegacySync();
   }
 
   @Override

--- a/base/src/com/google/idea/blaze/base/sync/aspects/BlazeIdeInterfaceAspectsImpl.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/BlazeIdeInterfaceAspectsImpl.java
@@ -399,7 +399,7 @@ public class BlazeIdeInterfaceAspectsImpl implements BlazeIdeInterface {
                 for (TargetFilePair targetFilePair : Futures.allAsList(futures).get()) {
                   if (targetFilePair.target != null) {
                     OutputArtifactWithoutDigest file = targetFilePair.file;
-                    String config = file.getConfigurationMnemonic();
+                    String config = file.getConfigurationMnemonicForLegacySync();
                     configurations.add(config);
                     TargetKey key = targetFilePair.target.getKey();
                     if (targetMap.putIfAbsent(key, targetFilePair.target) == null) {

--- a/base/src/com/google/idea/blaze/base/sync/workspace/ArtifactLocationDecoderImpl.java
+++ b/base/src/com/google/idea/blaze/base/sync/workspace/ArtifactLocationDecoderImpl.java
@@ -140,9 +140,8 @@ public final class ArtifactLocationDecoderImpl implements ArtifactLocationDecode
     if (ix2 == -1) {
       return new SourceArtifact(decode(location));
     }
-    String configMnemonic = execRootPath.substring(ix1 + 1, ix2);
     return new LocalFileOutputArtifactWithoutDigest(
       decode(location), Path.of(execRootPath),
-      Path.of(location.getRootExecutionPathFragment()).getNameCount(), configMnemonic);
+      Path.of(location.getRootExecutionPathFragment()).getNameCount());
   }
 }

--- a/base/tests/utils/unit/com/google/idea/blaze/base/sync/FakeRemoteOutputArtifact.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/sync/FakeRemoteOutputArtifact.java
@@ -51,11 +51,6 @@ public class FakeRemoteOutputArtifact implements RemoteOutputArtifact {
   }
 
   @Override
-  public String getConfigurationMnemonic() {
-    return "";
-  }
-
-  @Override
   public Path getArtifactPath() {
     return artifactPath;
   }

--- a/base/tests/utils/unit/com/google/idea/blaze/base/sync/workspace/MockArtifactLocationDecoder.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/sync/workspace/MockArtifactLocationDecoder.java
@@ -60,7 +60,6 @@ public class MockArtifactLocationDecoder implements ArtifactLocationDecoder {
       return new FakeRemoteOutputArtifact(file, workspaceRoot.toPath().relativize(file.toPath()), artifactPathPrefixLength);
     }
     return new LocalFileOutputArtifactWithoutDigest(
-      decode(artifact), Path.of(artifact.getExecutionRootRelativePath()), artifactPathPrefixLength,
-      artifact.getExecutionRootRelativePath());
+      decode(artifact), Path.of(artifact.getExecutionRootRelativePath()), artifactPathPrefixLength);
   }
 }

--- a/shared/java/com/google/idea/blaze/common/artifact/OutputArtifactWithoutDigest.java
+++ b/shared/java/com/google/idea/blaze/common/artifact/OutputArtifactWithoutDigest.java
@@ -21,7 +21,12 @@ import javax.annotation.Nullable;
 public interface OutputArtifactWithoutDigest extends BlazeArtifact, OutputArtifactInfo {
 
   /** The path component related to the build configuration. */
-  String getConfigurationMnemonic();
+  default String getConfigurationMnemonicForLegacySync(){
+    return getArtifactPathPrefixLength() >= 2 && getArtifactPath().getNameCount() >= 2
+      ? getArtifactPath().getName(1).toString()
+      : "";
+
+  };
 
   /**
    * Returns the {@link ArtifactState} for this output, used for serialization/diffing purposes. Can

--- a/shared/javatests/com/google/idea/blaze/common/artifact/TestOutputArtifact.java
+++ b/shared/javatests/com/google/idea/blaze/common/artifact/TestOutputArtifact.java
@@ -30,7 +30,6 @@ public abstract class TestOutputArtifact implements OutputArtifact {
           .setDigest("digest")
           .setArtifactPath(Path.of("path/file"))
           .setArtifactPathPrefixLength(0)
-          .setConfigurationMnemonic("mnemonic")
           .build();
 
   public static TestOutputArtifact forDigest(String digest) {
@@ -58,9 +57,6 @@ public abstract class TestOutputArtifact implements OutputArtifact {
   @Override
   public abstract int getArtifactPathPrefixLength();
 
-  @Override
-  public abstract String getConfigurationMnemonic();
-
   @Nullable
   @Override
   public ArtifactState toArtifactState() {
@@ -79,8 +75,6 @@ public abstract class TestOutputArtifact implements OutputArtifact {
     public abstract Builder setArtifactPath(Path value);
 
     public abstract Builder setArtifactPathPrefixLength(int value);
-
-    public abstract Builder setConfigurationMnemonic(String value);
 
     public abstract TestOutputArtifact build();
   }


### PR DESCRIPTION
Cherry pick AOSP commit [1c670d4ec9fc74ec6afe716cc2d1cc2d8746b4c8](https://cs.android.com/android-studio/platform/tools/adt/idea/+/1c670d4ec9fc74ec6afe716cc2d1cc2d8746b4c8).

Configuration mnemonics are computed as the second entry in the artifact
prefix path and can be computed the same way on demand.

This is to simplify BEP parsing.

Bug: n/a
Test: n/a
Change-Id: Ice44e0cadd93f529275a1b70e019bad6111479f4

AOSP: 1c670d4ec9fc74ec6afe716cc2d1cc2d8746b4c8
