### PR TITLE
[AOSP-pick] qs_info groups are not concern of ArtifactTracker

### DIFF
--- a/base/src/com/google/idea/blaze/base/qsync/BazelDependencyBuilder.java
+++ b/base/src/com/google/idea/blaze/base/qsync/BazelDependencyBuilder.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multimaps;
 import com.google.common.collect.Sets;
 import com.google.common.io.ByteSource;
 import com.google.common.io.MoreFiles;
@@ -400,7 +401,7 @@ public class BazelDependencyBuilder implements DependencyBuilder {
             blazeBuildOutputs.buildId(), buildTime);
 
     return OutputInfo.create(
-      allArtifacts,
+      Multimaps.filterKeys(allArtifacts, it -> it != OutputGroup.ARTIFACT_INFO_FILE && it != OutputGroup.CC_INFO_FILE),
       artifactInfoFilesBuilder.build(),
       ccInfoBuilder.build(),
       blazeBuildOutputs.targetsWithErrors().stream()

--- a/querysync/java/com/google/idea/blaze/qsync/deps/OutputInfo.java
+++ b/querysync/java/com/google/idea/blaze/qsync/deps/OutputInfo.java
@@ -54,10 +54,6 @@ public abstract class OutputInfo {
 
   public abstract DependencyBuildContext getBuildContext();
 
-  public ImmutableList<OutputArtifact> get(OutputGroup group) {
-    return getOutputGroups().get(group);
-  }
-
   public ImmutableList<OutputArtifact> getJars() {
     return getOutputGroups().get(OutputGroup.JARS);
   }
@@ -71,7 +67,7 @@ public abstract class OutputInfo {
   }
 
   public boolean isEmpty() {
-    return getOutputGroups().isEmpty();
+    return getOutputGroups().isEmpty() && getCcCompilationInfo().isEmpty() && getArtifactInfo().isEmpty();
   }
 
   @VisibleForTesting


### PR DESCRIPTION
Cherry pick AOSP commit [634ac56970c0b24819e52c2d583baecab5e421e9](https://cs.android.com/android-studio/platform/tools/adt/idea/+/634ac56970c0b24819e52c2d583baecab5e421e9).

Artifacts from these groups describe the input to the artifact tracker
and are already processed at this point. While there is no harm in
processing them twice they result in misleading messages to the build
output about the number of artifacts requested and actually fetched.

Bug: n/a
Test: n/a
Change-Id: I0ea69b11e5aba00f38fee80f57afe8009c9d86c0

AOSP: 634ac56970c0b24819e52c2d583baecab5e421e9
