### PR TITLE
[AOSP-pick] Prepare for multi-info-file experiment

### DIFF
--- a/aspect/build_dependencies.bzl
+++ b/aspect/build_dependencies.bzl
@@ -76,10 +76,19 @@ JVM_SRC_ATTRS = _unique(["srcs"] + IDE_JAVA.srcs_attributes + IDE_KOTLIN.srcs_at
 def _noneToEmpty(d):
     return d if d else depset()
 
-def _package_dependencies_impl(target, ctx):
+def _package_dependencies_impl(target, ctx, params):
     dep_info = target[DependenciesInfo]
-    java_info_file = _write_java_target_info(target, ctx)
-    cc_info_files = _write_cc_target_info(target, ctx) + ([dep_info.cc_toolchain_info.file] if dep_info.cc_toolchain_info else [])
+    target_to_artifacts = target[DependenciesInfo].target_to_artifacts
+    if target_to_artifacts:
+        java_info_file = [_write_java_target_info(target.label, target_to_artifacts, ctx)]
+    else:
+        java_info_file = []
+
+    cc_compilation_info = target[DependenciesInfo].cc_compilation_info
+    if cc_compilation_info:
+        cc_info_files = [_write_cc_target_info(target.label, cc_compilation_info, ctx)] + ([dep_info.cc_toolchain_info.file] if dep_info.cc_toolchain_info else [])
+    else:
+        cc_info_files = []
 
     return [OutputGroupInfo(
         qs_jars = _noneToEmpty(dep_info.compile_time_jars),
@@ -90,36 +99,31 @@ def _package_dependencies_impl(target, ctx):
         qs_cc_info = cc_info_files,
     )]
 
-def _write_java_target_info(target, ctx, custom_prefix = ""):
+def _write_java_target_info(label, target_to_artifacts, ctx, custom_prefix = ""):
     """Write java target info to a file in proto format.
 
     The proto format used is defined by proto bazel.intellij.JavaArtifacts.
     """
-    target_to_artifacts = target[DependenciesInfo].target_to_artifacts
-    if not target_to_artifacts:
-        return []
-    file_name = custom_prefix + target.label.name + ".java-info.txt"
+    file_name = custom_prefix + label.name + ".java-info.txt"
     artifact_info_file = ctx.actions.declare_file(file_name)
     ctx.actions.write(
         artifact_info_file,
         _encode_target_info_proto(target_to_artifacts),
     )
-    return [artifact_info_file]
+    return artifact_info_file
 
-def _write_cc_target_info(target, ctx):
+def _write_cc_target_info(label, cc_compilation_info, ctx):
     """Write CC target info to a file in proto format.
 
     The proto format used defined by proto bazel.intellij.CcCompilationInfo.
     """
-    if not target[DependenciesInfo].cc_compilation_info:
-        return []
-    cc_info_file_name = target.label.name + ".cc-info.txt"
+    cc_info_file_name = label.name + ".cc-info.txt"
     cc_info_file = ctx.actions.declare_file(cc_info_file_name)
     ctx.actions.write(
         cc_info_file,
-        _encode_cc_compilation_info_proto(target.label, target[DependenciesInfo].cc_compilation_info),
+        _encode_cc_compilation_info_proto(label, cc_compilation_info),
     )
-    return [cc_info_file]
+    return cc_info_file
 
 DependenciesInfo = provider(
     "The out-of-project dependencies",
@@ -296,10 +300,16 @@ def _encode_cc_compilation_info_proto(label, cc_compilation_info):
         ]),
     )
 
-package_dependencies = aspect(
-    implementation = _package_dependencies_impl,
-    required_aspect_providers = [[DependenciesInfo]],
-)
+def package_dependencies(parameters):
+    def _impl(target, ctx):
+        return _package_dependencies_impl(target, ctx, parameters)
+
+    return aspect(
+        implementation = _impl,
+        required_aspect_providers = [[DependenciesInfo]],
+    )
+
+package_dependencies_for_tests = package_dependencies(struct())
 
 def declares_android_resources(target, ctx):
     """
@@ -1024,7 +1034,9 @@ collect_all_dependencies_for_tests = aspect(
 def _write_java_info_txt_impl(ctx):
     info_txt_files = []
     for dep in ctx.attr.deps:
-        info_txt_files.extend(_write_java_target_info(dep, ctx, custom_prefix = ctx.label.name + "."))
+        target_to_artifacts = dep[DependenciesInfo].target_to_artifacts
+        if target_to_artifacts:
+            info_txt_files.extend([_write_java_target_info(dep.label, target_to_artifacts, ctx, custom_prefix = ctx.label.name + ".")])
     return DefaultInfo(files = depset(info_txt_files))
 
 def collect_dependencies_aspect_for_tests(custom_aspect_impl):

--- a/aswb/testdata/projects/test_projects.bzl
+++ b/aswb/testdata/projects/test_projects.bzl
@@ -59,7 +59,7 @@ load(
     "ALWAYS_BUILD_RULES",
     "DependenciesInfo",
     "collect_all_dependencies_for_tests",
-    "package_dependencies",
+    "package_dependencies_for_tests",
 )
 
 def _test_build_deps_impl(ctx):
@@ -267,7 +267,7 @@ test_build_deps_desc = rule(
     implementation = _test_build_dep_desc_impl,
     attrs = {
         "deps": attr.label_list(
-            aspects = [collect_all_dependencies_for_tests, package_dependencies],
+            aspects = [collect_all_dependencies_for_tests, package_dependencies_for_tests],
         ),
     },
 )

--- a/base/src/com/google/idea/blaze/base/qsync/BazelDependencyBuilder.java
+++ b/base/src/com/google/idea/blaze/base/qsync/BazelDependencyBuilder.java
@@ -297,7 +297,7 @@ public class BazelDependencyBuilder implements DependencyBuilder {
     result.append(")\n");
     result.append("\n");
     result.append("collect_dependencies = _collect_dependencies(_config)\n");
-    result.append("package_dependencies = _package_dependencies\n");
+    result.append("package_dependencies = _package_dependencies(_config)\n");
     return result.toString();
   }
 

--- a/base/tests/integrationtests/com/google/idea/blaze/base/qsync/BazelDependencyBuilderTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/qsync/BazelDependencyBuilderTest.java
@@ -112,7 +112,7 @@ _config = struct(
 )
 
 collect_dependencies = _collect_dependencies(_config)
-package_dependencies = _package_dependencies
+package_dependencies = _package_dependencies(_config)
 """);
   }
 }


### PR DESCRIPTION
Cherry pick AOSP commit [fb1c97bd657f78bd71d5f234363f986e0fdba369](https://cs.android.com/android-studio/platform/tools/adt/idea/+/fb1c97bd657f78bd71d5f234363f986e0fdba369).

STAT (diff to AOSP): 2 insertions(+), 2 deletion(-)

1. Make _write_java_target_info usable in other contexts
2. Make package_depedencies aspect depend on the config

Bug: 327638725
Test: SyncedInBazelProjectTest
Change-Id: I5b095323ece99e11636c74cc84c807b06fa92b80

AOSP: fb1c97bd657f78bd71d5f234363f986e0fdba369
