### PR TITLE
[AOSP-pick] Add transitive deps

### DIFF
--- a/aswb/testdata/projects/gencode_twowaydeps/project/BUILD
+++ b/aswb/testdata/projects/gencode_twowaydeps/project/BUILD
@@ -15,6 +15,7 @@ kt_jvm_library(
     ],
     deps = [
         ":java",
+        "//aswb/testdata/projects/gencode_twowaydeps/external:interface",
     ],
 )
 

--- a/base/src/com/google/idea/blaze/base/project/indexing/BUILD
+++ b/base/src/com/google/idea/blaze/base/project/indexing/BUILD
@@ -12,6 +12,8 @@ kt_jvm_library(
     ],
     deps = [
         "//base",
+        "//common/experiments",
+        "//querysync",
         "//intellij_platform_sdk:plugin_api",
         "//intellij_platform_sdk:jsr305",  # unuseddeps: keep
     ],

--- a/querysync/BUILD
+++ b/querysync/BUILD
@@ -13,6 +13,8 @@ package(default_visibility = [
     "//java/com/google/devtools/intellij/blaze/plugin/cpp:__subpackages__",
     "//java/com/google/devtools/intellij/blaze/plugin/querysync:__subpackages__",
     "//java/com/google/devtools/intellij/g3plugins/services:__subpackages__",
+    "//java/com/google/devtools/intellij/protobuf:__subpackages__",
+    "//javatests/com/google/devtools/intellij/protobuf:__subpackages__",
 ])
 
 # A build rule to expose individual targets under java/ to users


### PR DESCRIPTION
Cherry pick AOSP commit [e2a28c9b677900f949a2bec28b242cb71bd867a8](https://cs.android.com/android-studio/platform/tools/adt/idea/+/e2a28c9b677900f949a2bec28b242cb71bd867a8).

Necessary once strict deps are enforced.

Test: existing
Bug: none
Change-Id: I131cfdf10fe66657a79177aea8c8993dc513692c

AOSP: e2a28c9b677900f949a2bec28b242cb71bd867a8
