### PR TITLE
[AOSP-pick] Remove TODOs and rename classes

### DIFF
--- a/aswb/src/com/google/idea/blaze/android/editor/ProjectUnresolvedResourceStatsCollector.java
+++ b/aswb/src/com/google/idea/blaze/android/editor/ProjectUnresolvedResourceStatsCollector.java
@@ -36,7 +36,7 @@ import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
 import com.google.idea.blaze.base.sync.projectview.WorkspaceFileFinder;
 import com.google.idea.blaze.base.sync.workspace.WorkspacePathResolver;
 import com.google.idea.blaze.base.sync.workspace.WorkspacePathResolverProvider;
-import com.google.idea.blaze.base.syncstatus.SyncStatusContributor;
+import com.google.idea.blaze.base.syncstatus.LegacySyncStatusContributor;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.fileTypes.FileType;
@@ -241,7 +241,7 @@ class ProjectUnresolvedResourceStatsCollector implements Disposable {
 
       BlazeProjectData blazeProjectData = blazeProjectDataManager.getBlazeProjectData();
       if (blazeProjectData != null) {
-        fileSyncStatus = SyncStatusContributor.getSyncStatus(project, blazeProjectData, vFile);
+        fileSyncStatus = LegacySyncStatusContributor.getSyncStatus(project, blazeProjectData, vFile);
         fileSyncStatus = fileSyncStatus == null ? SyncStatus.UNSYNCED : fileSyncStatus;
       }
     }

--- a/aswb/src/com/google/idea/blaze/android/run/BlazeAndroidRunConfigurationCommonState.java
+++ b/aswb/src/com/google/idea/blaze/android/run/BlazeAndroidRunConfigurationCommonState.java
@@ -23,11 +23,10 @@ import com.google.idea.blaze.android.run.state.DebuggerSettingsState;
 import com.google.idea.blaze.base.command.BlazeCommandName;
 import com.google.idea.blaze.base.command.BlazeFlags;
 import com.google.idea.blaze.base.command.BlazeInvocationContext;
-import com.google.idea.blaze.base.lang.AdditionalLanguagesHelper;
+import com.google.idea.blaze.base.lang.LegacyAdditionalLanguagesHelper;
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.primitives.LanguageClass;
 import com.google.idea.blaze.base.projectview.ProjectViewSet;
-import com.google.idea.blaze.base.qsync.QuerySync;
 import com.google.idea.blaze.base.run.state.RunConfigurationFlagsState;
 import com.google.idea.blaze.base.run.state.RunConfigurationState;
 import com.google.idea.blaze.base.run.state.RunConfigurationStateEditor;
@@ -125,7 +124,7 @@ public class BlazeAndroidRunConfigurationCommonState implements RunConfiguration
           ValidationErrorCompat.fatal(
               "Native debugging requires C language support.",
               () ->
-                  AdditionalLanguagesHelper.enableLanguageSupport(
+                  LegacyAdditionalLanguagesHelper.enableLanguageSupport(
                       project, ImmutableList.of(LanguageClass.C))));
     }
 

