### PR TITLE
[AOSP-pick] Make thread pools a concern of ProjectLoader

### DIFF
--- a/base/src/com/google/idea/blaze/base/qsync/ProjectLoaderImpl.java
+++ b/base/src/com/google/idea/blaze/base/qsync/ProjectLoaderImpl.java
@@ -21,6 +21,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.idea.blaze.base.bazel.BuildSystem;
 import com.google.idea.blaze.base.bazel.BuildSystemProvider;
 import com.google.idea.blaze.base.command.info.BlazeInfo;
@@ -70,6 +71,7 @@ import com.google.idea.common.experiments.BoolExperiment;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.ModificationTracker;
 import com.intellij.openapi.util.SimpleModificationTracker;
+import com.intellij.util.concurrency.AppExecutorUtil;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
@@ -86,11 +88,17 @@ public class ProjectLoaderImpl implements ProjectLoader {
   public final static BoolExperiment enableExperimentalQuery = new BoolExperiment("query.sync.experimental.query", false);
   public final static BoolExperiment runQueryInWorkspace = new BoolExperiment("query.sync.run.query.in.workspace", true);
 
-  private final ListeningExecutorService executor;
+  protected final ListeningExecutorService executor;
+
   private final SimpleModificationTracker projectModificationTracker;
   protected final Project project;
 
-  public ProjectLoaderImpl(ListeningExecutorService executor, Project project) {
+  public ProjectLoaderImpl(Project project) {
+    this(MoreExecutors.listeningDecorator(
+      AppExecutorUtil.createBoundedApplicationPoolExecutor("QuerySync", 128)), project);
+  }
+
+  protected ProjectLoaderImpl(ListeningExecutorService executor, Project project) {
     this.executor = executor;
     this.project = project;
     this.projectModificationTracker = new SimpleModificationTracker();

--- a/base/src/com/google/idea/blaze/base/qsync/QuerySyncManager.java
+++ b/base/src/com/google/idea/blaze/base/qsync/QuerySyncManager.java
@@ -19,7 +19,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
@@ -65,7 +64,6 @@ import com.intellij.openapi.util.ModificationTracker;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import com.intellij.serviceContainer.NonInjectable;
-import com.intellij.util.concurrency.AppExecutorUtil;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;
@@ -97,10 +95,6 @@ public class QuerySyncManager implements Disposable {
   public static final String NOTIFICATION_GROUP = "QuerySyncBuild";
 
   private final Project project;
-  protected final ListeningExecutorService executor =
-      MoreExecutors.listeningDecorator(
-          AppExecutorUtil.createBoundedApplicationPoolExecutor("QuerySync", 128));
-
   private final ProjectLoader loader;
   private volatile QuerySyncProject loadedProject;
 
@@ -146,7 +140,7 @@ public class QuerySyncManager implements Disposable {
   @NonInjectable
   public QuerySyncManager(Project project, @Nullable ProjectLoader loader) {
     this.project = project;
-    this.loader = loader != null ? loader : createProjectLoader(executor, project);
+    this.loader = loader != null ? loader : createProjectLoader(project);
     this.syncStatus = new QuerySyncStatus(project);
     this.fileListener = QuerySyncAsyncFileListener.createAndListen(project, this);
     this.cacheCleaner = new CacheCleaner(project, this);
@@ -160,8 +154,8 @@ public class QuerySyncManager implements Disposable {
     return Optional.of("https://github.com/bazelbuild/intellij/blob/master/docs/querysync.md");
   }
 
-  protected ProjectLoader createProjectLoader(ListeningExecutorService executor, Project project) {
-    return new ProjectLoaderImpl(executor, project);
+  protected ProjectLoader createProjectLoader(Project project) {
+    return new ProjectLoaderImpl(project);
   }
 
   public ModificationTracker getProjectModificationTracker() {


### PR DESCRIPTION
Cherry pick AOSP commit [5e5d44f03d41187cd05cf8af016da6da0735fda1](https://cs.android.com/android-studio/platform/tools/adt/idea/+/5e5d44f03d41187cd05cf8af016da6da0735fda1).

STAT (diff to AOSP): 0 insertions(+), 0 deletion(-)

Thread pools and executors are not different from all other services
that the project loader instantiates.

Bug: n/a
Test: n/a
Change-Id: I75026cdae75c1e4bafc39a116fa1f39fd03ea6ad

AOSP: 5e5d44f03d41187cd05cf8af016da6da0735fda1
