### PR TITLE
Revert "Disable CLion MacOS CI"

### DIFF
--- a/.bazelci/clion.yml
+++ b/.bazelci/clion.yml
@@ -65,8 +65,6 @@ tasks:
       - --test_output=errors
     test_targets:
       - //:clwb_tests
-    soft_fail:
-      - exit_status: 1
   CLion-MacOS-OSS-latest-stable:
     name: CLion MacOS OSS Latest Stable
     platform: macos_arm64
@@ -80,8 +78,6 @@ tasks:
       - --test_output=errors
     test_targets:
       - //:clwb_tests
-    soft_fail:
-      - exit_status: 1
   CLion-Linux-OSS-under-dev:
     name: CLion Linux OSS Under Development
     platform: ubuntu2204


### PR DESCRIPTION
Reverts bazelbuild/intellij#7359, since https://github.com/bazelbuild/continuous-integration/issues/2183 has been fixed.