### PR TITLE
[AOSP-pick] Make BuildArtifactCache an independent service

### DIFF
--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -312,6 +312,12 @@
                     serviceImplementation="com.google.idea.blaze.base.targetmaps.TransitiveDependencyMap"/>
     <projectService serviceImplementation="com.google.idea.blaze.base.settings.BlazeImportSettingsManager"/>
     <projectService serviceImplementation="com.google.idea.blaze.base.sync.status.BlazeSyncStatusStateManager"/>
+    <projectService serviceInterface="com.google.idea.blaze.common.artifact.BuildArtifactCache"
+            serviceImplementation="com.google.idea.blaze.common.artifact.BuildArtifactCacheDirectory"/>
+    <projectService serviceInterface="com.google.idea.blaze.common.artifact.ArtifactFetcher"
+            serviceImplementation="com.google.idea.blaze.base.qsync.DynamicallyDispatchingArtifactFetcher"/>
+    <projectService serviceInterface="com.google.idea.blaze.common.artifact.BuildArtifactCache$CleanRequest"
+            serviceImplementation="com.google.idea.blaze.base.qsync.CacheCleaner"/>
     <applicationService serviceImplementation="com.google.idea.blaze.base.settings.BlazeUserSettings" id="BlazeUserSettings"/>
     <applicationService serviceImplementation="com.google.idea.blaze.base.sync.autosync.AutoSyncSettings" order="after BlazeUserSettings"/>
     <projectService serviceInterface="com.google.idea.blaze.base.lang.buildfile.language.semantics.BuildLanguageSpecProvider"

