### PR TITLE
[AOSP-pick] Never ask for artifacts without output group

### DIFF
--- a/aswb/src/com/google/idea/blaze/android/run/binary/mobileinstall/MobileInstallBuildStep.java
+++ b/aswb/src/com/google/idea/blaze/android/run/binary/mobileinstall/MobileInstallBuildStep.java
@@ -245,7 +245,7 @@ public class MobileInstallBuildStep implements ApkBuildStep {
 
       AndroidDeployInfo deployInfoProto =
           deployInfoHelper.readDeployInfoProtoForTarget(
-              label, buildResultHelper, fileName -> fileName.endsWith(deployInfoSuffix));
+              label, "mobile_install_INTERNAL_", buildResultHelper, fileName -> fileName.endsWith(deployInfoSuffix));
       deployInfo =
           deployInfoHelper.extractDeployInfoAndInvalidateManifests(
               project, new File(executionRoot), deployInfoProto);

--- a/aswb/src/com/google/idea/blaze/android/run/deployinfo/BlazeApkDeployInfoProtoHelper.java
+++ b/aswb/src/com/google/idea/blaze/android/run/deployinfo/BlazeApkDeployInfoProtoHelper.java
@@ -27,7 +27,6 @@ import com.google.idea.blaze.android.manifest.ParsedManifestService;
 import com.google.idea.blaze.base.command.buildresult.BuildResultParser;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtifactsException;
-import com.google.idea.blaze.base.command.buildresult.LocalFileArtifact;
 import com.google.idea.blaze.base.command.buildresult.bepparser.ParsedBepOutput;
 import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.common.Interners;
