### PR TITLE
[AOSP-pick] Set moduleInfo on light class construction

### DIFF
--- a/aswb/src/com/google/idea/blaze/android/resources/BlazeRClass.java
+++ b/aswb/src/com/google/idea/blaze/android/resources/BlazeRClass.java
@@ -67,9 +67,9 @@ public class BlazeRClass extends ResourceRepositoryRClass {
           public AndroidLightField.FieldModifier getFieldModifier() {
             return AndroidLightField.FieldModifier.NON_FINAL;
           }
-        });
+        },
+        AndroidLightClassModuleInfo.from(androidFacet.getModule()));
     this.androidFacet = androidFacet;
-    setModuleInfo(getModule(), false);
     VirtualFile virtualFile = getContainingFile().getViewProvider().getVirtualFile();
     virtualFile.putUserData(
         MODULE_POINTER_KEY, ModulePointerManager.getInstance(getProject()).create(getModule()));


### PR DESCRIPTION
Cherry pick AOSP commit [5e907fbd0f6a77a1f8afcc8bcf399bb9e3e78a0a](https://cs.android.com/android-studio/platform/tools/adt/idea/+/5e907fbd0f6a77a1f8afcc8bcf399bb9e3e78a0a).

The existing pattern is that derived classes are supposed to call
`setModuleInfo` during their initialization. Most do, but some have
missed it, and this results in the Kotlin plugin not being able to
appropriately identify the classes.

I'm changing the code pattern to require `ModuleInfo` to be passed in
via the constructor. The parameter is currently nullable in the super AndroidLightClassBase for the cases that don't have module information yet, so this change shouldn't affect any behavior. I'll follow up with another change to actually set the module information.

Bug: n/a
Test: covered by existing
Change-Id: I2358ac1cd475880d76310df6b56fe04d64173017

AOSP: 5e907fbd0f6a77a1f8afcc8bcf399bb9e3e78a0a
