### PR TITLE
[AOSP-pick] Build workflows cleanup in tools/adt/idea (Part 1)

### DIFF
--- a/base/BUILD
+++ b/base/BUILD
@@ -339,6 +339,8 @@ java_library(
     ],
     deps = [
         ":base",
+        "//base/src/com/google/idea/blaze/base/command/buildresult/bepparser",
+        "//shared/java/com/google/idea/blaze/exception",
         "//third_party/java/auto_value",
         "//intellij_platform_sdk:plugin_api",
         "//intellij_platform_sdk:jsr305",

--- a/base/src/com/google/idea/blaze/base/bazel/AbstractBuildInvoker.java
+++ b/base/src/com/google/idea/blaze/base/bazel/AbstractBuildInvoker.java
@@ -21,12 +21,14 @@ import com.google.errorprone.annotations.MustBeClosed;
 import com.google.idea.blaze.base.async.FutureUtil;
 import com.google.idea.blaze.base.async.FutureUtil.FutureResult;
 import com.google.idea.blaze.base.bazel.BuildSystem.BuildInvoker;
+import com.google.idea.blaze.base.command.BlazeCommand;
 import com.google.idea.blaze.base.command.BlazeCommandName;
 import com.google.idea.blaze.base.command.BlazeCommandRunner;
 import com.google.idea.blaze.base.command.BlazeFlags;
 import com.google.idea.blaze.base.command.BlazeInvocationContext;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelperBep;
+import com.google.idea.blaze.base.command.buildresult.bepparser.BuildEventStreamProvider;
 import com.google.idea.blaze.base.command.info.BlazeInfo;
 import com.google.idea.blaze.base.command.info.BlazeInfoProvider;
 import com.google.idea.blaze.base.command.info.BlazeInfoRunner;
@@ -36,7 +38,9 @@ import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.scope.scopes.TimingScope.EventType;
 import com.google.idea.blaze.base.settings.BuildBinaryType;
 import com.google.idea.blaze.base.sync.SyncScope.SyncFailedException;
+import com.google.idea.blaze.exception.BuildException;
 import com.intellij.openapi.project.Project;
+import java.io.InputStream;
 import java.util.List;
 import javax.annotation.Nullable;
 
@@ -106,6 +110,34 @@ public abstract class AbstractBuildInvoker implements BuildInvoker {
   @Override
   public BuildSystem getBuildSystem() {
     return buildSystem;
+  }
+
+  @Override
+  public BuildEventStreamProvider invoke(BlazeCommand.Builder blazeCommandBuilder)
+    throws BuildException {
+    throw new UnsupportedOperationException(
+      String.format("The %s does not support invoke method", this.getClass().getSimpleName()));
+  }
+
+  @Override
+  public InputStream invokeQuery(BlazeCommand.Builder blazeCommandBuilder) {
+    throw new UnsupportedOperationException(
+      String.format(
+        "The %s does not support invokeQuery method", this.getClass().getSimpleName()));
+  }
+
+  @Override
+  public InputStream invokeInfo(BlazeCommand.Builder blazeCommandBuilder) {
+    throw new UnsupportedOperationException(
+      String.format(
+        "The %s does not support invokeInfo method", this.getClass().getSimpleName()));
+  }
+
+  @Override
+  public List<String> getBuildFlags() {
+    throw new UnsupportedOperationException(
+      String.format(
+        "The %s does not support getBuildFlags method", this.getClass().getSimpleName()));
   }
 
   @Override

--- a/base/src/com/google/idea/blaze/base/bazel/AbstractBuildInvoker1.java
+++ b/base/src/com/google/idea/blaze/base/bazel/AbstractBuildInvoker1.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2025 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.bazel;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.idea.blaze.base.async.FutureUtil;
+import com.google.idea.blaze.base.async.executor.BlazeExecutor;
+import com.google.idea.blaze.base.bazel.BuildSystem.BuildInvoker;
+import com.google.idea.blaze.base.command.BlazeCommand;
+import com.google.idea.blaze.base.command.BlazeCommandName;
+import com.google.idea.blaze.base.command.BlazeCommandRunner;
+import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
+import com.google.idea.blaze.base.command.info.BlazeInfo;
+import com.google.idea.blaze.base.scope.BlazeContext;
+import com.google.idea.blaze.base.scope.scopes.TimingScope;
+import com.google.idea.blaze.base.settings.BuildSystemName;
+import com.google.idea.blaze.base.sync.SyncScope.SyncFailedException;
+import com.intellij.openapi.project.Project;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import javax.annotation.Nullable;
+
+/**
+ * Base class for implementations of {@link BuildInvoker} that provides getters and deals with
+ * running `blaze info`.
+ */
+// TODO(b/374906681): Replace @link{AbstractBuildInvoker} and its usages by this class
+public abstract class AbstractBuildInvoker1 implements BuildInvoker {
+  protected final Project project;
+  protected final BlazeContext blazeContext;
+  private final String binaryPath;
+  private BlazeInfo blazeInfo;
+
+  public AbstractBuildInvoker1(Project project, BlazeContext blazeContext, String binaryPath) {
+    this.project = project;
+    this.blazeContext = blazeContext;
+    this.binaryPath = binaryPath;
+  }
+
+  @Override
+  public String getBinaryPath() {
+    return this.binaryPath;
+  }
+
+  @Override
+  @Nullable
+  public synchronized BlazeInfo getBlazeInfo() throws SyncFailedException {
+    if (blazeInfo == null) {
+      blazeInfo = getBlazeInfoResult();
+    }
+    return blazeInfo;
+  }
+
+  private BlazeInfo getBlazeInfoResult() throws SyncFailedException {
+    ListenableFuture<BlazeInfo> blazeInfoFuture;
+    FutureUtil.FutureResult<BlazeInfo> result;
+    blazeInfoFuture = Futures.transform(BlazeExecutor.getInstance().submit(() -> {
+                                          try (InputStream stream = invokeInfo(BlazeCommand.builder(this, BlazeCommandName.INFO, project))) {
+                                            return stream.readAllBytes();
+                                          }
+                                        }), bytes -> BlazeInfo.create(BuildSystemName.Blaze, parseBlazeInfoResult(new String(bytes, StandardCharsets.UTF_8).trim())),
+                                        BlazeExecutor.getInstance().getExecutor());
+
+    result =
+      FutureUtil.waitForFuture(blazeContext, blazeInfoFuture).timed(BuildSystemName.Blaze + "Info", TimingScope.EventType.BlazeInvocation)
+        .withProgressMessage(String.format("Running %s info...", BuildSystemName.Blaze))
+        .onError(String.format("Could not run %s info", BuildSystemName.Blaze)).run();
+
+    if (result.success()) {
+      return result.result();
+    }
+    //TODO (b/374906681) Replace with BuildException once legacy sync is deprecated
+    throw new SyncFailedException(String.format("Failed to run `%s info`", getBinaryPath()), result.exception());
+  }
+
+  @Override
+  public BuildResultHelper createBuildResultHelper() {
+    throw new UnsupportedOperationException("This method should not be called, this invoker does not support build result helpers.");
+  }
+
+  @Override
+  public BlazeCommandRunner getCommandRunner() {
+    throw new UnsupportedOperationException("This method should not be called, this invoker does not support command runners.");
+  }
+
+  @Override
+  public boolean supportsHomeBlazerc() {
+    throw new UnsupportedOperationException("This method should not be called, this invoker does not support this method.");
+  }
+
+  @Override
+  public BuildSystem getBuildSystem() {
+    throw new UnsupportedOperationException("This method should not be called, this invoker does not support this method.");
+  }
+
+  @Override
+  public boolean supportsParallelism() {
+    throw new UnsupportedOperationException("This method should not be called, this invoker does not support this method.");
+  }
+
+  private static ImmutableMap<String, String> parseBlazeInfoResult(String blazeInfoString) {
+    ImmutableMap.Builder<String, String> blazeInfoMapBuilder = ImmutableMap.builder();
+    String[] blazeInfoLines = blazeInfoString.split("\n");
+    for (String blazeInfoLine : blazeInfoLines) {
+      // Just split on the first ":".
+      String[] keyValue = blazeInfoLine.split(":", 2);
+      if (keyValue.length != 2) {
+        // ignore any extraneous stdout
+        continue;
+      }
+      String key = keyValue[0].trim();
+      String value = keyValue[1].trim();
+      blazeInfoMapBuilder.put(key, value);
+    }
+    return blazeInfoMapBuilder.build();
+  }
+}

--- a/base/src/com/google/idea/blaze/base/bazel/BazelBuildSystem.java
+++ b/base/src/com/google/idea/blaze/base/bazel/BazelBuildSystem.java
@@ -36,6 +36,7 @@ import com.google.idea.blaze.base.settings.BuildSystemName;
 import com.intellij.openapi.project.Project;
 import java.io.File;
 import java.util.Optional;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 class BazelBuildSystem implements BuildSystem {
@@ -43,14 +44,7 @@ class BazelBuildSystem implements BuildSystem {
   class BazelInvoker extends AbstractBuildInvoker {
 
     public BazelInvoker(Project project, BlazeContext blazeContext, String path) {
-      super(
-          project,
-          blazeContext,
-          BuildBinaryType.BAZEL,
-          path,
-          false,
-          BazelBuildSystem.this,
-          new CommandLineBlazeCommandRunner());
+      super(project, blazeContext, BuildBinaryType.BAZEL, path, false, BazelBuildSystem.this, new CommandLineBlazeCommandRunner());
     }
 
     @Override
@@ -66,14 +60,17 @@ class BazelBuildSystem implements BuildSystem {
   }
 
   @Override
-  public BuildInvoker getBuildInvoker(
-      Project project, BlazeContext context, ExecutorType executorType, Kind targetKind) {
+  public BuildInvoker getBuildInvoker(Project project, BlazeContext context, Set<BuildInvoker.Capability> requirements) {
     return getBuildInvoker(project, context);
   }
 
   @Override
-  public BuildInvoker getBuildInvoker(
-      Project project, BlazeContext context, BlazeCommandName command) {
+  public BuildInvoker getBuildInvoker(Project project, BlazeContext context, ExecutorType executorType, Kind targetKind) {
+    return getBuildInvoker(project, context);
+  }
+
+  @Override
+  public BuildInvoker getBuildInvoker(Project project, BlazeContext context, BlazeCommandName command) {
     return getBuildInvoker(project, context);
   }
 
@@ -83,7 +80,8 @@ class BazelBuildSystem implements BuildSystem {
     File projectSpecificBinary = getProjectSpecificBazelBinary(project);
     if (projectSpecificBinary != null) {
       binaryPath = projectSpecificBinary.getPath();
-    } else {
+    }
+    else {
       BlazeUserSettings settings = BlazeUserSettings.getInstance();
       binaryPath = settings.getBazelBinaryPath();
     }
@@ -110,8 +108,7 @@ class BazelBuildSystem implements BuildSystem {
   }
 
   @Override
-  public void populateBlazeVersionData(
-      WorkspaceRoot workspaceRoot, BlazeInfo blazeInfo, BlazeVersionData.Builder builder) {
+  public void populateBlazeVersionData(WorkspaceRoot workspaceRoot, BlazeInfo blazeInfo, BlazeVersionData.Builder builder) {
     builder.setBazelVersion(BazelVersion.parseVersion(blazeInfo));
   }
 

--- a/base/src/com/google/idea/blaze/base/bazel/BazelExitCodeException.java
+++ b/base/src/com/google/idea/blaze/base/bazel/BazelExitCodeException.java
@@ -36,36 +36,31 @@ import com.google.idea.blaze.exception.BuildException;
  */
 public class BazelExitCodeException extends BuildException {
 
-  /** Options that may be passed to {@link #throwIfFailed} to modify its behavior. */
+  /**
+   * Options that may be passed to {@link #throwIfFailed} to modify its behavior.
+   */
   public enum ThrowOption {
-    ALLOW_PARTIAL_SUCCESS,
-    ALLOW_BUILD_FAILURE,
+    ALLOW_PARTIAL_SUCCESS, ALLOW_BUILD_FAILURE,
   }
 
   private final int exitCode;
 
-  public static void throwIfFailed(
-      BlazeCommand.Builder command, BuildResult result, ThrowOption... options)
-      throws BazelExitCodeException {
+  public static void throwIfFailed(BlazeCommand.Builder command, BuildResult result, ThrowOption... options) throws BazelExitCodeException {
     if (result.status == Status.SUCCESS) {
       return;
     }
-    throwIfFailed(command, result.exitCode, options);
+    throwIfFailed(command.build(), result.exitCode, options);
   }
 
-  public static void throwIfFailed(
-      BlazeCommand.Builder command, int exitCode, ThrowOption... options)
-      throws BazelExitCodeException {
-    throwIfFailed("Command: " + command.build(), exitCode, options);
+  public static void throwIfFailed(BlazeCommand command, int exitCode, ThrowOption... options) throws BazelExitCodeException {
+    throwIfFailed("Command: " + command, exitCode, options);
   }
 
-  public static void throwIfFailed(String message, int exitCode, ThrowOption... options)
-      throws BazelExitCodeException {
+  public static void throwIfFailed(String message, int exitCode, ThrowOption... options) throws BazelExitCodeException {
     if (allowExitCode(exitCode, options)) {
       return;
     }
-    throw new BazelExitCodeException(
-        String.format("Build command failed with %d.\n%s", exitCode, message), exitCode);
+    throw new BazelExitCodeException(String.format("Build command failed with %d.\n%s", exitCode, message), exitCode);
   }
 
   private static boolean allowExitCode(int exitCode, ThrowOption... options) {

--- a/base/src/com/google/idea/blaze/base/bazel/BuildSystem.java
+++ b/base/src/com/google/idea/blaze/base/bazel/BuildSystem.java
@@ -15,10 +15,13 @@
  */
 package com.google.idea.blaze.base.bazel;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.MustBeClosed;
+import com.google.idea.blaze.base.command.BlazeCommand;
 import com.google.idea.blaze.base.command.BlazeCommandName;
 import com.google.idea.blaze.base.command.BlazeCommandRunner;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
+import com.google.idea.blaze.base.command.buildresult.bepparser.BuildEventStreamProvider;
 import com.google.idea.blaze.base.command.info.BlazeInfo;
 import com.google.idea.blaze.base.model.BlazeVersionData;
 import com.google.idea.blaze.base.model.primitives.Kind;
@@ -31,8 +34,14 @@ import com.google.idea.blaze.base.settings.BlazeImportSettings.ProjectType;
 import com.google.idea.blaze.base.settings.BuildBinaryType;
 import com.google.idea.blaze.base.settings.BuildSystemName;
 import com.google.idea.blaze.base.sync.SyncScope.SyncFailedException;
+import com.google.idea.blaze.base.sync.aspects.BlazeBuildOutputs;
+import com.google.idea.blaze.exception.BuildException;
 import com.intellij.openapi.project.Project;
+import java.io.File;
+import java.io.InputStream;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Encapsulates interactions with a Bazel based build system.
@@ -42,20 +51,74 @@ import java.util.Optional;
  */
 public interface BuildSystem {
 
-  /** Strategy to use for builds that are part of a project sync. */
+  /**
+   * Strategy to use for builds that are part of a project sync.
+   */
   enum SyncStrategy {
-    /** Never parallelize sync builds. */
+    /**
+     * Never parallelize sync builds.
+     */
     SERIAL,
-    /** Parallelize sync builds if it's deemed likely that doing so will be faster. */
+    /**
+     * Parallelize sync builds if it's deemed likely that doing so will be faster.
+     */
     DECIDE_AUTOMATICALLY,
-    /** Always parallelize sync builds. */
+    /**
+     * Always parallelize sync builds.
+     */
     PARALLEL,
   }
 
-  /** Encapsulates a means of executing build commands, often as a Bazel compatible binary. */
+  /**
+   * Encapsulates a means of executing build commands, often as a Bazel compatible binary.
+   */
   interface BuildInvoker {
 
-    /** Returns the type of this build interface. Used for logging purposes. */
+    enum Capability {
+      IS_LOCAL, SUPPORTS_CLI, SUPPORTS_PARALLELISM, SUPPORTS_API, SUPPORTS_DBIP
+    }
+
+    default ImmutableSet<Capability> getCapabilities() {
+      throw new UnsupportedOperationException("This invoker does not support capabilities.");
+    }
+
+    /**
+     * Returns the BEP output file if accessible.
+     */
+    default File bepOutputFile() {
+      throw new UnsupportedOperationException(
+        String.format("The %s does not support accessing the bep output file", this.getClass().getSimpleName()));
+    }
+
+    /**
+     * Runs a blaze command, parses the build results into a {@link BlazeBuildOutputs} object.
+     */
+    BuildEventStreamProvider invoke(BlazeCommand.Builder blazeCommandBuilder) throws BuildException;
+
+    /**
+     * Runs a blaze query command.
+     *
+     * @return {@link InputStream} from the stdout of the blaze invocation and null if the query fails
+     */
+    @MustBeClosed
+    InputStream invokeQuery(BlazeCommand.Builder blazeCommandBuilder) throws BuildException;
+
+    /**
+     * Runs a blaze info command.
+     *
+     * @return {@link InputStream} from the stdout of the blaze invocation and null if blaze info fails
+     */
+    @MustBeClosed
+    InputStream invokeInfo(BlazeCommand.Builder blazeCommandBuilder) throws BuildException;
+
+    /**
+     * @return a list of build flags
+     */
+    List<String> getBuildFlags();
+
+    /**
+     * Returns the type of this build interface. Used for logging purposes.
+     */
     BuildBinaryType getType();
 
     /**
@@ -66,7 +129,9 @@ public interface BuildSystem {
      */
     String getBinaryPath();
 
-    /** Indicates if multiple invocations can be made at once. */
+    /**
+     * Indicates if multiple invocations can be made at once.
+     */
     boolean supportsParallelism();
 
     BlazeInfo getBlazeInfo() throws SyncFailedException;
@@ -78,41 +143,60 @@ public interface BuildSystem {
     @MustBeClosed
     BuildResultHelper createBuildResultHelper();
 
-    /** Returns a {@link BlazeCommandRunner} to be used to invoke the build. */
+    /**
+     * Returns a {@link BlazeCommandRunner} to be used to invoke the build.
+     */
     BlazeCommandRunner getCommandRunner();
 
-    /** Indicates whether the invoker supports user .blazerc from home directories. */
+    /**
+     * Indicates whether the invoker supports user .blazerc from home directories.
+     */
     default boolean supportsHomeBlazerc() {
       return true;
     }
 
-    /** Returns the BuildSystem object. */
+    /**
+     * Returns the BuildSystem object.
+     */
     BuildSystem getBuildSystem();
   }
 
-  /** Returns the type of the build system. */
+  /**
+   * Returns the type of the build system.
+   */
   BuildSystemName getName();
 
-  /** Get a Blaze invoker. */
+  /**
+   * Get a Blaze invoker with desired capabilities.
+   */
+  BuildInvoker getBuildInvoker(Project project, BlazeContext context, Set<BuildInvoker.Capability> requirements);
+
+  /**
+   * Get a Blaze invoker.
+   */
   BuildInvoker getBuildInvoker(Project project, BlazeContext context);
 
-  /** Get a Blaze invoker specific to executor type and run config. */
+  /**
+   * Get a Blaze invoker specific to executor type and run config.
+   */
   default BuildInvoker getBuildInvoker(
-      Project project, BlazeContext context, ExecutorType executorType, Kind targetKind) {
+    Project project, BlazeContext context, ExecutorType executorType, Kind targetKind) {
     throw new UnsupportedOperationException(
-        String.format(
-            "The getBuildInvoker method specific to executor type and target kind is not"
-                + " implemented in %s",
-            this.getClass().getSimpleName()));
+      String.format(
+        "The getBuildInvoker method specific to executor type and target kind is not"
+        + " implemented in %s",
+        this.getClass().getSimpleName()));
   }
 
-  /** Get a Blaze invoker specific to the blaze command. */
+  /**
+   * Get a Blaze invoker specific to the blaze command.
+   */
   default BuildInvoker getBuildInvoker(
-      Project project, BlazeContext context, BlazeCommandName command) {
+    Project project, BlazeContext context, BlazeCommandName command) {
     throw new UnsupportedOperationException(
-        String.format(
-            "The getBuildInvoker method specific to a blaze command is not implemented in %s",
-            this.getClass().getSimpleName()));
+      String.format(
+        "The getBuildInvoker method specific to a blaze command is not implemented in %s",
+        this.getClass().getSimpleName()));
   }
 
   /**
@@ -122,14 +206,20 @@ public interface BuildSystem {
    */
   Optional<BuildInvoker> getParallelBuildInvoker(Project project, BlazeContext context);
 
-  /** Return the strategy for remote syncs to be used with this build system. */
+  /**
+   * Return the strategy for remote syncs to be used with this build system.
+   */
   SyncStrategy getSyncStrategy(Project project);
 
-  /** Populates the passed builder with version data. */
+  /**
+   * Populates the passed builder with version data.
+   */
   void populateBlazeVersionData(
-      WorkspaceRoot workspaceRoot, BlazeInfo blazeInfo, BlazeVersionData.Builder builder);
+    WorkspaceRoot workspaceRoot, BlazeInfo blazeInfo, BlazeVersionData.Builder builder);
 
-  /** Get bazel only version. Returns empty if it's not bazel project. */
+  /**
+   * Get bazel only version. Returns empty if it's not bazel project.
+   */
   Optional<String> getBazelVersionString(BlazeInfo blazeInfo);
 
   /**
@@ -140,12 +230,15 @@ public interface BuildSystem {
     if (Blaze.getProjectType(project) != ProjectType.QUERY_SYNC
         && getSyncStrategy(project) == SyncStrategy.PARALLEL) {
       return getParallelBuildInvoker(project, context).orElse(getBuildInvoker(project, context));
-    } else {
+    }
+    else {
       return getBuildInvoker(project, context);
     }
   }
 
-  /** Returns invocation link for the given invocation ID. */
+  /**
+   * Returns invocation link for the given invocation ID.
+   */
   default Optional<String> getInvocationLink(String invocationId) {
     return Optional.empty();
   }

--- a/base/src/com/google/idea/blaze/base/command/CommandLineBlazeCommandRunner.java
+++ b/base/src/com/google/idea/blaze/base/command/CommandLineBlazeCommandRunner.java
@@ -221,7 +221,7 @@ public class CommandLineBlazeCommandRunner implements BlazeCommandRunner {
               .run();
       SyncQueryStatsScope.fromContext(context).ifPresent(stats -> stats.setBazelExitCode(retVal));
       BazelExitCodeException.throwIfFailed(
-          blazeCommandBuilder, retVal, ThrowOption.ALLOW_PARTIAL_SUCCESS);
+          blazeCommandBuilder.build(), retVal, ThrowOption.ALLOW_PARTIAL_SUCCESS);
       return new BufferedInputStream(
           Files.newInputStream(tempFile, StandardOpenOption.DELETE_ON_CLOSE));
     } catch (IOException e) {
@@ -256,7 +256,7 @@ public class CommandLineBlazeCommandRunner implements BlazeCommandRunner {
               .ignoreExitCode(true)
               .build()
               .run();
-      BazelExitCodeException.throwIfFailed(blazeCommandBuilder, exitCode);
+      BazelExitCodeException.throwIfFailed(blazeCommandBuilder.build(), exitCode);
       return new BufferedInputStream(
           Files.newInputStream(tmpFile, StandardOpenOption.DELETE_ON_CLOSE));
     } catch (IOException e) {
@@ -286,16 +286,17 @@ public class CommandLineBlazeCommandRunner implements BlazeCommandRunner {
       OutputStream stderr = closer.register(
           LineProcessingOutputStream.of(
               new PrintOutputLineProcessor(context)));
+      BlazeCommand command = blazeCommandBuilder.build();
       int exitCode =
           ExternalTask.builder(WorkspaceRoot.fromProject(project))
-              .addBlazeCommand(blazeCommandBuilder.build())
+              .addBlazeCommand(command)
               .context(context)
               .stdout(stdout)
               .stderr(stderr)
               .ignoreExitCode(true)
               .build()
               .run();
-      BazelExitCodeException.throwIfFailed(blazeCommandBuilder, exitCode);
+      BazelExitCodeException.throwIfFailed(command, exitCode);
       return new BufferedInputStream(
           Files.newInputStream(tmpFile, StandardOpenOption.DELETE_ON_CLOSE));
     } catch (IOException e) {

--- a/base/tests/utils/unit/com/google/idea/blaze/base/bazel/FakeBuildInvoker.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/bazel/FakeBuildInvoker.java
@@ -16,27 +16,38 @@
 package com.google.idea.blaze.base.bazel;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.UnmodifiableIterator;
+import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos;
 import com.google.errorprone.annotations.MustBeClosed;
 import com.google.idea.blaze.base.bazel.BuildSystem.BuildInvoker;
+import com.google.idea.blaze.base.command.BlazeCommand;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
+import com.google.idea.blaze.base.command.buildresult.bepparser.BuildEventStreamProvider;
 import com.google.idea.blaze.base.command.info.BlazeInfo;
 import com.google.idea.blaze.base.settings.BuildBinaryType;
 import com.google.idea.blaze.base.settings.BuildSystemName;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Optional;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
-/** Simple implementation of {@link BuildInvoker} for injecting dependencies in test code. */
+/**
+ * Simple implementation of {@link BuildInvoker} for injecting dependencies in test code.
+ */
 @AutoValue
 public abstract class FakeBuildInvoker implements BuildInvoker {
 
   public static Builder builder() {
     return new AutoValue_FakeBuildInvoker.Builder()
-        .type(BuildBinaryType.NONE)
-        .binaryPath("")
-        .supportsParallelism(false)
-        .buildResultHelperSupplier(() -> null)
-        .commandRunner(new FakeBlazeCommandRunner())
-        .buildSystem(FakeBuildSystem.builder(BuildSystemName.Blaze).build());
+      .type(BuildBinaryType.NONE)
+      .binaryPath("")
+      .supportsParallelism(false)
+      .buildResultHelperSupplier(() -> null)
+      .commandRunner(new FakeBlazeCommandRunner())
+      .buildFlags(ImmutableList.of())
+      .buildSystem(FakeBuildSystem.builder(BuildSystemName.Blaze).build());
   }
 
   @Override
@@ -44,6 +55,24 @@ public abstract class FakeBuildInvoker implements BuildInvoker {
 
   @Override
   public abstract String getBinaryPath();
+
+  @Override
+  public BuildEventStreamProvider invoke(BlazeCommand.Builder blazeCommandBuilder) {
+    return fakeBuildEventStreamProvider();
+  }
+
+  @Override
+  public InputStream invokeQuery(BlazeCommand.Builder blazeCommandBuilder) {
+    return InputStream.nullInputStream();
+  }
+
+  @Override
+  public InputStream invokeInfo(BlazeCommand.Builder blazeCommandBuilder) {
+    return InputStream.nullInputStream();
+  }
+
+  @Override
+  public abstract List<String> getBuildFlags();
 
   @Override
   @Nullable
@@ -68,6 +97,42 @@ public abstract class FakeBuildInvoker implements BuildInvoker {
   @Override
   public abstract FakeBlazeCommandRunner getCommandRunner();
 
+  private BuildEventStreamProvider fakeBuildEventStreamProvider() {
+    return new BuildEventStreamProvider() {
+      private UnmodifiableIterator<BuildEventStreamProtos.BuildEvent> messages = ImmutableList.of(
+        BuildEventStreamProtos.BuildEvent.newBuilder().setId(BuildEventStreamProtos.BuildEventId.newBuilder().setStarted(
+            BuildEventStreamProtos.BuildEventId.BuildStartedId.getDefaultInstance()))
+          .setStarted(BuildEventStreamProtos.BuildStarted.newBuilder().setUuid("buildId")).build(),
+        BuildEventStreamProtos.BuildEvent.newBuilder().setId(BuildEventStreamProtos.BuildEventId.newBuilder().setBuildFinished(
+            BuildEventStreamProtos.BuildEventId.BuildFinishedId.getDefaultInstance()))
+          .setFinished(BuildEventStreamProtos.BuildFinished.newBuilder()).build()).iterator();
+
+      @Override
+      public Object getId() {
+        return Optional.empty();
+      }
+
+      @Nullable
+      @Override
+      public BuildEventStreamProtos.BuildEvent getNext() {
+        if (messages.hasNext()) {
+          return messages.next();
+        }
+        return null;
+      }
+
+      @Override
+      public long getBytesConsumed() {
+        return 0;
+      }
+
+      @Override
+      public void close() {
+
+      }
+    };
+  }
+
   /**
    * Builder class for instances of {@link com.google.idea.blaze.base.bazel.FakeBuildInvoker}.
    *
@@ -90,7 +155,8 @@ public abstract class FakeBuildInvoker implements BuildInvoker {
 
     public abstract Builder commandRunner(FakeBlazeCommandRunner runner);
 
+    public abstract Builder buildFlags(java.util.List<String> value);
+
     public abstract Builder buildSystem(BuildSystem buildSystem);
   }
-
 }

--- a/base/tests/utils/unit/com/google/idea/blaze/base/bazel/FakeBuildSystem.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/bazel/FakeBuildSystem.java
@@ -24,6 +24,7 @@ import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.settings.BuildSystemName;
 import com.intellij.openapi.project.Project;
 import java.util.Optional;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -39,9 +40,7 @@ import javax.annotation.Nullable;
 public abstract class FakeBuildSystem implements BuildSystem {
 
   public static Builder builder(BuildSystemName name) {
-    return new AutoValue_FakeBuildSystem.Builder()
-      .setName(name)
-      .setSyncStrategy(SyncStrategy.SERIAL);
+    return new AutoValue_FakeBuildSystem.Builder().setName(name).setSyncStrategy(SyncStrategy.SERIAL);
   }
 
   @Override
@@ -52,6 +51,11 @@ public abstract class FakeBuildSystem implements BuildSystem {
 
   @Override
   public BuildInvoker getBuildInvoker(Project project, BlazeContext context) {
+    return getBuildInvoker();
+  }
+
+  @Override
+  public BuildInvoker getBuildInvoker(Project project, BlazeContext context, Set<BuildInvoker.Capability> requirements) {
     return getBuildInvoker();
   }
 
@@ -70,8 +74,7 @@ public abstract class FakeBuildSystem implements BuildSystem {
   protected abstract SyncStrategy getSyncStrategy();
 
   @Override
-  public void populateBlazeVersionData(
-    WorkspaceRoot workspaceRoot, BlazeInfo blazeInfo, BlazeVersionData.Builder builder) { }
+  public void populateBlazeVersionData(WorkspaceRoot workspaceRoot, BlazeInfo blazeInfo, BlazeVersionData.Builder builder) { }
 
   abstract Optional<String> getBazelVersionString();
 

--- a/shared/java/com/google/idea/blaze/exception/BUILD
+++ b/shared/java/com/google/idea/blaze/exception/BUILD
@@ -5,5 +5,8 @@ licenses(["notice"])
 java_library(
     name = "exception",
     srcs = glob(["*.java"]),
-    visibility = ["//shared:__subpackages__"],
+    visibility = [
+        "//base:__subpackages__",
+        "//shared:__subpackages__",
+    ],
 )


### PR DESCRIPTION
Cherry pick AOSP commit [d196137f8c6936ed368c5accdcdf42fc1d401ce9](https://cs.android.com/android-studio/platform/tools/adt/idea/+/d196137f8c6936ed368c5accdcdf42fc1d401ce9).

1. Adds the new method to obtain a build invoker from a build system.
2. Adds the new methods to invoke blaze/bazel commands via the invokers.
3. Minor changes to the BazelExitCodeException class.

This CL does not affect the users. The AbstractBuildInvoker1 class is added temporarily (to make the CL compile), and it will replace AbstractBuildInvoker in the subsequent CL.

The subsequent CL will replace all usages of AbstractBuildInvoker with
the new one, and get rid of existing invokers, command runners, and build result helpers.

The lint warnings about java_library are unrelated to the change and
seem safe to ignore.

Bug:374906681

Test: n/a
Change-Id: Ia5a6ba4490e4b32cd8c16c572b3a1feae7f5dcac

AOSP: d196137f8c6936ed368c5accdcdf42fc1d401ce9