@@ -50,14 +49,14 @@ import java.util.stream.Stream;
  */
 public class BlazeApkDeployInfoProtoHelper {
   public AndroidDeployInfo readDeployInfoProtoForTarget(
-    Label target, BuildResultHelper buildResultHelper, Predicate<String> pathFilter)
+    Label target, String outputGroup,BuildResultHelper buildResultHelper, Predicate<String> pathFilter)
       throws GetDeployInfoException {
     ImmutableList<OutputArtifact> outputArtifacts;
     ImmutableSet<OutputArtifact> targetOutputArtifacts;
     ParsedBepOutput bepOutput;
     try (final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {
       bepOutput = BuildResultParser.getBuildOutput(bepStream, Interners.STRING);
-      targetOutputArtifacts = bepOutput.getDirectArtifactsForTarget(target.toString());
+      targetOutputArtifacts = bepOutput.getOutputGroupTargetArtifacts(outputGroup, target.toString());
       outputArtifacts =
         targetOutputArtifacts.stream().filter(it -> pathFilter.test(it.getBazelOutRelativePath()))
           .collect(toImmutableList());

--- a/aswb/src/com/google/idea/blaze/android/run/runner/BlazeInstrumentationTestApkBuildStep.java
+++ b/aswb/src/com/google/idea/blaze/android/run/runner/BlazeInstrumentationTestApkBuildStep.java
@@ -47,7 +47,7 @@ import java.io.File;
 
 /** Builds the APKs required for an android instrumentation test. */
 public class BlazeInstrumentationTestApkBuildStep implements ApkBuildStep {
-
+  private static final String ANDROID_DEPLOY_INFO_OUTPUT_GROUP_NAME = "android_deploy_info";
   /** Subject to change with changes to android build rules. */
   private static final String DEPLOY_INFO_FILE_SUFFIX = ".deployinfo.pb";
 
@@ -134,6 +134,7 @@ public class BlazeInstrumentationTestApkBuildStep implements ApkBuildStep {
         AndroidDeployInfo instrumentorDeployInfoProto =
             deployInfoHelper.readDeployInfoProtoForTarget(
                 instrumentationInfo.testApp,
+                ANDROID_DEPLOY_INFO_OUTPUT_GROUP_NAME,
                 buildResultHelper,
                 fileName -> fileName.endsWith(DEPLOY_INFO_FILE_SUFFIX));
         if (instrumentationInfo.isSelfInstrumentingTest()) {
@@ -144,6 +145,7 @@ public class BlazeInstrumentationTestApkBuildStep implements ApkBuildStep {
           AndroidDeployInfo targetDeployInfoProto =
               deployInfoHelper.readDeployInfoProtoForTarget(
                   instrumentationInfo.targetApp,
+                  ANDROID_DEPLOY_INFO_OUTPUT_GROUP_NAME,
                   buildResultHelper,
                   fileName -> fileName.endsWith(DEPLOY_INFO_FILE_SUFFIX));
           deployInfo =

--- a/aswb/src/com/google/idea/blaze/android/run/runner/FullApkBuildStep.java
+++ b/aswb/src/com/google/idea/blaze/android/run/runner/FullApkBuildStep.java
@@ -58,6 +58,7 @@ import java.util.List;
 
 /** Builds the APK using normal blaze build. */
 public class FullApkBuildStep implements ApkBuildStep {
+  private static final String ANDROID_DEPLOY_INFO_OUTPUT_GROUP_NAME = "android_deploy_info";
   @VisibleForTesting public static final String DEPLOY_INFO_SUFFIX = ".deployinfo.pb";
 
   /** Controls the post-build remote APK fetching step. */
@@ -218,8 +219,8 @@ public class FullApkBuildStep implements ApkBuildStep {
       }
 
       AndroidDeployInfo deployInfoProto =
-          deployInfoHelper.readDeployInfoProtoForTarget(
-              label, buildResultHelper, fileName -> fileName.endsWith(DEPLOY_INFO_SUFFIX));
+        deployInfoHelper.readDeployInfoProtoForTarget(
+          label, ANDROID_DEPLOY_INFO_OUTPUT_GROUP_NAME, buildResultHelper, fileName -> fileName.endsWith(DEPLOY_INFO_SUFFIX));
       ImmutableList<File> libs =
           nativeSymbolFinderList.stream()
               .flatMap(

--- a/aswb/tests/integrationtests/com/google/idea/blaze/android/functional/BlazeInstrumentationTestApkBuildStepIntegrationTest.java
+++ b/aswb/tests/integrationtests/com/google/idea/blaze/android/functional/BlazeInstrumentationTestApkBuildStepIntegrationTest.java
@@ -119,9 +119,9 @@ public class BlazeInstrumentationTestApkBuildStepIntegrationTest
     AndroidDeployInfo fakeAppProto = AndroidDeployInfo.newBuilder().build();
     BlazeAndroidDeployInfo mockDeployInfo = mock(BlazeAndroidDeployInfo.class);
     when(helper.readDeployInfoProtoForTarget(
-            eq(instrumentorTarget), any(BuildResultHelper.class), any()))
+            eq(instrumentorTarget),  eq("android_deploy_info"), any(BuildResultHelper.class), any()))
         .thenReturn(fakeInstrumentorProto);
-    when(helper.readDeployInfoProtoForTarget(eq(appTarget), any(BuildResultHelper.class), any()))
+    when(helper.readDeployInfoProtoForTarget(eq(appTarget), eq("android_deploy_info"), any(BuildResultHelper.class), any()))
         .thenReturn(fakeAppProto);
     when(helper.extractInstrumentationTestDeployInfoAndInvalidateManifests(
             eq(getProject()),
@@ -165,7 +165,7 @@ public class BlazeInstrumentationTestApkBuildStepIntegrationTest
     AndroidDeployInfo fakeInstrumentorProto = AndroidDeployInfo.newBuilder().build();
     BlazeAndroidDeployInfo mockDeployInfo = mock(BlazeAndroidDeployInfo.class);
     when(helper.readDeployInfoProtoForTarget(
-            eq(instrumentorTarget), any(BuildResultHelper.class), any()))
+            eq(instrumentorTarget), eq("android_deploy_info"), any(BuildResultHelper.class), any()))
         .thenReturn(fakeInstrumentorProto);
     when(helper.extractDeployInfoAndInvalidateManifests(
             eq(getProject()), eq(new File(getExecRoot())), eq(fakeInstrumentorProto)))
@@ -205,9 +205,9 @@ public class BlazeInstrumentationTestApkBuildStepIntegrationTest
     AndroidDeployInfo fakeInstrumentorProto = AndroidDeployInfo.newBuilder().build();
     AndroidDeployInfo fakeAppProto = AndroidDeployInfo.newBuilder().build();
     when(helper.readDeployInfoProtoForTarget(
-            eq(instrumentorTarget), any(BuildResultHelper.class), any()))
+            eq(instrumentorTarget), eq("android_deploy_info"), any(BuildResultHelper.class), any()))
         .thenReturn(fakeInstrumentorProto);
-    when(helper.readDeployInfoProtoForTarget(eq(appTarget), any(BuildResultHelper.class), any()))
+    when(helper.readDeployInfoProtoForTarget(eq(appTarget), eq("android_deploy_info"), any(BuildResultHelper.class), any()))
         .thenReturn(fakeAppProto);
     when(helper.extractInstrumentationTestDeployInfoAndInvalidateManifests(
             any(), any(), any(), any()))
@@ -245,9 +245,9 @@ public class BlazeInstrumentationTestApkBuildStepIntegrationTest
     AndroidDeployInfo fakeAppProto = AndroidDeployInfo.newBuilder().build();
     BlazeAndroidDeployInfo mockDeployInfo = mock(BlazeAndroidDeployInfo.class);
     when(helper.readDeployInfoProtoForTarget(
-            eq(instrumentorTarget), any(BuildResultHelper.class), any()))
+            eq(instrumentorTarget), eq("android_deploy_info"), any(BuildResultHelper.class), any()))
         .thenReturn(fakeInstrumentorProto);
-    when(helper.readDeployInfoProtoForTarget(eq(appTarget), any(BuildResultHelper.class), any()))
+    when(helper.readDeployInfoProtoForTarget(eq(appTarget), eq("android_deploy_info"), any(BuildResultHelper.class), any()))
         .thenReturn(fakeAppProto);
     when(helper.extractInstrumentationTestDeployInfoAndInvalidateManifests(
             eq(getProject()),
@@ -295,9 +295,9 @@ public class BlazeInstrumentationTestApkBuildStepIntegrationTest
     AndroidDeployInfo fakeAppProto = AndroidDeployInfo.newBuilder().build();
     BlazeAndroidDeployInfo mockDeployInfo = mock(BlazeAndroidDeployInfo.class);
     when(helper.readDeployInfoProtoForTarget(
-            eq(instrumentorTarget), any(BuildResultHelper.class), any()))
+            eq(instrumentorTarget), eq("android_deploy_info"), any(BuildResultHelper.class), any()))
         .thenReturn(fakeInstrumentorProto);
-    when(helper.readDeployInfoProtoForTarget(eq(appTarget), any(BuildResultHelper.class), any()))
+    when(helper.readDeployInfoProtoForTarget(eq(appTarget), eq("android_deploy_info"), any(BuildResultHelper.class), any()))
         .thenReturn(fakeAppProto);
     when(helper.extractInstrumentationTestDeployInfoAndInvalidateManifests(
             eq(getProject()),

--- a/aswb/tests/integrationtests/com/google/idea/blaze/android/functional/FullApkBuildStepIntegrationTest.java
+++ b/aswb/tests/integrationtests/com/google/idea/blaze/android/functional/FullApkBuildStepIntegrationTest.java
@@ -117,7 +117,7 @@ public class FullApkBuildStepIntegrationTest extends BlazeAndroidIntegrationTest
 
     BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
     AndroidDeployInfo fakeProto = AndroidDeployInfo.newBuilder().build();
-    when(helper.readDeployInfoProtoForTarget(eq(buildTarget), any(BuildResultHelper.class), any()))
+    when(helper.readDeployInfoProtoForTarget(eq(buildTarget), eq("android_deploy_info"), any(BuildResultHelper.class), any()))
         .thenReturn(fakeProto);
     when(helper.extractDeployInfoAndInvalidateManifests(
             eq(getProject()), eq(new File(getExecRoot())), eq(fakeProto), any()))
@@ -158,7 +158,7 @@ public class FullApkBuildStepIntegrationTest extends BlazeAndroidIntegrationTest
 
     BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
     AndroidDeployInfo fakeProto = AndroidDeployInfo.newBuilder().build();
-    when(helper.readDeployInfoProtoForTarget(eq(buildTarget), any(BuildResultHelper.class), any()))
+    when(helper.readDeployInfoProtoForTarget(eq(buildTarget), eq("android_deploy_info"), any(BuildResultHelper.class), any()))
         .thenReturn(fakeProto);
     when(helper.extractDeployInfoAndInvalidateManifests(
             eq(getProject()), eq(new File(getExecRoot())), eq(fakeProto), any()))
@@ -207,7 +207,7 @@ public class FullApkBuildStepIntegrationTest extends BlazeAndroidIntegrationTest
 
     BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
     AndroidDeployInfo fakeProto = AndroidDeployInfo.newBuilder().build();
-    when(helper.readDeployInfoProtoForTarget(eq(buildTarget), any(BuildResultHelper.class), any()))
+    when(helper.readDeployInfoProtoForTarget(eq(buildTarget), eq("android_deploy_info"), any(BuildResultHelper.class), any()))
         .thenReturn(fakeProto);
     when(helper.extractDeployInfoAndInvalidateManifests(
             eq(getProject()), eq(new File(getExecRoot())), eq(fakeProto), any()))
@@ -250,7 +250,7 @@ public class FullApkBuildStepIntegrationTest extends BlazeAndroidIntegrationTest
 
     BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
     AndroidDeployInfo fakeProto = AndroidDeployInfo.newBuilder().build();
-    when(helper.readDeployInfoProtoForTarget(eq(buildTarget), any(BuildResultHelper.class), any()))
+    when(helper.readDeployInfoProtoForTarget(eq(buildTarget), eq("android_deploy_info"), any(BuildResultHelper.class), any()))
         .thenReturn(fakeProto);
     // Expect symbol files to be passed to Helper when building DeployInfo.
     when(helper.extractDeployInfoAndInvalidateManifests(
@@ -296,7 +296,7 @@ public class FullApkBuildStepIntegrationTest extends BlazeAndroidIntegrationTest
 
     BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
     AndroidDeployInfo fakeProto = AndroidDeployInfo.getDefaultInstance();
-    when(helper.readDeployInfoProtoForTarget(eq(buildTarget), any(BuildResultHelper.class), any()))
+    when(helper.readDeployInfoProtoForTarget(eq(buildTarget), eq("android_deploy_info"), any(BuildResultHelper.class), any()))
         .thenReturn(fakeProto);
     // Expect symbol files to be passed to Helper when building DeployInfo.
     when(helper.extractDeployInfoAndInvalidateManifests(
@@ -341,7 +341,7 @@ public class FullApkBuildStepIntegrationTest extends BlazeAndroidIntegrationTest
 
     BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
     AndroidDeployInfo fakeProto = AndroidDeployInfo.getDefaultInstance();
-    when(helper.readDeployInfoProtoForTarget(eq(buildTarget), any(BuildResultHelper.class), any()))
+    when(helper.readDeployInfoProtoForTarget(eq(buildTarget), eq("android_deploy_info"), any(BuildResultHelper.class), any()))
         .thenReturn(fakeProto);
     when(helper.extractDeployInfoAndInvalidateManifests(
             eq(getProject()), eq(new File(getExecRoot())), eq(fakeProto), eq(symbolFiles)))
@@ -377,7 +377,7 @@ public class FullApkBuildStepIntegrationTest extends BlazeAndroidIntegrationTest
     // Return fake deploy info proto and mocked deploy info data object.
     AndroidDeployInfo fakeProto = AndroidDeployInfo.newBuilder().build();
     BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
-    when(helper.readDeployInfoProtoForTarget(eq(buildTarget), any(BuildResultHelper.class), any()))
+    when(helper.readDeployInfoProtoForTarget(eq(buildTarget), eq("android_deploy_info"), any(BuildResultHelper.class), any()))
         .thenReturn(fakeProto);
     when(helper.extractDeployInfoAndInvalidateManifests(any(), any(), any(), any()))
         .thenThrow(new GetDeployInfoException("Fake Exception"));
@@ -409,7 +409,7 @@ public class FullApkBuildStepIntegrationTest extends BlazeAndroidIntegrationTest
     BlazeAndroidDeployInfo mockDeployInfo = mock(BlazeAndroidDeployInfo.class);
     when(mockDeployInfo.getApksToDeploy()).thenReturn(ImmutableList.of());
     BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
-    when(helper.readDeployInfoProtoForTarget(eq(buildTarget), any(BuildResultHelper.class), any()))
+    when(helper.readDeployInfoProtoForTarget(eq(buildTarget), eq("android_deploy_info"), any(BuildResultHelper.class), any()))
         .thenReturn(fakeProto);
     when(helper.extractDeployInfoAndInvalidateManifests(
             eq(getProject()), eq(new File(getExecRoot())), eq(fakeProto), any()))
@@ -443,7 +443,7 @@ public class FullApkBuildStepIntegrationTest extends BlazeAndroidIntegrationTest
     BlazeAndroidDeployInfo mockDeployInfo = mock(BlazeAndroidDeployInfo.class);
     when(mockDeployInfo.getApksToDeploy()).thenReturn(ImmutableList.of());
     BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
-    when(helper.readDeployInfoProtoForTarget(eq(buildTarget), any(BuildResultHelper.class), any()))
+    when(helper.readDeployInfoProtoForTarget(eq(buildTarget), eq("android_deploy_info"), any(BuildResultHelper.class), any()))
         .thenReturn(fakeProto);
     when(helper.extractDeployInfoAndInvalidateManifests(
             eq(getProject()), eq(new File(getExecRoot())), eq(fakeProto), any()))

--- a/aswb/tests/integrationtests/com/google/idea/blaze/android/functional/MobileInstallBuildStepIntegrationTest.java
+++ b/aswb/tests/integrationtests/com/google/idea/blaze/android/functional/MobileInstallBuildStepIntegrationTest.java
@@ -40,7 +40,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Integration tests for {@link MobileInstallBuildStep} */
+/**
+ * Integration tests for {@link MobileInstallBuildStep}
+ */
 @RunWith(JUnit4.class)
 public final class MobileInstallBuildStepIntegrationTest extends MobileInstallBuildStepTestCase {
   @Test
@@ -53,15 +55,15 @@ public final class MobileInstallBuildStepIntegrationTest extends MobileInstallBu
     AndroidDeployInfo fakeProto = AndroidDeployInfo.newBuilder().build();
     BlazeAndroidDeployInfo mockDeployInfo = mock(BlazeAndroidDeployInfo.class);
     BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
-    when(helper.readDeployInfoProtoForTarget(eq(buildTarget), any(BuildResultHelper.class), any()))
-        .thenReturn(fakeProto);
+    when(helper.readDeployInfoProtoForTarget(eq(buildTarget), eq("mobile_install_INTERNAL_"), any(BuildResultHelper.class), any()))
+      .thenReturn(fakeProto);
     when(helper.extractDeployInfoAndInvalidateManifests(
-            getProject(), new File(getExecRoot()), fakeProto))
-        .thenReturn(mockDeployInfo);
+      getProject(), new File(getExecRoot()), fakeProto))
+      .thenReturn(mockDeployInfo);
 
     // Perform
     MobileInstallBuildStep buildStep =
-        new MobileInstallBuildStep(getProject(), buildTarget, blazeFlags, execFlags, helper);
+      new MobileInstallBuildStep(getProject(), buildTarget, blazeFlags, execFlags, helper);
     buildStep.build(context, new DeviceSession(null, deviceFutures, null));
 
     // Verify
@@ -71,7 +73,7 @@ public final class MobileInstallBuildStepIntegrationTest extends MobileInstallBu
     assertThat(externalTaskInterceptor.getCommand()).containsAllIn(blazeFlags);
     assertThat(externalTaskInterceptor.getCommand()).containsAllIn(execFlags);
     assertThat(externalTaskInterceptor.getCommand())
-        .containsAnyOf("serial-number", "serial-number:tcp:0");
+      .containsAnyOf("serial-number", "serial-number:tcp:0");
     assertThat(externalTaskInterceptor.getCommand()).contains(buildTarget.toString());
   }
 
@@ -85,11 +87,11 @@ public final class MobileInstallBuildStepIntegrationTest extends MobileInstallBu
     AndroidDeployInfo fakeProto = AndroidDeployInfo.newBuilder().build();
     BlazeAndroidDeployInfo mockDeployInfo = mock(BlazeAndroidDeployInfo.class);
     BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
-    when(helper.readDeployInfoProtoForTarget(eq(buildTarget), any(BuildResultHelper.class), any()))
-        .thenReturn(fakeProto);
+    when(helper.readDeployInfoProtoForTarget(eq(buildTarget), eq("mobile_install_INTERNAL_"), any(BuildResultHelper.class), any()))
+      .thenReturn(fakeProto);
     when(helper.extractDeployInfoAndInvalidateManifests(
-            getProject(), new File(getExecRoot()), fakeProto))
-        .thenReturn(mockDeployInfo);
+      getProject(), new File(getExecRoot()), fakeProto))
+      .thenReturn(mockDeployInfo);
 
     // Setup mock AdbTunnelConfigurator for testing device port flags.
     AdbTunnelConfigurator tunnelConfigurator = mock(AdbTunnelConfigurator.class);
@@ -99,7 +101,7 @@ public final class MobileInstallBuildStepIntegrationTest extends MobileInstallBu
 
     // Perform
     MobileInstallBuildStep buildStep =
-        new MobileInstallBuildStep(getProject(), buildTarget, blazeFlags, execFlags, helper);
+      new MobileInstallBuildStep(getProject(), buildTarget, blazeFlags, execFlags, helper);
     buildStep.build(context, new DeviceSession(null, deviceFutures, null));
 
     // Verify
@@ -111,7 +113,7 @@ public final class MobileInstallBuildStepIntegrationTest extends MobileInstallBu
     assertThat(externalTaskInterceptor.getCommand()).contains("--device");
     // workaround for inconsistent stateful AndroidDebugBridge class.
     assertThat(externalTaskInterceptor.getCommand())
-        .containsAnyOf("serial-number", "serial-number:tcp:0");
+      .containsAnyOf("serial-number", "serial-number:tcp:0");
     assertThat(externalTaskInterceptor.getCommand()).contains(buildTarget.toString());
   }
 
@@ -125,11 +127,11 @@ public final class MobileInstallBuildStepIntegrationTest extends MobileInstallBu
     AndroidDeployInfo fakeProto = AndroidDeployInfo.newBuilder().build();
     BlazeAndroidDeployInfo mockDeployInfo = mock(BlazeAndroidDeployInfo.class);
     BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
-    when(helper.readDeployInfoProtoForTarget(eq(buildTarget), any(BuildResultHelper.class), any()))
-        .thenReturn(fakeProto);
+    when(helper.readDeployInfoProtoForTarget(eq(buildTarget), eq("mobile_install_INTERNAL_"), any(BuildResultHelper.class), any()))
+      .thenReturn(fakeProto);
     when(helper.extractDeployInfoAndInvalidateManifests(
-            getProject(), new File(getExecRoot()), fakeProto))
-        .thenReturn(mockDeployInfo);
+      getProject(), new File(getExecRoot()), fakeProto))
+      .thenReturn(mockDeployInfo);
 
     // Setup mock AdbTunnelConfigurator for testing device port flags.
     AdbTunnelConfigurator tunnelConfigurator = mock(AdbTunnelConfigurator.class);
@@ -139,7 +141,7 @@ public final class MobileInstallBuildStepIntegrationTest extends MobileInstallBu
 
     // Perform
     MobileInstallBuildStep buildStep =
-        new MobileInstallBuildStep(getProject(), buildTarget, blazeFlags, execFlags, helper);
+      new MobileInstallBuildStep(getProject(), buildTarget, blazeFlags, execFlags, helper);
     buildStep.build(context, new DeviceSession(null, deviceFutures, null));
 
     // Verify
@@ -163,18 +165,18 @@ public final class MobileInstallBuildStepIntegrationTest extends MobileInstallBu
     AndroidDeployInfo fakeProto = AndroidDeployInfo.newBuilder().build();
     BlazeAndroidDeployInfo mockDeployInfo = mock(BlazeAndroidDeployInfo.class);
     BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
-    when(helper.readDeployInfoProtoForTarget(eq(buildTarget), any(BuildResultHelper.class), any()))
-        .thenReturn(fakeProto);
+    when(helper.readDeployInfoProtoForTarget(eq(buildTarget), eq("mobile_install_INTERNAL_"), any(BuildResultHelper.class), any()))
+      .thenReturn(fakeProto);
     when(helper.extractDeployInfoAndInvalidateManifests(
-            getProject(), new File(getExecRoot()), fakeProto))
-        .thenReturn(mockDeployInfo);
+      getProject(), new File(getExecRoot()), fakeProto))
+      .thenReturn(mockDeployInfo);
 
     // Do not pass AdbTunnelConfigurator.
     registerExtension(AdbTunnelConfiguratorProvider.EP_NAME, providerCxt -> null);
 
     // Perform
     MobileInstallBuildStep buildStep =
