### PR TITLE
[AOSP-pick] Mark ASwB K2 compatible

### DIFF
--- a/kotlin/src/META-INF/blaze-kotlin.xml
+++ b/kotlin/src/META-INF/blaze-kotlin.xml
@@ -35,4 +35,9 @@
     <extensionPoint qualifiedName="com.google.idea.blaze.kotlinxCoroutinesDebuggingLibProvider" interface="com.google.idea.blaze.kotlin.run.debug.KotlinxCoroutinesDebuggingLibProvider"/>
   </extensionPoints>
 
+  <!-- This is temporary mechanism to mark certain plugins as K2-compatible. See IntelliJ commit cf213fb139 for details. -->
+  <extensions defaultExtensionNs="org.jetbrains.kotlin">
+    <!--suppress PluginXmlValidity -->
+    <supportsKotlinPluginMode supportsK2="true"/>
+  </extensions>
 </idea-plugin>


### PR DESCRIPTION
Cherry pick AOSP commit [0b0d5f4723ab9035155be4fbc3e3e9921fccad36](https://cs.android.com/android-studio/platform/tools/adt/idea/+/0b0d5f4723ab9035155be4fbc3e3e9921fccad36).

Bug: 363410313
Test: bazel test //tools/adt/idea/aswb/kotlin:integration_tests \
  --jvmopt="-Didea.kotlin.plugin.use.k2=true"
Change-Id: I81ef3129c7195d4795221b7847ae652ae7bcf173

AOSP: 0b0d5f4723ab9035155be4fbc3e3e9921fccad36
