### PR TITLE
[AOSP-pick] Delete getLocalInvoker method

### DIFF
--- a/base/src/com/google/idea/blaze/base/bazel/BazelBuildSystem.java
+++ b/base/src/com/google/idea/blaze/base/bazel/BazelBuildSystem.java
@@ -96,11 +96,6 @@ class BazelBuildSystem implements BuildSystem {
   }
 
   @Override
-  public Optional<BuildInvoker> getLocalBuildInvoker(Project project, BlazeContext context) {
-    return Optional.of(getBuildInvoker(project, context));
-  }
-
-  @Override
   public SyncStrategy getSyncStrategy(Project project) {
     return SyncStrategy.SERIAL;
   }

--- a/base/src/com/google/idea/blaze/base/bazel/BuildSystem.java
+++ b/base/src/com/google/idea/blaze/base/bazel/BuildSystem.java
@@ -115,9 +115,6 @@ public interface BuildSystem {
             this.getClass().getSimpleName()));
   }
 
-  /** Get a Blaze invoker that only run build locally. */
-  Optional<BuildInvoker> getLocalBuildInvoker(Project project, BlazeContext context);
-
   /**
    * Get a Blaze invoker that supports multiple calls in parallel, if this build system supports it.
    *

--- a/base/tests/utils/unit/com/google/idea/blaze/base/bazel/BuildSystemProviderWrapper.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/bazel/BuildSystemProviderWrapper.java
@@ -287,11 +287,6 @@ public class BuildSystemProviderWrapper implements BuildSystemProvider {
     }
 
     @Override
-    public Optional<BuildInvoker> getLocalBuildInvoker(Project project, BlazeContext context) {
-      return inner.getLocalBuildInvoker(project, context).map(i -> new BuildInvokerWrapper(i));
-    }
-
-    @Override
     public SyncStrategy getSyncStrategy(Project project) {
       if (syncStrategy != null) {
         return syncStrategy;

--- a/base/tests/utils/unit/com/google/idea/blaze/base/bazel/FakeBuildSystem.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/bazel/FakeBuildSystem.java
@@ -40,8 +40,8 @@ public abstract class FakeBuildSystem implements BuildSystem {
 
   public static Builder builder(BuildSystemName name) {
     return new AutoValue_FakeBuildSystem.Builder()
-        .setName(name)
-        .setSyncStrategy(SyncStrategy.SERIAL);
+      .setName(name)
+      .setSyncStrategy(SyncStrategy.SERIAL);
   }
 
   @Override
@@ -57,13 +57,6 @@ public abstract class FakeBuildSystem implements BuildSystem {
 
   abstract Optional<BuildInvoker> getParallelBuildInvoker();
 
-  abstract Optional<BuildInvoker> getLocalBuildInvoker();
-
-  @Override
-  public Optional<BuildInvoker> getLocalBuildInvoker(Project project, BlazeContext context) {
-    return getParallelBuildInvoker();
-  }
-
   @Override
   public Optional<BuildInvoker> getParallelBuildInvoker(Project project, BlazeContext context) {
     return getParallelBuildInvoker();
@@ -78,7 +71,7 @@ public abstract class FakeBuildSystem implements BuildSystem {
 
   @Override
   public void populateBlazeVersionData(
-      WorkspaceRoot workspaceRoot, BlazeInfo blazeInfo, BlazeVersionData.Builder builder) {}
+    WorkspaceRoot workspaceRoot, BlazeInfo blazeInfo, BlazeVersionData.Builder builder) { }
 
   abstract Optional<String> getBazelVersionString();
 
@@ -106,8 +99,6 @@ public abstract class FakeBuildSystem implements BuildSystem {
     public abstract Builder setBuildInvoker(BuildInvoker value);
 
     public abstract Builder setParallelBuildInvoker(Optional<BuildInvoker> value);
-
-    public abstract Builder setLocalBuildInvoker(Optional<BuildInvoker> value);
 
     public abstract Builder setBazelVersionString(Optional<String> value);
 


### PR DESCRIPTION
Cherry pick AOSP commit [9a8f19c0c0700a58ebc5373b3bbfc93755846ad4](https://cs.android.com/android-studio/platform/tools/adt/idea/+/9a8f19c0c0700a58ebc5373b3bbfc93755846ad4).

STAT (diff to AOSP): 0 insertions(+), 0 deletion(-)

The getLocalInvoker() method was added as a hack to get build flags from the blazerc present at the home directory that's inaccessible by the build-api. We've migrated to using canonical blazercs or checked-in blazercs, so this hack is no longer needed.

This is a small CL as part of the build workflow clean-up. In subsequent CLs, we'll modify the BuildInvoker and BuildSystem interfaces in such a way that we have only one getBuildInvoker method so that the caller don't have to care about which invoker to obtain.

Bug:378707836

Test: n/a
Change-Id: I59d9f4d1f2cfad2043845052a358d229497d1fa4

AOSP: 9a8f19c0c0700a58ebc5373b3bbfc93755846ad4
