### PR TITLE
[AOSP-pick] Provide a helper function to check IDE version mismatch

### DIFF
--- a/base/BUILD
+++ b/base/BUILD
@@ -464,6 +464,17 @@ java_library(
 )
 
 java_library(
+    name = "version_checker",
+    srcs = [
+        "src/com/google/idea/blaze/base/util/VersionChecker.java",
+    ],
+    visibility = G3PLUGINS_VISIBILITY,
+    deps = [
+        "//intellij_platform_sdk:plugin_api",
+    ],
+)
+
+java_library(
     name = "unit_test_utils",
     testonly = 1,
     srcs = glob(["tests/utils/unit/**/*.java"]),

--- a/base/src/com/google/idea/blaze/base/util/VersionChecker.java
+++ b/base/src/com/google/idea/blaze/base/util/VersionChecker.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.util;
+
+import com.intellij.openapi.application.ApplicationInfo;
+import com.intellij.openapi.application.PathManager;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.util.BuildNumber;
+import com.intellij.openapi.util.SystemInfo;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+
+/**
+ * Help class provides function to check if IDE version meet requirements.
+ */
+public class VersionChecker {
+  private static final Logger logger = Logger.getInstance(VersionChecker.class);
+
+  /**
+   * Returns true if the version of IDE is not the same as product-info. If mismatch is found, a background upgrade may happen when IDE is running. In that case, user need to restart IDE to run with latest lib.
+   */
+  public static boolean versionMismatch() {
+    BuildNumber buildNumberFromProductInfo =
+      BuildNumber.fromString(readBuildNumberFromProductInfo());
+    BuildNumber buildNumberFromApplicationInfo = ApplicationInfo.getInstance().getBuild();
+
+    return !buildNumberFromProductInfo.equals(buildNumberFromApplicationInfo);
+  }
+
+  static String readBuildNumberFromProductInfo() {
+    Path location = Paths.get(PathManager.getHomePath());
+    // Version mismatch is unexpected on macOS (due to different installation process), but this
+    // check is included as a precaution.
+    if (SystemInfo.isMac) {
+      location = location.resolve("Resources");
+    }
+
+    Path info = location.resolve("product-info.json");
+    if (Files.exists(info)) {
+      try {
+        String json = Files.readString(info);
+        JsonObject jsonObject = new Gson().fromJson(json, JsonObject.class);
+        return jsonObject.get("productCode").getAsString()
+               + "-"
+               + jsonObject.get("buildNumber").getAsString();
+      }
+      catch (IOException e) {
+        logger.error("Error parsing product-info.json", e);
+      }
+    }
+    return "";
+  }
+}

--- a/base/tests/unittests/com/google/idea/blaze/base/util/VersionCheckerTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/util/VersionCheckerTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2025 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.util;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.TruthJUnit.assume;
+
+import com.google.idea.testing.IntellijRule;
+import com.intellij.openapi.util.SystemInfo;
+import java.time.ZonedDateTime;
+import java.util.Calendar;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.junit.Rule;
+import com.intellij.openapi.application.ApplicationInfo;
+import org.jetbrains.annotations.NotNull;
+import com.intellij.openapi.util.NlsSafe;
+import com.intellij.openapi.util.BuildNumber;
+import com.intellij.openapi.extensions.PluginId;
+import org.jetbrains.annotations.Nullable;
+
+@RunWith(JUnit4.class)
+public class VersionCheckerTest {
+  @Rule public IntellijRule intellij = new IntellijRule();
+
+  @Before
+  public void setup() {
+    // we are testing with a linux sdk, therefore these tests do not work on mac
+    assume().that(SystemInfo.isMac).isFalse();
+  }
+
+  @Test
+  public void testCheckIfNeedToNotify_versionMatched() {
+    String expectedVersion = VersionChecker.readBuildNumberFromProductInfo();
+    TestApplicationInfo testApplicationInfo = new TestApplicationInfo(BuildNumber.fromString(expectedVersion));
+    intellij.registerApplicationService(ApplicationInfo.class, testApplicationInfo);
+    assertThat(VersionChecker.versionMismatch()).isFalse();
+  }
+
+  @Test
+  public void testCheckIfNeedToNotify_versionNotMatched() {
+    TestApplicationInfo testApplicationInfo = new TestApplicationInfo(BuildNumber.fromString("AI-1.2.3.4.12345"));
+    intellij.registerApplicationService(ApplicationInfo.class, testApplicationInfo);
+    assertThat(VersionChecker.versionMismatch()).isTrue();
+  }
+
+  private static class TestApplicationInfo extends ApplicationInfo {
+    private final BuildNumber buildNumber;
+
+    TestApplicationInfo(BuildNumber buildNumber) {
+      this.buildNumber = buildNumber;
+    }
+
+    @Override
+    public Calendar getBuildDate() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public @NotNull ZonedDateTime getBuildTime() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public @NotNull BuildNumber getBuild() {
+      return buildNumber;
+    }
+
+    @Override
+    public @NotNull String getApiVersion() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getMajorVersion() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getMinorVersion() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getMicroVersion() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getPatchVersion() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public @NlsSafe String getVersionName() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public @NlsSafe String getCompanyName() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public @NlsSafe String getShortCompanyName() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getCompanyURL() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public @Nullable String getProductUrl() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public @Nullable String getJetBrainsTvUrl() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean hasHelp() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean hasContextHelp() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public @NlsSafe @NotNull String getFullVersion() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public @NlsSafe @NotNull String getStrictVersion() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getFullApplicationName() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isEssentialPlugin(@NotNull String pluginId) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isEssentialPlugin(@NotNull PluginId pluginId) {
+      throw new UnsupportedOperationException();
+    }
+  }
+}


### PR DESCRIPTION
Cherry pick AOSP commit [66cf6b4272639534964cd7cfd2056257c2fd8def](https://cs.android.com/android-studio/platform/tools/adt/idea/+/66cf6b4272639534964cd7cfd2056257c2fd8def).

STAT (diff to AOSP): 0 insertions(+), 0 deletion(-)

It's used to detect if IDE get upgrade without a restart.Move it from g3plugin/ to a more common place for future usage.

Bug: b/391401923
Test: existing tests
Change-Id: Ic8ac58ca3df1aa7f00eb52a309ddb7e73a8e4191

AOSP: 66cf6b4272639534964cd7cfd2056257c2fd8def
