### PR TITLE
[AOSP-pick] Add java_and_deps test project

### DIFF
--- a/testing/test_deps/projects/java_and_deps/.bazelproject
+++ b/testing/test_deps/projects/java_and_deps/.bazelproject
@@ -1,0 +1,7 @@
+
+directories:
+  java_and_deps/project
+
+android_sdk_platform: android-34
+
+

--- a/testing/test_deps/projects/java_and_deps/BUILD
+++ b/testing/test_deps/projects/java_and_deps/BUILD
@@ -1,0 +1,20 @@
+package(default_visibility = ["//visibility:private"])
+
+java_library(
+    name = "sample",
+    srcs = glob(["java/com/example/sample/*.java"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        ":lib",
+        "//simple_java/java/com/example/sample/nested",
+        "@maven//:com_google_guava_guava",
+    ],
+)
+
+java_library(
+    name = "lib",
+    srcs = glob(["java/com/example/lib/*.java"]),
+    visibility = ["//visibility:public"],
+    deps = [
+    ],
+)

--- a/testing/test_deps/projects/java_and_deps/deps/top_level_lib_1/BUILD
+++ b/testing/test_deps/projects/java_and_deps/deps/top_level_lib_1/BUILD
@@ -1,0 +1,10 @@
+package(default_visibility = ["//visibility:private"])
+
+java_library(
+    name = "top_level_lib_1",
+    srcs = glob(["java/com/example/top_level_lib_1/*.java"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//java_and_deps/deps/transitive_dep_lib",
+    ],
+)

--- a/testing/test_deps/projects/java_and_deps/deps/top_level_lib_1/java/com/example/top_level_lib_1/Lib1.java
+++ b/testing/test_deps/projects/java_and_deps/deps/top_level_lib_1/java/com/example/top_level_lib_1/Lib1.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.top_level_lib_1;
+
+import com.example.transitive_dep_lib.DepLib;
+
+/** Lib1 test class. */
+public record Lib1(String data, DepLib dep) {
+  public static Lib1 createTest() {
+    return new Lib1("test", new DepLib("test"));
+  }
+}

--- a/testing/test_deps/projects/java_and_deps/deps/top_level_lib_2/BUILD
+++ b/testing/test_deps/projects/java_and_deps/deps/top_level_lib_2/BUILD
@@ -1,0 +1,10 @@
+package(default_visibility = ["//visibility:private"])
+
+java_library(
+    name = "top_level_lib_2",
+    srcs = glob(["java/com/example/top_level_lib_2/*.java"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//java_and_deps/deps/transitive_dep_lib",
+    ],
+)

--- a/testing/test_deps/projects/java_and_deps/deps/top_level_lib_2/java/com/example/top_level_lib_2/Lib2.java
+++ b/testing/test_deps/projects/java_and_deps/deps/top_level_lib_2/java/com/example/top_level_lib_2/Lib2.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.top_level_lib_2;
+
+import com.example.transitive_dep_lib.DepLib;
+
+/** Lib2 test class. */
+public record Lib2(String data, DepLib depLib) {
+  public static Lib2 createTest() {
+    return new Lib2("test", new DepLib("test"));
+  }
+}

--- a/testing/test_deps/projects/java_and_deps/deps/transitive_dep_lib/BUILD
+++ b/testing/test_deps/projects/java_and_deps/deps/transitive_dep_lib/BUILD
@@ -1,0 +1,9 @@
+package(default_visibility = ["//visibility:private"])
+
+java_library(
+    name = "transitive_dep_lib",
+    srcs = glob(["java/com/example/transitive_dep_lib/*.java"]),
+    visibility = ["//visibility:public"],
+    deps = [
+    ],
+)

--- a/testing/test_deps/projects/java_and_deps/deps/transitive_dep_lib/java/com/example/transitive_dep_lib/DepLib.java
+++ b/testing/test_deps/projects/java_and_deps/deps/transitive_dep_lib/java/com/example/transitive_dep_lib/DepLib.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.transitive_dep_lib;
+
+/** DepLib test class. */
+public record DepLib(String data) {}

--- a/testing/test_deps/projects/java_and_deps/project/BUILD
+++ b/testing/test_deps/projects/java_and_deps/project/BUILD
@@ -1,0 +1,21 @@
+package(default_visibility = ["//visibility:private"])
+
+java_library(
+    name = "sample",
+    srcs = glob(["java/com/example/sample/*.java"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        ":lib",
+        "//java_and_deps/deps/top_level_lib_1",
+        "//java_and_deps/project/java/com/example/sample/nested",
+    ],
+)
+
+java_library(
+    name = "lib",
+    srcs = glob(["java/com/example/lib/*.java"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//java_and_deps/deps/top_level_lib_2",
+    ],
+)

--- a/testing/test_deps/projects/java_and_deps/project/java/com/example/lib/LibClass.java
+++ b/testing/test_deps/projects/java_and_deps/project/java/com/example/lib/LibClass.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.lib;
+
+/** LibClass test class. */
+public final class LibClass {
+  private final String hello;
+
+  public LibClass(String hello) {
+    this.hello = hello;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    LibClass libClass = (LibClass) o;
+
+    return hello.equals(libClass.hello);
+  }
+
+  @Override
+  public int hashCode() {
+    return hello.hashCode();
+  }
+}

--- a/testing/test_deps/projects/java_and_deps/project/java/com/example/sample/Class1.java
+++ b/testing/test_deps/projects/java_and_deps/project/java/com/example/sample/Class1.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.sample;
+
+import com.example.lib.LibClass;
+import com.example.sample.nested.NestedClass;
+import com.example.top_level_lib_1.Lib1;
+
+/** Class1 test class */
+public class Class1 {
+  private final LibClass libClass = new LibClass("hello");
+  private final NestedClass nestedClass = new NestedClass();
+  public final Lib1 lib1 = Lib1.createTest();
+
+  public void method() {
+    System.out.println(libClass.getClass());
+    System.out.println(nestedClass.getClass());
+    System.out.println(lib1.getClass());
+  }
+}

--- a/testing/test_deps/projects/java_and_deps/project/java/com/example/sample/nested/BUILD
+++ b/testing/test_deps/projects/java_and_deps/project/java/com/example/sample/nested/BUILD
@@ -1,0 +1,19 @@
+package(default_visibility = ["//simple_java:__pkg__"])
+
+java_library(
+    name = "nested",
+    srcs = glob(["**/NestedClass.java"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//java_and_deps/deps/top_level_lib_2",
+    ],
+)
+
+java_library(
+    name = "nested2",
+    srcs = glob(["**/NestedClass2.java"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//java_and_deps/deps/transitive_dep_lib",
+    ],
+)

--- a/testing/test_deps/projects/java_and_deps/project/java/com/example/sample/nested/NestedClass.java
+++ b/testing/test_deps/projects/java_and_deps/project/java/com/example/sample/nested/NestedClass.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.sample.nested;
+
+import com.example.top_level_lib_2.Lib2;
+
+/** NestedClass test class. */
+public final class NestedClass {
+  private final Lib2 lib2 = Lib2.createTest();
+
+  public void method() {
+    System.out.println(lib2.getClass());
+  }
+}

--- a/testing/test_deps/projects/java_and_deps/project/java/com/example/sample/nested/NestedClass2.java
+++ b/testing/test_deps/projects/java_and_deps/project/java/com/example/sample/nested/NestedClass2.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.sample.nested;
+
+import com.example.transitive_dep_lib.DepLib;
+
+/** NestedClass2 test class. */
+public final class NestedClass2 {
+  {
+    System.out.println(DepLib.class);
+  }
+}


### PR DESCRIPTION
Cherry pick AOSP commit [f7fc4849a82b66eeb3c07b73c537c57f19778ee4](https://cs.android.com/android-studio/platform/tools/adt/idea/+/f7fc4849a82b66eeb3c07b73c537c57f19778ee4).

STAT (diff to AOSP): 0 insertions(+), 0 deletion(-)

that should enable tests that inspect details of external dependency
reporting since its targets do not depend on external dependencies.

Bug: 327638725
Test: n/a
Change-Id: Iaadc9d4dd2a33d84d0be1872d53b6cfe00d0e8e6

AOSP: f7fc4849a82b66eeb3c07b73c537c57f19778ee4
