### PR TITLE
[AOSP-pick] Delete unused additional_class_rules attribute

### DIFF
--- a/aswb/BUILD
+++ b/aswb/BUILD
@@ -182,7 +182,6 @@ intellij_integration_test_suite(
             "tests/integrationtests/com/google/idea/blaze/android/functional/AswbMergedManifestTest.java",  #b/222322106
         ],
     ),
-    additional_class_rules = [],
     data = [
         "testdata/golden.png",
         "testdata/ic_banner.png",

--- a/testing/test_defs.bzl
+++ b/testing/test_defs.bzl
@@ -154,7 +154,6 @@ def intellij_integration_test_suite(
         srcs,
         test_package_root,
         deps,
-        additional_class_rules = [],
         size = "medium",
         jvm_flags = [],
         runtime_deps = [],
@@ -196,7 +195,6 @@ def intellij_integration_test_suite(
         name = suite_class_name,
         srcs = srcs,
         test_package_root = test_package_root,
-        class_rules = additional_class_rules,
         run_with = "com.google.idea.testing.IntellijIntegrationSuite",
     )
 


### PR DESCRIPTION
Cherry pick AOSP commit [3358a60218376c733b8196f1f001e85ed1405c8b](https://cs.android.com/android-studio/platform/tools/adt/idea/+/3358a60218376c733b8196f1f001e85ed1405c8b).

Bug: 333377957
Test: n/a
Change-Id: I111979e339decaa9d07c08ff049f2fc56804d6e1

AOSP: 3358a60218376c733b8196f1f001e85ed1405c8b