--- a/base/src/com/google/idea/blaze/base/qsync/CacheCleaner.java
+++ b/base/src/com/google/idea/blaze/base/qsync/CacheCleaner.java
@@ -42,12 +42,10 @@ public class CacheCleaner implements BuildArtifactCache.CleanRequest {
   private final Logger logger = Logger.getInstance(CacheCleaner.class);
 
   private final Project project;
-  private final QuerySyncManager querySyncManager;
   private final AtomicReference<AccessToken> activeCleanRequest = new AtomicReference<>();
 
-  CacheCleaner(Project project, QuerySyncManager qsm) {
+  CacheCleaner(Project project) {
     this.project = project;
-    this.querySyncManager = qsm;
   }
 
   @Override
@@ -83,11 +81,7 @@ public class CacheCleaner implements BuildArtifactCache.CleanRequest {
             new Task.Backgroundable(project, "Cleaning build cache") {
               @Override
               public void run(@NotNull ProgressIndicator progressIndicator) {
-                BuildArtifactCache cache =
-                    querySyncManager
-                        .getLoadedProject()
-                        .map(QuerySyncProject::getBuildArtifactCache)
-                        .orElse(null);
+                BuildArtifactCache cache = project.getService(BuildArtifactCache.class);
                 if (cache == null) {
                   return;
                 }

--- a/base/src/com/google/idea/blaze/base/qsync/DynamicallyDispatchingArtifactFetcher.java
+++ b/base/src/com/google/idea/blaze/base/qsync/DynamicallyDispatchingArtifactFetcher.java
@@ -22,10 +22,12 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.idea.blaze.base.qsync.cache.ArtifactFetchers;
 import com.google.idea.blaze.common.Context;
 import com.google.idea.blaze.common.PrintOutput;
 import com.google.idea.blaze.common.artifact.ArtifactFetcher;
 import com.google.idea.blaze.common.artifact.OutputArtifact;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Pair;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -39,8 +41,8 @@ public class DynamicallyDispatchingArtifactFetcher implements ArtifactFetcher<Ou
 
   private final ImmutableList<ArtifactFetcher<?>> fetchers;
 
-  public DynamicallyDispatchingArtifactFetcher(ImmutableList<ArtifactFetcher<?>> fetchers) {
-    this.fetchers = fetchers;
+  public DynamicallyDispatchingArtifactFetcher(Project project) {
+    this.fetchers = ImmutableList.copyOf(ArtifactFetchers.EP_NAME.getExtensionList());
   }
 
   @Override

--- a/base/src/com/google/idea/blaze/base/qsync/ProjectLoaderImpl.java
+++ b/base/src/com/google/idea/blaze/base/qsync/ProjectLoaderImpl.java
@@ -252,13 +252,7 @@ public class ProjectLoaderImpl implements ProjectLoader {
     Registry projectTransformRegistry = new Registry();
     SnapshotHolder graph = new SnapshotHolder();
     graph.addListener((c, i) -> projectModificationTracker.incModificationCount());
-    Path buildCachePath = getBuildCachePath(project);
-    BuildArtifactCache artifactCache =
-        BuildArtifactCache.create(
-          buildCachePath,
-            createArtifactFetcher(),
-            executor,
-            QuerySyncManager.getInstance(project).cacheCleanRequest());
+    BuildArtifactCache artifactCache = project.getService(BuildArtifactCache.class);
 
     DependencyBuilder dependencyBuilder =
       createDependencyBuilder(
@@ -382,11 +376,6 @@ public class ProjectLoaderImpl implements ProjectLoader {
 
   private Path getSnapshotFilePath(BlazeImportSettings importSettings) {
     return BlazeDataStorage.getProjectDataDir(importSettings).toPath().resolve("qsyncdata.gz");
-  }
-
-  private ArtifactFetcher<OutputArtifact> createArtifactFetcher() {
-    return new DynamicallyDispatchingArtifactFetcher(
-        ImmutableList.copyOf(ArtifactFetchers.EP_NAME.getExtensions()));
   }
 
   /**

--- a/base/src/com/google/idea/blaze/base/qsync/QuerySyncManager.java
+++ b/base/src/com/google/idea/blaze/base/qsync/QuerySyncManager.java
@@ -143,7 +143,7 @@ public class QuerySyncManager implements Disposable {
     this.loader = loader != null ? loader : createProjectLoader(project);
     this.syncStatus = new QuerySyncStatus(project);
     this.fileListener = QuerySyncAsyncFileListener.createAndListen(project, this);
-    this.cacheCleaner = new CacheCleaner(project, this);
+    this.cacheCleaner = new CacheCleaner(project);
   }
 
   /**

--- a/querysync/java/com/google/idea/blaze/qsync/deps/BUILD
+++ b/querysync/java/com/google/idea/blaze/qsync/deps/BUILD
@@ -21,6 +21,7 @@ java_library(
         "//shared:proto",
         "//shared:vcs",
         "//third_party/java/auto_value",
+        "//intellij_platform_sdk:plugin_api",
         "@com_google_guava_guava//jar",
         "@protobuf//:protobuf_java",
         "@error_prone_annotations//jar",

--- a/shared/java/com/google/idea/blaze/common/artifact/BUILD
+++ b/shared/java/com/google/idea/blaze/common/artifact/BUILD
@@ -13,6 +13,7 @@ java_library(
     deps = [
         "@jsr305_annotations//jar",
         "//shared",
+        "//intellij_platform_sdk:plugin_api",
         "@com_google_guava_guava//jar",
         "@error_prone_annotations//jar",
     ],


### PR DESCRIPTION
Cherry pick AOSP commit [dcad2a45d63a39ae85d52aaf7d3c8a4ac3af91af](https://cs.android.com/android-studio/platform/tools/adt/idea/+/dcad2a45d63a39ae85d52aaf7d3c8a4ac3af91af).

Make BuildArtifactCache an independent IntelliJ project service, so that
it may be invoked in both LegacySync and QuerySync projects.

Bug: 385469770
Bug: 392903689
Bug: 392903190
Test: Existing tests are deleted as am not sure how to test project
service

Change-Id: Id1605d87e596aaac84c9a7d77f5d0bd884761213

AOSP: dcad2a45d63a39ae85d52aaf7d3c8a4ac3af91af
