### PR TITLE
[AOSP-pick] Parameterize aspect at instantiation

### DIFF
--- a/aspect/build_dependencies.bzl
+++ b/aspect/build_dependencies.bzl
@@ -355,15 +355,11 @@ def declares_aar_import(ctx):
     """
     return ctx.rule.kind == "aar_import" and hasattr(ctx.rule.attr, "aar")
 
-def _collect_dependencies_impl(target, ctx):
+def _collect_dependencies_impl(target, ctx, params):
     return _collect_dependencies_core_impl(
         target,
         ctx,
-        ctx.attr.include,
-        ctx.attr.exclude,
-        ctx.attr.always_build_rules,
-        ctx.attr.generate_aidl_classes,
-        ctx.attr.use_generated_srcjars,
+        params,
         test_mode = False,
     )
 
@@ -371,11 +367,13 @@ def _collect_all_dependencies_for_tests_impl(target, ctx):
     return _collect_dependencies_core_impl(
         target,
         ctx,
-        include = None,
-        exclude = None,
-        always_build_rules = ALWAYS_BUILD_RULES,
-        generate_aidl_classes = None,
-        use_generated_srcjars = True,
+        struct(
+            include = None,
+            exclude = None,
+            always_build_rules = ALWAYS_BUILD_RULES,
+            generate_aidl_classes = None,
+            use_generated_srcjars = True,
+        ),
         test_mode = True,
     )
 
@@ -383,11 +381,13 @@ def collect_dependencies_for_test(target, ctx, include = []):
     return _collect_dependencies_core_impl(
         target,
         ctx,
-        include = ",".join(include),
-        exclude = "",
-        always_build_rules = ALWAYS_BUILD_RULES,
-        generate_aidl_classes = None,
-        use_generated_srcjars = True,
+        struct(
+            include = include,
+            exclude = "",
+            always_build_rules = ALWAYS_BUILD_RULES,
+            generate_aidl_classes = None,
+            use_generated_srcjars = True,
+        ),
         test_mode = False,
     )
 
@@ -409,29 +409,19 @@ def _target_within_project_scope(label, include, exclude):
     if repo != "":
         return False # We don't support external includes, so all external repos are outside the project scope
     if include:
-        for inc in include.split(","):
-            # This is not a valid label, but can be passed to aspect when `directories: .` is set in the projectview
-            if (inc == "//"):
-                result = True
-                break
-
-            inc = Label(inc)
-            if _get_repo_name(inc) == repo and _package_prefix_match(package, inc.package):
-                result = True
-                break
-
+        if len(include) == 1 and include[0] == "//":
+             # when workspace root is included
+             result = True
+        else:
+            for inc in [Label(i) for i in include]:
+                if _get_repo_name(inc) == repo and _package_prefix_match(package, inc.package):
+                    result = True
+                    break
     if result and len(exclude) > 0:
-        for exc in exclude.split(","):
-            # Same as for includes
-            if (exc == "//"):
-                result = False
-                break
-
-            exc = Label(exc)
+        for exc in [Label(i) for i in exclude]:
             if _get_repo_name(exc) == repo and _package_prefix_match(package, exc.package):
                 result = False
                 break
-
     return result
 
 def _get_dependency_attribute(rule, attr):
@@ -476,7 +466,7 @@ def _collect_own_java_artifacts(
     rule = ctx.rule
 
     must_build_main_artifacts = (
-        not target_is_within_project_scope or rule.kind in always_build_rules.split(",")
+        not target_is_within_project_scope or rule.kind in always_build_rules
     )
 
     own_jar_files = []
@@ -741,20 +731,12 @@ def _collect_own_and_dependency_cc_info(target, rule, test_mode):
 def _collect_dependencies_core_impl(
         target,
         ctx,
-        include,
-        exclude,
-        always_build_rules,
-        generate_aidl_classes,
-        use_generated_srcjars,
+        params,
         test_mode):
     java_dep_info = _collect_java_dependencies_core_impl(
         target,
         ctx,
-        include,
-        exclude,
-        always_build_rules,
-        generate_aidl_classes,
-        use_generated_srcjars,
+        params,
         test_mode,
     )
     cc_dep_info = None
@@ -768,22 +750,18 @@ def _collect_dependencies_core_impl(
 def _collect_java_dependencies_core_impl(
         target,
         ctx,
-        include,
-        exclude,
-        always_build_rules,
-        generate_aidl_classes,
-        use_generated_srcjars,
+        params,
         test_mode):
-    target_is_within_project_scope = _target_within_project_scope(target.label, include, exclude) and not test_mode
+    target_is_within_project_scope = _target_within_project_scope(target.label, params.include, params.exclude) and not test_mode
     dependency_infos = _get_followed_java_dependency_infos(ctx.rule)
 
     target_to_artifacts, compile_jars, aars, gensrcs = _collect_own_and_dependency_java_artifacts(
         target,
         ctx,
         dependency_infos,
-        always_build_rules,
-        generate_aidl_classes,
-        use_generated_srcjars,
+        params.always_build_rules,
+        params.generate_aidl_classes,
+        params.use_generated_srcjars,
         target_is_within_project_scope,
     )
 
@@ -794,9 +772,9 @@ def _collect_java_dependencies_core_impl(
             target,
             ctx,
             can_follow_dependencies,
-            always_build_rules,
-            generate_aidl_classes,
-            use_generated_srcjars,
+            params.always_build_rules,
+            params.generate_aidl_classes,
+            params.use_generated_srcjars,
             target_is_within_project_scope = True,
         )
         test_mode_own_files = struct(
@@ -995,43 +973,27 @@ FOLLOW_ATTRIBUTES = _unique(FOLLOW_JAVA_ATTRIBUTES + FOLLOW_CC_ATTRIBUTES + FOLL
 
 TOOLCHAINS_ASPECTS = IDE_KOTLIN.toolchains_aspects + IDE_CC.toolchains_aspects
 
-collect_dependencies = aspect(
-    implementation = _collect_dependencies_impl,
-    provides = [DependenciesInfo],
-    attr_aspects = FOLLOW_ATTRIBUTES,
-    attrs = {
-        "include": attr.string(
-            doc = "Comma separated list of workspace paths included in the project as source. Any targets inside here will not be built.",
-            mandatory = True,
-        ),
-        "exclude": attr.string(
-            doc = "Comma separated list of exclusions to 'include'.",
-            default = "",
-        ),
-        "always_build_rules": attr.string(
-            doc = "Comma separated list of rules. Any targets belonging to these rules will be built, regardless of location",
-            default = "",
-        ),
-        "generate_aidl_classes": attr.bool(
-            doc = "If True, generates classes for aidl files included as source for the project targets",
-            default = False,
-        ),
-        "use_generated_srcjars": attr.bool(
-            doc = "If True, collects generated source jars for a target instead of compiled jar",
-            default = False,
-        ),
-        "_build_zip": attr.label(
-            allow_files = True,
-            cfg = "exec",
-            executable = True,
-            default = ZIP_TOOL_LABEL,
-        ),
-    },
-    fragments = ["cpp"],
-    **{
-        "toolchains_aspects": TOOLCHAINS_ASPECTS,
-    } if TOOLCHAINS_ASPECTS else {}
-)
+def collect_dependencies(parameters):
+    def _impl(target, ctx):
+        return _collect_dependencies_impl(target, ctx, parameters)
+
+    return aspect(
+        implementation = _impl,
+        provides = [DependenciesInfo],
+        attr_aspects = FOLLOW_ATTRIBUTES,
+        attrs = {
+            "_build_zip": attr.label(
+                allow_files = True,
+                cfg = "exec",
+                executable = True,
+                default = ZIP_TOOL_LABEL,
+            ),
+        },
+        fragments = ["cpp"],
+        **{
+            "toolchains_aspects": TOOLCHAINS_ASPECTS,
+        } if TOOLCHAINS_ASPECTS else {}
+    )
 
 collect_all_dependencies_for_tests = aspect(
     doc = """