-        new MobileInstallBuildStep(getProject(), buildTarget, blazeFlags, execFlags, helper);
+      new MobileInstallBuildStep(getProject(), buildTarget, blazeFlags, execFlags, helper);
     buildStep.build(context, new DeviceSession(null, deviceFutures, null));
 
     // Verify
@@ -186,7 +188,7 @@ public final class MobileInstallBuildStepIntegrationTest extends MobileInstallBu
     assertThat(externalTaskInterceptor.getCommand()).contains("--device");
     // workaround for inconsistent stateful AndroidDebugBridge class.
     assertThat(externalTaskInterceptor.getCommand())
-        .containsAnyOf("serial-number", "serial-number:tcp:0");
+      .containsAnyOf("serial-number", "serial-number:tcp:0");
     assertThat(externalTaskInterceptor.getCommand()).contains(buildTarget.toString());
   }
 
@@ -198,28 +200,28 @@ public final class MobileInstallBuildStepIntegrationTest extends MobileInstallBu
     // Mobile-install build step requires only one device be active.  DeviceFutures class is final,
     // so we have to make one with a stub AndroidDevice.
     DeviceFutures deviceFutures =
-        new DeviceFutures(ImmutableList.of(new FakeDevice(), new FakeDevice()));
+      new DeviceFutures(ImmutableList.of(new FakeDevice(), new FakeDevice()));
 
     // Return fake deploy info proto and mocked deploy info data object.
     AndroidDeployInfo fakeProto = AndroidDeployInfo.newBuilder().build();
     BlazeAndroidDeployInfo mockDeployInfo = mock(BlazeAndroidDeployInfo.class);
     BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
