### PR TITLE
[AOSP-pick] Fix navigation to sources

### DIFF
--- a/java/src/com/google/idea/blaze/java/qsync/ClassFileJavaSourceFinder.java
+++ b/java/src/com/google/idea/blaze/java/qsync/ClassFileJavaSourceFinder.java
@@ -162,9 +162,10 @@ public class ClassFileJavaSourceFinder {
 
     return snapshot
         .getArtifactIndex()
-        .getInfoForArtifact(jarPath)
-        .map(JavaArtifactInfo::sources)
-        .orElse(ImmutableSet.of());
+        .getInfoForJarArtifact(jarPath)
+        .stream()
+        .flatMap(it -> it.sources().stream())
+        .collect(toImmutableSet());
   }
 
   // private ImmutableSet<PsiFile> filterByExpectedQualified

--- a/java/tests/integrationtests/com/google/idea/blaze/java/qsync/ClassFileJavaSourceFinderTest.java
+++ b/java/tests/integrationtests/com/google/idea/blaze/java/qsync/ClassFileJavaSourceFinderTest.java
@@ -34,6 +34,8 @@ import com.google.idea.blaze.common.Context;
 import com.google.idea.blaze.common.Label;
 import com.google.idea.blaze.qsync.QuerySyncProjectSnapshot;
 import com.google.idea.blaze.qsync.SnapshotHolder;
+import com.google.idea.blaze.qsync.artifacts.BuildArtifact;
+import com.google.idea.blaze.qsync.deps.ArtifactDirectories;
 import com.google.idea.blaze.qsync.deps.ArtifactTracker;
 import com.google.idea.blaze.qsync.deps.JavaArtifactInfo;
 import com.google.idea.blaze.qsync.project.ProjectProto;
@@ -44,6 +46,9 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.impl.compiled.ClsFileImpl;
 import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase4;
+import com.intellij.testFramework.rules.TempDirectory;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
 import org.junit.Before;
