### PR TITLE
[AOSP-pick] Automatically exclude `.aswb` from analysis

### DIFF
--- a/base/src/com/google/idea/blaze/base/qsync/BazelDependencyBuilder.java
+++ b/base/src/com/google/idea/blaze/base/qsync/BazelDependencyBuilder.java
@@ -119,6 +119,7 @@ public class BazelDependencyBuilder implements DependencyBuilder {
 
   public static final StringExperiment aspectLocation =
     new StringExperiment("qsync.build.aspect.location");
+  public static final String INVOCATION_FILES_DIR = ".aswb";
 
   public record BuildDependencyParameters(
     ImmutableList<String> include,
@@ -298,23 +299,23 @@ public class BazelDependencyBuilder implements DependencyBuilder {
   public InvocationFiles getInvocationFiles(Set<Label> buildTargets, BuildDependencyParameters parameters) {
     String aspectFileName = String.format("qs-%s.bzl", getProjectHash());
     ImmutableMap.Builder<Path, ByteSource> files = ImmutableMap.builder();
-    files.put(Path.of(".aswb/BUILD"), ByteSource.empty());
-    files.put(Path.of(".aswb/build_dependencies.bzl"), getBundledAspect("build_dependencies.bzl"));
-    files.put(Path.of(".aswb/build_dependencies_deps.bzl"), getBundledAspect("build_dependencies_deps.bzl"));
-    files.put(Path.of(".aswb/" + aspectFileName), getByteSourceFromString(getBuildDependenciesParametersFileContent(parameters)));
+    files.put(Path.of(INVOCATION_FILES_DIR + "/BUILD"), ByteSource.empty());
+    files.put(Path.of(INVOCATION_FILES_DIR + "/build_dependencies.bzl"), getBundledAspect("build_dependencies.bzl"));
+    files.put(Path.of(INVOCATION_FILES_DIR + "/build_dependencies_deps.bzl"), getBundledAspect("build_dependencies_deps.bzl"));
+    files.put(Path.of(INVOCATION_FILES_DIR + "/" + aspectFileName), getByteSourceFromString(getBuildDependenciesParametersFileContent(parameters)));
     Optional<String> targetPatternFileWorkspaceRelativeFile;
     if (buildUseTargetPatternFile.getValue()) {
       String patternsFileName = String.format("targets-%s.txt", getProjectHash());
-      files.put(Path.of(".aswb/" + patternsFileName),
+      files.put(Path.of(INVOCATION_FILES_DIR + "/" + patternsFileName),
                 getByteSourceFromString(buildTargets.stream().map(Label::toString).collect(Collectors.joining("\n"))));
-      targetPatternFileWorkspaceRelativeFile = Optional.of(".aswb/" + patternsFileName);
+      targetPatternFileWorkspaceRelativeFile = Optional.of(INVOCATION_FILES_DIR + "/" + patternsFileName);
     }
     else {
       targetPatternFileWorkspaceRelativeFile = Optional.empty();
     }
     return new InvocationFiles(
       files.build(),
-      Label.of(String.format("//.aswb:" + aspectFileName)).toString(),
+      Label.of(String.format("//" + INVOCATION_FILES_DIR + ":" + aspectFileName)).toString(),
       targetPatternFileWorkspaceRelativeFile
     );
   }

--- a/base/src/com/google/idea/blaze/base/qsync/ProjectLoaderImpl.java
+++ b/base/src/com/google/idea/blaze/base/qsync/ProjectLoaderImpl.java
@@ -227,8 +227,11 @@ public class ProjectLoaderImpl implements ProjectLoader {
             .setLanguageClasses(
                 LanguageClasses.toQuerySync(workspaceLanguageSettings.getActiveLanguages()))
             .setTestSources(testSourceGlobs)
-            .setSystemExcludes(importRoots.systemExcludes())
-            .build();
+            .setSystemExcludes(ImmutableSet.<Path>builder()
+                                 .addAll(importRoots.systemExcludes())
+                                 .add(Path.of(BazelDependencyBuilder.INVOCATION_FILES_DIR))
+                                 .build())
+          .build();
 
     Path snapshotFilePath = getSnapshotFilePath(importSettings);
 


### PR DESCRIPTION
Cherry pick AOSP commit [0e3f55d9877643728fef79d577442a7cbac1f0e8](https://cs.android.com/android-studio/platform/tools/adt/idea/+/0e3f55d9877643728fef79d577442a7cbac1f0e8).

as it is not a project package.

Bug: 393157715
Test: n/a
Change-Id: I43ebec1ffa2aea943712a33172e53db52814dc3c

AOSP: 0e3f55d9877643728fef79d577442a7cbac1f0e8