-    when(helper.readDeployInfoProtoForTarget(eq(buildTarget), any(BuildResultHelper.class), any()))
-        .thenReturn(fakeProto);
+    when(helper.readDeployInfoProtoForTarget(eq(buildTarget), eq("mobile_install_INTERNAL_"), any(BuildResultHelper.class), any()))
+      .thenReturn(fakeProto);
     when(helper.extractDeployInfoAndInvalidateManifests(
-            getProject(), new File(getExecRoot()), fakeProto))
-        .thenReturn(mockDeployInfo);
+      getProject(), new File(getExecRoot()), fakeProto))
+      .thenReturn(mockDeployInfo);
 
     // Perform
     MobileInstallBuildStep buildStep =
-        new MobileInstallBuildStep(
-            getProject(), buildTarget, ImmutableList.of(), ImmutableList.of(), helper);
+      new MobileInstallBuildStep(
+        getProject(), buildTarget, ImmutableList.of(), ImmutableList.of(), helper);
     buildStep.build(context, new DeviceSession(null, deviceFutures, null));
 
     // Verify
     assertThat(context.hasErrors()).isTrue();
     assertThat(messageCollector.getMessages())
-        .contains("Only one device can be used with mobile-install.");
+      .contains("Only one device can be used with mobile-install.");
   }
 
   @Test
