### PR TITLE
[AOSP-pick] Inform user when we have zero build steps.

### DIFF
--- a/aswb/src/com/android/tools/idea/run/tasks/DeployTasksHelper.java
+++ b/aswb/src/com/android/tools/idea/run/tasks/DeployTasksHelper.java
@@ -40,7 +40,8 @@ public class DeployTasksHelper {
                     deployOptions.getPmInstallFlags(),
                     deployOptions.getInstallOnAllUsers(),
                     deployOptions.getAlwaysInstallWithPm(),
-                    deployOptions.getAllowAssumeVerified())
+                    deployOptions.getAllowAssumeVerified(),
+                    true /* TODO: Assume blaze always build for now.  */)
                 .run(launchContext.getDevice(), launchContext.getProgressIndicator());
       } catch (DeployerException e) {
         throw new AndroidExecutionException(e.getId(), e.getMessage());

--- a/aswb/src/com/google/idea/blaze/android/run/runner/MobileInstallApplicationDeployer.java
+++ b/aswb/src/com/google/idea/blaze/android/run/runner/MobileInstallApplicationDeployer.java
@@ -38,6 +38,7 @@ public class MobileInstallApplicationDeployer implements ApplicationDeployer {
       @NotNull IDevice device,
       @NotNull ApkInfo apkInfo,
       @NotNull DeployOptions deployOptions,
+      boolean hasMakeBeforeRun,
       ProgressIndicator indicator) {
     App app = getAppToInstall(apkInfo);
     return new Deployer.Result(false, false, false, app);
@@ -49,6 +50,7 @@ public class MobileInstallApplicationDeployer implements ApplicationDeployer {
       @NotNull IDevice device,
       @NotNull ApkInfo app,
       @NotNull DeployOptions deployOptions,
+      boolean hasMakeBeforeRun,
       ProgressIndicator indicator) {
     throw new RuntimeException("Apply changes is not supported for mobile-install");
   }
@@ -59,6 +61,7 @@ public class MobileInstallApplicationDeployer implements ApplicationDeployer {
       @NotNull IDevice device,
       @NotNull ApkInfo app,
       @NotNull DeployOptions deployOptions,
+      boolean hasMakeBeforeRun,
       ProgressIndicator indicator)
       throws DeployerException {
     throw new RuntimeException("Apply code changes is not supported for mobile-install");


### PR DESCRIPTION
Cherry pick AOSP commit [a53665122127a37f0cb63ee788d9df8cdf9f8890](https://cs.android.com/android-studio/platform/tools/adt/idea/+/a53665122127a37f0cb63ee788d9df8cdf9f8890).

Bug: 391682554
Test: Manually on invalid Runconfigs.
Change-Id: I656bf29f5e8c0dc312a4db4e7e1ebb6ca82fcc30

AOSP: a53665122127a37f0cb63ee788d9df8cdf9f8890
