### PR TITLE
[AOSP-pick] Change code to always enable lint

### DIFF
--- a/aswb/src/com/google/idea/blaze/android/libraries/AndroidLintCollector.java
+++ b/aswb/src/com/google/idea/blaze/android/libraries/AndroidLintCollector.java
@@ -31,9 +31,6 @@ import java.util.Objects;
 
 /** {@inheritDoc} Collecting lint rule jars from {@code AarLibrary} */
 public class AndroidLintCollector implements LintCollector {
-  public static final FeatureRolloutExperiment lintEnabled =
-      new FeatureRolloutExperiment("blaze.android.libraries.lint.enabled");
-
   @Override
   public ImmutableList<File> collectLintJars(Project project, BlazeProjectData blazeProjectData) {
     ArtifactLocationDecoder artifactLocationDecoder = blazeProjectData.getArtifactLocationDecoder();
@@ -48,6 +45,6 @@ public class AndroidLintCollector implements LintCollector {
 
   @Override
   public boolean isEnabled() {
-    return lintEnabled.isEnabled();
+    return true;
   }
 }


### PR DESCRIPTION
Cherry pick AOSP commit [96ae94e415aeb86b8f215d1bb7f1494c1035eb5c](https://cs.android.com/android-studio/platform/tools/adt/idea/+/96ae94e415aeb86b8f215d1bb7f1494c1035eb5c).

This experiment has been set since July 2022. This enables removing
of the experiment from g3-experiment.properties.

Bug: 391569121
Test: Manually build and run ASwB with this change
Change-Id: I0e88f15f0906fd78c39379571a74bca9e4ec1d2a

AOSP: 96ae94e415aeb86b8f215d1bb7f1494c1035eb5c
