### PR TITLE
[AOSP-pick] Support enum experiments and string defaults

### DIFF
--- a/common/experiments/src/com/google/idea/common/experiments/EnumExperiment.java
+++ b/common/experiments/src/com/google/idea/common/experiments/EnumExperiment.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.common.experiments;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+
+import com.intellij.openapi.diagnostic.Logger;
+import com.jgoodies.common.base.Strings;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+/** String-valued experiment. */
+public class EnumExperiment<T extends Enum<?>> extends Experiment {
+  private final static Logger logger = Logger.getInstance(EnumExperiment.class);
+
+  public final String defaultStringValue;
+  private final Map<String, T> values;
+  private final T defaultValue;
+
+  public EnumExperiment(String key, T defaultValue) {
+    super(key);
+    this.defaultValue = defaultValue;
+    this.defaultStringValue = defaultValue.name().toLowerCase(Locale.ROOT);
+    //noinspection unchecked
+    values = Arrays.stream(defaultValue.getDeclaringClass().getEnumConstants()).collect(toImmutableMap(it -> it.name().toLowerCase(Locale.ROOT), it -> (T)it));
+  }
+
+  public T getValue() {
+    String experimentString = ExperimentService.getInstance().getExperimentString(this, null);
+    T value = experimentString != null ? values.get(experimentString.toLowerCase(Locale.ROOT)) : null;
+    if (value == null && Strings.isNotEmpty(experimentString)){
+      logger.error(String.format("Experiment %s: unknown value: %s", getKey(), experimentString), new Throwable());
+    }
+    return Optional.ofNullable(value).orElse(defaultValue);
+  }
+
+  @Override
+  public String getLogValue() {
+    return String.valueOf(getValue());
+  }
+
+  @Override
+  public String getRawDefault() {
+    return defaultStringValue;
+  }
+}

--- a/common/experiments/src/com/google/idea/common/experiments/StringExperiment.java
+++ b/common/experiments/src/com/google/idea/common/experiments/StringExperiment.java
@@ -20,8 +20,15 @@ import javax.annotation.Nullable;
 /** String-valued experiment. */
 public class StringExperiment extends Experiment {
 
-  public StringExperiment(String key) {
+  public final String defaultValue;
+
+  public StringExperiment(String key, String defaultValue) {
     super(key);
+    this.defaultValue = defaultValue;
+  }
+
+  public StringExperiment(String key) {
+    this(key, null);
   }
 
   @Nullable
@@ -36,6 +43,6 @@ public class StringExperiment extends Experiment {
 
   @Override
   public String getRawDefault() {
-    return null;
+    return defaultValue;
   }
 }

--- a/common/experiments/tests/unittests/com/google/idea/common/experiments/ExperimentServiceImplTest.java
+++ b/common/experiments/tests/unittests/com/google/idea/common/experiments/ExperimentServiceImplTest.java
@@ -37,9 +37,12 @@ import kotlin.coroutines.EmptyCoroutineContext;
 @RunWith(JUnit4.class)
 public class ExperimentServiceImplTest {
 
+  enum TestEnum {AA, DefaultBB, CC}
+
   private static final BoolExperiment BOOL_EXPERIMENT = new BoolExperiment("test.property", false);
   private static final StringExperiment STRING_EXPERIMENT = new StringExperiment("test.property");
   private static final IntExperiment INT_EXPERIMENT = new IntExperiment("test.property", 0);
+  private static final EnumExperiment<TestEnum>ENUM_EXPERIMENT = new EnumExperiment<>("test.enum", TestEnum.DefaultBB);
   private static final CoroutineScope DUMMY_SCOPE = CoroutineScopeKt.CoroutineScope(
       EmptyCoroutineContext.INSTANCE);
 
@@ -84,6 +87,39 @@ public class ExperimentServiceImplTest {
     assertThat(experimentService.getExperimentString(STRING_EXPERIMENT, null)).isEqualTo("hi");
     assertThat(experimentService.getAllQueriedExperiments())
         .containsExactly(STRING_EXPERIMENT.getKey(), STRING_EXPERIMENT);
+  }
+
+  @Test
+  public void testEnumProperty() {
+    ExperimentService experimentService =
+        new ExperimentServiceImpl(DUMMY_SCOPE,
+            new MapExperimentLoader("id", ENUM_EXPERIMENT.getKey(), "cc"));
+    intellij.registerApplicationComponent(ExperimentService.class, experimentService);
+    assertThat(ENUM_EXPERIMENT.getValue()).isEqualTo(TestEnum.CC);
+    assertThat(experimentService.getAllQueriedExperiments())
+        .containsExactly(ENUM_EXPERIMENT.getKey(), ENUM_EXPERIMENT);
+  }
+
+  @Test
+  public void testEnumProperty_caseInsensitivity() {
+    ExperimentService experimentService =
+        new ExperimentServiceImpl(DUMMY_SCOPE,
+            new MapExperimentLoader("id", ENUM_EXPERIMENT.getKey(), "Aa"));
+    intellij.registerApplicationComponent(ExperimentService.class, experimentService);
+    assertThat(ENUM_EXPERIMENT.getValue()).isEqualTo(TestEnum.AA);
+    assertThat(experimentService.getAllQueriedExperiments())
+        .containsExactly(ENUM_EXPERIMENT.getKey(), ENUM_EXPERIMENT);
+  }
+
+  @Test
+  public void testEnumProperty_default() {
+    ExperimentService experimentService =
+        new ExperimentServiceImpl(DUMMY_SCOPE,
+            new MapExperimentLoader("id"));
+    intellij.registerApplicationComponent(ExperimentService.class, experimentService);
+    assertThat(ENUM_EXPERIMENT.getValue()).isEqualTo(TestEnum.DefaultBB);
+    assertThat(experimentService.getAllQueriedExperiments())
+        .containsExactly(ENUM_EXPERIMENT.getKey(), ENUM_EXPERIMENT);
   }
 
   @Test


### PR DESCRIPTION
Cherry pick AOSP commit [9d258111d252d18b41a12460faa99e608755c578](https://cs.android.com/android-studio/platform/tools/adt/idea/+/9d258111d252d18b41a12460faa99e608755c578).

STAT (diff to AOSP): 0 insertions(+), 0 deletion(-)

Bug: n/a
Test: ExperimentServiceImplTest
Change-Id: I99e6541b3b77562dcc5bc4a67a34e37ca226dcc4

AOSP: 9d258111d252d18b41a12460faa99e608755c578
