### PR TITLE
[AOSP-pick] Clean up usages of @com_google_protobuf//:protobuf_java

### DIFF
--- a/querysync/javatests/com/google/idea/blaze/qsync/deps/BUILD
+++ b/querysync/javatests/com/google/idea/blaze/qsync/deps/BUILD
@@ -55,7 +55,7 @@ java_test(
         "//shared",
         "//third_party/java/junit",
         "//third_party/java/truth",
-        "@protobuf//:protobuf_java",
         "@com_google_guava_guava//jar",
+        "@protobuf//:protobuf_java",
     ],
 )

--- a/querysync/javatests/com/google/idea/blaze/qsync/testdata/BUILD
+++ b/querysync/javatests/com/google/idea/blaze/qsync/testdata/BUILD
@@ -246,7 +246,7 @@ java_library(
     deps = [
         "//querysync/java/com/google/idea/blaze/qsync/java:java_target_info_java_proto",
         "@bazel_tools//tools/java/runfiles",
-        "@protobuf//:protobuf_java",
         "@com_google_guava_guava//jar",
+        "@protobuf//:protobuf_java",
     ],
 )


### PR DESCRIPTION
Cherry pick AOSP commit [1f25b080153fa75504b01f8bfa9f19389f705590](https://cs.android.com/android-studio/platform/tools/adt/idea/+/1f25b080153fa75504b01f8bfa9f19389f705590).

STAT (diff to AOSP): 0 insertions(+), 0 deletion(-)

This version of protobuf should only be used for the native implementation
and for common proto definitions.

Test: existing
Bug: none
Change-Id: Id94e6a5b74ef52d5c389e448506e13b2e1bdb002

AOSP: 1f25b080153fa75504b01f8bfa9f19389f705590
