### PR TITLE
[AOSP-pick] Pin aswb test targets to java 17

### DIFF
--- a/aswb/testdata/projects/android1/external/BUILD
+++ b/aswb/testdata/projects/android1/external/BUILD
@@ -7,6 +7,7 @@ package(
 android_library(
     name = "lib",
     srcs = glob(["lib/java/**/*.java"]),
+    javacopts = ["-source 17 -target 17"],
     manifest = "lib/AndroidManifest.xml",
     resource_files = glob(["lib/res/**"]),
 )

--- a/aswb/testdata/projects/android1/project/BUILD
+++ b/aswb/testdata/projects/android1/project/BUILD
@@ -54,6 +54,7 @@ android_library(
     name = "lib",
     srcs = glob(["lib/java/**/*.java"]),
     custom_package = "com.example.bazel",
+    javacopts = ["-source 17 -target 17"],
     manifest = "lib/AndroidManifest.xml",
     resource_files = glob(["lib/res/**"]),
 )


### PR DESCRIPTION
Cherry pick AOSP commit [eaa36d02bb623ebe7f1cdda68488bf1b95d0a144](https://cs.android.com/android-studio/platform/tools/adt/idea/+/eaa36d02bb623ebe7f1cdda68488bf1b95d0a144).

STAT (diff to AOSP): 0 insertions(+), 0 deletion(-)

to keep targets compiling when `java_language_version` would be swithed
to 21 in `studio-main`

Bug: 390012852
Test: this is a test
Change-Id: I3b4875578177754aceb84e86a01435c3629c6d5a

AOSP: eaa36d02bb623ebe7f1cdda68488bf1b95d0a144