@@ -234,21 +236,21 @@ public final class MobileInstallBuildStepIntegrationTest extends MobileInstallBu
     // Return fake deploy info proto and mocked deploy info data object.
     AndroidDeployInfo fakeProto = AndroidDeployInfo.newBuilder().build();
     BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
-    when(helper.readDeployInfoProtoForTarget(eq(buildTarget), any(BuildResultHelper.class), any()))
-        .thenReturn(fakeProto);
+    when(helper.readDeployInfoProtoForTarget(eq(buildTarget), eq("mobile_install_INTERNAL_"), any(BuildResultHelper.class), any()))
+      .thenReturn(fakeProto);
     when(helper.extractDeployInfoAndInvalidateManifests(any(), any(), any()))
-        .thenThrow(new GetDeployInfoException("Fake Exception"));
+      .thenThrow(new GetDeployInfoException("Fake Exception"));
 
     // Perform
     MobileInstallBuildStep buildStep =
-        new MobileInstallBuildStep(
-            getProject(), buildTarget, ImmutableList.of(), ImmutableList.of(), helper);
+      new MobileInstallBuildStep(
+        getProject(), buildTarget, ImmutableList.of(), ImmutableList.of(), helper);
     buildStep.build(context, new DeviceSession(null, deviceFutures, null));
 
     // Verify
     assertThat(context.hasErrors()).isTrue();
     assertThat(messageCollector.getMessages())
