### PR TITLE
Make ProjectOpenProcessors no strong info holder by default

### DIFF
--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -413,7 +413,7 @@
                  description="Determines whether AutoImportProjectOpenProcessor is a strong info holders."
                  key="bazel.project.auto.open"/>
     <registryKey defaultValue="true"
-                 description="Determines whether BlazeProjectOpenProcessor is a strong info holders."
+                 description="Determines whether BlazeProjectOpenProcessor is a strong info holder."
                  key="bazel.project.auto.open.if.present"/>
     <registryKey defaultValue="false"
                  description="The Bazel Plugin sometimes uses the --query_file option to pass the query via a file. By default, the file is deleted immediately after the query execution is finished. Set this flag to true to avoid file deletion"

--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -409,12 +409,9 @@
     <registryKey defaultValue="false"
                  description="Scan for non-root source folders in source jars. (requires re-sync)"
                  key="bazel.sync.detect.source.roots"/>
-    <registryKey defaultValue="true"
-                 description="By default Bazel plugin takes control and opens project if .ijwb folder is present. This property can be used to disable this behavior to allow to open .idea or other project models if they are exists."
-                 key="bazel.project.auto.open.if.present"/>
     <registryKey defaultValue="false"
-                 description="Google plugin is not exclusive anymore, and we need to give a chance to BSP to chime in. Otherwise neither will import the project if .idea folder is present. This property can be used to give a priority to .ijwb or alike over .idea *and* BSP."
-                 key="bazel.project.prefer.google.plugin"/>
+                 description="Determines whether Bazel ProjectOpenProcessors are strong info holders or not."
+                 key="bazel.project.auto.open"/>
     <registryKey defaultValue="false"
                  description="The Bazel Plugin sometimes uses the --query_file option to pass the query via a file. By default, the file is deleted immediately after the query execution is finished. Set this flag to true to avoid file deletion"
                  key="bazel.sync.keep.query.files"/>

--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -410,8 +410,11 @@
                  description="Scan for non-root source folders in source jars. (requires re-sync)"
                  key="bazel.sync.detect.source.roots"/>
     <registryKey defaultValue="false"
-                 description="Determines whether Bazel ProjectOpenProcessors are strong info holders or not."
+                 description="Determines whether AutoImportProjectOpenProcessor is a strong info holders."
                  key="bazel.project.auto.open"/>
+    <registryKey defaultValue="true"
+                 description="Determines whether BlazeProjectOpenProcessor is a strong info holders."
+                 key="bazel.project.auto.open.if.present"/>
     <registryKey defaultValue="false"
                  description="The Bazel Plugin sometimes uses the --query_file option to pass the query via a file. By default, the file is deleted immediately after the query execution is finished. Set this flag to true to avoid file deletion"
                  key="bazel.sync.keep.query.files"/>

--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -410,7 +410,7 @@
                  description="Scan for non-root source folders in source jars. (requires re-sync)"
                  key="bazel.sync.detect.source.roots"/>
     <registryKey defaultValue="false"
-                 description="Determines whether AutoImportProjectOpenProcessor is a strong info holders."
+                 description="Determines whether AutoImportProjectOpenProcessor is a strong info holder."
                  key="bazel.project.auto.open"/>
     <registryKey defaultValue="true"
                  description="Determines whether BlazeProjectOpenProcessor is a strong info holder."

--- a/base/src/com/google/idea/blaze/base/project/AutoImportProjectOpenProcessor.java
+++ b/base/src/com/google/idea/blaze/base/project/AutoImportProjectOpenProcessor.java
@@ -80,8 +80,7 @@ public class AutoImportProjectOpenProcessor extends ProjectOpenProcessor {
 
   @Override
   public boolean isStrongProjectInfoHolder() {
-      return !PluginManagerCore.isPluginInstalled(PluginId.getId("org.jetbrains.bazel")) ||
-              Registry.is("bazel.project.prefer.google.plugin");
+      return Registry.is("bazel.project.auto.open");
   }
 
   @Override

--- a/base/src/com/google/idea/blaze/base/project/BlazeProjectOpenProcessor.java
+++ b/base/src/com/google/idea/blaze/base/project/BlazeProjectOpenProcessor.java
@@ -73,7 +73,7 @@ public class BlazeProjectOpenProcessor extends ProjectOpenProcessor {
 
   @Override
   public boolean isStrongProjectInfoHolder() {
-    return Registry.is("bazel.project.auto.open");
+    return Registry.is("bazel.project.auto.open.if.present");
   }
 
   @Override

--- a/base/src/com/google/idea/blaze/base/project/BlazeProjectOpenProcessor.java
+++ b/base/src/com/google/idea/blaze/base/project/BlazeProjectOpenProcessor.java
@@ -73,7 +73,7 @@ public class BlazeProjectOpenProcessor extends ProjectOpenProcessor {
 
   @Override
   public boolean isStrongProjectInfoHolder() {
-    return Registry.is("bazel.project.auto.open.if.present", false);
+    return Registry.is("bazel.project.auto.open");
   }
 
   @Override


### PR DESCRIPTION
In order to not automatically import every project as a Bazel project even if there are other project models available, the ProjectOpenProcessors cannot be strong info holders by default. 

The old behavior can be restored by setting the `bazel.project.auto.open` registry key to true.

Removes the following obsolete registry keys: 
- `bazel.project.prefer.google.plugin`
- `bazel.project.auto.open.if.present`