### PR TITLE
[AOSP-pick] Simplify ParsedBepOutput public interface

### DIFF
--- a/base/src/com/google/idea/blaze/base/command/buildresult/bepparser/ParsedBepOutput.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/bepparser/ParsedBepOutput.java
@@ -29,9 +29,9 @@ import com.google.common.collect.SetMultimap;
 import com.google.idea.blaze.common.artifact.OutputArtifact;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Predicate;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
+import org.jetbrains.annotations.TestOnly;
 
 /** A data class representing blaze's build event protocol (BEP) output for a build. */
 public final class ParsedBepOutput {
@@ -114,37 +114,29 @@ public final class ParsedBepOutput {
   }
 
   /** Returns all output artifacts of the build. */
-  public ImmutableSet<OutputArtifact> getAllOutputArtifacts(Predicate<String> pathFilter) {
+  @TestOnly
+  public ImmutableSet<OutputArtifact> getAllOutputArtifactsForTesting() {
     return fileSets.values().stream()
         .map(s -> s.parsedOutputs)
         .flatMap(List::stream)
-        .filter(o -> pathFilter.test(o.getBazelOutRelativePath()))
         .collect(toImmutableSet());
   }
 
   /** Returns the set of artifacts directly produced by the given target. */
-  public ImmutableSet<OutputArtifact> getDirectArtifactsForTarget(
-      String label, Predicate<String> pathFilter) {
+  public ImmutableSet<OutputArtifact> getDirectArtifactsForTarget(String label) {
     return targetFileSets.get(label).stream()
         .map(s -> fileSets.get(s).parsedOutputs)
         .flatMap(List::stream)
-        .filter(o -> pathFilter.test(o.getBazelOutRelativePath()))
         .collect(toImmutableSet());
   }
 
-  public ImmutableList<OutputArtifact> getOutputGroupArtifacts(
-      String outputGroup, Predicate<String> pathFilter) {
+  public ImmutableList<OutputArtifact> getOutputGroupArtifacts(String outputGroup) {
     return fileSets.values().stream()
         .filter(f -> f.outputGroups.contains(outputGroup))
         .map(f -> f.parsedOutputs)
         .flatMap(List::stream)
-        .filter(o -> pathFilter.test(o.getBazelOutRelativePath()))
         .distinct()
         .collect(toImmutableList());
-  }
-
-  public ImmutableList<OutputArtifact> getOutputGroupArtifacts(String outputGroup) {
-    return getOutputGroupArtifacts(outputGroup, s -> true);
   }
 
   /**

--- a/base/tests/unittests/com/google/idea/blaze/base/command/buildresult/BuildEventProtocolOutputReaderTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/command/buildresult/BuildEventProtocolOutputReaderTest.java
@@ -64,7 +64,6 @@ import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.function.Predicate;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -118,33 +117,11 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
 
     ImmutableSet<OutputArtifact> parsedFilenames =
         BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)))
-            .getAllOutputArtifacts(path -> true);
+            .getAllOutputArtifactsForTesting();
 
     assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
         .containsExactlyElementsIn(filePaths.stream().map(File::new).toArray())
         .inOrder();
-  }
-
-  @Test
-  public void parseAllOutputsWithFilter_singleFileEvent_returnsFilteredOutputs() throws Exception {
-    Predicate<String> filter = path -> path.endsWith(".py");
-    ImmutableList<String> filePaths =
-        ImmutableList.of(
-            "/usr/local/lib/File.py", "/usr/bin/python2.7", "/usr/local/home/script.sh");
-    ImmutableList<BuildEvent.Builder> events =
-        ImmutableList.of(
-            configuration("config-id", "k8-opt"),
-            setOfFiles(filePaths, "set-id"),
-            targetComplete(
-                "//some:target",
-                "config-id",
-                ImmutableList.of(outputGroup("name", ImmutableList.of("set-id")))));
-
-    ImmutableSet<OutputArtifact> parsedFilenames =
-        BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events))).getAllOutputArtifacts(filter);
-
-    assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
-        .containsExactly(new File("/usr/local/lib/File.py"));
   }
 
   @Test
@@ -155,7 +132,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
 
     ImmutableSet<OutputArtifact> parsedFilenames =
         BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(targetFinishedEvent)))
-            .getAllOutputArtifacts(path -> true);
+            .getAllOutputArtifactsForTesting();
 
     assertThat(parsedFilenames).isEmpty();
   }
@@ -182,7 +159,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
 
     ImmutableSet<OutputArtifact> parsedFilenames =
         BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)))
-            .getAllOutputArtifacts(path -> true);
+            .getAllOutputArtifactsForTesting();
 
     assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
         .containsExactlyElementsIn(filePaths.stream().map(File::new).toArray())
@@ -227,7 +204,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
 
     ImmutableSet<OutputArtifact> parsedFilenames =
         BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)))
-            .getAllOutputArtifacts(path -> true);
+            .getAllOutputArtifactsForTesting();
 
     assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
         .containsExactlyElementsIn(allFiles)
@@ -264,7 +241,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
 
     ImmutableSet<OutputArtifact> parsedFilenames =
         BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)))
-            .getAllOutputArtifacts(path -> true);
+            .getAllOutputArtifactsForTesting();
 
     assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
         .containsExactlyElementsIn(allFiles)
@@ -296,7 +273,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
 
     ImmutableSet<OutputArtifact> parsedFilenames =
         BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)))
-            .getDirectArtifactsForTarget("//some:target", path -> true);
+            .getDirectArtifactsForTarget("//some:target");
 
     assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
         .containsExactlyElementsIn(allFiles)
@@ -336,7 +313,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
 
     ImmutableSet<OutputArtifact> parsedFilenames =
         BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)))
-            .getDirectArtifactsForTarget("//some:target", path -> true);
+            .getDirectArtifactsForTarget("//some:target");
 
     assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
         .containsExactlyElementsIn(allFiles)
@@ -382,7 +359,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
 
     ImmutableList<OutputArtifact> parsedFilenames =
         BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)))
-            .getOutputGroupArtifacts("group-name", path -> true);
+            .getOutputGroupArtifacts("group-name");
 
     assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
         .containsExactlyElementsIn(allFiles)
@@ -423,7 +400,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
 
     ImmutableList<OutputArtifact> parsedFilenames =
         BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)))
-            .getOutputGroupArtifacts("group-1", path -> true);
+            .getOutputGroupArtifacts("group-1");
 
     assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
         .containsExactlyElementsIn(allFiles)

--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrRunConfigurationRunner.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrRunConfigurationRunner.java
@@ -171,7 +171,7 @@ public class BlazeCidrRunConfigurationRunner implements BlazeCommandRunConfigura
         candidateFiles =
             LocalFileArtifact.getLocalFiles(
                     BuildResultParser.getBuildOutput(bepStream, Interners.STRING)
-                        .getDirectArtifactsForTarget(target.toString(), file -> true))
+                        .getDirectArtifactsForTarget(target.toString()))
                 .stream()
                 .filter(File::canExecute)
                 .collect(Collectors.toList());

--- a/golang/src/com/google/idea/blaze/golang/run/BlazeGoRunConfigurationRunner.java
+++ b/golang/src/com/google/idea/blaze/golang/run/BlazeGoRunConfigurationRunner.java
@@ -373,7 +373,7 @@ public class BlazeGoRunConfigurationRunner implements BlazeCommandRunConfigurati
           candidateFiles =
               LocalFileArtifact.getLocalFiles(
                       BuildResultParser.getBuildOutput(bepStream, Interners.STRING)
-                          .getDirectArtifactsForTarget(label.toString(), file -> true))
+                          .getDirectArtifactsForTarget(label.toString()))
                   .stream()
                   .filter(File::canExecute)
                   .collect(Collectors.toList());

--- a/java/src/com/google/idea/blaze/java/run/hotswap/ClassFileManifestBuilder.java
+++ b/java/src/com/google/idea/blaze/java/run/hotswap/ClassFileManifestBuilder.java
@@ -145,7 +145,7 @@ public class ClassFileManifestBuilder {
         jars =
             LocalFileArtifact.getLocalFiles(
                 BuildResultParser.getBuildOutput(bepStream, Interners.STRING)
-                  .getOutputGroupArtifacts(JavaClasspathAspectStrategy.OUTPUT_GROUP, file -> true))
+                  .getOutputGroupArtifacts(JavaClasspathAspectStrategy.OUTPUT_GROUP))
                 .stream()
                 .filter(f -> f.getName().endsWith(".jar"))
                 .collect(toImmutableList());

--- a/python/src/com/google/idea/blaze/python/run/BlazePyRunConfigurationRunner.java
+++ b/python/src/com/google/idea/blaze/python/run/BlazePyRunConfigurationRunner.java
@@ -346,7 +346,7 @@ public class BlazePyRunConfigurationRunner implements BlazeCommandRunConfigurati
         candidateFiles =
             LocalFileArtifact.getLocalFiles(
                 BuildResultParser.getBuildOutput(bepStream, Interners.STRING)
-                  .getDirectArtifactsForTarget(target.toString(), file -> true).asList())
+                  .getDirectArtifactsForTarget(target.toString()).asList())
                 .stream()
                 .filter(File::canExecute)
                 .collect(Collectors.toList());

--- a/scala/src/com/google/idea/blaze/scala/run/producers/GenerateDeployableJarTaskProvider.java
+++ b/scala/src/com/google/idea/blaze/scala/run/producers/GenerateDeployableJarTaskProvider.java
@@ -192,7 +192,7 @@ class GenerateDeployableJarTaskProvider
       try (final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {
         outputs = LocalFileArtifact.getLocalFiles(
             BuildResultParser.getBuildOutput(bepStream, Interners.STRING)
-                .getDirectArtifactsForTarget(String.format("%s_deploy.jar", target), file -> true));
+                .getDirectArtifactsForTarget(String.format("%s_deploy.jar", target)));
       }
 
       if (outputs.isEmpty()) {


### PR DESCRIPTION
Cherry pick AOSP commit [7fbfbd9ad4ed3a2b6b5da32fba25f5c4429a19bc](https://cs.android.com/android-studio/platform/tools/adt/idea/+/7fbfbd9ad4ed3a2b6b5da32fba25f5c4429a19bc).

1. as a pre-requisite also reduce the amount of details logged when
   the IDE is unable to find expected output artifacts.

2. drop artifact filtering support as it is rarely used and can filters
   can be applied afterwards.

Bug: 327638725
Test: n/a
Change-Id: Ibc4008f6340d7f08c6b220e871e9a3c1c090dd97

AOSP: 7fbfbd9ad4ed3a2b6b5da32fba25f5c4429a19bc
