### PR TITLE
CLion qsync improvements for Mac

### DIFF
--- a/base/src/com/google/idea/blaze/base/qsync/ProjectLoader.java
+++ b/base/src/com/google/idea/blaze/base/qsync/ProjectLoader.java
@@ -146,9 +146,13 @@ public class ProjectLoader {
     RenderJarBuilder renderJarBuilder = createRenderJarBuilder(workspaceRoot, buildSystem);
     AppInspectorBuilder appInspectorBuilder = createAppInspectorBuilder(buildSystem);
 
+    BlazeInfo blazeInfo =
+        new BazelInfoHandler(buildSystem.getBuildInvoker(project, context))
+            .getBazelInfo();
+
     Path ideProjectBasePath = Paths.get(checkNotNull(project.getBasePath()));
     ProjectPath.Resolver projectPathResolver =
-        ProjectPath.Resolver.create(workspaceRoot.path(), ideProjectBasePath);
+        ProjectPath.Resolver.create(workspaceRoot.path(), ideProjectBasePath, blazeInfo.getExecutionRoot().toPath());
 
     ProjectProtoTransform.Registry projectTransformRegistry = new Registry();
     SnapshotHolder graph = new SnapshotHolder();
@@ -226,9 +230,6 @@ public class ProjectLoader {
             versionHandler);
     QuerySyncSourceToTargetMap sourceToTargetMap =
         new QuerySyncSourceToTargetMap(graph, workspaceRoot.path());
-    BlazeInfo blazeInfo =
-        new BazelInfoHandler(buildSystem.getBuildInvoker(project, context))
-            .getBazelInfo();
     ExternalWorkspaceData externalWorkspaceData = ExternalWorkspaceDataProvider.getInstance(project)
         .getExternalWorkspaceData(context, projectViewSet, versionHandler.getBazelVersion(), blazeInfo);
 

--- a/clwb/tests/integrationtests/com/google/idea/blaze/clwb/QuerySyncTest.java
+++ b/clwb/tests/integrationtests/com/google/idea/blaze/clwb/QuerySyncTest.java
@@ -40,6 +40,7 @@ public class QuerySyncTest extends ClwbIntegrationTestCase {
 
     checkAnalysis();
     checkCompiler();
+    checkTest();
     checkResolveRulesCC();
   }
 
@@ -61,6 +62,16 @@ public class QuerySyncTest extends ClwbIntegrationTestCase {
     // }
 
     assertContainsHeader("iostream", compilerSettings);
+  }
+
+  private void checkTest() throws ExecutionException {
+    final var result = enableAnalysisFor(findProjectFile("main/test.cc"));
+    result.assertNoErrors();
+
+    final var compilerSettings = findFileCompilerSettings("main/test.cc");
+
+    assertContainsHeader("iostream", compilerSettings);
+    assertContainsHeader("catch2/catch_test_macros.hpp", compilerSettings);
   }
 
   // TODO: find a common place for shared test between async (SimpleTest) and qsync

--- a/clwb/tests/integrationtests/com/google/idea/blaze/clwb/QuerySyncTest.java
+++ b/clwb/tests/integrationtests/com/google/idea/blaze/clwb/QuerySyncTest.java
@@ -44,8 +44,8 @@ public class QuerySyncTest extends ClwbIntegrationTestCase {
   }
 
   private void checkAnalysis() throws ExecutionException {
-    final var success = enableAnalysisFor(findProjectFile("main/hello-world.cc"));
-    assertThat(success).isTrue();
+    final var result = enableAnalysisFor(findProjectFile("main/hello-world.cc"));
+    result.assertNoErrors();
   }
 
   private void checkCompiler() {

--- a/clwb/tests/integrationtests/com/google/idea/blaze/clwb/base/ClwbIntegrationTestCase.java
+++ b/clwb/tests/integrationtests/com/google/idea/blaze/clwb/base/ClwbIntegrationTestCase.java
@@ -273,27 +273,42 @@ public abstract class ClwbIntegrationTestCase extends HeavyPlatformTestCase {
     return false;
   }
 
-  protected boolean enableAnalysisFor(VirtualFile file) throws ExecutionException {
+  protected SyncOutput enableAnalysisFor(VirtualFile file) throws ExecutionException {
+    final var context = BlazeContext.create();
+
+    final var output = new SyncOutput();
+    output.install(context);
+
     final var manager = QuerySyncManager.getInstance(myProject);
     final var targets = manager.getTargetsToBuild(file).targets();
 
-    final var future = manager.enableAnalysis(
-        targets,
-        QuerySyncActionStatsScope.createForFile(getClass(), null, file),
-        TaskOrigin.USER_ACTION
-    );
+    final var projects = manager.getLoadedProject();
+    assertThat(projects).isPresent();
+
+    final var future = CompletableFuture.runAsync(() -> {
+      try {
+        projects.get().enableAnalysis(context, targets);
+      } catch (Exception e) {
+        LOG.error("enable analysis failed", e);
+      }
+    }, ApplicationManager.getApplication()::executeOnPooledThread);
 
     while (!future.isDone()) {
       PlatformTestUtil.dispatchAllInvocationEventsInIdeEventQueue();
     }
 
+    context.close();
+    LOG.info(String.format("PROJECT BUILD LOG:%n%s", output.collectLog()));
+
     try {
-      return future.get();
+      future.get();
+    } catch (ExecutionException e) {
+      LOG.error("enable analysis failed", e);
     } catch (InterruptedException e) {
-      fail("enable analysis was interrupted");
+      LOG.error("enable analysis was interrupted", e);
     }
 
-    return false;
+    return output;
   }
 
   protected VirtualFile findProjectFile(String relativePath) {

--- a/cpp/src/com/google/idea/blaze/cpp/qsync/CcProjectModelUpdateOperation.java
+++ b/cpp/src/com/google/idea/blaze/cpp/qsync/CcProjectModelUpdateOperation.java
@@ -21,6 +21,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import com.google.idea.blaze.base.scope.output.IssueOutput;
 import com.google.idea.blaze.base.util.UrlUtil;
 import com.google.idea.blaze.common.Context;
 import com.google.idea.blaze.common.PrintOutput;
@@ -34,6 +35,7 @@ import com.google.idea.blaze.qsync.project.ProjectProto.CcCompilerSettings;
 import com.google.idea.blaze.qsync.project.ProjectProto.CcLanguage;
 import com.google.idea.blaze.qsync.project.ProjectProto.CcSourceFile;
 import com.google.idea.blaze.qsync.project.ProjectProto.CcWorkspace;
+import com.intellij.build.events.MessageEvent;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.WriteAction;
 import com.intellij.openapi.diagnostic.Logger;
@@ -211,8 +213,17 @@ public class CcProjectModelUpdateOperation implements Disposable {
           messages.freezeValues().values().stream()
               .flatMap(Collection::stream)
               .collect(ImmutableList.toImmutableList());
-      frozenMessages.forEach(
-          m -> context.output(PrintOutput.log(m.getType().name() + ": " + m.getText())));
+
+      for (final var message : frozenMessages) {
+        final var kind = switch (message.getType()) {
+          case ERROR -> MessageEvent.Kind.ERROR;
+          case WARNING -> MessageEvent.Kind.WARNING;
+        };
+
+        IssueOutput.issue(kind, "COMPILER INFO COLLECTION")
+            .withDescription(message.getText())
+            .submit(context);
+      }
     } finally {
       if (!sessionClosed) {
         session.dispose();

--- a/querysync/java/com/google/idea/blaze/qsync/deps/ArtifactDirectories.java
+++ b/querysync/java/com/google/idea/blaze/qsync/deps/ArtifactDirectories.java
@@ -60,8 +60,10 @@ public class ArtifactDirectories {
       return GEN_CC_HEADERS.resolveChild(includePath);
     } else if (includePath.isAbsolute()) {
       return ProjectPath.absolute(includePath);
+    } else if (includePath.startsWith("external")) {
+      return ProjectPath.execrootRelative(includePath);
     } else {
-      return ProjectPath.WORKSPACE_ROOT.resolveChild(includePath);
+      return ProjectPath.workspaceRelative(includePath);
     }
   }
 }

--- a/querysync/java/com/google/idea/blaze/qsync/deps/CcToolchain.java
+++ b/querysync/java/com/google/idea/blaze/qsync/deps/CcToolchain.java
@@ -70,7 +70,7 @@ public abstract class CcToolchain {
     return builder()
         .id(proto.getId())
         .compiler(proto.getCompiler())
-        .compilerExecutable(ProjectPath.workspaceRelative(proto.getCompilerExecutable()))
+        .compilerExecutable(ProjectPath.execrootRelative(proto.getCompilerExecutable()))
         .cpu(proto.getCpu())
         .targetGnuSystemName(proto.getTargetName())
         .builtInIncludeDirectories(

--- a/querysync/java/com/google/idea/blaze/qsync/project/ProjectPath.java
+++ b/querysync/java/com/google/idea/blaze/qsync/project/ProjectPath.java
@@ -32,6 +32,7 @@ public abstract class ProjectPath {
     WORKSPACE,
     PROJECT,
     ABSOLUTE,
+    EXECROOT,
   }
 
   public abstract Root rootType();
@@ -62,6 +63,9 @@ public abstract class ProjectPath {
       case ABSOLUTE:
         proto.setBase(Base.ABSOLUTE);
         break;
+      case EXECROOT:
+        proto.setBase(Base.EXECROOT);
+        break;
     }
     return proto.setPath(relativePath().toString()).setInnerPath(innerJarPath().toString()).build();
   }
@@ -72,6 +76,14 @@ public abstract class ProjectPath {
 
   public static ProjectPath workspaceRelative(String path) {
     return workspaceRelative(Path.of(path));
+  }
+
+  public static ProjectPath execrootRelative(Path path) {
+    return create(Root.EXECROOT, path);
+  }
+
+  public static ProjectPath execrootRelative(String path) {
+    return execrootRelative(Path.of(path));
   }
 
   public static ProjectPath projectRelative(Path path) {
@@ -99,6 +111,8 @@ public abstract class ProjectPath {
         return Root.WORKSPACE;
       case ABSOLUTE:
         return Root.ABSOLUTE;
+      case EXECROOT:
+        return Root.EXECROOT;
       default:
         throw new IllegalArgumentException(base.name());
     }
@@ -124,14 +138,16 @@ public abstract class ProjectPath {
   public abstract static class Resolver {
 
     @VisibleForTesting
-    public static final Resolver EMPTY_FOR_TESTING = create(Path.of(""), Path.of(""));
+    public static final Resolver EMPTY_FOR_TESTING = create(Path.of(""), Path.of(""), Path.of(""));
 
     abstract Path workspaceRoot();
 
     abstract Path projectRoot();
 
-    public static Resolver create(Path workspaceRoot, Path projectRoot) {
-      return new AutoValue_ProjectPath_Resolver(workspaceRoot, projectRoot);
+    abstract Path execRoot();
+
+    public static Resolver create(Path workspaceRoot, Path projectRoot, Path execRoot) {
+      return new AutoValue_ProjectPath_Resolver(workspaceRoot, projectRoot, execRoot);
     }
 
     public Path resolve(ProjectPath path) {
@@ -142,6 +158,8 @@ public abstract class ProjectPath {
           return projectRoot().resolve(path.relativePath());
         case ABSOLUTE:
           return path.relativePath();
+        case EXECROOT:
+          return execRoot().resolve(path.relativePath());
       }
       throw new IllegalStateException(path.rootType().name());
     }

--- a/querysync/java/com/google/idea/blaze/qsync/project/project.proto
+++ b/querysync/java/com/google/idea/blaze/qsync/project/project.proto
@@ -72,6 +72,7 @@ message ProjectPath {
     WORKSPACE = 1;
     PROJECT = 2;
     ABSOLUTE = 3;
+    EXECROOT = 4;
   }
 
   // path to the content root, relative to base.

--- a/querysync/javatests/com/google/idea/blaze/qsync/cc/CcWorkspaceBuilderTest.java
+++ b/querysync/javatests/com/google/idea/blaze/qsync/cc/CcWorkspaceBuilderTest.java
@@ -123,7 +123,9 @@ public class CcWorkspaceBuilderTest {
 
     FlagResolver resolver =
         new FlagResolver(
-            ProjectPath.Resolver.create(Path.of("/workspace"), Path.of("/project")), false);
+            ProjectPath.Resolver.create(Path.of("/workspace"), Path.of("/project"), Path.of("/execroot")),
+            false
+        );
 
     CcWorkspaceBuilder builder =
         new CcWorkspaceBuilder(

--- a/querysync/javatests/com/google/idea/blaze/qsync/cc/ConfigureCcCompilationTest.java
+++ b/querysync/javatests/com/google/idea/blaze/qsync/cc/ConfigureCcCompilationTest.java
@@ -150,7 +150,9 @@ public class ConfigureCcCompilationTest {
     CcCompilerSettings compilerSettings = sourceFile.getCompilerSettings();
     FlagResolver resolver =
         new FlagResolver(
-            ProjectPath.Resolver.create(Path.of("/workspace"), Path.of("/project")), false);
+            ProjectPath.Resolver.create(Path.of("/workspace"), Path.of("/project"), Path.of("/execroot")),
+            false
+        );
     assertThat(resolver.resolveAll(workspace.getFlagSetsOrThrow(compilerSettings.getFlagSetId())))
         .containsExactly(
             "-DDEBUG",
@@ -168,7 +170,7 @@ public class ConfigureCcCompilationTest {
             "--sharedopt",
             "--cppopt");
 
-    assertThat(compilerSettings.getCompilerExecutablePath().getBase()).isEqualTo(Base.WORKSPACE);
+    assertThat(compilerSettings.getCompilerExecutablePath().getBase()).isEqualTo(Base.EXECROOT);
     assertThat(compilerSettings.getCompilerExecutablePath().getPath())
         .isEqualTo("workspace/path/to/clang");
 

--- a/querysync/javatests/com/google/idea/blaze/qsync/java/AddDependencySrcJarsTest.java
+++ b/querysync/javatests/com/google/idea/blaze/qsync/java/AddDependencySrcJarsTest.java
@@ -61,7 +61,11 @@ public class AddDependencySrcJarsTest {
   public void createDirs() throws IOException {
     workspaceRoot = tempDir.newFolder("workspace").toPath();
     pathResolver =
-        ProjectPath.Resolver.create(workspaceRoot, tempDir.newFolder("project").toPath());
+        ProjectPath.Resolver.create(
+            workspaceRoot,
+            tempDir.newFolder("project").toPath(),
+            tempDir.newFolder("execroot").toPath()
+        );
   }
 
   @Test


### PR DESCRIPTION
1. Make cc compiler path exec root relative. The path was workspace relative before which is not correct.
2. Also make external include paths exec root relative.

Also added test for external include paths. To run qsync tests on mac we are still missing xcode integration.