-        .contains("Could not read apk deploy info from build: Fake Exception");
+      .contains("Could not read apk deploy info from build: Fake Exception");
   }
 
   @Test
@@ -264,22 +266,22 @@ public final class MobileInstallBuildStepIntegrationTest extends MobileInstallBu
     AndroidDeployInfo fakeProto = AndroidDeployInfo.newBuilder().build();
     BlazeAndroidDeployInfo mockDeployInfo = mock(BlazeAndroidDeployInfo.class);
     BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
-    when(helper.readDeployInfoProtoForTarget(eq(buildTarget), any(BuildResultHelper.class), any()))
-        .thenReturn(fakeProto);
+    when(helper.readDeployInfoProtoForTarget(eq(buildTarget), eq("mobile_install_INTERNAL_"), any(BuildResultHelper.class), any()))
+      .thenReturn(fakeProto);
     when(helper.extractDeployInfoAndInvalidateManifests(
-            getProject(), new File(getExecRoot()), fakeProto))
-        .thenReturn(mockDeployInfo);
+      getProject(), new File(getExecRoot()), fakeProto))
+      .thenReturn(mockDeployInfo);
 
     // Perform
     MobileInstallBuildStep buildStep =
-        new MobileInstallBuildStep(
-            getProject(), buildTarget, ImmutableList.of(), ImmutableList.of(), helper);
+      new MobileInstallBuildStep(
+        getProject(), buildTarget, ImmutableList.of(), ImmutableList.of(), helper);
     buildStep.build(context, new DeviceSession(null, deviceFutures, null));
 
     // Verify
     assertThat(context.hasErrors()).isTrue();
     assertThat(messageCollector.getMessages())
