### PR TITLE
[AOSP-pick] Remove unused DBiP experimental flag

### DIFF
--- a/base/src/com/google/idea/blaze/base/command/BlazeCommandRunnerExperiments.java
+++ b/base/src/com/google/idea/blaze/base/command/BlazeCommandRunnerExperiments.java
@@ -25,8 +25,6 @@ import com.intellij.openapi.util.SystemInfo;
 public class BlazeCommandRunnerExperiments {
   public static final BoolExperiment USE_SINGLEJAR_FOR_DEBUGGING =
     new BoolExperiment("debug.localtests.singlejar.enable", true);
-  public static final BoolExperiment ENABLE_DBIP_ONCORP =
-    new BoolExperiment("dbip.cloudtop.pilot.enable", false);
   public static final BoolExperiment ANDROID_JNI_LIBRARY_FORCE_ANDROID =
     new BoolExperiment("debug.localtests.android.jni.library", SystemInfo.isMac);
   private static final String DBIP_ONCORP_ENV = System.getenv("REPLACE_BLAZE_WITH_DBIP");
@@ -34,9 +32,6 @@ public class BlazeCommandRunnerExperiments {
   private BlazeCommandRunnerExperiments() { }
 
   public static boolean enableDbipOncorp() {
-    if (DBIP_ONCORP_ENV != null && !DBIP_ONCORP_ENV.isEmpty() && !DBIP_ONCORP_ENV.equals("0")) {
-      return true;
-    }
-    return ENABLE_DBIP_ONCORP.getValue();
+    return DBIP_ONCORP_ENV != null && !DBIP_ONCORP_ENV.isEmpty() && !DBIP_ONCORP_ENV.equals("0");
   }
 }


### PR DESCRIPTION
Cherry pick AOSP commit [669b5ab0e54ec97a14a8723cdaf50e83cad33fa4](https://cs.android.com/android-studio/platform/tools/adt/idea/+/669b5ab0e54ec97a14a8723cdaf50e83cad33fa4).

The DBiP on-corp is no longer a pilot experiment, and the interested users should follow go/dbip-onboarding instead. Currently, only one ASwB user has this flag set to true, and we can safely delete it.
https://plx.corp.google.com/scripts2/script_f6._44cdd4_098e_4dcb_a994_13dee866f1b2

Bug:378707836

Test: n/a
Change-Id: I1244016a797b3da7bab6004e6dd16c4e25a21fd0

AOSP: 669b5ab0e54ec97a14a8723cdaf50e83cad33fa4