--- a/base/BUILD
+++ b/base/BUILD
@@ -579,6 +579,8 @@ intellij_integration_test_suite(
         "//querysync",
         "//querysync/javatests/com/google/idea/blaze/qsync/artifacts:mock_artifact_cache",
         "//shared:exception",
+        "//shared/java/com/google/idea/blaze/common",
+        "//shared/java/com/google/idea/blaze/common/artifact",
         "//shared/javatests/com/google/idea/blaze/common:test_utils",
         "//intellij_platform_sdk:plugin_api",
         "//intellij_platform_sdk:jsr305",

--- a/base/tests/integrationtests/com/google/idea/blaze/base/qsync/BazelDependencyBuilderTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/qsync/BazelDependencyBuilderTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2025 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.qsync;
+
+import static com.google.common.truth.Truth.assertThat;
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.io.ByteSource;
+import com.google.idea.blaze.base.BlazeIntegrationTestCase;
+import com.google.idea.blaze.base.bazel.BazelBuildSystemProvider;
+import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
+import com.google.idea.blaze.common.Label;
+import com.google.idea.blaze.qsync.artifacts.MockArtifactCache;
+import com.google.idea.blaze.qsync.project.ProjectDefinition;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class BazelDependencyBuilderTest extends BlazeIntegrationTestCase {
+
+  public static synchronized File getRunfilesWorkspaceRoot() {
+    // Use the sandboxed root provided for bazel tests.
+    String workspace = requireNonNull(System.getenv("TEST_WORKSPACE"));
+    String workspaceParent = requireNonNull(System.getenv("TEST_SRCDIR"));
+    return new File(workspaceParent, workspace);
+  }
+
+  @Rule
+  public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Before
+  public void before() {
+    // TODO: b/388249589 - reuse com.google.idea.blaze.android.google3.qsync.testrules.QuerySyncEnvironmentRule instead.
+    System.setProperty(
+      "qsync.aspect.build_dependencies.bzl.file",
+      getRunfilesWorkspaceRoot()
+        .toPath()
+        .resolve("aspect/build_dependencies.bzl")
+        .toString());
+    System.setProperty(
+      "qsync.aspect.build_dependencies_deps.bzl.file",
+      getRunfilesWorkspaceRoot()
+        .toPath()
+        .resolve("aspect/build_dependencies_deps.bzl")
+        .toString());
+  }
+
+  @Test
+  public void generatesValidAspectConfiguration() throws IOException {
+    final var dependencyBuilder =
+      new BazelDependencyBuilder(getProject(),
+                                 new BazelBuildSystemProvider().getBuildSystem(),
+                                 ProjectDefinition.builder().build(),
+                                 new WorkspaceRoot(temporaryFolder.getRoot()),
+                                 Optional.empty(),
+                                 new MockArtifactCache(temporaryFolder.newFolder().toPath()),
+                                 ImmutableSet.of("always_build_rule1", "always_build_rule2")
+                                 );
+
+    assertThat(dependencyBuilder.getGeneratedAspectLabel().toString()).startsWith("//.aswb:qs-");
+    final var generatedAspectName = dependencyBuilder.getGeneratedAspectLabel().name();
+    ImmutableMap<Path, ByteSource> aspectFiles = dependencyBuilder.getAspectFiles(new BazelDependencyBuilder.BuildDependencyParameters(
+      ImmutableList.of("dir1", "dir2"),
+      ImmutableList.of("dir1/sub1"),
+      ImmutableList.of("always_build_rule1", "always_build_rule2"),
+      true,
+      false
+    ));
+    assertThat(new String(aspectFiles.get(Path.of(".aswb", generatedAspectName)).openStream().readAllBytes(), StandardCharsets.UTF_8))
+      .isEqualTo("""
+load(':build_dependencies.bzl', _collect_dependencies = 'collect_dependencies', _package_dependencies = 'package_dependencies')
+_config = struct(
+  include = [
+    "dir1",
+    "dir2",
+  ],
+  exclude = [
+    "dir1/sub1",
+  ],
+  always_build_rules = [
+    "always_build_rule1",
+    "always_build_rule2",
+  ],
+  generate_aidl_classes = True,
+  use_generated_srcjars = False,
+)
+
+collect_dependencies = _collect_dependencies(_config)
+package_dependencies = _package_dependencies
+""");
+  }
+}

--- a/shared/java/com/google/idea/blaze/common/artifact/BUILD
+++ b/shared/java/com/google/idea/blaze/common/artifact/BUILD
@@ -6,6 +6,7 @@ java_library(
     name = "artifact",
     srcs = glob(["*.java"]),
     visibility = [
+        "//base:__subpackages__",
         "//shared:__subpackages__",
         "//javatests/com/google/devtools/intellij/blaze/plugin/aswb:__subpackages__",
     ],


### PR DESCRIPTION
Cherry pick AOSP commit [2e116b56c18f3c50f832e759537321ed0ba6fb34](https://cs.android.com/android-studio/platform/tools/adt/idea/+/2e116b56c18f3c50f832e759537321ed0ba6fb34).

This is to unify the test and production flows and make manual testing
from the command line tolerable.

It should also make the aspect configuration visible in CitC snapshots
and aspect builds easily reproducible in users' workspaces.

Bug: 327638725
Test: BazelDependencyBuilderTest
Change-Id: I4cf4b408097cecc7d324310d98c18ce36900468e

AOSP: 2e116b56c18f3c50f832e759537321ed0ba6fb34
