### PR TITLE
[AOSP-pick] Add experimental support for target pattern file

### DIFF
--- a/base/BUILD
+++ b/base/BUILD
@@ -576,6 +576,8 @@ intellij_integration_test_suite(
         ":base",
         ":integration_test_utils",
         ":unit_test_utils",
+        "//common/experiments",
+        "//common/experiments:unit_test_utils",
         "//proto:proto_deps",
         "//querysync",
         "//querysync/javatests/com/google/idea/blaze/qsync/artifacts:mock_artifact_cache",

--- a/base/tests/integrationtests/com/google/idea/blaze/base/qsync/BazelDependencyBuilderTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/qsync/BazelDependencyBuilderTest.java
@@ -23,11 +23,19 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.ByteSource;
 import com.google.idea.blaze.base.BlazeIntegrationTestCase;
+import com.google.idea.blaze.base.MockProjectViewManager;
 import com.google.idea.blaze.base.bazel.BazelBuildSystemProvider;
 import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
+import com.google.idea.blaze.base.projectview.ProjectViewSet;
+import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.common.Label;
 import com.google.idea.blaze.qsync.artifacts.MockArtifactCache;
 import com.google.idea.blaze.qsync.project.ProjectDefinition;
+import com.google.idea.blaze.qsync.project.QuerySyncLanguage;
+import com.google.idea.common.experiments.ExperimentService;
+import com.google.idea.common.experiments.MockExperimentService;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.testFramework.ServiceContainerUtil;
 
 import java.io.File;
 import java.io.IOException;
@@ -53,6 +61,7 @@ public class BazelDependencyBuilderTest extends BlazeIntegrationTestCase {
 
   @Rule
   public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+  private final MockExperimentService experimentService = new MockExperimentService();
 
   @Before
   public void before() {
@@ -69,6 +78,8 @@ public class BazelDependencyBuilderTest extends BlazeIntegrationTestCase {
         .toPath()
         .resolve("aspect/build_dependencies_deps.bzl")
         .toString());
+    ServiceContainerUtil.registerComponentInstance(ApplicationManager.getApplication(), ExperimentService.class, experimentService,
+                                                   getTestRootDisposable());
   }
 
   @Test
@@ -81,40 +92,73 @@ public class BazelDependencyBuilderTest extends BlazeIntegrationTestCase {
                                  Optional.empty(),
                                  new MockArtifactCache(temporaryFolder.newFolder().toPath()),
                                  ImmutableSet.of("always_build_rule1", "always_build_rule2")
-                                 );
+      );
 
     final var generatedAspectName = String.format("qs-%s.bzl", dependencyBuilder.getProjectHash());
-    final var invocationFiles = dependencyBuilder.getInvocationFiles(new BazelDependencyBuilder.BuildDependencyParameters(
-      ImmutableList.of("dir1", "dir2"),
-      ImmutableList.of("dir1/sub1"),
-      ImmutableList.of("always_build_rule1", "always_build_rule2"),
-      true,
-      false,
-      true
-    ));
+    final var invocationFiles = dependencyBuilder.getInvocationFiles(
+      ImmutableSet.of(Label.of("//target1:target1"), Label.of("//target2:target2")),
+      new BazelDependencyBuilder.BuildDependencyParameters(
+        ImmutableList.of("dir1", "dir2"),
+        ImmutableList.of("dir1/sub1"),
+        ImmutableList.of("always_build_rule1", "always_build_rule2"),
+        true,
+        false,
+        true
+      ));
     assertThat(invocationFiles.aspectFileLabel()).isEqualTo(String.format("//.aswb:qs-%s.bzl", dependencyBuilder.getProjectHash()));
-    assertThat(new String(invocationFiles.files().get(Path.of(".aswb", generatedAspectName)).openStream().readAllBytes(), StandardCharsets.UTF_8))
+    assertThat(
+      new String(invocationFiles.files().get(Path.of(".aswb", generatedAspectName)).openStream().readAllBytes(), StandardCharsets.UTF_8))
       .isEqualTo("""
-load(':build_dependencies.bzl', _collect_dependencies = 'collect_dependencies', _package_dependencies = 'package_dependencies')
-_config = struct(
-  include = [
-    "dir1",
-    "dir2",
-  ],
-  exclude = [
-    "dir1/sub1",
-  ],
-  always_build_rules = [
-    "always_build_rule1",
-    "always_build_rule2",
-  ],
-  generate_aidl_classes = True,
-  use_generated_srcjars = False,
-  experiment_multi_info_file = True,
-)
+                   load(':build_dependencies.bzl', _collect_dependencies = 'collect_dependencies', _package_dependencies = 'package_dependencies')
+                   _config = struct(
+                     include = [
+                       "dir1",
+                       "dir2",
+                     ],
+                     exclude = [
+                       "dir1/sub1",
+                     ],
+                     always_build_rules = [
+                       "always_build_rule1",
+                       "always_build_rule2",
+                     ],
+                     generate_aidl_classes = True,
+                     use_generated_srcjars = False,
+                     experiment_multi_info_file = True,
+                   )
+                   
+                   collect_dependencies = _collect_dependencies(_config)
+                   package_dependencies = _package_dependencies(_config)
+                   """);
+  }
 
-collect_dependencies = _collect_dependencies(_config)
-package_dependencies = _package_dependencies(_config)
-""");
+  @Test
+  public void generatesValidTargetPatternFile() throws IOException {
+    experimentService.setExperiment(BazelDependencyBuilder.buildUseTargetPatternFile, true);
+    new MockProjectViewManager(getProject()).setProjectView(new ProjectViewSet(ImmutableList.of()));
+    final var dependencyBuilder =
+      new BazelDependencyBuilder(getProject(),
+                                 new BazelBuildSystemProvider().getBuildSystem(),
+                                 ProjectDefinition.builder().build(),
+                                 new WorkspaceRoot(temporaryFolder.getRoot()),
+                                 Optional.empty(),
+                                 new MockArtifactCache(temporaryFolder.newFolder().toPath()),
+                                 ImmutableSet.of("always_build_rule1", "always_build_rule2")
+      );
+
+    final var generatedTargetPatternName = Label.of(String.format("//.aswb:targets-%s.txt", dependencyBuilder.getProjectHash())).name();
+    final var invocationInfo = dependencyBuilder.getInvocationInfo(
+      BlazeContext.create(),
+      ImmutableSet.of(Label.of("//target1:target1"), Label.of("//target2:target2")),
+      ImmutableSet.of(QuerySyncLanguage.JAVA, QuerySyncLanguage.CC)
+    );
+    ImmutableMap<Path, ByteSource> invocationFiles =
+      invocationInfo.invocationWorkspaceFiles();
+    assertThat(
+      new String(invocationFiles.get(Path.of(".aswb", generatedTargetPatternName)).openStream().readAllBytes(), StandardCharsets.UTF_8))
+      .isEqualTo("""
+                   //target1:target1
+                   //target2:target2""");
+    assertThat(invocationInfo.argsAndFlags()).contains("--target_pattern_file=.aswb/" + generatedTargetPatternName);
   }
 }


### PR DESCRIPTION
Cherry pick AOSP commit [cec59f254d4c35f0999d20d0d1fa8d74b55adadf](https://cs.android.com/android-studio/platform/tools/adt/idea/+/cec59f254d4c35f0999d20d0d1fa8d74b55adadf).

Bug: 327638725
Test: BazelDependencyBuilderTest
Change-Id: Ie0772a45ca86d20e65bee98b49b799b071b266c3

AOSP: cec59f254d4c35f0999d20d0d1fa8d74b55adadf
