### PR TITLE
[AOSP-pick] Always use BlazeBuildOutputs

### DIFF
--- a/aswb/src/com/google/idea/blaze/android/run/deployinfo/BlazeApkDeployInfoProtoHelper.java
+++ b/aswb/src/com/google/idea/blaze/android/run/deployinfo/BlazeApkDeployInfoProtoHelper.java
@@ -29,6 +29,7 @@ import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtifactsException;
 import com.google.idea.blaze.base.command.buildresult.bepparser.ParsedBepOutput;
 import com.google.idea.blaze.base.model.primitives.Label;
+import com.google.idea.blaze.base.sync.aspects.BlazeBuildOutputs;
 import com.google.idea.blaze.common.Interners;
 import com.google.idea.blaze.common.artifact.OutputArtifact;
 import com.intellij.openapi.diagnostic.Logger;
@@ -53,10 +54,12 @@ public class BlazeApkDeployInfoProtoHelper {
       throws GetDeployInfoException {
     ImmutableList<OutputArtifact> outputArtifacts;
     ImmutableSet<OutputArtifact> targetOutputArtifacts;
-    ParsedBepOutput bepOutput;
+
+    BlazeBuildOutputs bazelOutputs;
     try (final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {
-      bepOutput = BuildResultParser.getBuildOutput(bepStream, Interners.STRING);
-      targetOutputArtifacts = bepOutput.getOutputGroupTargetArtifacts(outputGroup, target.toString());
+      final var bepOutput = BuildResultParser.getBuildOutput(bepStream, Interners.STRING);
+      bazelOutputs = BlazeBuildOutputs.fromParsedBepOutput(bepOutput);
+      targetOutputArtifacts = bazelOutputs.getTargetArtifacts(target.toString(), outputGroup);
       outputArtifacts =
         targetOutputArtifacts.stream().filter(it -> pathFilter.test(it.getBazelOutRelativePath()))
           .collect(toImmutableList());

--- a/base/src/com/google/idea/blaze/base/command/buildresult/bepparser/BepParser.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/bepparser/BepParser.java
@@ -178,15 +178,12 @@ public final class BepParser {
     semaphore.start();
     try {
       BepParserState state = parseBep(stream, nullableInterner);
-      ImmutableMap<String, ParsedBepOutput.FileSet> filesMap =
+      ImmutableMap<String, ParsedBepOutput.FileSet> fileSetMap =
         fillInTransitiveFileSetData(state.fileSets, state.outputs, state.startTimeMillis);
       return new ParsedBepOutput(
         state.buildId,
         state.workspaceStatus,
-        filesMap,
-        state.outputs.fileSetStream()
-          .collect(ImmutableSetMultimap.flatteningToImmutableSetMultimap(OutputGroupTargetConfigFileSets::target,
-                                                               it -> it.fileSetNames().stream())),
+        fileSetMap,
         state.startTimeMillis,
         state.buildResult,
         stream.getBytesConsumed(),

--- a/base/src/com/google/idea/blaze/base/command/buildresult/bepparser/ParsedBepOutput.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/bepparser/ParsedBepOutput.java
@@ -15,7 +15,6 @@
  */
 package com.google.idea.blaze.base.command.buildresult.bepparser;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.stream.Collectors.groupingBy;
 
@@ -23,9 +22,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Maps;
-import com.google.common.collect.SetMultimap;
 import com.google.idea.blaze.common.artifact.OutputArtifact;
 import java.util.List;
 import java.util.Set;
@@ -42,7 +39,6 @@ public final class ParsedBepOutput {
           "build-id",
           ImmutableMap.of(),
           ImmutableMap.of(),
-          ImmutableSetMultimap.of(),
           0,
           0,
           0,
@@ -53,10 +49,8 @@ public final class ParsedBepOutput {
   final ImmutableMap<String, String> workspaceStatus;
 
   /** A map from file set ID to file set, with the same ordering as the BEP stream. */
-  private final ImmutableMap<String, FileSet> fileSets;
-
-  /** The set of named file sets directly produced by each target. */
-  private final SetMultimap<String, String> targetFileSets;
+  @VisibleForTesting
+  public final ImmutableMap<String, FileSet> fileSets;
 
   final long syncStartTimeMillis;
 
@@ -68,7 +62,6 @@ public final class ParsedBepOutput {
     @Nullable String buildId,
     ImmutableMap<String, String> workspaceStatus,
     ImmutableMap<String, FileSet> fileSets,
-    ImmutableSetMultimap<String, String> targetFileSets,
     long syncStartTimeMillis,
     int buildResult,
     long bepBytesConsumed,
@@ -76,7 +69,6 @@ public final class ParsedBepOutput {
     this.buildId = buildId;
     this.workspaceStatus = workspaceStatus;
     this.fileSets = fileSets;
-    this.targetFileSets = targetFileSets;
     this.syncStartTimeMillis = syncStartTimeMillis;
     this.buildResult = buildResult;
     this.bepBytesConsumed = bepBytesConsumed;
@@ -110,35 +102,6 @@ public final class ParsedBepOutput {
         .collect(toImmutableSet());
   }
 
-  /** Returns the set of artifacts directly produced by the given target.
-   * Deprecated since AOSP pick b228d1ef2bdb093b73203176ec8158061042505e */
-  @Deprecated
-  public ImmutableSet<OutputArtifact> getDirectArtifactsForTarget(String label) {
-    return targetFileSets.get(label).stream()
-        .map(s -> fileSets.get(s).parsedOutputs)
-        .flatMap(List::stream)
-        .collect(toImmutableSet());
-  }
-
-  /** Returns the set of artifacts directly produced by the given target. */
-  public ImmutableSet<OutputArtifact> getOutputGroupTargetArtifacts(String outputGroup, String label) {
-    return fileSets.values().stream()
-      .filter(f -> f.targets.contains(label) && f.outputGroups.contains(outputGroup))
-      .map(f -> f.parsedOutputs)
-      .flatMap(List::stream)
-      .distinct()
-      .collect(toImmutableSet());
-  }
-
-  public ImmutableList<OutputArtifact> getOutputGroupArtifacts(String outputGroup) {
-    return fileSets.values().stream()
-        .filter(f -> f.outputGroups.contains(outputGroup))
-        .map(f -> f.parsedOutputs)
-        .flatMap(List::stream)
-        .distinct()
-        .collect(toImmutableList());
-  }
-
   /**
    * Returns a map from artifact key to {@link BepArtifactData} for all artifacts reported during
    * the build.
@@ -157,10 +120,13 @@ public final class ParsedBepOutput {
     return targetsWithErrors;
   }
 
-  static class FileSet {
-    private final ImmutableList<OutputArtifact> parsedOutputs;
-    private final ImmutableSet<String> outputGroups;
-    private final ImmutableSet<String> targets;
+  public static class FileSet {
+    @VisibleForTesting
+    public final ImmutableList<OutputArtifact> parsedOutputs;
+    @VisibleForTesting
+    public final ImmutableSet<String> outputGroups;
+    @VisibleForTesting
+    public final ImmutableSet<String> targets;
 
     FileSet(
       ImmutableList<OutputArtifact> parsedOutputs,

--- a/base/src/com/google/idea/blaze/base/sync/aspects/BlazeBuildOutputs.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/BlazeBuildOutputs.java
@@ -43,6 +43,9 @@ import java.util.stream.Stream;
  */
 public interface BlazeBuildOutputs {
 
+  @Deprecated
+  ImmutableSet<OutputArtifact> getTargetArtifacts(String label);
+
   ImmutableSet<OutputArtifact> getTargetArtifacts(String label, String outputGroup);
 
   ImmutableList<OutputArtifact> getOutputGroupArtifacts(String outputGroup);
@@ -189,6 +192,17 @@ public interface BlazeBuildOutputs {
       ImmutableSetMultimap.Builder<String, OutputArtifact> perTarget = ImmutableSetMultimap.builder();
       artifacts.values().forEach(a -> a.topLevelTargets.forEach(t -> perTarget.put(t, a.artifact)));
       this.perTargetArtifacts = perTarget.build();
+    }
+
+    /** Returns the output artifacts generated for target with given label. */
+    @Override
+    @Deprecated
+    public ImmutableSet<OutputArtifact> getTargetArtifacts(String label) {
+      // TODO: solodkyy - This is slow although it is invoked at most two times.
+      return artifacts.values().stream()
+          .filter(a -> a.topLevelTargets.contains(label))
+          .map(a -> a.artifact)
+          .collect(toImmutableSet());
     }
 
     /** Returns the output artifacts generated for target with given label. */

--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrRunConfigurationRunner.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrRunConfigurationRunner.java
@@ -32,6 +32,7 @@ import com.google.idea.blaze.base.run.BlazeBeforeRunCommandHelper;
 import com.google.idea.blaze.base.run.BlazeCommandRunConfiguration;
 import com.google.idea.blaze.base.run.ExecutorType;
 import com.google.idea.blaze.base.run.confighandler.BlazeCommandRunConfigurationRunner;
+import com.google.idea.blaze.base.sync.aspects.BlazeBuildOutputs;
 import com.google.idea.blaze.base.util.SaveUtil;
 import com.google.idea.blaze.common.Interners;
 import com.intellij.execution.ExecutionException;
@@ -170,9 +171,10 @@ public class BlazeCidrRunConfigurationRunner implements BlazeCommandRunConfigura
       try (final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {
         candidateFiles =
             LocalFileArtifact.getLocalFiles(
-                    BuildResultParser.getBuildOutput(bepStream, Interners.STRING)
-                        //TODO: define outputGroup and switch to ParsedBepOutput.getOutputGroupTargetArtifacts
-                        .getDirectArtifactsForTarget(target.toString()))
+                  BlazeBuildOutputs.fromParsedBepOutput(
+                    BuildResultParser.getBuildOutput(bepStream, Interners.STRING))
+                        //TODO: define outputGroup and switch method to one that takes outputGroup as well
+                        .getTargetArtifacts(target.toString()))
                 .stream()
                 .filter(File::canExecute)
                 .collect(Collectors.toList());

--- a/golang/src/com/google/idea/blaze/golang/run/BlazeGoRunConfigurationRunner.java
+++ b/golang/src/com/google/idea/blaze/golang/run/BlazeGoRunConfigurationRunner.java
@@ -52,6 +52,7 @@ import com.google.idea.blaze.base.run.confighandler.BlazeCommandRunConfiguration
 import com.google.idea.blaze.base.run.state.BlazeCommandRunConfigurationCommonState;
 import com.google.idea.blaze.base.settings.Blaze;
 import com.google.idea.blaze.base.settings.BuildSystemName;
+import com.google.idea.blaze.base.sync.aspects.BlazeBuildOutputs;
 import com.google.idea.blaze.base.sync.data.BlazeDataStorage;
 import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
 import com.google.idea.blaze.base.util.SaveUtil;
@@ -372,9 +373,10 @@ public class BlazeGoRunConfigurationRunner implements BlazeCommandRunConfigurati
         try (final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {
           candidateFiles =
               LocalFileArtifact.getLocalFiles(
-                      BuildResultParser.getBuildOutput(bepStream, Interners.STRING)
-                          //TODO: define outputGroup and switch to ParsedBepOutput.getOutputGroupTargetArtifacts
-                          .getDirectArtifactsForTarget(label.toString()))
+                   BlazeBuildOutputs.fromParsedBepOutput(
+                      BuildResultParser.getBuildOutput(bepStream, Interners.STRING))
+                          //TODO: define outputGroup and switch method to one that takes outputGroup as well
+                          .getTargetArtifacts(label.toString()))
                   .stream()
                   .filter(File::canExecute)
                   .collect(Collectors.toList());

--- a/java/src/com/google/idea/blaze/java/fastbuild/FastBuildServiceImpl.java
+++ b/java/src/com/google/idea/blaze/java/fastbuild/FastBuildServiceImpl.java
@@ -54,6 +54,7 @@ import com.google.idea.blaze.base.scope.output.StatusOutput;
 import com.google.idea.blaze.base.scope.scopes.TimingScope.EventType;
 import com.google.idea.blaze.base.settings.Blaze;
 import com.google.idea.blaze.base.settings.BuildSystemName;
+import com.google.idea.blaze.base.sync.aspects.BlazeBuildOutputs;
 import com.google.idea.blaze.common.Interners;
 import com.google.idea.blaze.java.AndroidBlazeRules;
 import com.google.idea.blaze.java.JavaBlazeRules;
@@ -328,8 +329,9 @@ final class FastBuildServiceImpl implements FastBuildService, ProjectComponent {
     try (final var bepStream = resultHelper.getBepStream(Optional.empty())) {
       ImmutableList<File> deployJarArtifacts =
           LocalFileArtifact.getLocalFiles(
-              BuildResultParser.getBuildOutput(bepStream, Interners.STRING)
-                  .getOutputGroupTargetArtifacts(
+              BlazeBuildOutputs.fromParsedBepOutput(
+                BuildResultParser.getBuildOutput(bepStream, Interners.STRING))
+                  .getTargetArtifacts(
                       aspectStrategy.getAspectOutputGroup(),
                       deployJarStrategy.deployJarOwnerLabel(label, blazeVersionData).toString())
                   .stream()
@@ -344,7 +346,8 @@ final class FastBuildServiceImpl implements FastBuildService, ProjectComponent {
     ImmutableList<File> ideInfoFiles;
     try (final var bepStream = resultHelper.getBepStream(Optional.empty())) {
       ideInfoFiles = LocalFileArtifact.getLocalFiles(
-          BuildResultParser.getBuildOutput(bepStream, Interners.STRING)
+          BlazeBuildOutputs.fromParsedBepOutput(
+            BuildResultParser.getBuildOutput(bepStream, Interners.STRING))
               .getOutputGroupArtifacts(
                   aspectStrategy.getAspectOutputGroup())
               .stream()

--- a/java/src/com/google/idea/blaze/java/run/hotswap/ClassFileManifestBuilder.java
+++ b/java/src/com/google/idea/blaze/java/run/hotswap/ClassFileManifestBuilder.java
@@ -33,7 +33,9 @@ import com.google.idea.blaze.base.run.BlazeBeforeRunCommandHelper;
 import com.google.idea.blaze.base.run.BlazeCommandRunConfiguration;
 import com.google.idea.blaze.base.run.ExecutorType;
 import com.google.idea.blaze.base.run.confighandler.BlazeCommandRunConfigurationRunner;
+import com.google.idea.blaze.base.command.buildresult.BuildResult;
 import com.google.idea.blaze.base.sync.SyncScope.SyncFailedException;
+import com.google.idea.blaze.base.sync.aspects.BlazeBuildOutputs;
 import com.google.idea.blaze.base.sync.aspects.storage.AspectStorageService;
 import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
 import com.google.idea.blaze.base.util.SaveUtil;
@@ -141,14 +143,15 @@ public class ClassFileManifestBuilder {
         throw new ExecutionException(e);
       }
       ImmutableList<File> jars;
-      try(final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {
+      try (final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {
         jars =
-            LocalFileArtifact.getLocalFiles(
-                BuildResultParser.getBuildOutput(bepStream, Interners.STRING)
-                  .getOutputGroupArtifacts(JavaClasspathAspectStrategy.OUTPUT_GROUP))
-                .stream()
-                .filter(f -> f.getName().endsWith(".jar"))
-                .collect(toImmutableList());
+          LocalFileArtifact.getLocalFiles(
+              BlazeBuildOutputs.fromParsedBepOutput(
+                  BuildResultParser.getBuildOutput(bepStream, Interners.STRING))
+                .getOutputGroupArtifacts(JavaClasspathAspectStrategy.OUTPUT_GROUP))
+            .stream()
+            .filter(f -> f.getName().endsWith(".jar"))
+            .collect(toImmutableList());
       } catch (GetArtifactsException e) {
         throw new ExecutionException("Failed to get debug binary: " + e.getMessage());
       }

--- a/python/src/com/google/idea/blaze/python/run/BlazePyRunConfigurationRunner.java
+++ b/python/src/com/google/idea/blaze/python/run/BlazePyRunConfigurationRunner.java
@@ -44,6 +44,7 @@ import com.google.idea.blaze.base.run.confighandler.BlazeCommandGenericRunConfig
 import com.google.idea.blaze.base.run.confighandler.BlazeCommandRunConfigurationRunner;
 import com.google.idea.blaze.base.run.state.BlazeCommandRunConfigurationCommonState;
 import com.google.idea.blaze.base.command.buildresult.BuildResult;
+import com.google.idea.blaze.base.sync.aspects.BlazeBuildOutputs;
 import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
 import com.google.idea.blaze.base.util.ProcessGroupUtil;
 import com.google.idea.blaze.base.util.SaveUtil;
@@ -343,14 +344,15 @@ public class BlazePyRunConfigurationRunner implements BlazeCommandRunConfigurati
         throw new ExecutionException(e);
       }
       List<File> candidateFiles;
-      try(final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {
+      try (final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {
         candidateFiles =
-            LocalFileArtifact.getLocalFiles(
-                BuildResultParser.getBuildOutput(bepStream, Interners.STRING)
-                  .getOutputGroupTargetArtifacts(DEFAULT_OUTPUT_GROUP_NAME, target.toString()).asList())
-                .stream()
-                .filter(File::canExecute)
-                .collect(Collectors.toList());
+          LocalFileArtifact.getLocalFiles(
+              BlazeBuildOutputs.fromParsedBepOutput(
+                  BuildResultParser.getBuildOutput(bepStream, Interners.STRING))
+                .getTargetArtifacts(target.toString(), DEFAULT_OUTPUT_GROUP_NAME).asList())
+            .stream()
+            .filter(File::canExecute)
+            .collect(Collectors.toList());
       } catch (GetArtifactsException e) {
         throw new ExecutionException(
             String.format(

--- a/scala/src/com/google/idea/blaze/scala/run/producers/GenerateDeployableJarTaskProvider.java
+++ b/scala/src/com/google/idea/blaze/scala/run/producers/GenerateDeployableJarTaskProvider.java
@@ -44,6 +44,7 @@ import com.google.idea.blaze.base.scope.scopes.ProblemsViewScope;
 import com.google.idea.blaze.base.scope.scopes.ToolWindowScope;
 import com.google.idea.blaze.base.settings.Blaze;
 import com.google.idea.blaze.base.settings.BlazeUserSettings;
+import com.google.idea.blaze.base.sync.aspects.BlazeBuildOutputs;
 import com.google.idea.blaze.base.util.SaveUtil;
 import com.google.idea.blaze.common.Interners;
 import com.intellij.execution.BeforeRunTask;
@@ -191,9 +192,10 @@ class GenerateDeployableJarTaskProvider
       List<File> outputs;
       try (final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {
         outputs = LocalFileArtifact.getLocalFiles(
-            BuildResultParser.getBuildOutput(bepStream, Interners.STRING)
-                //TODO: define outputGroup and switch to ParsedBepOutput.getOutputGroupTargetArtifacts
-                .getDirectArtifactsForTarget(String.format("%s_deploy.jar", target)));
+            BlazeBuildOutputs.fromParsedBepOutput(
+              BuildResultParser.getBuildOutput(bepStream, Interners.STRING))
+                  //TODO: define outputGroup and switch method to one that takes outputGroup as well
+                  .getTargetArtifacts(String.format("%s_deploy.jar", target)));
       }
 
       if (outputs.isEmpty()) {


### PR DESCRIPTION
Cherry pick AOSP commit [1c9f33b7a59023dd8e79a1092cbe23dfd149eedb](https://cs.android.com/android-studio/platform/tools/adt/idea/+/1c9f33b7a59023dd8e79a1092cbe23dfd149eedb).

instead of raw ParsedBepOutputs.  This is a step towards unifying them.

Bug: 327638725
Test: n/a
Change-Id: I23e3d9d0b4637ef8ac65458a4f4916f3e1dbd6a0

AOSP: 1c9f33b7a59023dd8e79a1092cbe23dfd149eedb
