### PR TITLE
Fix make variable expansion

### DIFF
--- a/aspect/intellij_info_impl.bzl
+++ b/aspect/intellij_info_impl.bzl
@@ -349,14 +349,13 @@ def _get_python_srcs_version(ctx):
     srcs_version = getattr(ctx.rule.attr, "srcs_version", "PY2AND3")
     return _SRCS_VERSION_MAPPING.get(srcs_version, default = SRC_PY2AND3)
 
-def _do_starlark_string_expansion(ctx, name, strings, extra_targets = []):
+def _do_starlark_string_expansion(ctx, name, strings, extra_targets = [], tokenization = True):
     # first, expand all starlark predefined paths:
     #   location, locations, rootpath, rootpaths, execpath, execpaths
     strings = [ctx.expand_location(value, targets = extra_targets) for value in strings]
 
     # then expand any regular GNU make style variables
-    strings = [expand_make_variables(name, value, ctx) for value in strings]
-    return strings
+    return expand_make_variables(ctx, tokenization, strings)
 
 ##### Builders for individual parts of the aspect output
 
@@ -375,7 +374,7 @@ def collect_py_info(target, ctx, semantics, ide_info, ide_info_file, output_grou
     to_build = get_py_info(target).transitive_sources
     args = getattr(ctx.rule.attr, "args", [])
     data_deps = getattr(ctx.rule.attr, "data", [])
-    args = _do_starlark_string_expansion(ctx, "args", args, data_deps)
+    args = _do_starlark_string_expansion(ctx, "args", args, data_deps, tokenization = False)
     imports = getattr(ctx.rule.attr, "imports", [])
     is_code_generator = False
 

--- a/clwb/tests/headlesstests/com/google/idea/blaze/clwb/SimpleTest.java
+++ b/clwb/tests/headlesstests/com/google/idea/blaze/clwb/SimpleTest.java
@@ -1,6 +1,7 @@
 package com.google.idea.blaze.clwb;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.idea.blaze.clwb.base.Assertions.assertContainsCompilerFlag;
 import static com.google.idea.blaze.clwb.base.Assertions.assertContainsHeader;
 import static com.google.idea.blaze.clwb.base.Assertions.assertContainsPattern;
 
@@ -43,6 +44,7 @@ public class SimpleTest extends ClwbHeadlessTestCase {
     }
 
     assertContainsHeader("iostream", compilerSettings);
+    assertContainsCompilerFlag("-Wall", compilerSettings);
   }
 
   private void checkTest() {

--- a/clwb/tests/headlesstests/com/google/idea/blaze/clwb/base/Assertions.java
+++ b/clwb/tests/headlesstests/com/google/idea/blaze/clwb/base/Assertions.java
@@ -7,6 +7,7 @@ import com.google.common.truth.StringSubject;
 import com.intellij.openapi.util.Ref;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.jetbrains.cidr.lang.toolchains.CidrCompilerSwitches.Format;
 import com.jetbrains.cidr.lang.workspace.OCCompilerSettings;
 import com.jetbrains.cidr.lang.workspace.headerRoots.HeadersSearchRoot;
 import java.util.List;
@@ -82,5 +83,13 @@ public class Assertions {
     final var match = list.stream().anyMatch(it -> pattern.matcher(it).matches());
 
     assertWithMessage(message).that(match).isTrue();
+  }
+
+  public static void assertContainsCompilerFlag(String flag, OCCompilerSettings settings) {
+    final var switches = settings.getCompilerSwitches();
+    assertThat(switches).isNotNull();
+
+    final var list = switches.getList(Format.BASH_SHELL);
+    assertThat(list).contains(flag);
   }
 }

--- a/clwb/tests/projects/simple/main/BUILD
+++ b/clwb/tests/projects/simple/main/BUILD
@@ -3,6 +3,10 @@ load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_test")
 cc_binary(
     name = "hello-world",
     srcs = ["hello-world.cc"],
+    copts = [
+        "-Wall",
+        "$(STACK_FRAME_UNLIMITED)", # empty make variable should be stripped by make variable tokenization
+    ],
 )
 
 cc_test(


### PR DESCRIPTION
The custom implementation form make variable expansion breaks in some edge cases. For example empty make variables. Therefore, this PR replaces the custom implementation with the [one](https://github.com/bazelbuild/bazel/blob/6f7faa659e5eb3e56c8a6274ebcb86884703d603/src/main/starlark/builtins_bzl/common/cc/cc_helper.bzl#L910) used by bazel. 
