### PR TITLE
Disable CLion MacOS CI

### DIFF
--- a/.bazelci/clion.yml
+++ b/.bazelci/clion.yml
@@ -65,6 +65,8 @@ tasks:
       - --test_output=errors
     test_targets:
       - //:clwb_tests
+    soft_fail:
+      - exit_status: 1
   CLion-MacOS-OSS-latest-stable:
     name: CLion MacOS OSS Latest Stable
     platform: macos_arm64
@@ -78,6 +80,8 @@ tasks:
       - --test_output=errors
     test_targets:
       - //:clwb_tests
+    soft_fail:
+      - exit_status: 1
   CLion-Linux-OSS-under-dev:
     name: CLion Linux OSS Under Development
     platform: ubuntu2204


### PR DESCRIPTION
Mark MacOS CI as soft fail, since MacOS runners are broken because of https://github.com/bazelbuild/continuous-integration/issues/2183.

Revert this after the issue is fixed.
