### PR TITLE
[AOSP-pick] Fix incorrect application of `if` in cc_info handling

### DIFF
--- a/aspect/build_dependencies.bzl
+++ b/aspect/build_dependencies.bzl
@@ -872,7 +872,7 @@ def _collect_cc_dependencies_core_impl(target, ctx, test_mode, experiment_multi_
     cc_info = _collect_own_and_dependency_cc_info(target, ctx.rule, test_mode)
     cc_info_files = []
     if experiment_multi_info_file:
-        cc_info_files = [_write_cc_target_info(target.label, cc_info.compilation_info, ctx)] + [cc_info.cc_toolchain_info.file] if cc_info.cc_toolchain_info else []
+        cc_info_files = [_write_cc_target_info(target.label, cc_info.compilation_info, ctx)] + ([cc_info.cc_toolchain_info.file] if cc_info.cc_toolchain_info else [])
 
     return create_cc_dependencies_info(
         cc_info_files = depset(cc_info_files) if experiment_multi_info_file else None,


### PR DESCRIPTION
Cherry pick AOSP commit [0320054c41615d65f59ce6bf724749178c9d831c](https://cs.android.com/android-studio/platform/tools/adt/idea/+/0320054c41615d65f59ce6bf724749178c9d831c).

Bug: n/a
Test: n/a (not trivial right now)
Change-Id: Ifa3f1e82579293bbc8afdc6505e8d76aaaadb659

AOSP: 0320054c41615d65f59ce6bf724749178c9d831c