@@ -58,6 +63,7 @@ import org.mockito.junit.MockitoRule;
 @RunWith(JUnit4.class)
 public class ClassFileJavaSourceFinderTest extends LightJavaCodeInsightFixtureTestCase4 {
 
+  @Rule public final TempDirectory tempDir = new TempDirectory();
   @Rule public final EdtRule edtRule = new EdtRule();
   @Rule public final Expect expect = Expect.create();
   @Rule public final MockitoRule mockito = MockitoJUnit.rule();
@@ -65,12 +71,28 @@ public class ClassFileJavaSourceFinderTest extends LightJavaCodeInsightFixtureTe
   @Mock public QuerySyncManager querySyncManager;
   @Mock public ArtifactTracker<?> artifactTracker;
   private final SnapshotHolder snapshotHolder = new SnapshotHolder();
+  public Path libraryArtifactAbsolutePath;
+  public Path javaDepsAbsolutePath;
+  public Path libraryArtifactPath;
+  public Path projectAbsolutePath;
 
   @Before
   public void initArtifactTracker() {
     // We can't use when(...).thenReturn(...) here due to generic arg in getArtifactTracker:
     doReturn(artifactTracker).when(querySyncManager).getArtifactTracker();
     when(querySyncManager.isProjectLoaded()).thenReturn(true);
+  }
+
+  @Before
+  public void initJar() throws IOException {
+    String localRelativeArtifactPath = "com/test/libtest.jar";
+    final var testDataJar = testData.get(localRelativeArtifactPath);
+    projectAbsolutePath = tempDir.newDirectory("project").toPath();
+    javaDepsAbsolutePath = projectAbsolutePath.resolve(ArtifactDirectories.JAVADEPS.relativePath());
+    libraryArtifactAbsolutePath = javaDepsAbsolutePath.resolve("blaze-out/k8/bin/" + localRelativeArtifactPath);
+    libraryArtifactPath = javaDepsAbsolutePath.relativize(libraryArtifactAbsolutePath);
+    Files.createDirectories(libraryArtifactAbsolutePath.getParent());
+    Files.copy(Path.of(testDataJar), libraryArtifactAbsolutePath);
   }
 
   @Before
@@ -84,7 +106,7 @@ public class ClassFileJavaSourceFinderTest extends LightJavaCodeInsightFixtureTe
   public void project_not_loaded() {
     VirtualFile classFile =
         JarFileSystem.getInstance()
-            .findFileByPath(testData.get("com/test/libtest.jar!/com/test/Test.class"));
+            .findFileByPath(libraryArtifactAbsolutePath.toString() + "!/com/test/Test.class");
     ClsFileImpl psiClassFile = (ClsFileImpl) getFixture().getPsiManager().findFile(classFile);
 
     when(querySyncManager.isProjectLoaded()).thenReturn(false);
@@ -99,11 +121,11 @@ public class ClassFileJavaSourceFinderTest extends LightJavaCodeInsightFixtureTe
   public void unknown_jarfile() {
     VirtualFile classFile =
         JarFileSystem.getInstance()
-            .findFileByPath(testData.get("com/test/libtest.jar!/com/test/Test.class"));
+            .findFileByPath(libraryArtifactAbsolutePath.toString() + "!/com/test/Test.class");
     ClsFileImpl psiClassFile = (ClsFileImpl) getFixture().getPsiManager().findFile(classFile);
     ClassFileJavaSourceFinder djsf =
         new ClassFileJavaSourceFinder(
-            getFixture().getProject(), querySyncManager, testData.root, Path.of("/"), psiClassFile);
+          getFixture().getProject(), querySyncManager, testData.root, Path.of("/"), psiClassFile);
     expect.that(djsf.findSourceFile()).isNull();
   }
 
@@ -111,44 +133,30 @@ public class ClassFileJavaSourceFinderTest extends LightJavaCodeInsightFixtureTe
   public void source_match() throws Exception {
     VirtualFile classFile =
         JarFileSystem.getInstance()
-            .findFileByPath(testData.get("com/test/libtest.jar!/com/test/Test.class"));
+            .findFileByPath(libraryArtifactAbsolutePath.toString() + "!/com/test/Test.class");
     ClsFileImpl psiClassFile = (ClsFileImpl) getFixture().getPsiManager().findFile(classFile);
     ClassFileJavaSourceFinder djsf =
         new ClassFileJavaSourceFinder(
-            getFixture().getProject(),
-            querySyncManager,
-            testData.root,
-            testData.root,
-            psiClassFile);
+          getFixture().getProject(),
+          querySyncManager,
+          testData.root,
+          projectAbsolutePath,
+          psiClassFile);
     ArtifactTracker.State artifactState =
-        ArtifactTracker.State.forJavaArtifacts(
-            ImmutableList.of(
-                JavaArtifactInfo.empty(Label.of("//com/test:test")).toBuilder()
-                    .setSources(
-                        ImmutableSet.of(
-                            Path.of("com/test/Test.java"), Path.of("com/test/AnotherClass.java")))
-                    .build()));
+      ArtifactTracker.State.forJavaArtifacts(
+        ImmutableList.of(
+          JavaArtifactInfo.empty(Label.of("//com/test:test")).toBuilder()
+            .setSources(
+              ImmutableSet.of(
+                Path.of("com/test/Test.java"), Path.of("com/test/AnotherClass.java")))
+            .setJars(ImmutableList.of(
+              BuildArtifact.create(
+                "digest-libtest.jar",
+                Path.of("blaze-out/k8/bin/com/test/libtest.jar"), Label.of("//com/test:test"))))
+            .build()));
     snapshotHolder.setCurrent(
         mock(Context.class),
         QuerySyncProjectSnapshot.EMPTY.toBuilder()
-            .project(
-                TextFormat.parse(
-                    Joiner.on("\n")
-                        .join(
-                            "artifact_directories {",
-                            "  directories {",
-                            "    key: \"\"",
-                            "    value {",
-                            "      contents {",
-                            "        key: \"com/test/libtest.jar\"",
-                            "        value {",
-                            "          target: \"//com/test:test\"",
-                            "        }",
-                            "      }",
-                            "    }",
-                            "  }",
-                            "}"),
-                    ProjectProto.Project.class))
             .artifactState(artifactState)
             .build());
 
@@ -163,47 +171,33 @@ public class ClassFileJavaSourceFinderTest extends LightJavaCodeInsightFixtureTe
   @Test
   public void source_name_duplicate_match() throws Exception {
     VirtualFile classFile =
-        JarFileSystem.getInstance()
-            .findFileByPath(testData.get("com/test/libtest.jar!/com/test/Test.class"));
-    ClsFileImpl psiClassFile = (ClsFileImpl) getFixture().getPsiManager().findFile(classFile);
+      JarFileSystem.getInstance()
+        .findFileByPath(libraryArtifactAbsolutePath.toString() + "!/com/test/Test.class");
+    ClsFileImpl psiClassFile = (ClsFileImpl)getFixture().getPsiManager().findFile(classFile);
     ClassFileJavaSourceFinder djsf =
-        new ClassFileJavaSourceFinder(
-            getFixture().getProject(),
-            querySyncManager,
-            testData.root,
-            testData.root,
-            psiClassFile);
+      new ClassFileJavaSourceFinder(
+        getFixture().getProject(),
+        querySyncManager,
+        testData.root,
+        projectAbsolutePath,
+        psiClassFile);
     ArtifactTracker.State artifactState =
-        ArtifactTracker.State.forJavaArtifacts(
-            ImmutableList.of(
-                JavaArtifactInfo.empty(Label.of("//com/test:test")).toBuilder()
-                    .setSources(
-                        ImmutableSet.of(
-                            Path.of("com/test/Test.java"),
-                            Path.of("com/test/AnotherClass.java"),
-                            Path.of("com/test2/Test.java")))
-                    .build()));
+      ArtifactTracker.State.forJavaArtifacts(
+        ImmutableList.of(
+          JavaArtifactInfo.empty(Label.of("//com/test:test")).toBuilder()
+            .setSources(
+              ImmutableSet.of(
+                Path.of("com/test/Test.java"),
+                Path.of("com/test/AnotherClass.java"),
+                Path.of("com/test2/Test.java")))
+            .setJars(ImmutableList.of(
+              BuildArtifact.create(
+                "digest-libtest.jar",
+                Path.of("blaze-out/k8/bin/com/test/libtest.jar"), Label.of("//com/test:test"))))
+            .build()));
     snapshotHolder.setCurrent(
-        mock(Context.class),
+      mock(Context.class),
         QuerySyncProjectSnapshot.EMPTY.toBuilder()
-            .project(
-                TextFormat.parse(
-                    Joiner.on("\n")
-                        .join(
-                            "artifact_directories {",
-                            "  directories {",
-                            "    key: \"\"",
-                            "    value {",
-                            "      contents {",
-                            "        key: \"com/test/libtest.jar\"",
-                            "        value {",
-                            "          target: \"//com/test:test\"",
-                            "        }",
-                            "      }",
-                            "    }",
-                            "  }",
-                            "}"),
-                    ProjectProto.Project.class))
             .artifactState(artifactState)
             .build());
 
@@ -219,11 +213,11 @@ public class ClassFileJavaSourceFinderTest extends LightJavaCodeInsightFixtureTe
   public void source_name_duplicate_no_match() {
     VirtualFile classFile =
         JarFileSystem.getInstance()
-            .findFileByPath(testData.get("com/test/libtest.jar!/com/test/Test.class"));
+            .findFileByPath(libraryArtifactAbsolutePath.toString() + "!/com/test/Test.class");
     ClsFileImpl psiClassFile = (ClsFileImpl) getFixture().getPsiManager().findFile(classFile);
     ClassFileJavaSourceFinder djsf =
         new ClassFileJavaSourceFinder(
-            getFixture().getProject(), querySyncManager, testData.root, Path.of("/"), psiClassFile);
+          getFixture().getProject(), querySyncManager, testData.root, Path.of("/"), psiClassFile);
     PsiElement navElement = djsf.findSourceFile();
     assertThat(navElement).isNull();
   }

--- a/querysync/java/com/google/idea/blaze/qsync/QuerySyncProjectSnapshot.java
+++ b/querysync/java/com/google/idea/blaze/qsync/QuerySyncProjectSnapshot.java
@@ -128,7 +128,7 @@ public abstract class QuerySyncProjectSnapshot {
 
   @Memoized
   public ArtifactIndex getArtifactIndex() {
-    return ArtifactIndex.create(artifactState(), project().getArtifactDirectories());
+    return ArtifactIndex.create(artifactState());
   }
 
   /**

--- a/testing/test_deps/projects/java_and_deps/deps/top_level_lib_1/BUILD
+++ b/testing/test_deps/projects/java_and_deps/deps/top_level_lib_1/BUILD
@@ -8,3 +8,9 @@ java_library(
         "//java_and_deps/deps/transitive_dep_lib",
     ],
 )
+
+java_library(
+    name = "reexported_top_level_lib_1",
+    visibility = ["//visibility:public"],
+    exports = [":top_level_lib_1"],
+)

--- a/testing/test_deps/projects/java_and_deps/project/BUILD
+++ b/testing/test_deps/projects/java_and_deps/project/BUILD
@@ -6,7 +6,7 @@ java_library(
     visibility = ["//visibility:public"],
     deps = [
         ":lib",
-        "//java_and_deps/deps/top_level_lib_1",
+        "//java_and_deps/deps/top_level_lib_1:reexported_top_level_lib_1",
         "//java_and_deps/project/java/com/example/sample/nested",
     ],
 )


### PR DESCRIPTION
Cherry pick AOSP commit [8008feb3219353f1465abd868635689e3f6ead4f](https://cs.android.com/android-studio/platform/tools/adt/idea/+/8008feb3219353f1465abd868635689e3f6ead4f).

when multiple targets report the same `compile_jar`` file.

Bug: 392565740
Test: ClassFileJavaSourceFinderTest
Change-Id: I5ba884a9a3360ea93a304f03004908679cd406f7

AOSP: 8008feb3219353f1465abd868635689e3f6ead4f
