### PR TITLE
[AOSP-pick] Remove one-argument form of registerDependency

### DIFF
--- a/aswb/src/com/google/idea/blaze/android/projectsystem/BlazeModuleSystemBase.java
+++ b/aswb/src/com/google/idea/blaze/android/projectsystem/BlazeModuleSystemBase.java
@@ -176,11 +176,6 @@ abstract class BlazeModuleSystemBase implements AndroidModuleSystem {
   }
 
   @Override
-  public void registerDependency(GradleCoordinate coordinate) {
-    registerDependency(coordinate, DependencyType.IMPLEMENTATION);
-  }
-
-  @Override
   public void registerDependency(GradleCoordinate coordinate, DependencyType type) {
     if (type != DependencyType.IMPLEMENTATION) {
       throw new UnsupportedOperationException("Unsupported dependency type in Blaze: " + type);

--- a/aswb/tests/unittests/com/google/idea/blaze/android/projectsystem/BazelModuleSystemTest.java
+++ b/aswb/tests/unittests/com/google/idea/blaze/android/projectsystem/BazelModuleSystemTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import com.android.tools.idea.projectsystem.DependencyType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.google.idea.blaze.android.resources.BlazeLightResourceClassService;
@@ -118,7 +119,7 @@ public class BazelModuleSystemTest extends BlazeTestCase {
     assertThat(buildFile).isNotNull();
     when(psiFile.getVirtualFile()).thenReturn(buildFile);
 
-    BazelModuleSystem.create(module).registerDependency(APP_COMPAT_V7);
+    BazelModuleSystem.create(module).registerDependency(APP_COMPAT_V7, DependencyType.IMPLEMENTATION);
 
     ArgumentCaptor<OpenFileDescriptor> descriptorCaptor =
         ArgumentCaptor.forClass(OpenFileDescriptor.class);
@@ -141,7 +142,7 @@ public class BazelModuleSystemTest extends BlazeTestCase {
         VirtualFileSystemProvider.getInstance().getSystem().findFileByPath("/foo/BUILD");
     assertThat(buildFile).isNotNull();
 
-    BazelModuleSystem.create(module).registerDependency(APP_COMPAT_V7);
+    BazelModuleSystem.create(module).registerDependency(APP_COMPAT_V7, DependencyType.IMPLEMENTATION);
 
     verify(FileEditorManager.getInstance(project)).openFile(buildFile, true);
     verifyNoMoreInteractions(FileEditorManager.getInstance(project));


### PR DESCRIPTION
Cherry pick AOSP commit [397705719a4a75d6988862d409a4fdd5b1830d26](https://cs.android.com/android-studio/platform/tools/adt/idea/+/397705719a4a75d6988862d409a4fdd5b1830d26).

The one remaining production user of it is trivially convertible to
the two-argument form.

Bug: 279886738
Test: existing tests adjusted
Change-Id: I8e2bb60a8a618d7d471616ee941e1dfc1f740fc5

AOSP: 397705719a4a75d6988862d409a4fdd5b1830d26
