### PR TITLE
[AOSP-pick] Rename build_id to build_id_for_logging

### DIFF
--- a/querysync/java/com/google/idea/blaze/qsync/deps/ArtifactTrackerStateDeserializer.java
+++ b/querysync/java/com/google/idea/blaze/qsync/deps/ArtifactTrackerStateDeserializer.java
@@ -72,9 +72,9 @@ public class ArtifactTrackerStateDeserializer {
 
   private void visitBuildContext(ArtifactTrackerProto.BuildContext buildContext) {
     buildContexts.put(
-        buildContext.getBuildId(),
+        buildContext.getBuildIdForLogging(),
         DependencyBuildContext.create(
-            buildContext.getBuildId(),
+            buildContext.getBuildIdForLogging(),
             Instant.ofEpochMilli(buildContext.getStartTimeMillis())));
   }
 

--- a/querysync/java/com/google/idea/blaze/qsync/deps/ArtifactTrackerStateSerializer.java
+++ b/querysync/java/com/google/idea/blaze/qsync/deps/ArtifactTrackerStateSerializer.java
@@ -29,7 +29,6 @@ import com.google.idea.blaze.qsync.java.ArtifactTrackerProto.Artifact;
 import com.google.idea.blaze.qsync.java.ArtifactTrackerProto.ArtifactTrackerState;
 import com.google.idea.blaze.qsync.java.ArtifactTrackerProto.BuildContext;
 import com.google.idea.blaze.qsync.project.ProjectPath;
-import com.google.idea.blaze.qsync.project.SnapshotSerializer;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Set;
@@ -64,19 +63,19 @@ public class ArtifactTrackerStateSerializer {
 
     ArtifactTrackerProto.TargetBuildInfo.Builder builder =
         ArtifactTrackerProto.TargetBuildInfo.newBuilder();
-    builder.setBuildId(targetBuildInfo.buildContext().buildId());
+    builder.setBuildId(targetBuildInfo.buildContext().buildIdForLogging());
     targetBuildInfo.javaInfo().ifPresent(ji -> visitJavaInfo(ji, builder));
     targetBuildInfo.ccInfo().ifPresent(cc -> visitCcInfo(cc, builder));
     proto.putBuiltDeps(target.toString(), builder.build());
   }
 
   private void visitBuildContext(DependencyBuildContext buildContext) {
-    if (buildIdsSeen.add(buildContext.buildId())) {
+    if (buildIdsSeen.add(buildContext.buildIdForLogging())) {
       BuildContext.Builder builder =
           proto
               .addBuildContextsBuilder()
               .setStartTimeMillis(buildContext.startTime().toEpochMilli())
-              .setBuildId(buildContext.buildId());
+              .setBuildIdForLogging(buildContext.buildIdForLogging());
     }
   }
 

--- a/querysync/java/com/google/idea/blaze/qsync/deps/DependencyBuildContext.java
+++ b/querysync/java/com/google/idea/blaze/qsync/deps/DependencyBuildContext.java
@@ -16,9 +16,7 @@
 package com.google.idea.blaze.qsync.deps;
 
 import com.google.auto.value.AutoValue;
-import com.google.idea.blaze.common.vcs.VcsState;
 import java.time.Instant;
-import java.util.Optional;
 
 /**
  * Basic information about a dependency build. This is used to track where built artifacts
@@ -30,7 +28,7 @@ public abstract class DependencyBuildContext {
   public static final DependencyBuildContext NONE = create("", Instant.EPOCH);
 
   /** The bazel build ID. */
-  public abstract String buildId();
+  public abstract String buildIdForLogging();
 
   /**
    * The time that the build was started at. Used to disambiguate between conflicting artifacts, by

--- a/querysync/java/com/google/idea/blaze/qsync/deps/NewArtifactTracker.java
+++ b/querysync/java/com/google/idea/blaze/qsync/deps/NewArtifactTracker.java
@@ -178,7 +178,7 @@ public class NewArtifactTracker<C extends Context<C>> implements ArtifactTracker
 
   private ImmutableMap<Label, ImmutableSetMultimap<BuildArtifact, ArtifactMetadata>>
   extractArtifactMetadata(
-      Iterable<TargetBuildInfo> targetBuildInfo, DigestMap digestMap, String buildId)
+      Iterable<TargetBuildInfo> targetBuildInfo, DigestMap digestMap, String buildIdForLogging)
       throws BuildException {
     Map<MetadataKey, ListenableFuture<ArtifactMetadata>> metadataFutures = Maps.newHashMap();
     for (TargetBuildInfo targetInfo : targetBuildInfo) {
@@ -200,7 +200,7 @@ public class NewArtifactTracker<C extends Context<C>> implements ArtifactTracker
                                     + " It was requested for metadata %s.",
                                 entry.getKey().artifactPath(),
                                 targetInfo.label(),
-                                buildId,
+                                buildIdForLogging,
                                 entry.getValue().getClass().getName())));
         ListenableFuture<CachedArtifact> artifact =
             artifactCache
@@ -214,7 +214,7 @@ public class NewArtifactTracker<C extends Context<C>> implements ArtifactTracker
                                 digest,
                                 entry.getKey().artifactPath(),
                                 targetInfo.label(),
-                                buildId,
+                                buildIdForLogging,
                                 entry.getValue().metadataClass().getName())));
         ListenableFuture<ArtifactMetadata> transformed =
             Futures.transformAsync(
@@ -245,7 +245,7 @@ public class NewArtifactTracker<C extends Context<C>> implements ArtifactTracker
                     entry.getKey().mdClass.getName(),
                     entry.getKey().artifact.artifactPath(),
                     entry.getKey().artifact.target(),
-                    buildId),
+                    buildIdForLogging),
                 e));
       }
     }
@@ -357,7 +357,7 @@ public class NewArtifactTracker<C extends Context<C>> implements ArtifactTracker
     // extract required metadata from the build artifacts
     ImmutableMap<Label, ImmutableSetMultimap<BuildArtifact, ArtifactMetadata>> metadata =
         extractArtifactMetadata(
-            newTargetInfo.values(), digestMap, outputInfo.getBuildContext().buildId());
+            newTargetInfo.values(), digestMap, outputInfo.getBuildContext().buildIdForLogging());
 
     // insert this metadata into newTargetInfo
     for (Map.Entry<Label, ImmutableSetMultimap<BuildArtifact, ArtifactMetadata>> entry :

--- a/querysync/java/com/google/idea/blaze/qsync/deps/artifact_tracker_state.proto
+++ b/querysync/java/com/google/idea/blaze/qsync/deps/artifact_tracker_state.proto
@@ -89,7 +89,7 @@ message JavaArtifacts {
 }
 
 message BuildContext {
-  string build_id = 1;
+  string build_id_for_logging = 1;
   int64 start_time_millis = 2;
   reserved 3;
 }


### PR DESCRIPTION
Cherry pick AOSP commit [f27d625a2c9a525fe23994e2b7b08acf0d004ee6](https://cs.android.com/android-studio/platform/tools/adt/idea/+/f27d625a2c9a525fe23994e2b7b08acf0d004ee6).

to avoid misuse.

Bug: n/a
Test: n/a
Change-Id: I9e06e8c8eae748c381f381f111543ee4460dab1d

AOSP: f27d625a2c9a525fe23994e2b7b08acf0d004ee6