-        .contains("Blaze build failed. See Blaze Console for details.");
+      .contains("Blaze build failed. See Blaze Console for details.");
   }
 
   @Test
@@ -296,15 +298,15 @@ public final class MobileInstallBuildStepIntegrationTest extends MobileInstallBu
     AndroidDeployInfo fakeProto = AndroidDeployInfo.newBuilder().build();
     BlazeAndroidDeployInfo mockDeployInfo = mock(BlazeAndroidDeployInfo.class);
     BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
-    when(helper.readDeployInfoProtoForTarget(eq(buildTarget), any(BuildResultHelper.class), any()))
-        .thenReturn(fakeProto);
+    when(helper.readDeployInfoProtoForTarget(eq(buildTarget), eq("mobile_install_INTERNAL_"), any(BuildResultHelper.class), any()))
+      .thenReturn(fakeProto);
     when(helper.extractDeployInfoAndInvalidateManifests(
-            getProject(), new File(getExecRoot()), fakeProto))
-        .thenReturn(mockDeployInfo);
+      getProject(), new File(getExecRoot()), fakeProto))
+      .thenReturn(mockDeployInfo);
 
     // Perform
     MobileInstallBuildStep buildStep =
-        new MobileInstallBuildStep(getProject(), buildTarget, blazeFlags, execFlags, helper);
+      new MobileInstallBuildStep(getProject(), buildTarget, blazeFlags, execFlags, helper);
     buildStep.build(context, new DeviceSession(null, deviceFutures, null));
 
     // Verify

--- a/base/src/com/google/idea/blaze/base/command/buildresult/bepparser/ParsedBepOutput.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/bepparser/ParsedBepOutput.java
@@ -122,12 +122,24 @@ public final class ParsedBepOutput {
         .collect(toImmutableSet());
   }
 
-  /** Returns the set of artifacts directly produced by the given target. */
+  /** Returns the set of artifacts directly produced by the given target.
+   * Deprecated since AOSP pick b228d1ef2bdb093b73203176ec8158061042505e */
+  @Deprecated
   public ImmutableSet<OutputArtifact> getDirectArtifactsForTarget(String label) {
     return targetFileSets.get(label).stream()
         .map(s -> fileSets.get(s).parsedOutputs)
         .flatMap(List::stream)
         .collect(toImmutableSet());
+  }
+
+  /** Returns the set of artifacts directly produced by the given target. */
+  public ImmutableSet<OutputArtifact> getOutputGroupTargetArtifacts(String outputGroup, String label) {
+    return fileSets.values().stream()
+      .filter(f -> f.targets.contains(label) && f.outputGroups.contains(outputGroup))
+      .map(f -> f.parsedOutputs)
+      .flatMap(List::stream)
+      .distinct()
+      .collect(toImmutableSet());
   }
 
   public ImmutableList<OutputArtifact> getOutputGroupArtifacts(String outputGroup) {

--- a/base/tests/unittests/com/google/idea/blaze/base/command/buildresult/BuildEventProtocolOutputReaderTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/command/buildresult/BuildEventProtocolOutputReaderTest.java
@@ -273,7 +273,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
 
     ImmutableSet<OutputArtifact> parsedFilenames =
         BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)))
-            .getDirectArtifactsForTarget("//some:target");
+            .getOutputGroupTargetArtifacts("group-name", "//some:target");
 
     assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
         .containsExactlyElementsIn(allFiles)
@@ -313,7 +313,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
 
     ImmutableSet<OutputArtifact> parsedFilenames =
         BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)))
-            .getDirectArtifactsForTarget("//some:target");
+            .getOutputGroupTargetArtifacts("group-name", "//some:target");
 
     assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
         .containsExactlyElementsIn(allFiles)

