### PR TITLE
[AOSP-pick] Skip no-ide targets in the aspect

### DIFF
--- a/aspect/build_dependencies.bzl
+++ b/aspect/build_dependencies.bzl
@@ -231,7 +231,7 @@ def merge_dependencies_info(target, ctx, java_dep_info, cc_dep_info, cc_toolchai
     """
 
     if not java_dep_info and not cc_dep_info and not cc_toolchain_dep_info:
-        return []
+        return create_dependencies_info(label = target.label)
 
     if cc_dep_info and cc_toolchain_dep_info:
         test_mode_cc_src_deps = depset(transitive = [cc_dep_info.test_mode_cc_src_deps, cc_toolchain_dep_info.test_mode_cc_src_deps])
@@ -473,7 +473,7 @@ def _get_followed_java_proto_dependencies(rule):
         deps.extend(_get_dependency_attribute(rule, "_toolchain"))
     return deps
 
-def _get_followed_java_dependency_infos(rule):
+def _get_followed_java_dependency_infos(label, rule):
     deps = []
     for attr in FOLLOW_JAVA_ATTRIBUTES:
         deps.extend(_get_dependency_attribute(rule, attr))
@@ -768,6 +768,10 @@ def _collect_dependencies_core_impl(
         ctx,
         params,
         test_mode):
+    if hasattr(ctx.rule.attr, "tags"):
+        if "no-ide" in ctx.rule.attr.tags:
+            return create_dependencies_info(label = target.label)
+
     java_dep_info = _collect_java_dependencies_core_impl(
         target,
         ctx,
@@ -788,7 +792,7 @@ def _collect_java_dependencies_core_impl(
         params,
         test_mode):
     target_is_within_project_scope = _target_within_project_scope(target.label, params.include, params.exclude) and not test_mode
-    dependency_infos = _get_followed_java_dependency_infos(ctx.rule)
+    dependency_infos = _get_followed_java_dependency_infos(target.label, ctx.rule)
 
     target_to_artifacts, compile_jars, aars, gensrcs = _collect_own_and_dependency_java_artifacts(
         target,

--- a/testing/test_deps/projects/java_and_deps/deps/no_ide/BUILD
+++ b/testing/test_deps/projects/java_and_deps/deps/no_ide/BUILD
@@ -3,6 +3,7 @@ package(default_visibility = ["//visibility:private"])
 java_library(
     name = "no_ide",
     srcs = glob(["java/com/example/no_ide/*.java"]),
+    tags = ["no-ide"],
     visibility = ["//visibility:public"],
     deps = [
     ],

--- a/testing/test_deps/projects/java_and_deps/project/BUILD
+++ b/testing/test_deps/projects/java_and_deps/project/BUILD
@@ -32,3 +32,13 @@ java_library(
         "//java_and_deps/deps/top_level_lib_2",
     ],
 )
+
+java_library(
+    name = "dep_on_no_ide",
+    srcs = glob(["java/com/example/dep_on_no_ide/*.java"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//java_and_deps/deps/no_ide",
+        "//java_and_deps/deps/top_level_lib_1",
+    ],
+)

--- a/testing/test_deps/projects/java_and_deps/project/java/com/example/dep_on_no_ide/DepOnNoIde.java
+++ b/testing/test_deps/projects/java_and_deps/project/java/com/example/dep_on_no_ide/DepOnNoIde.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.dep_on_no_ide;
+
+import com.example.no_ide.NoIdeLib;
+import com.example.top_level_lib_1.Lib1;
+
+/** DepOnNoIde test class */
+public class DepOnNoIde {
+  public final NoIdeLib noIdeLib = new NoIdeLib("test");
+  public final Lib1 lib1 = Lib1.createTest();
+
+  public void method() {
+    System.out.println(noIdeLib.getClass());
+    System.out.println(lib1.getClass());
+  }
+}


### PR DESCRIPTION
Cherry pick AOSP commit [9e3e119028b077018793189e2fb52fc91732c31f](https://cs.android.com/android-studio/platform/tools/adt/idea/+/9e3e119028b077018793189e2fb52fc91732c31f).

STAT (diff to AOSP): 0 insertions(+), 0 deletion(-)

even if other targets depend on them. `no-ide` targets are marked as
such for a purpose. Usually their output is available by other means.

Do not even output warnings as it produces enough noise by not usable.

Bug: 391112715
Test: SyncedInBazelProjectTest.javaAndDeps
Change-Id: I3b4265cd9a400c1a16d7ba18f141122fb77e29d3

AOSP: 9e3e119028b077018793189e2fb52fc91732c31f
