### PR TITLE
[AOSP-pick] Remove build system check in NewVectorAssetAction

### DIFF
--- a/aswb/src/com/google/idea/blaze/android/projectsystem/BlazeModuleSystemBase.java
+++ b/aswb/src/com/google/idea/blaze/android/projectsystem/BlazeModuleSystemBase.java
@@ -161,11 +161,6 @@ abstract class BlazeModuleSystemBase implements AndroidModuleSystem {
   }
 
   @Override
-  public CapabilityStatus canGeneratePngFromVectorGraphics() {
-    return new CapabilitySupported();
-  }
-
-  @Override
   public List<NamedModuleTemplate> getModuleTemplates(@Nullable VirtualFile targetDirectory) {
     return BlazeAndroidModuleTemplate.getTemplates(module, targetDirectory);
   }


### PR DESCRIPTION
Cherry pick AOSP commit [d33b1db1cb84f9320718a889d346497db79362c8](https://cs.android.com/android-studio/platform/tools/adt/idea/+/d33b1db1cb84f9320718a889d346497db79362c8).

The check, for whether PNG generation is supported, and subsequent
check against the minSdk version, is substantially incomplete, eliding
as it does any mention of the support library's varying compatibility
support for vector drawables.

Given this, the check is of limited utility, and (worse) actively
prevents the user from doing what they need to in cases where their
action is completely valid.  Remove the check, which also makes the
question of whether the build system automatically generates PNGs for
vector drawables irrelevant.

Bug: none filed
Test: existing
Change-Id: I11a3df3b57df714f5f4e71ced88bae9a9ad7e0d2

AOSP: d33b1db1cb84f9320718a889d346497db79362c8
