### PR TITLE
[AOSP-pick] Remove getPathToAapt from the Android Project System

### DIFF
--- a/aswb/src/com/google/idea/blaze/android/projectsystem/BazelProjectSystem.java
+++ b/aswb/src/com/google/idea/blaze/android/projectsystem/BazelProjectSystem.java
@@ -102,13 +102,6 @@ public class BazelProjectSystem implements AndroidProjectSystem {
   }
 
   @Override
-  public Path getPathToAapt() {
-    return AaptInvoker.getPathToAapt(
-        AndroidSdks.getInstance().tryToChooseSdkHandler(),
-        new LogWrapper(BazelProjectSystem.class));
-  }
-
-  @Override
   public ProjectSystemBuildManager getBuildManager() {
     return buildManager;
   }


### PR DESCRIPTION
Cherry pick AOSP commit [900ecd1be2a015e7f9cd245e702d9a5949143700](https://cs.android.com/android-studio/platform/tools/adt/idea/+/900ecd1be2a015e7f9cd245e702d9a5949143700).

It is no longer used, and not really a project-system concept in any
case.

Bug: none filed
Test: existing
Change-Id: Ife023ce2a13bf9e5b61d766ab1b70c72edd58311

AOSP: 900ecd1be2a015e7f9cd245e702d9a5949143700
