### PR TITLE
[AOSP-pick] Complete separation of legacy BepParser

### DIFF
--- a/aswb/src/com/google/idea/blaze/android/run/deployinfo/BlazeApkDeployInfoProtoHelper.java
+++ b/aswb/src/com/google/idea/blaze/android/run/deployinfo/BlazeApkDeployInfoProtoHelper.java
@@ -53,7 +53,7 @@ public class BlazeApkDeployInfoProtoHelper {
     Label target, String outputGroup,BuildResultHelper buildResultHelper, Predicate<String> pathFilter)
       throws GetDeployInfoException {
     ImmutableList<OutputArtifact> outputArtifacts;
-    ImmutableSet<OutputArtifact> targetOutputArtifacts;
+    ImmutableList<OutputArtifact> targetOutputArtifacts;
 
     BlazeBuildOutputs bazelOutputs;
     try (final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {

--- a/base/src/com/google/idea/blaze/base/buildview/BazelExecService.kt
+++ b/base/src/com/google/idea/blaze/base/buildview/BazelExecService.kt
@@ -190,7 +190,7 @@ class BazelExecService(private val project: Project, private val scope: Coroutin
 
       provider.getBepStream(Optional.empty()).use { bepStream ->
         BlazeBuildOutputs.fromParsedBepOutputForLegacy(
-          BuildResultParser.getBuildOutput(bepStream, Interners.STRING),
+          BuildResultParser.getBuildOutputForLegacySync(bepStream, Interners.STRING),
         )
       }
     }

--- a/base/src/com/google/idea/blaze/base/command/buildresult/BuildResultHelperBep.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/BuildResultHelperBep.java
@@ -15,8 +15,6 @@
  */
 package com.google.idea.blaze.base.command.buildresult;
 
-import static com.google.idea.blaze.base.command.buildresult.bepparser.BepParser.parseBepArtifacts;
-
 import com.google.idea.blaze.base.command.buildresult.bepparser.BuildEventStreamProvider;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;

--- a/base/src/com/google/idea/blaze/base/command/buildresult/BuildResultParser.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/BuildResultParser.java
@@ -48,6 +48,26 @@ public final class BuildResultParser {
   }
 
   /**
+   * Parses the BEP stream and returns the corresponding {@link ParsedBepOutput}. May only be
+   * called once on a given stream.
+   *
+   * <p>As BEP retrieval can be memory-intensive for large projects, implementations of
+   * getBuildOutput may restrict parallelism for cases in which many builds are executed in parallel
+   * (e.g. remote builds).
+   */
+  public static ParsedBepOutput.Legacy getBuildOutputForLegacySync(
+    BuildEventStreamProvider bepStream, Interner<String> stringInterner)
+    throws BuildResultHelper.GetArtifactsException {
+    try {
+      return BepParser.parseBepArtifactsForLegacySync(bepStream, stringInterner);
+    } catch (BuildEventStreamProvider.BuildEventStreamException e) {
+      BuildResultHelper.logger.error(e);
+      throw new BuildResultHelper.GetArtifactsException(String.format(
+        "Failed to parse bep for build id: %s: %s", bepStream.getId(), e.getMessage()));
+    }
+  }
+
+  /**
    * Parses BEP stream and returns the corresponding {@link BlazeTestResults}. May
    * only be called once on a given stream.
    */

--- a/base/src/com/google/idea/blaze/base/command/buildresult/bepparser/BepParser.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/bepparser/BepParser.java
@@ -24,7 +24,6 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Interner;
 import com.google.common.collect.Interners;
 import com.google.common.collect.Maps;
@@ -37,6 +36,7 @@ import com.google.idea.common.experiments.BoolExperiment;
 import com.google.idea.common.experiments.IntExperiment;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.Service;
+import java.util.ArrayDeque;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -57,12 +57,6 @@ public final class BepParser {
     new IntExperiment("bep.parsing.concurrency.limit", 5);
 
   private BepParser() {}
-
-  /** Parses BEP events into {@link ParsedBepOutput} */
-  public static ParsedBepOutput parseBepArtifacts(BuildEventStreamProvider stream)
-    throws BuildEventStreamProvider.BuildEventStreamException {
-    return parseBepArtifacts(stream, null);
-  }
 
   /**
    * A record of the top level file sets output by the given {@link #outputGroup}, {@link #target} and {@link #config}.
@@ -162,6 +156,82 @@ public final class BepParser {
     String buildId = null;
     long startTimeMillis = 0L;
     int buildResult = 0;
+
+    private ImmutableList<OutputArtifact> traverseFileSets(Stream<OutputGroupTargetConfigFileSets> fileSetNames) {
+      final var queue = new ArrayDeque<String>();
+      final var visited = new HashSet<String>();
+      final var emitted = new HashSet<String>();
+      final var result = ImmutableList.<OutputArtifact>builder();
+      fileSetNames.flatMap(it -> it.fileSetNames().stream())
+        .distinct()
+        .forEach(filesetName -> {
+                   if (visited.add(filesetName)) {
+                     queue.addLast(filesetName);
+                   }
+                 }
+        );
+      while (!queue.isEmpty()) {
+        final var fileSetName = queue.removeFirst();
+        final var fileSet = fileSets.data.get(fileSetName);
+        for (final var  fileSetId : fileSet.getFileSetsList()) {
+          if (visited.add(fileSetId.getId())) {
+            queue.addLast(fileSetId.getId());
+          }
+        }
+        final var artifacts = parseFiles(fileSet, startTimeMillis);
+        for (OutputArtifact artifact : artifacts) {
+          if (emitted.add(artifact.getArtifactPath().toString())) {
+            result.add(artifact);
+          }
+        }
+      }
+      return result.build();
+    }
+  }
+
+  /**
+   * Parses BEP events into {@link ParsedBepOutput}.
+   */
+  public static ParsedBepOutput parseBepArtifacts(BuildEventStreamProvider stream, @Nullable Interner<String> nullableInterner)
+    throws BuildEventStreamProvider.BuildEventStreamException {
+    BepParserState state = parseBep(stream, nullableInterner);
+    final long bepBytesConsumed = stream.getBytesConsumed();
+    return new ParsedBepOutput() {
+      @Override
+      public int buildResult() {
+        return state.buildResult;
+      }
+
+      @Override
+      public long bepBytesConsumed() {
+        return bepBytesConsumed;
+      }
+
+      @Override
+      public String idForLogging() {
+        return state.buildId;
+      }
+
+      @Override
+      public ImmutableList<OutputArtifact> getOutputGroupTargetArtifacts(String outputGroup, String label) {
+        return state.traverseFileSets(state.outputs.outputGroupTargetFileSetStream(outputGroup, label));
+      }
+
+      @Override
+      public ImmutableList<OutputArtifact> getOutputGroupArtifacts(String outputGroup) {
+        return state.traverseFileSets(state.outputs.outputGroupFileSetStream(outputGroup));
+      }
+
+      @Override
+      public ImmutableSet<String> targetsWithErrors() {
+        return ImmutableSet.copyOf(state.targetsWithErrors);
+      }
+
+      @Override
+      public ImmutableList<OutputArtifact> getAllOutputArtifactsForTesting() {
+        return state.traverseFileSets(state.outputs.fileSetStream());
+      }
+    };
   }
 
   /**
@@ -171,16 +241,16 @@ public final class BepParser {
    * <p>BEP protos often contain many duplicate strings both within a single stream and across
    * shards running in parallel, so a {@link Interner} is used to share references.
    */
-  public static ParsedBepOutput parseBepArtifacts(
-      BuildEventStreamProvider stream, @Nullable Interner<String> nullableInterner)
+  public static ParsedBepOutput.Legacy parseBepArtifactsForLegacySync(
+    BuildEventStreamProvider stream, @Nullable Interner<String> nullableInterner)
     throws BuildEventStreamProvider.BuildEventStreamException {
     final var semaphore = ApplicationManager.getApplication().getService(BepParserSemaphore.class);
     semaphore.start();
     try {
       BepParserState state = parseBep(stream, nullableInterner);
-      ImmutableMap<String, ParsedBepOutput.FileSet> fileSetMap =
+      ImmutableMap<String, ParsedBepOutput.Legacy.FileSet> fileSetMap =
         fillInTransitiveFileSetData(state.fileSets, state.outputs, state.startTimeMillis);
-      return new ParsedBepOutput(
+      return new ParsedBepOutput.Legacy(
         state.buildId,
         state.workspaceStatus,
         fileSetMap,
@@ -255,7 +325,7 @@ public final class BepParser {
    * Only top-level targets have configuration mnemonic, producing target, and output group data
    * explicitly provided in BEP. This method fills in that data for the transitive closure.
    */
-  private static ImmutableMap<String, ParsedBepOutput.FileSet> fillInTransitiveFileSetData(
+  private static ImmutableMap<String, ParsedBepOutput.Legacy.FileSet> fillInTransitiveFileSetData(
     FileSets namedFileSets, OutputGroupTargetConfigFileSetMap data, long startTimeMillis) {
     Map<String, FileSetBuilder> fileSets =
       ImmutableMap.copyOf(
@@ -393,8 +463,8 @@ public final class BepParser {
       return namedSet != null && configId != null;
     }
 
-    ParsedBepOutput.FileSet build(long startTimeMillis) {
-      return new ParsedBepOutput.FileSet(parseFiles(namedSet, startTimeMillis), outputGroups, targets);
+    ParsedBepOutput.Legacy.FileSet build(long startTimeMillis) {
+      return new ParsedBepOutput.Legacy.FileSet(parseFiles(namedSet, startTimeMillis), outputGroups, targets);
     }
   }
 }

--- a/base/src/com/google/idea/blaze/base/command/buildresult/bepparser/ParsedBepOutput.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/bepparser/ParsedBepOutput.java
@@ -31,114 +31,166 @@ import javax.annotation.Nullable;
 import org.jetbrains.annotations.TestOnly;
 
 /** A data class representing blaze's build event protocol (BEP) output for a build. */
-public final class ParsedBepOutput {
-
-  @VisibleForTesting
-  public static final ParsedBepOutput EMPTY =
-      new ParsedBepOutput(
-          "build-id",
-          ImmutableMap.of(),
-          ImmutableMap.of(),
-          0,
-          0,
-          0,
-          ImmutableSet.of());
-
-  @Nullable public final String buildId;
-
-  final ImmutableMap<String, String> workspaceStatus;
-
-  /** A map from file set ID to file set, with the same ordering as the BEP stream. */
-  @VisibleForTesting
-  public final ImmutableMap<String, FileSet> fileSets;
-
-  final long syncStartTimeMillis;
-
-  private final int buildResult;
-  private final long bepBytesConsumed;
-  private final ImmutableSet<String> targetsWithErrors;
-
-  ParsedBepOutput(
-    @Nullable String buildId,
-    ImmutableMap<String, String> workspaceStatus,
-    ImmutableMap<String, FileSet> fileSets,
-    long syncStartTimeMillis,
-    int buildResult,
-    long bepBytesConsumed,
-    ImmutableSet<String> targetsWithErrors) {
-    this.buildId = buildId;
-    this.workspaceStatus = workspaceStatus;
-    this.fileSets = fileSets;
-    this.syncStartTimeMillis = syncStartTimeMillis;
-    this.buildResult = buildResult;
-    this.bepBytesConsumed = bepBytesConsumed;
-    this.targetsWithErrors = targetsWithErrors;
-  }
+public interface ParsedBepOutput {
+  /**
+   * The exit code of the Bazel build.
+   */
+  int buildResult();
 
   /**
-   * Returns URI of the source that the build consumed, if available. The format will be VCS
-   * specific. If present, the value will be can be used with {@link
-   * com.google.idea.blaze.base.vcs.BlazeVcsHandlerProvider.BlazeVcsHandler#vcsStateForSourceUri(String)}.
+   * The total number of bytes in the build event protocol output.
    */
-  public ImmutableMap<String, String> getWorkspaceStatus() {
-    return workspaceStatus;
-  }
+  long bepBytesConsumed();
 
-  /** Returns the build result. */
-  public int getBuildResult() {
-    return buildResult;
-  }
+  /**
+   * An obscure ID that can be used to identify the build in the external environment.
+   *
+   * <p><em>DO NOT</em> attempt to interpret or compare.
+   */
+  String idForLogging();
 
-  public long getBepBytesConsumed() {
-    return bepBytesConsumed;
-  }
+  /**
+   * A list of the artifacts outputted by the given target to the given output group.
+   *
+   * <p>Note that the same artifact may be outputted by multiple targets and into multiple output groups.
+   */
+  ImmutableList<OutputArtifact> getOutputGroupTargetArtifacts(String outputGroup, String label);
 
-  /** Returns all output artifacts of the build. */
+  /**
+   * A de-duplicated list of the artifacts outputted to the given output group.
+   *
+   * <p>Note that the same artifact may be outputted by multiple targets and into multiple output groups. Such artifacts are included in the
+   * resulting list only once.
+   */
+  ImmutableList<OutputArtifact> getOutputGroupArtifacts(String outputGroup);
+
+  /**
+   * Label of any targets that were not build because of build errors.
+   */
+  ImmutableSet<String> targetsWithErrors();
+
+  /**
+   * A de-duplicated list of all artifacts produced by the build.
+   */
   @TestOnly
-  public ImmutableSet<OutputArtifact> getAllOutputArtifactsForTesting() {
-    return fileSets.values().stream()
+  ImmutableList<OutputArtifact> getAllOutputArtifactsForTesting();
+
+  class Legacy {
+
+    @VisibleForTesting
+    public static final ParsedBepOutput.Legacy EMPTY =
+      new ParsedBepOutput.Legacy(
+        "build-id",
+        ImmutableMap.of(),
+        ImmutableMap.of(),0,
+        0,
+        0,
+        ImmutableSet.of());
+
+    @Nullable public final String buildId;
+
+    final ImmutableMap<String, String> workspaceStatus;
+
+     /**
+     * A map from file set ID to file set, with the same ordering as the BEP stream.
+     */
+    @VisibleForTesting
+    public final ImmutableMap<String, FileSet> fileSets;
+
+    final long syncStartTimeMillis;
+
+    private final int buildResult;
+    private final long bepBytesConsumed;
+    private final ImmutableSet<String> targetsWithErrors;
+
+    Legacy(
+      @Nullable String buildId,
+      ImmutableMap<String, String> workspaceStatus,
+      ImmutableMap<String, FileSet> fileSets,
+      long syncStartTimeMillis,
+      int buildResult,
+      long bepBytesConsumed,
+      ImmutableSet<String> targetsWithErrors) {
+      this.buildId = buildId;
+      this.workspaceStatus = workspaceStatus;
+      this.fileSets = fileSets;
+      this.syncStartTimeMillis = syncStartTimeMillis;
+      this.buildResult = buildResult;
+      this.bepBytesConsumed = bepBytesConsumed;
+      this.targetsWithErrors = targetsWithErrors;
+    }
+
+    /**
+     * Returns URI of the source that the build consumed, if available. The format will be VCS
+     * specific. If present, the value will be can be used with {@link
+     * com.google.idea.blaze.base.vcs.BlazeVcsHandlerProvider.BlazeVcsHandler#vcsStateForSourceUri(String)}.
+     */
+    public ImmutableMap<String, String> getWorkspaceStatus() {
+      return workspaceStatus;
+    }
+
+    /**
+     * Returns the build result.
+     */
+    public int getBuildResult() {
+      return buildResult;
+    }
+
+    public long getBepBytesConsumed() {
+      return bepBytesConsumed;
+    }
+
+    /**
+     * Returns all output artifacts of the build.
+     */
+    @TestOnly
+    public ImmutableSet<OutputArtifact> getAllOutputArtifactsForTesting() {
+      return fileSets.values().stream()
         .map(s -> s.parsedOutputs)
         .flatMap(List::stream)
         .collect(toImmutableSet());
-  }
-
-  /**
-   * Returns a map from artifact key to {@link BepArtifactData} for all artifacts reported during
-   * the build.
-   */
-  public ImmutableMap<String, BepArtifactData> getFullArtifactData() {
-    return ImmutableMap.copyOf(
-      Maps.transformValues(
-        fileSets.values().stream()
-          .flatMap(FileSet::toPerArtifactData)
-          .collect(groupingBy(d -> d.artifact.getBazelOutRelativePath(), toImmutableSet())),
-        BepArtifactData::combine));
-  }
-
-  /** Returns the set of build targets that had an error. */
-  public ImmutableSet<String> getTargetsWithErrors() {
-    return targetsWithErrors;
-  }
-
-  public static class FileSet {
-    @VisibleForTesting
-    public final ImmutableList<OutputArtifact> parsedOutputs;
-    @VisibleForTesting
-    public final ImmutableSet<String> outputGroups;
-    @VisibleForTesting
-    public final ImmutableSet<String> targets;
-
-    FileSet(
-      ImmutableList<OutputArtifact> parsedOutputs,
-        Set<String> outputGroups,
-        Set<String> targets) {
-      this.parsedOutputs = parsedOutputs;
-      this.outputGroups = ImmutableSet.copyOf(outputGroups);
-      this.targets = ImmutableSet.copyOf(targets);
     }
 
-    private Stream<BepArtifactData> toPerArtifactData() {
-      return parsedOutputs.stream().map(a -> new BepArtifactData(a, outputGroups, targets));
+    /**
+     * Returns a map from artifact key to {@link BepArtifactData} for all artifacts reported during
+     * the build.
+     */
+    public ImmutableMap<String, BepArtifactData> getFullArtifactData() {
+      return ImmutableMap.copyOf(
+        Maps.transformValues(
+          fileSets.values().stream()
+            .flatMap(FileSet::toPerArtifactData)
+            .collect(groupingBy(d -> d.artifact.getBazelOutRelativePath(), toImmutableSet())),
+          BepArtifactData::combine));
+    }
+
+    /**
+     * Returns the set of build targets that had an error.
+     */
+    public ImmutableSet<String> getTargetsWithErrors() {
+      return targetsWithErrors;
+    }
+
+    public static class FileSet {
+      @VisibleForTesting
+      public final ImmutableList<OutputArtifact> parsedOutputs;
+      @VisibleForTesting
+      public final ImmutableSet<String> outputGroups;
+      @VisibleForTesting
+      public final ImmutableSet<String> targets;
+
+      FileSet(
+        ImmutableList<OutputArtifact> parsedOutputs,
+        Set<String> outputGroups,
+        Set<String> targets) {
+        this.parsedOutputs = parsedOutputs;
+        this.outputGroups = ImmutableSet.copyOf(outputGroups);
+        this.targets = ImmutableSet.copyOf(targets);
+      }
+
+      private Stream<BepArtifactData> toPerArtifactData() {
+        return parsedOutputs.stream().map(a -> new BepArtifactData(a, outputGroups, targets));
+      }
     }
   }
 }

--- a/base/src/com/google/idea/blaze/base/sync/aspects/BlazeBuildOutputs.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/BlazeBuildOutputs.java
@@ -17,7 +17,6 @@ package com.google.idea.blaze.base.sync.aspects;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.getOnlyElement;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -43,10 +42,7 @@ import java.util.stream.Stream;
  */
 public interface BlazeBuildOutputs {
 
-  @Deprecated
-  ImmutableSet<OutputArtifact> getTargetArtifacts(String label);
-
-  ImmutableSet<OutputArtifact> getTargetArtifacts(String label, String outputGroup);
+  ImmutableList<OutputArtifact> getTargetArtifacts(String label, String outputGroup);
 
   ImmutableList<OutputArtifact> getOutputGroupArtifacts(String outputGroup);
 
@@ -122,25 +118,47 @@ public interface BlazeBuildOutputs {
   }
 
 
-  static BlazeBuildOutputs fromParsedBepOutput(
-    ParsedBepOutput parsedOutput) {
-    final var result = BuildResult.fromExitCode(parsedOutput.getBuildResult());
-    ImmutableMap<String, BuildResult> buildIdWithResult =
-      parsedOutput.buildId != null
-      ? ImmutableMap.of(parsedOutput.buildId, result)
-      : ImmutableMap.of();
-    return new BlazeBuildOutputsImpl(
-      result,
-      result.status == Status.FATAL_ERROR
-      ? ImmutableMap.of()
-      : parsedOutput.getFullArtifactData(),
-      buildIdWithResult,
-      parsedOutput.getTargetsWithErrors(),
-      parsedOutput.getBepBytesConsumed());
+  static BlazeBuildOutputs fromParsedBepOutput(ParsedBepOutput parsedOutput) {
+    return new BlazeBuildOutputs() {
+      @Override
+      public ImmutableList<OutputArtifact> getTargetArtifacts(String label, String outputGroup) {
+        return parsedOutput.getOutputGroupTargetArtifacts(outputGroup, label);
+      }
+
+      @Override
+      public ImmutableList<OutputArtifact> getOutputGroupArtifacts(String outputGroup) {
+        return parsedOutput.getOutputGroupArtifacts(outputGroup);
+      }
+
+      @Override
+      public ImmutableSet<String> targetsWithErrors() {
+        return parsedOutput.targetsWithErrors();
+      }
+
+      @Override
+      public BuildResult buildResult() {
+        return BuildResult.fromExitCode(parsedOutput.buildResult());
+      }
+
+      @Override
+      public String idForLogging() {
+        return parsedOutput.idForLogging();
+      }
+
+      @Override
+      public String buildId() {
+        return "";
+      }
+
+      @Override
+      public boolean isEmpty() {
+        return false;
+      }
+    };
   }
 
   static BlazeBuildOutputs.Legacy fromParsedBepOutputForLegacy(
-    ParsedBepOutput parsedOutput) {
+    ParsedBepOutput.Legacy parsedOutput) {
     final var result = BuildResult.fromExitCode(parsedOutput.getBuildResult());
     ImmutableMap<String, BuildResult> buildIdWithResult =
       parsedOutput.buildId != null
@@ -196,23 +214,12 @@ public interface BlazeBuildOutputs {
 
     /** Returns the output artifacts generated for target with given label. */
     @Override
-    @Deprecated
-    public ImmutableSet<OutputArtifact> getTargetArtifacts(String label) {
-      // TODO: solodkyy - This is slow although it is invoked at most two times.
-      return artifacts.values().stream()
-          .filter(a -> a.topLevelTargets.contains(label))
-          .map(a -> a.artifact)
-          .collect(toImmutableSet());
-    }
-
-    /** Returns the output artifacts generated for target with given label. */
-    @Override
-    public ImmutableSet<OutputArtifact> getTargetArtifacts(String label, String outputGroup) {
+    public ImmutableList<OutputArtifact> getTargetArtifacts(String label, String outputGroup) {
       // TODO: solodkyy - This is slow although it is invoked at most two times.
       return artifacts.values().stream()
         .filter(a -> a.outputGroups.contains(outputGroup) && a.topLevelTargets.contains(label))
         .map(a -> a.artifact)
-        .collect(toImmutableSet());
+        .collect(toImmutableList());
     }
 
   /** Returns all output artifacts. */

--- a/base/tests/utils/unit/com/google/idea/blaze/base/bazel/BepUtils.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/bazel/BepUtils.java
@@ -127,6 +127,6 @@ public final class BepUtils {
 
   public static ParsedBepOutput parsedBep(List<BuildEvent> events)
       throws IOException, BuildEventStreamException {
-    return BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)));
+    return BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)), null);
   }
 }

--- a/base/tests/utils/unit/com/google/idea/blaze/base/bazel/FakeBlazeCommandRunner.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/bazel/FakeBlazeCommandRunner.java
@@ -68,7 +68,7 @@ public class FakeBlazeCommandRunner implements BlazeCommandRunner {
         buildResultHelper -> {
           try (final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {
             return BlazeBuildOutputs.fromParsedBepOutputForLegacy(
-                BuildResultParser.getBuildOutput(bepStream, Interners.STRING));
+                BuildResultParser.getBuildOutputForLegacySync(bepStream, Interners.STRING));
           }
         });
   }
@@ -108,7 +108,7 @@ public class FakeBlazeCommandRunner implements BlazeCommandRunner {
       BuildDepsStatsScope.fromContext(context).ifPresent(stats -> stats.setBazelExitCode(exitCode));
       try (final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {
         return BlazeBuildOutputs.fromParsedBepOutputForLegacy(
-            BuildResultParser.getBuildOutput(bepStream, Interners.STRING));
+            BuildResultParser.getBuildOutputForLegacySync(bepStream, Interners.STRING));
       }
     } catch (GetArtifactsException e) {
       return BlazeBuildOutputs.noOutputsForLegacy(BuildResult.FATAL_ERROR);

--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrRunConfigurationRunner.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrRunConfigurationRunner.java
@@ -58,6 +58,8 @@ import java.util.stream.Collectors;
 
 /** CLion-specific handler for {@link BlazeCommandRunConfiguration}s. */
 public class BlazeCidrRunConfigurationRunner implements BlazeCommandRunConfigurationRunner {
+  private static final String DEFAULT_OUTPUT_GROUP_NAME = "default";
+
   private final BlazeCommandRunConfiguration configuration;
 
   /** Calculated during the before-run task, and made available to the debugger. */
@@ -173,8 +175,7 @@ public class BlazeCidrRunConfigurationRunner implements BlazeCommandRunConfigura
             LocalFileArtifact.getLocalFiles(
                   BlazeBuildOutputs.fromParsedBepOutput(
                     BuildResultParser.getBuildOutput(bepStream, Interners.STRING))
-                        //TODO: define outputGroup and switch method to one that takes outputGroup as well
-                        .getTargetArtifacts(target.toString()))
+                      .getTargetArtifacts(target.toString(), DEFAULT_OUTPUT_GROUP_NAME))
                 .stream()
                 .filter(File::canExecute)
                 .collect(Collectors.toList());

--- a/golang/src/com/google/idea/blaze/golang/run/BlazeGoRunConfigurationRunner.java
+++ b/golang/src/com/google/idea/blaze/golang/run/BlazeGoRunConfigurationRunner.java
@@ -97,6 +97,8 @@ import javax.annotation.Nullable;
 /** Go-specific run configuration runner. */
 public class BlazeGoRunConfigurationRunner implements BlazeCommandRunConfigurationRunner {
 
+  private static final String DEFAULT_OUTPUT_GROUP_NAME = "default";
+
   // The actual Bazel shell script uses "1", which is considered as true.
   // For robustness, we include other common representations of true.
   private static final List<String> TRUTHY_ENV_VALUES_LOWER = List.of("true", "1", "yes", "on");
@@ -375,8 +377,7 @@ public class BlazeGoRunConfigurationRunner implements BlazeCommandRunConfigurati
               LocalFileArtifact.getLocalFiles(
                    BlazeBuildOutputs.fromParsedBepOutput(
                       BuildResultParser.getBuildOutput(bepStream, Interners.STRING))
-                          //TODO: define outputGroup and switch method to one that takes outputGroup as well
-                          .getTargetArtifacts(label.toString()))
+                          .getTargetArtifacts(label.toString(), DEFAULT_OUTPUT_GROUP_NAME))
                   .stream()
                   .filter(File::canExecute)
                   .collect(Collectors.toList());

--- a/scala/src/com/google/idea/blaze/scala/run/producers/GenerateDeployableJarTaskProvider.java
+++ b/scala/src/com/google/idea/blaze/scala/run/producers/GenerateDeployableJarTaskProvider.java
@@ -69,6 +69,9 @@ import javax.swing.Icon;
 
 class GenerateDeployableJarTaskProvider
     extends BeforeRunTaskProvider<GenerateDeployableJarTaskProvider.Task> {
+
+  private static final String DEFAULT_OUTPUT_GROUP_NAME = "default";
+
   private static final Key<GenerateDeployableJarTaskProvider.Task> ID =
       Key.create("GenerateDeployableJarTarget");
 
@@ -194,8 +197,7 @@ class GenerateDeployableJarTaskProvider
         outputs = LocalFileArtifact.getLocalFiles(
             BlazeBuildOutputs.fromParsedBepOutput(
               BuildResultParser.getBuildOutput(bepStream, Interners.STRING))
-                  //TODO: define outputGroup and switch method to one that takes outputGroup as well
-                  .getTargetArtifacts(String.format("%s_deploy.jar", target)));
+                  .getTargetArtifacts(String.format("%s_deploy.jar", target), DEFAULT_OUTPUT_GROUP_NAME));
       }
 
       if (outputs.isEmpty()) {


### PR DESCRIPTION
Cherry pick AOSP commit [37e18eda7680a8c01922353f88ebdde516fd76ff](https://cs.android.com/android-studio/platform/tools/adt/idea/+/37e18eda7680a8c01922353f88ebdde516fd76ff).

STAT (diff to AOSP): 157 insertions(+), 41 deletion(-)

Bug: 327638725
Test: BuildEventProtocolOutputReaderTest
Test: BuildEventProtocolOutputReaderLegacyTest
Change-Id: Ia54df932fbf5f6bf090c7810962b0996f335b910

AOSP: 37e18eda7680a8c01922353f88ebdde516fd76ff
