### PR TITLE
Bump bazel version for headless tests 

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -58,18 +58,18 @@ bazel_binaries = use_extension(
     dev_dependency = True,
 )
 bazel_binaries.download(version = "6.5.0")
-bazel_binaries.download(version = "7.4.1")
+bazel_binaries.download(version = "7.5.0")
 bazel_binaries.download(
     current = True,
-    version = "8.0.1",
+    version = "8.1.1",
 )
 use_repo(
     bazel_binaries,
     "bazel_binaries",
     "bazel_binaries_bazelisk",
     "build_bazel_bazel_6_5_0",
-    "build_bazel_bazel_7_4_1",
-    "build_bazel_bazel_8_0_1",
+    "build_bazel_bazel_7_5_0",
+    "build_bazel_bazel_8_1_1",
 )
 
 bazel_dep(name = "rules_jvm_external", version = "6.7")


### PR DESCRIPTION
Bazel 7.4.1 -> 7.5.0
Bazel 8.0.1 -> 8.1.1