--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrRunConfigurationRunner.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrRunConfigurationRunner.java
@@ -171,6 +171,7 @@ public class BlazeCidrRunConfigurationRunner implements BlazeCommandRunConfigura
         candidateFiles =
             LocalFileArtifact.getLocalFiles(
                     BuildResultParser.getBuildOutput(bepStream, Interners.STRING)
+                        //TODO: define outputGroup and switch to ParsedBepOutput.getOutputGroupTargetArtifacts
                         .getDirectArtifactsForTarget(target.toString()))
                 .stream()
                 .filter(File::canExecute)

--- a/golang/src/com/google/idea/blaze/golang/run/BlazeGoRunConfigurationRunner.java
+++ b/golang/src/com/google/idea/blaze/golang/run/BlazeGoRunConfigurationRunner.java
@@ -373,6 +373,7 @@ public class BlazeGoRunConfigurationRunner implements BlazeCommandRunConfigurati
           candidateFiles =
               LocalFileArtifact.getLocalFiles(
                       BuildResultParser.getBuildOutput(bepStream, Interners.STRING)
+                          //TODO: define outputGroup and switch to ParsedBepOutput.getOutputGroupTargetArtifacts
                           .getDirectArtifactsForTarget(label.toString()))
                   .stream()
                   .filter(File::canExecute)

--- a/java/src/com/google/idea/blaze/java/fastbuild/FastBuildServiceImpl.java
+++ b/java/src/com/google/idea/blaze/java/fastbuild/FastBuildServiceImpl.java
@@ -329,7 +329,8 @@ final class FastBuildServiceImpl implements FastBuildService, ProjectComponent {
       ImmutableList<File> deployJarArtifacts =
           LocalFileArtifact.getLocalFiles(
               BuildResultParser.getBuildOutput(bepStream, Interners.STRING)
-                  .getDirectArtifactsForTarget(
+                  .getOutputGroupTargetArtifacts(
+                      aspectStrategy.getAspectOutputGroup(),
                       deployJarStrategy.deployJarOwnerLabel(label, blazeVersionData).toString())
                   .stream()
                   .filter(artifact -> artifact.getArtifactPath().endsWith(deployJarLabel.targetName().toString()))

--- a/python/src/com/google/idea/blaze/python/run/BlazePyRunConfigurationRunner.java
+++ b/python/src/com/google/idea/blaze/python/run/BlazePyRunConfigurationRunner.java
@@ -89,6 +89,7 @@ import javax.annotation.Nullable;
 
 /** Python-specific run configuration runner. */
 public class BlazePyRunConfigurationRunner implements BlazeCommandRunConfigurationRunner {
+  private static final String DEFAULT_OUTPUT_GROUP_NAME = "default";
 
   /** This inserts flags provided by any BlazePyDebugHelpers to the pydevd.py invocation */
 
@@ -346,7 +347,7 @@ public class BlazePyRunConfigurationRunner implements BlazeCommandRunConfigurati
         candidateFiles =
             LocalFileArtifact.getLocalFiles(
                 BuildResultParser.getBuildOutput(bepStream, Interners.STRING)
-                  .getDirectArtifactsForTarget(target.toString()).asList())
+                  .getOutputGroupTargetArtifacts(DEFAULT_OUTPUT_GROUP_NAME, target.toString()).asList())
                 .stream()
                 .filter(File::canExecute)
                 .collect(Collectors.toList());

--- a/scala/src/com/google/idea/blaze/scala/run/producers/GenerateDeployableJarTaskProvider.java
+++ b/scala/src/com/google/idea/blaze/scala/run/producers/GenerateDeployableJarTaskProvider.java
@@ -192,6 +192,7 @@ class GenerateDeployableJarTaskProvider
       try (final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {
         outputs = LocalFileArtifact.getLocalFiles(
             BuildResultParser.getBuildOutput(bepStream, Interners.STRING)
+                //TODO: define outputGroup and switch to ParsedBepOutput.getOutputGroupTargetArtifacts
                 .getDirectArtifactsForTarget(String.format("%s_deploy.jar", target)));
       }
 


### PR DESCRIPTION
Cherry pick AOSP commit [b228d1ef2bdb093b73203176ec8158061042505e](https://cs.android.com/android-studio/platform/tools/adt/idea/+/b228d1ef2bdb093b73203176ec8158061042505e).

1. Builds may get multiple aspects applied resulting in multiple
   additional artifacts returned.

2. Make `getOutputGroupTargetArtifacts` return all artifacts declared by
   the target as its outputs instead of ambiguously defined direct
   artifacts, which in its current implementation is implementation
   dependent and returns top level named file sets only. Note, a single
   target may itself produce multiple nested file sets without
   participation of other targets at all. File sets basically follow the
   structure fo depsets. Perhaps the amount of logging in callers
   reflects the incorrect behavior.

3. When requesting `AndroidDeployInfo` from local build mirror the
   implementation providing support for remote builds and pass the
   output group name explicitly. note, these two implementations need
   to converged before they can be merged.

Bug: 385469770
Bug: 327638725
Test: existing
Change-Id: Idfb90474e74cd6e4fa9978452f687138c69df13c

AOSP: b228d1ef2bdb093b73203176ec8158061042505e
