### PR TITLE
[AOSP-pick] Make output group names shorter and consistent

### DIFF
--- a/aspect/build_dependencies.bzl
+++ b/aspect/build_dependencies.bzl
@@ -73,21 +73,21 @@ IDE_CC = _validate_ide(
 
 JVM_SRC_ATTRS = _unique(["srcs"] + IDE_JAVA.srcs_attributes + IDE_KOTLIN.srcs_attributes)
 
+def _noneToEmpty(d):
+    return d if d else depset()
+
 def _package_dependencies_impl(target, ctx):
-    java_info_file = _write_java_target_info(target, ctx)
-    cc_info_file = _write_cc_target_info(target, ctx)
-
-    def noneToEmpty(d):
-        return d if d else depset()
-
     dep_info = target[DependenciesInfo]
+    java_info_file = _write_java_target_info(target, ctx)
+    cc_info_files = _write_cc_target_info(target, ctx) + ([dep_info.cc_toolchain_info.file] if dep_info.cc_toolchain_info else [])
+
     return [OutputGroupInfo(
-        qsync_jars = noneToEmpty(dep_info.compile_time_jars),
-        artifact_info_file = java_info_file,
-        qsync_aars = noneToEmpty(dep_info.aars),
-        qsync_gensrcs = noneToEmpty(dep_info.gensrcs),
-        cc_headers = noneToEmpty(dep_info.cc_headers),
-        cc_info_file = cc_info_file + ([dep_info.cc_toolchain_info.file] if dep_info.cc_toolchain_info else []),
+        qs_jars = _noneToEmpty(dep_info.compile_time_jars),
+        qs_info = java_info_file,
+        qs_aars = _noneToEmpty(dep_info.aars),
+        qs_gensrcs = _noneToEmpty(dep_info.gensrcs),
+        qs_cc_headers = _noneToEmpty(dep_info.cc_headers),
+        qs_cc_info = cc_info_files,
     )]
 
 def _write_java_target_info(target, ctx, custom_prefix = ""):

--- a/aswb/testdata/projects/test_projects.bzl
+++ b/aswb/testdata/projects/test_projects.bzl
@@ -196,8 +196,8 @@ def _test_build_dep_desc_impl(ctx):
     output_groups = {}
     for t in ctx.attr.deps:
         label = str(t.label)
-        f += t[OutputGroupInfo].artifact_info_file.to_list()
-        f += t[OutputGroupInfo].cc_info_file.to_list()
+        f += t[OutputGroupInfo].qs_info.to_list()
+        f += t[OutputGroupInfo].qs_cc_info.to_list()
 
         # Add all output groups to a dict of [target name] -> [OutputGroupInfo]
         output_groups[label] = t[OutputGroupInfo]

--- a/querysync/java/com/google/idea/blaze/qsync/deps/OutputGroup.java
+++ b/querysync/java/com/google/idea/blaze/qsync/deps/OutputGroup.java
@@ -17,12 +17,12 @@ package com.google.idea.blaze.qsync.deps;
 
 /** Represents an output group produced by the {@code build_dependencies.bzl} aspect. */
 public enum OutputGroup {
-  JARS("qsync_jars"),
-  AARS("qsync_aars"),
-  GENSRCS("qsync_gensrcs"),
-  ARTIFACT_INFO_FILE("artifact_info_file"),
-  CC_HEADERS("cc_headers"),
-  CC_INFO_FILE("cc_info_file");
+  JARS("qs_jars"),
+  AARS("qs_aars"),
+  GENSRCS("qs_gensrcs"),
+  ARTIFACT_INFO_FILE("qs_info"),
+  CC_HEADERS("qs_cc_headers"),
+  CC_INFO_FILE("qs_cc_info");
 
   private final String name;
 


### PR DESCRIPTION
Cherry pick AOSP commit [b2ae825899d167f1f08445d4f6ad29b8f3c14cf3](https://cs.android.com/android-studio/platform/tools/adt/idea/+/b2ae825899d167f1f08445d4f6ad29b8f3c14cf3).

and get rid of a nested function because ASwB editor doe snot support
them.

Bug: n/a
Test: SyncedInBazelProjectTest
Change-Id: Ib572b1aec4767a78a64f1027ac7fd04cb7d9fa18

AOSP: b2ae825899d167f1f08445d4f6ad29b8f3c14cf3
