### PR TITLE
[AOSP-pick] Fix skip finding output experiment implementation

### DIFF
--- a/base/src/com/google/idea/blaze/base/qsync/FileRefresher.java
+++ b/base/src/com/google/idea/blaze/base/qsync/FileRefresher.java
@@ -46,7 +46,7 @@ public class FileRefresher {
 
   private static final Logger logger = Logger.getInstance(DependencyTrackerImpl.class);
   private static final FeatureRolloutExperiment skipFindingBuildOutputsExperiment =
-    new FeatureRolloutExperiment("query.sync.skip.finding.build.output");
+    new FeatureRolloutExperiment("query.sync.skip.finding.build.output.2");
 
   private final Project project;
 
@@ -97,6 +97,10 @@ public class FileRefresher {
                     });
               });
         });
+    }
+    if (skipFindingBuildOutputsExperiment.isEnabled()) {
+      virtualFiles.addAll(
+        getFileParentsAsVirtualFilesMarkedDirty(context, updatedFiles));
     }
     refreshFilesRecursively(virtualFiles.build());
     context.output(


### PR DESCRIPTION
Cherry pick AOSP commit [cd03c25523b886dc9686cc67199f17ee8270b913](https://cs.android.com/android-studio/platform/tools/adt/idea/+/cd03c25523b886dc9686cc67199f17ee8270b913).

When skipping finding artifact roots on the EDT we still need to
refresh these files.

Rename the experiment so it can be safely re-enabled (already done for
this name).

Bug: n/a
Test: n/a
Change-Id: Icb1043e0fc6181a53f68f0f5284c0e377e989c8d

AOSP: cd03c25523b886dc9686cc67199f17ee8270b913
