### PR TITLE
[AOSP-pick] Make FileApiArtifactFetcher thread pool configurable

### DIFF
--- a/base/BUILD
+++ b/base/BUILD
@@ -442,6 +442,7 @@ java_library(
     visibility = G3PLUGINS_VISIBILITY,
     deps = [
         ":base",
+        "//common/experiments",
         "//shared",
         "//shared:artifact",
         "//intellij_platform_sdk:plugin_api",

--- a/base/src/com/google/idea/blaze/base/qsync/cache/ArtifactFetchers.java
+++ b/base/src/com/google/idea/blaze/base/qsync/cache/ArtifactFetchers.java
@@ -28,8 +28,4 @@ public class ArtifactFetchers {
 
   public static final ExtensionPointName<ArtifactFetcher<?>> EP_NAME =
       ExtensionPointName.create("com.google.idea.blaze.qsync.ArtifactFetcher");
-
-  public static final ListeningExecutorService EXECUTOR =
-      MoreExecutors.listeningDecorator(
-          AppExecutorUtil.createBoundedApplicationPoolExecutor("ArtifactBulkCopyExecutor", 128));
 }

--- a/base/src/com/google/idea/blaze/base/qsync/cache/FileApiArtifactFetcher.java
+++ b/base/src/com/google/idea/blaze/base/qsync/cache/FileApiArtifactFetcher.java
@@ -19,18 +19,33 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.idea.blaze.base.command.buildresult.LocalFileOutputArtifact;
 import com.google.idea.blaze.base.io.FileOperationProvider;
 import com.google.idea.blaze.common.Context;
 import com.google.idea.blaze.common.artifact.ArtifactFetcher;
+import com.google.idea.common.experiments.IntExperiment;
+import com.intellij.util.concurrency.AppExecutorUtil;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.Map.Entry;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 /** Implementation of {@link ArtifactFetcher} that copy file via file api. */
 public class FileApiArtifactFetcher implements ArtifactFetcher<LocalFileOutputArtifact> {
+  public static final IntExperiment maxThreads = new IntExperiment("aswb.file.api.artifact.fetcher.max.threads", 128);
+  public static final ListeningExecutorService EXECUTOR =
+    MoreExecutors.listeningDecorator(
+      // Wrap into a bounded executor as it also allows to give it a name.
+      AppExecutorUtil.createBoundedApplicationPoolExecutor("FileApiArtifactFetcher",
+                                                           new ThreadPoolExecutor(1, maxThreads.getValue(),
+                                                                                  10L, TimeUnit.SECONDS,
+                                                                                  new SynchronousQueue<Runnable>()), maxThreads.getValue()));
   @Override
   public ListenableFuture<?> copy(
       ImmutableMap<? extends LocalFileOutputArtifact, ArtifactDestination> artifactToDest,
@@ -39,7 +54,7 @@ public class FileApiArtifactFetcher implements ArtifactFetcher<LocalFileOutputAr
     for (Entry<? extends LocalFileOutputArtifact, ArtifactDestination> entry :
         artifactToDest.entrySet()) {
       tasks.add(
-          ArtifactFetchers.EXECUTOR.submit(
+          EXECUTOR.submit(
               () -> {
                 Path dest = entry.getValue().path;
                 LocalFileOutputArtifact localFileOutputArtifact = entry.getKey();


### PR DESCRIPTION
Cherry pick AOSP commit [9bec8358b15d0579e6ae214588d6a5f2a27f5651](https://cs.android.com/android-studio/platform/tools/adt/idea/+/9bec8358b15d0579e6ae214588d6a5f2a27f5651).

STAT (diff to AOSP): 0 insertions(+), 0 deletion(-)

via `aswb.file.api.artifact.fetcher.max.threads` experiment with the
default value of 128.

Bug: 327638725
Test: n/a
Change-Id: I788a1ac8165cc419dfd461e6ddeb32ca783e9376

AOSP: 9bec8358b15d0579e6ae214588d6a5f2a27f5651