--- a/base/BUILD
+++ b/base/BUILD
@@ -273,8 +273,8 @@ java_library(
 java_library(
     name = "library_to_target_api",
     srcs = [
+        "src/com/google/idea/blaze/base/model/LegacyLibraryToTargetResolver.java",
         "src/com/google/idea/blaze/base/model/LibraryKey.java",
-        "src/com/google/idea/blaze/base/model/LibraryToTargetResolver.java",
     ],
     neverlink = 1,
     visibility = G3PLUGINS_VISIBILITY,

--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -474,7 +474,7 @@
     <codeStyleSettingsProvider implementation="com.google.idea.blaze.base.lang.buildfile.formatting.BuildCodeStyleSettingsProvider"/>
     <editor.backspaceModeOverride language="BUILD" implementationClass="com.intellij.codeInsight.editorActions.SmartBackspaceDisabler"/>
     <filetype.stubBuilder filetype="BUILD" implementationClass="com.google.idea.blaze.base.lang.buildfile.stubs.BuildFileStubBuilder"/>
-    <editorNotificationProvider implementation="com.google.idea.blaze.base.lang.AdditionalLanguagesHelper"/>
+    <editorNotificationProvider implementation="com.google.idea.blaze.base.lang.LegacyAdditionalLanguagesHelper"/>
     <editorNotificationProvider implementation="com.google.idea.blaze.base.dependencies.ExternalFileProjectManagementHelper"/>
     <usageTypeProvider implementation="com.google.idea.blaze.base.lang.buildfile.findusages.BuildUsageTypeProvider"/>
     <renameInputValidator implementation="com.google.idea.blaze.base.lang.buildfile.refactor.TargetRenameValidator"/>
@@ -503,7 +503,7 @@
     <extensionPoint qualifiedName="com.google.idea.blaze.base.lang.buildfile.DumbAnnotator" interface="com.google.idea.blaze.base.lang.buildfile.validation.BuildAnnotator"/>
     <extensionPoint qualifiedName="com.google.idea.blaze.base.lang.buildfile.Annotator" interface="com.google.idea.blaze.base.lang.buildfile.validation.BuildAnnotator"/>
     <extensionPoint qualifiedName="com.google.idea.blaze.BlazeConsoleLineProcessorProvider" interface="com.google.idea.blaze.base.console.BlazeConsoleLineProcessorProvider"/>
-    <extensionPoint qualifiedName="com.google.idea.blaze.SyncStatusContributor" interface="com.google.idea.blaze.base.syncstatus.SyncStatusContributor"/>
+    <extensionPoint qualifiedName="com.google.idea.blaze.SyncStatusContributor" interface="com.google.idea.blaze.base.syncstatus.LegacySyncStatusContributor"/>
     <extensionPoint qualifiedName="com.google.idea.blaze.BuildResultHelperProvider"
                     interface="com.google.idea.blaze.base.command.buildresult.BuildResultHelperProvider"/>
     <extensionPoint qualifiedName="com.google.idea.blaze.OutputArtifactParser"
@@ -603,7 +603,7 @@
     <extensionPoint qualifiedName="com.google.idea.blaze.BinaryContextProvider" interface="com.google.idea.blaze.base.run.producers.BinaryContextProvider"/>
     <extensionPoint qualifiedName="com.google.idea.blaze.HeuristicTestIdentifier" interface="com.google.idea.blaze.base.run.producers.HeuristicTestIdentifier"/>
     <extensionPoint qualifiedName="com.google.idea.blaze.OutputsProvider" interface="com.google.idea.blaze.base.model.OutputsProvider"/>
-    <extensionPoint qualifiedName="com.google.idea.blaze.LibraryToTargetResolver" interface="com.google.idea.blaze.base.model.LibraryToTargetResolver"/>
+    <extensionPoint qualifiedName="com.google.idea.blaze.LibraryToTargetResolver" interface="com.google.idea.blaze.base.model.LegacyLibraryToTargetResolver"/>
     <extensionPoint qualifiedName="com.google.idea.blaze.VcsSyncListener" interface="com.google.idea.blaze.base.vcs.VcsSyncListener"/>
     <extensionPoint qualifiedName="com.google.idea.blaze.CommonMacroContributor" interface="com.google.idea.blaze.base.lang.buildfile.completion.CommonMacroContributor"/>
     <extensionPoint qualifiedName="com.google.idea.blaze.BinaryPathRemapper" interface="com.google.idea.blaze.base.async.process.BinaryPathRemapper"/>

--- a/base/src/com/google/idea/blaze/base/dependencies/AddSourceToProjectAction.java
+++ b/base/src/com/google/idea/blaze/base/dependencies/AddSourceToProjectAction.java
@@ -26,7 +26,7 @@ import com.google.idea.blaze.base.model.primitives.TargetExpression;
 import com.google.idea.blaze.base.run.targetfinder.FuturesUtil;
 import com.google.idea.blaze.base.settings.ui.AddDirectoryToProjectAction;
 import com.google.idea.blaze.base.sync.autosync.ProjectTargetManager.SyncStatus;
-import com.google.idea.blaze.base.syncstatus.SyncStatusContributor;
+import com.google.idea.blaze.base.syncstatus.LegacySyncStatusContributor;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.Presentation;
@@ -172,7 +172,7 @@ class AddSourceToProjectAction extends BlazeProjectAction {
 
     if (!addDirectories
         && (AddSourceToProjectHelper.sourceCoveredByProjectViewTargets(context)
-            || SyncStatusContributor.getSyncStatus(project, context.file) != SyncStatus.UNSYNCED)) {
+            || LegacySyncStatusContributor.getSyncStatus(project, context.file) != SyncStatus.UNSYNCED)) {
       return null;
     }
     return "Add source file to project";

--- a/base/src/com/google/idea/blaze/base/lang/LegacyAdditionalLanguagesHelper.java
+++ b/base/src/com/google/idea/blaze/base/lang/LegacyAdditionalLanguagesHelper.java
@@ -55,7 +55,7 @@ import javax.annotation.Nullable;
  * Detects usage of files in supported but inactive languages, and offers to add them to the project
  * view.
  */
-public class AdditionalLanguagesHelper
+public class LegacyAdditionalLanguagesHelper
     extends EditorNotifications.Provider<EditorNotificationPanel> {
 
   private static final Key<EditorNotificationPanel> KEY = Key.create("add additional language");
@@ -65,7 +65,7 @@ public class AdditionalLanguagesHelper
   private final Project project;
   private final EditorNotifications notifications;
 
-  AdditionalLanguagesHelper(Project project) {
+  LegacyAdditionalLanguagesHelper(Project project) {
     this.project = project;
     this.notifications = EditorNotifications.getInstance(project);
 
@@ -107,7 +107,6 @@ public class AdditionalLanguagesHelper
       return null;
     }
     if (Blaze.getProjectType(project).equals(ProjectType.QUERY_SYNC)) {
-      // TODO(b/260643753)
       return null;
     }
     BlazeProjectData projectData =

--- a/base/src/com/google/idea/blaze/base/model/LegacyLibraryToTargetResolver.java
+++ b/base/src/com/google/idea/blaze/base/model/LegacyLibraryToTargetResolver.java
@@ -24,9 +24,9 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 /** Resolves a given library to a Blaze target */
-public interface LibraryToTargetResolver {
+public interface LegacyLibraryToTargetResolver {
 
-  ExtensionPointName<LibraryToTargetResolver> EP_NAME =
+  ExtensionPointName<LegacyLibraryToTargetResolver> EP_NAME =
       ExtensionPointName.create("com.google.idea.blaze.LibraryToTargetResolver");
 
   /**

--- a/base/src/com/google/idea/blaze/base/sync/aspects/BlazeIdeInterfaceAspectsImpl.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/BlazeIdeInterfaceAspectsImpl.java
@@ -49,7 +49,7 @@ import com.google.idea.blaze.base.ideinfo.TargetIdeInfo;
 import com.google.idea.blaze.base.ideinfo.TargetKey;
 import com.google.idea.blaze.base.ideinfo.TargetMap;
 import com.google.idea.blaze.base.issueparser.BlazeIssueParser;
-import com.google.idea.blaze.base.lang.AdditionalLanguagesHelper;
+import com.google.idea.blaze.base.lang.LegacyAdditionalLanguagesHelper;
 import com.google.idea.blaze.base.model.AspectSyncProjectData;
 import com.google.idea.blaze.base.model.BlazeVersionData;
 import com.google.idea.blaze.base.model.ProjectTargetData;
@@ -532,7 +532,7 @@ public class BlazeIdeInterfaceAspectsImpl implements BlazeIdeInterface {
             new NavigatableAdapter() {
               @Override
               public void navigate(boolean requestFocus) {
-                AdditionalLanguagesHelper.enableLanguageSupport(project, sorted);
+                LegacyAdditionalLanguagesHelper.enableLanguageSupport(project, sorted);
               }
             })
         .submit(context);

--- a/base/src/com/google/idea/blaze/base/syncstatus/LegacySyncStatusContributor.java
+++ b/base/src/com/google/idea/blaze/base/syncstatus/LegacySyncStatusContributor.java
@@ -38,9 +38,9 @@ import javax.annotation.Nullable;
  * Implemented on a per-language basis to indicate source files of that language which weren't built
  * in the most recent sync.
  */
-public interface SyncStatusContributor {
+public interface LegacySyncStatusContributor {
 
-  ExtensionPointName<SyncStatusContributor> EP_NAME =
+  ExtensionPointName<LegacySyncStatusContributor> EP_NAME =
       ExtensionPointName.create("com.google.idea.blaze.SyncStatusContributor");
 
   /**
@@ -50,7 +50,6 @@ public interface SyncStatusContributor {
   @Nullable
   static SyncStatus getSyncStatus(Project project, VirtualFile vf) {
     if (Blaze.getProjectType(project) == ProjectType.QUERY_SYNC) {
-      // TODO(b/260643753) update this for querysync
       return null;
     }
     BlazeProjectData projectData =
@@ -97,7 +96,7 @@ public interface SyncStatusContributor {
   @Nullable
   PsiFileAndName toPsiFileAndName(BlazeProjectData projectData, ProjectViewNode<?> node);
 
-  /** Whether this {@link SyncStatusContributor} handles the given file type, for this project. */
+  /** Whether this {@link LegacySyncStatusContributor} handles the given file type, for this project. */
   boolean handlesFile(BlazeProjectData projectData, VirtualFile file);
 
   /** The {@link PsiFile} and UI text associated with a {@link ProjectViewNode}. */

--- a/base/src/com/google/idea/blaze/base/syncstatus/SyncStatusEditorTabColorProvider.java
+++ b/base/src/com/google/idea/blaze/base/syncstatus/SyncStatusEditorTabColorProvider.java
@@ -38,7 +38,7 @@ public class SyncStatusEditorTabColorProvider implements EditorTabColorProvider 
       return null;
     }
 
-    SyncStatus syncStatus = SyncStatusContributor.getSyncStatus(project, file);
+    SyncStatus syncStatus = LegacySyncStatusContributor.getSyncStatus(project, file);
     if (Objects.equals(syncStatus, SyncStatus.UNSYNCED)) {
       return UNSYNCED_COLOR;
     }

--- a/base/src/com/google/idea/blaze/base/syncstatus/SyncStatusEditorTabTitleProvider.java
+++ b/base/src/com/google/idea/blaze/base/syncstatus/SyncStatusEditorTabTitleProvider.java
@@ -37,7 +37,7 @@ public class SyncStatusEditorTabTitleProvider implements EditorTabTitleProvider,
     }
 
     SyncStatus status = ApplicationManager.getApplication()
-        .runReadAction((Computable<SyncStatus>) () -> SyncStatusContributor.getSyncStatus(project, file));
+        .runReadAction((Computable<SyncStatus>) () -> LegacySyncStatusContributor.getSyncStatus(project, file));
 
     if (status == null) {
       return null;

--- a/base/src/com/google/idea/blaze/base/syncstatus/SyncStatusNodeDecorator.java
+++ b/base/src/com/google/idea/blaze/base/syncstatus/SyncStatusNodeDecorator.java
@@ -20,7 +20,7 @@ import com.google.idea.blaze.base.settings.Blaze;
 import com.google.idea.blaze.base.settings.BlazeImportSettings.ProjectType;
 import com.google.idea.blaze.base.sync.autosync.ProjectTargetManager.SyncStatus;
 import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
-import com.google.idea.blaze.base.syncstatus.SyncStatusContributor.PsiFileAndName;
+import com.google.idea.blaze.base.syncstatus.LegacySyncStatusContributor.PsiFileAndName;
 import com.intellij.ide.projectView.PresentationData;
 import com.intellij.ide.projectView.ProjectViewNode;
 import com.intellij.ide.projectView.ProjectViewNodeDecorator;
@@ -53,7 +53,7 @@ public class SyncStatusNodeDecorator implements ProjectViewNodeDecorator {
     }
     VirtualFile vf = fileAndName.psiFile.getVirtualFile();
     SyncStatus status =
-        vf == null ? null : SyncStatusContributor.getSyncStatus(project, projectData, vf);
+        vf == null ? null : LegacySyncStatusContributor.getSyncStatus(project, projectData, vf);
     if (status == SyncStatus.UNSYNCED) {
       data.clearText();
       data.addText(fileAndName.name, SimpleTextAttributes.GRAY_ATTRIBUTES);
@@ -69,7 +69,7 @@ public class SyncStatusNodeDecorator implements ProjectViewNodeDecorator {
 
   @Nullable
   private static PsiFileAndName toPsiFile(BlazeProjectData projectData, ProjectViewNode<?> node) {
-    return Arrays.stream(SyncStatusContributor.EP_NAME.getExtensions())
+    return Arrays.stream(LegacySyncStatusContributor.EP_NAME.getExtensions())
         .map(c -> c.toPsiFileAndName(projectData, node))
         .filter(Objects::nonNull)
         .findFirst()

--- a/base/tests/utils/unit/com/google/idea/blaze/base/model/FakeLibraryToTargetResolver.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/model/FakeLibraryToTargetResolver.java
@@ -25,8 +25,8 @@ import com.intellij.openapi.project.Project;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-/** Fake implementation of {@link LibraryToTargetResolver} for use in tests. */
-public final class FakeLibraryToTargetResolver implements LibraryToTargetResolver {
+/** Fake implementation of {@link LegacyLibraryToTargetResolver} for use in tests. */
+public final class FakeLibraryToTargetResolver implements LegacyLibraryToTargetResolver {
 
   private ImmutableMap<LibraryKey, Label> libraryKeyToLabelMap = ImmutableMap.of();
 

--- a/clwb/src/com/google/idea/blaze/clwb/oclang/run/test/GoogleTestLocation.java
+++ b/clwb/src/com/google/idea/blaze/clwb/oclang/run/test/GoogleTestLocation.java
@@ -16,7 +16,7 @@
 package com.google.idea.blaze.clwb.oclang.run.test;
 
 import com.google.idea.blaze.base.sync.autosync.ProjectTargetManager.SyncStatus;
-import com.google.idea.blaze.base.syncstatus.SyncStatusContributor;
+import com.google.idea.blaze.base.syncstatus.LegacySyncStatusContributor;
 import com.google.idea.blaze.clwb.oclang.run.CidrGoogleTestUtilAdapter;
 import com.intellij.execution.Location;
 import com.intellij.execution.PsiLocation;
@@ -182,7 +182,7 @@ public class GoogleTestLocation extends PsiLocation<PsiElement> {
     if (virtualFile == null) {
       return false;
     }
-    SyncStatus status = SyncStatusContributor.getSyncStatus(file.getProject(), virtualFile);
+    SyncStatus status = LegacySyncStatusContributor.getSyncStatus(file.getProject(), virtualFile);
     if (status != null && (status == SyncStatus.UNSYNCED || status == SyncStatus.IN_PROGRESS)) {
       MacroCallLocator locator = new MacroCallLocator();
       file.accept(locator);

--- a/cpp/src/com/google/idea/blaze/cpp/oclang/CppSyncStatusContributor.java
+++ b/cpp/src/com/google/idea/blaze/cpp/oclang/CppSyncStatusContributor.java
@@ -17,7 +17,7 @@ package com.google.idea.blaze.cpp.oclang;
 
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.primitives.LanguageClass;
-import com.google.idea.blaze.base.syncstatus.SyncStatusContributor;
+import com.google.idea.blaze.base.syncstatus.LegacySyncStatusContributor;
 import com.intellij.ide.projectView.ProjectViewNode;
 import com.intellij.ide.projectView.impl.nodes.PsiFileNode;
 import com.intellij.openapi.fileTypes.FileType;
@@ -28,7 +28,7 @@ import com.jetbrains.cidr.lang.OCFileType;
 import com.jetbrains.cidr.lang.psi.OCFile;
 import javax.annotation.Nullable;
 
-class CppSyncStatusContributor implements SyncStatusContributor {
+class CppSyncStatusContributor implements LegacySyncStatusContributor {
 
   @Nullable
   @Override

--- a/golang/src/com/google/idea/blaze/golang/sync/GoSyncStatusContributor.java
+++ b/golang/src/com/google/idea/blaze/golang/sync/GoSyncStatusContributor.java
@@ -18,14 +18,14 @@ package com.google.idea.blaze.golang.sync;
 import com.goide.psi.GoFile;
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.primitives.LanguageClass;
-import com.google.idea.blaze.base.syncstatus.SyncStatusContributor;
+import com.google.idea.blaze.base.syncstatus.LegacySyncStatusContributor;
 import com.intellij.ide.projectView.ProjectViewNode;
 import com.intellij.ide.projectView.impl.nodes.PsiFileNode;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import javax.annotation.Nullable;
 
-class GoSyncStatusContributor implements SyncStatusContributor {
+class GoSyncStatusContributor implements LegacySyncStatusContributor {
 
   @Nullable
   @Override

--- a/java/src/com/google/idea/blaze/java/syncstatus/JavaSyncStatusContributor.java
+++ b/java/src/com/google/idea/blaze/java/syncstatus/JavaSyncStatusContributor.java
@@ -17,7 +17,7 @@ package com.google.idea.blaze.java.syncstatus;
 
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.primitives.LanguageClass;
-import com.google.idea.blaze.base.syncstatus.SyncStatusContributor;
+import com.google.idea.blaze.base.syncstatus.LegacySyncStatusContributor;
 import com.intellij.ide.projectView.ProjectViewNode;
 import com.intellij.ide.projectView.impl.nodes.ClassTreeNode;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -25,7 +25,7 @@ import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiFile;
 import javax.annotation.Nullable;
 
-class JavaSyncStatusContributor implements SyncStatusContributor {
+class JavaSyncStatusContributor implements LegacySyncStatusContributor {
 
   @Nullable
   @Override

--- a/kotlin/src/com/google/idea/blaze/kotlin/syncstatus/KotlinSyncStatusContributor.java
+++ b/kotlin/src/com/google/idea/blaze/kotlin/syncstatus/KotlinSyncStatusContributor.java
@@ -17,7 +17,7 @@ package com.google.idea.blaze.kotlin.syncstatus;
 
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.primitives.LanguageClass;
-import com.google.idea.blaze.base.syncstatus.SyncStatusContributor;
+import com.google.idea.blaze.base.syncstatus.LegacySyncStatusContributor;
 import com.intellij.ide.projectView.ProjectViewNode;
 import com.intellij.openapi.vfs.VirtualFile;
 import javax.annotation.Nullable;
@@ -26,7 +26,7 @@ import org.jetbrains.kotlin.idea.projectView.KtFileTreeNode;
 import org.jetbrains.kotlin.psi.KtClassOrObject;
 import org.jetbrains.kotlin.psi.KtFile;
 
-class KotlinSyncStatusContributor implements SyncStatusContributor {
+class KotlinSyncStatusContributor implements LegacySyncStatusContributor {
 
   @Nullable
   @Override

--- a/python/src/com/google/idea/blaze/python/sync/PySyncStatusContributor.java
+++ b/python/src/com/google/idea/blaze/python/sync/PySyncStatusContributor.java
@@ -17,7 +17,7 @@ package com.google.idea.blaze.python.sync;
 
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.primitives.LanguageClass;
-import com.google.idea.blaze.base.syncstatus.SyncStatusContributor;
+import com.google.idea.blaze.base.syncstatus.LegacySyncStatusContributor;
 import com.intellij.ide.projectView.ProjectViewNode;
 import com.intellij.ide.projectView.impl.nodes.PsiFileNode;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -25,7 +25,7 @@ import com.intellij.psi.PsiFile;
 import com.jetbrains.python.psi.PyFile;
 import javax.annotation.Nullable;
 
-class PySyncStatusContributor implements SyncStatusContributor {
+class PySyncStatusContributor implements LegacySyncStatusContributor {
 
   @Nullable
   @Override

--- a/scala/src/com/google/idea/blaze/scala/sync/ScalaSyncStatusContributor.java
+++ b/scala/src/com/google/idea/blaze/scala/sync/ScalaSyncStatusContributor.java
@@ -17,7 +17,7 @@ package com.google.idea.blaze.scala.sync;
 
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.primitives.LanguageClass;
-import com.google.idea.blaze.base.syncstatus.SyncStatusContributor;
+import com.google.idea.blaze.base.syncstatus.LegacySyncStatusContributor;
 import com.intellij.ide.projectView.ProjectViewNode;
 import com.intellij.ide.projectView.impl.nodes.ClassTreeNode;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -25,7 +25,7 @@ import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiFile;
 import javax.annotation.Nullable;
 
-class ScalaSyncStatusContributor implements SyncStatusContributor {
+class ScalaSyncStatusContributor implements LegacySyncStatusContributor {
 
   @Nullable
   @Override


### PR DESCRIPTION
Cherry pick AOSP commit [e604e90c8a4f583184fcf4ade5ad3b69c2e282f9](https://cs.android.com/android-studio/platform/tools/adt/idea/+/e604e90c8a4f583184fcf4ade5ad3b69c2e282f9).

1. There is nothing to do in the query sync mode
2. Rename classes to make sure they are not used in the query sync mode

Bug: 260643753
Test: n/a
Change-Id: I4b4eb7f61169bc8034ac69faeb4771d0cd090b81

AOSP: e604e90c8a4f583184fcf4ade5ad3b69c2e282f9
