### PR TITLE
[AOSP-pick] Reproduce no-ide test ignored in tests

### DIFF
--- a/testing/test_deps/projects/java_and_deps/deps/no_ide/BUILD
+++ b/testing/test_deps/projects/java_and_deps/deps/no_ide/BUILD
@@ -1,0 +1,9 @@
+package(default_visibility = ["//visibility:private"])
+
+java_library(
+    name = "no_ide",
+    srcs = glob(["java/com/example/no_ide/*.java"]),
+    visibility = ["//visibility:public"],
+    deps = [
+    ],
+)

--- a/testing/test_deps/projects/java_and_deps/deps/no_ide/java/com/example/no_ide/NoIdeLib.java
+++ b/testing/test_deps/projects/java_and_deps/deps/no_ide/java/com/example/no_ide/NoIdeLib.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.no_ide;
+
+/** NoIdeLib test class. */
+public record NoIdeLib(String data) {}

--- a/testing/test_deps/projects/java_and_deps/project/BUILD
+++ b/testing/test_deps/projects/java_and_deps/project/BUILD
@@ -12,6 +12,19 @@ java_library(
 )
 
 java_library(
+    name = "sample_no_ide",
+    srcs = glob(["java/com/example/sample/*.java"]),
+    tags = ["no-ide"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":lib",
+        "//java_and_deps/deps/no_ide",
+        "//java_and_deps/deps/top_level_lib_1",
+        "//java_and_deps/project/java/com/example/sample/nested",
+    ],
+)
+
+java_library(
     name = "lib",
     srcs = glob(["java/com/example/lib/*.java"]),
     visibility = ["//visibility:public"],


### PR DESCRIPTION
Cherry pick AOSP commit [c20387d230b1b65127e4baa7c5145c220151dfb6](https://cs.android.com/android-studio/platform/tools/adt/idea/+/c20387d230b1b65127e4baa7c5145c220151dfb6).

Add test `no-ide` targets that result in target selection ambiguity,
which results in a test failure unless specifically handled in the test.

Disable `SyncedInBazelProjectTest.javaAndDeps` as it now catches the
issue.

Bug: 391112715
Test: n/a
Change-Id: I788f061b31d58bf7b958fcc0e15dc8daeb476f02

AOSP: c20387d230b1b65127e4baa7c5145c220151dfb6
