### PR TITLE
[AOSP-pick] Exclude no-ide targets from query results

### DIFF
--- a/querysync/java/com/google/idea/blaze/qsync/query/QuerySpec.java
+++ b/querysync/java/com/google/idea/blaze/qsync/query/QuerySpec.java
@@ -56,7 +56,13 @@ public abstract class QuerySpec implements TruncatingFormattable {
         if (baseExpression.isEmpty()) {
           return Optional.empty();
         }
-        return Optional.of("(" + baseExpression + ")");
+        final var baseQuery = baseExpression(querySpec);
+        return Optional.of(
+          "let base = " +
+        baseQuery +
+        "\n" +
+        """
+    in $base - attr("tags", "[\\[,]no-ide[\\],]", $base)""");
       }
     },
 

--- a/querysync/javatests/com/google/idea/blaze/qsync/query/QuerySpecTest.java
+++ b/querysync/javatests/com/google/idea/blaze/qsync/query/QuerySpecTest.java
@@ -34,7 +34,8 @@ public class QuerySpecTest {
         .includePath(Path.of("some/included/path"))
         .supportedRuleClasses(BlazeQueryParser.getAllSupportedRuleClasses())
         .build();
-    assertThat(qs.getQueryExpression()).hasValue("(//some/included/path/...:*)");
+    assertThat(qs.getQueryExpression()).hasValue("let base = //some/included/path/...:*\n" +
+        "in $base - attr(\"tags\", \"[\\[,]no-ide[\\],]\", $base)");
   }
 
   @Test
@@ -64,7 +65,8 @@ public class QuerySpecTest {
         .supportedRuleClasses(BlazeQueryParser.getAllSupportedRuleClasses())
         .build();
     assertThat(qs.getQueryExpression())
-      .hasValue("(//some/included/path/...:* + //another/included/path/...:*)");
+      .hasValue("let base = //some/included/path/...:* + //another/included/path/...:*\n" +
+          "in $base - attr(\"tags\", \"[\\[,]no-ide[\\],]\", $base)");
   }
 
   @Test
@@ -79,9 +81,8 @@ public class QuerySpecTest {
         .supportedRuleClasses(BlazeQueryParser.getAllSupportedRuleClasses())
         .build();
     assertThat(qs.getQueryExpression())
-      .hasValue(
-        "(//some/included/path/...:* + //another/included/path/...:* -"
-        + " //some/included/path/excluded/...:* - //another/included/path/excluded/...:*)");
+      .hasValue("let base = //some/included/path/...:* + //another/included/path/...:* - //some/included/path/excluded/...:* - //another/included/path/excluded/...:*\n" +
+          "in $base - attr(\"tags\", \"[\\[,]no-ide[\\],]\", $base)");
   }
 
   @Test


### PR DESCRIPTION
Cherry pick AOSP commit [a4267596e72fdfc3b22d6bbdc93ca15b181ac80a](https://cs.android.com/android-studio/platform/tools/adt/idea/+/a4267596e72fdfc3b22d6bbdc93ca15b181ac80a).

1. Filter out `no-ide` targets in the query phase.
2. Re-enable `SyncedInBazelProjectTest.javaAndDeps` test, which proves
   that `no-ide` is targets are not in the query results.

Bug: n/a
Test: SyncedInBazelProjectTest.javaAndDeps
Change-Id: I7a0405a70415cb1e24ebe96b84e36643958fe14a

AOSP: a4267596e72fdfc3b22d6bbdc93ca15b181ac80a
