### PR TITLE
[AOSP-pick] Consolidate containingFile in light class base

### DIFF
--- a/aswb/src/com/google/idea/blaze/android/resources/BlazeRClass.java
+++ b/aswb/src/com/google/idea/blaze/android/resources/BlazeRClass.java
@@ -70,7 +70,7 @@ public class BlazeRClass extends ResourceRepositoryRClass {
         });
     this.androidFacet = androidFacet;
     setModuleInfo(getModule(), false);
-    VirtualFile virtualFile = myFile.getViewProvider().getVirtualFile();
+    VirtualFile virtualFile = getContainingFile().getViewProvider().getVirtualFile();
     virtualFile.putUserData(
         MODULE_POINTER_KEY, ModulePointerManager.getInstance(getProject()).create(getModule()));
     virtualFile.putUserData(LIGHT_CLASS_KEY, ResourceRepositoryRClass.class);


### PR DESCRIPTION
Cherry pick AOSP commit [0f4a002ba09dac1484490a98dd04dcea7776d0df](https://cs.android.com/android-studio/platform/tools/adt/idea/+/0f4a002ba09dac1484490a98dd04dcea7776d0df).

STAT (diff to AOSP): 0 insertions(+), 0 deletion(-)

All AndroidLightClassBase implementations need to specify a containing
file, and they all do it in mostly-similar-but-not-quite-identical ways.
This change consolidates the logic in the super class, requiring the
data to be passed in the constructor.

Nothing should change with this commit; existing behavior for the
containing classes has been maintained. (In upcoming changes, I'll try
to reduce some of the differences; eg, making sure all in-memory Java
files have a package name set.)

Bug: n/a
Test: Covered by existing
Change-Id: I56c94050c370e10e0ee49e0e805bdc9eaa2b7137

AOSP: 0f4a002ba09dac1484490a98dd04dcea7776d0df
