### PR TITLE
[AOSP-pick] Merge Local Blaze and Bazel Invokers

### DIFF
--- a/base/src/com/google/idea/blaze/base/bazel/AbstractBuildInvoker.java
+++ b/base/src/com/google/idea/blaze/base/bazel/AbstractBuildInvoker.java
@@ -134,13 +134,6 @@ public abstract class AbstractBuildInvoker implements BuildInvoker {
   }
 
   @Override
-  public List<String> getBuildFlags() {
-    throw new UnsupportedOperationException(
-      String.format(
-        "The %s does not support getBuildFlags method", this.getClass().getSimpleName()));
-  }
-
-  @Override
   @Nullable
   public synchronized BlazeInfo getBlazeInfo() throws SyncFailedException {
     if (blazeInfo == null) {

--- a/base/src/com/google/idea/blaze/base/bazel/AbstractBuildInvoker1.java
+++ b/base/src/com/google/idea/blaze/base/bazel/AbstractBuildInvoker1.java
@@ -19,20 +19,21 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.idea.blaze.base.async.FutureUtil;
-import com.google.idea.blaze.base.async.executor.BlazeExecutor;
 import com.google.idea.blaze.base.bazel.BuildSystem.BuildInvoker;
-import com.google.idea.blaze.base.command.BlazeCommand;
 import com.google.idea.blaze.base.command.BlazeCommandName;
 import com.google.idea.blaze.base.command.BlazeCommandRunner;
+import com.google.idea.blaze.base.command.BlazeFlags;
+import com.google.idea.blaze.base.command.BlazeInvocationContext;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
 import com.google.idea.blaze.base.command.info.BlazeInfo;
+import com.google.idea.blaze.base.command.info.BlazeInfoRunner;
+import com.google.idea.blaze.base.projectview.ProjectViewManager;
+import com.google.idea.blaze.base.projectview.ProjectViewSet;
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.scope.scopes.TimingScope;
-import com.google.idea.blaze.base.settings.BuildSystemName;
 import com.google.idea.blaze.base.sync.SyncScope.SyncFailedException;
 import com.intellij.openapi.project.Project;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
+import java.util.List;
 import javax.annotation.Nullable;
 
 /**
@@ -44,11 +45,13 @@ public abstract class AbstractBuildInvoker1 implements BuildInvoker {
   protected final Project project;
   protected final BlazeContext blazeContext;
   private final String binaryPath;
+  private final BuildSystem buildSystem;
   private BlazeInfo blazeInfo;
 
-  public AbstractBuildInvoker1(Project project, BlazeContext blazeContext, String binaryPath) {
+  public AbstractBuildInvoker1(Project project, BlazeContext blazeContext, BuildSystem buildSystem, String binaryPath) {
     this.project = project;
     this.blazeContext = blazeContext;
+    this.buildSystem = buildSystem;
     this.binaryPath = binaryPath;
   }
 
@@ -67,25 +70,35 @@ public abstract class AbstractBuildInvoker1 implements BuildInvoker {
   }
 
   private BlazeInfo getBlazeInfoResult() throws SyncFailedException {
-    ListenableFuture<BlazeInfo> blazeInfoFuture;
-    FutureUtil.FutureResult<BlazeInfo> result;
-    blazeInfoFuture = Futures.transform(BlazeExecutor.getInstance().submit(() -> {
-                                          try (InputStream stream = invokeInfo(BlazeCommand.builder(this, BlazeCommandName.INFO, project))) {
-                                            return stream.readAllBytes();
-                                          }
-                                        }), bytes -> BlazeInfo.create(BuildSystemName.Blaze, parseBlazeInfoResult(new String(bytes, StandardCharsets.UTF_8).trim())),
-                                        BlazeExecutor.getInstance().getExecutor());
-
-    result =
-      FutureUtil.waitForFuture(blazeContext, blazeInfoFuture).timed(BuildSystemName.Blaze + "Info", TimingScope.EventType.BlazeInvocation)
-        .withProgressMessage(String.format("Running %s info...", BuildSystemName.Blaze))
-        .onError(String.format("Could not run %s info", BuildSystemName.Blaze)).run();
-
+    ListenableFuture<BlazeInfo> future = runBlazeInfo();
+    FutureUtil.FutureResult<BlazeInfo> result =
+      FutureUtil.waitForFuture(blazeContext, future)
+        .timed(buildSystem.getName() + "Info", TimingScope.EventType.BlazeInvocation)
+        .withProgressMessage(String.format("Running %s info...", buildSystem.getName()))
+        .onError(String.format("Could not run %s info", buildSystem.getName()))
+        .run();
     if (result.success()) {
       return result.result();
     }
-    //TODO (b/374906681) Replace with BuildException once legacy sync is deprecated
-    throw new SyncFailedException(String.format("Failed to run `%s info`", getBinaryPath()), result.exception());
+    throw new SyncFailedException(
+      String.format("Failed to run `%s info`", getBinaryPath()), result.exception());
+  }
+
+  private ListenableFuture<BlazeInfo> runBlazeInfo() {
+    ProjectViewSet viewSet = ProjectViewManager.getInstance(project).getProjectViewSet();
+    if (viewSet == null) {
+      // defer the failure until later when it can be handled more easily:
+      return Futures.immediateFailedFuture(new IllegalStateException("Empty project view set"));
+    }
+    List<String> syncFlags =
+      BlazeFlags.blazeFlags(
+        project,
+        viewSet,
+        BlazeCommandName.INFO,
+        blazeContext,
+        BlazeInvocationContext.SYNC_CONTEXT);
+    return BlazeInfoRunner.getInstance()
+      .runBlazeInfo(project, this, blazeContext, buildSystem.getName(), syncFlags);
   }
 
   @Override
@@ -105,7 +118,7 @@ public abstract class AbstractBuildInvoker1 implements BuildInvoker {
 
   @Override
   public BuildSystem getBuildSystem() {
-    throw new UnsupportedOperationException("This method should not be called, this invoker does not support this method.");
+    return this.buildSystem;
   }
 
   @Override

--- a/base/src/com/google/idea/blaze/base/bazel/BazelBuildSystem.java
+++ b/base/src/com/google/idea/blaze/base/bazel/BazelBuildSystem.java
@@ -15,11 +15,7 @@
  */
 package com.google.idea.blaze.base.bazel;
 
-import com.google.errorprone.annotations.MustBeClosed;
 import com.google.idea.blaze.base.command.BlazeCommandName;
-import com.google.idea.blaze.base.command.CommandLineBlazeCommandRunner;
-import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
-import com.google.idea.blaze.base.command.buildresult.BuildResultHelperBep;
 import com.google.idea.blaze.base.command.info.BlazeInfo;
 import com.google.idea.blaze.base.model.BlazeVersionData;
 import com.google.idea.blaze.base.model.primitives.Kind;
@@ -30,7 +26,6 @@ import com.google.idea.blaze.base.projectview.section.sections.BazelBinarySectio
 import com.google.idea.blaze.base.qsync.BazelQueryRunner;
 import com.google.idea.blaze.base.run.ExecutorType;
 import com.google.idea.blaze.base.scope.BlazeContext;
-import com.google.idea.blaze.base.settings.BlazeUserSettings;
 import com.google.idea.blaze.base.settings.BuildBinaryType;
 import com.google.idea.blaze.base.settings.BuildSystemName;
 import com.intellij.openapi.project.Project;
@@ -40,19 +35,6 @@ import java.util.Set;
 import javax.annotation.Nullable;
 
 class BazelBuildSystem implements BuildSystem {
-
-  class BazelInvoker extends AbstractBuildInvoker {
-
-    public BazelInvoker(Project project, BlazeContext blazeContext, String path) {
-      super(project, blazeContext, BuildBinaryType.BAZEL, path, false, BazelBuildSystem.this, new CommandLineBlazeCommandRunner());
-    }
-
-    @Override
-    @MustBeClosed
-    public BuildResultHelper createBuildResultHelper() {
-      return new BuildResultHelperBep();
-    }
-  }
 
   @Override
   public BuildSystemName getName() {
@@ -76,16 +58,7 @@ class BazelBuildSystem implements BuildSystem {
 
   @Override
   public BuildInvoker getBuildInvoker(Project project, BlazeContext context) {
-    String binaryPath;
-    File projectSpecificBinary = getProjectSpecificBazelBinary(project);
-    if (projectSpecificBinary != null) {
-      binaryPath = projectSpecificBinary.getPath();
-    }
-    else {
-      BlazeUserSettings settings = BlazeUserSettings.getInstance();
-      binaryPath = settings.getBazelBinaryPath();
-    }
-    return new BazelInvoker(project, context, binaryPath);
+    return new LocalInvoker(project, context, this, BuildBinaryType.BAZEL);
   }
 
   @Override

--- a/base/src/com/google/idea/blaze/base/bazel/BuildSystem.java
+++ b/base/src/com/google/idea/blaze/base/bazel/BuildSystem.java
@@ -37,9 +37,7 @@ import com.google.idea.blaze.base.sync.SyncScope.SyncFailedException;
 import com.google.idea.blaze.base.sync.aspects.BlazeBuildOutputs;
 import com.google.idea.blaze.exception.BuildException;
 import com.intellij.openapi.project.Project;
-import java.io.File;
 import java.io.InputStream;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -83,14 +81,6 @@ public interface BuildSystem {
     }
 
     /**
-     * Returns the BEP output file if accessible.
-     */
-    default File bepOutputFile() {
-      throw new UnsupportedOperationException(
-        String.format("The %s does not support accessing the bep output file", this.getClass().getSimpleName()));
-    }
-
-    /**
      * Runs a blaze command, parses the build results into a {@link BlazeBuildOutputs} object.
      */
     BuildEventStreamProvider invoke(BlazeCommand.Builder blazeCommandBuilder) throws BuildException;
@@ -110,11 +100,6 @@ public interface BuildSystem {
      */
     @MustBeClosed
     InputStream invokeInfo(BlazeCommand.Builder blazeCommandBuilder) throws BuildException;
-
-    /**
-     * @return a list of build flags
-     */
-    List<String> getBuildFlags();
 
     /**
      * Returns the type of this build interface. Used for logging purposes.

--- a/base/src/com/google/idea/blaze/base/bazel/LocalInvoker.java
+++ b/base/src/com/google/idea/blaze/base/bazel/LocalInvoker.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2025 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.bazel;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.io.Closer;
+import com.google.idea.blaze.base.async.process.ExternalTask;
+import com.google.idea.blaze.base.async.process.LineProcessingOutputStream;
+import com.google.idea.blaze.base.async.process.PrintOutputLineProcessor;
+import com.google.idea.blaze.base.command.BlazeCommand;
+import com.google.idea.blaze.base.command.BlazeCommandName;
+import com.google.idea.blaze.base.command.BlazeCommandRunner;
+import com.google.idea.blaze.base.command.CommandLineBlazeCommandRunner;
+import com.google.idea.blaze.base.command.WorkspaceRootReplacement;
+import com.google.idea.blaze.base.command.buildresult.BuildEventProtocolUtils;
+import com.google.idea.blaze.base.command.buildresult.BuildResult;
+import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
+import com.google.idea.blaze.base.command.buildresult.BuildResultHelperBep;
+import com.google.idea.blaze.base.command.buildresult.bepparser.BuildEventStreamProvider;
+import com.google.idea.blaze.base.console.BlazeConsoleLineProcessorProvider;
+import com.google.idea.blaze.base.execution.BazelGuard;
+import com.google.idea.blaze.base.execution.ExecutionDeniedException;
+import com.google.idea.blaze.base.logging.utils.querysync.BuildDepsStatsScope;
+import com.google.idea.blaze.base.logging.utils.querysync.SyncQueryStatsScope;
+import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
+import com.google.idea.blaze.base.projectview.ProjectViewManager;
+import com.google.idea.blaze.base.projectview.ProjectViewSet;
+import com.google.idea.blaze.base.projectview.section.sections.BazelBinarySection;
+import com.google.idea.blaze.base.scope.BlazeContext;
+import com.google.idea.blaze.base.scope.output.IssueOutput;
+import com.google.idea.blaze.base.settings.Blaze;
+import com.google.idea.blaze.base.settings.BlazeUserSettings;
+import com.google.idea.blaze.base.settings.BuildBinaryType;
+import com.google.idea.blaze.common.PrintOutput;
+import com.google.idea.blaze.exception.BuildException;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+
+/**
+ * A local Blaze/Bazel invoker that issues commands via CLI.
+ */
+public class LocalInvoker extends AbstractBuildInvoker1 {
+  private static Logger logger = Logger.getInstance(LocalInvoker.class);
+  private final BuildBinaryType buildBinaryType;
+
+  public LocalInvoker(Project project, BlazeContext blazeContext, BuildSystem buildSystem, BuildBinaryType binaryType) {
+    super(project, blazeContext, buildSystem, binaryPath(binaryType, project));
+    this.buildBinaryType = binaryType;
+  }
+
+  @Override
+  public BuildResultHelper createBuildResultHelper() {
+    return new BuildResultHelperBep();
+  }
+
+  @Override
+  public BlazeCommandRunner getCommandRunner() {
+    return new CommandLineBlazeCommandRunner();
+  }
+
+  @Override
+  public boolean supportsHomeBlazerc() {
+    return true;
+  }
+
+  @Override
+  public boolean supportsParallelism() {
+    return false;
+  }
+
+  @Override
+  public ImmutableSet<Capability> getCapabilities() {
+    return ImmutableSet.of(Capability.IS_LOCAL, Capability.SUPPORTS_CLI);
+  }
+
+  @Override
+  public BuildEventStreamProvider invoke(BlazeCommand.Builder blazeCommandBuilder)
+    throws BuildException {
+    try {
+      performGuardCheck(project, blazeContext);
+    }
+    catch (ExecutionDeniedException e) {
+      throw new BuildException(e.getMessage(), e);
+    }
+    File outputFile = BuildEventProtocolUtils.createTempOutputFile();
+    BuildResult buildResult =
+      issueBuild(blazeCommandBuilder, WorkspaceRoot.fromProject(project), blazeContext, outputFile);
+    if (blazeCommandBuilder.build().getName().equals(BlazeCommandName.BUILD)) {
+      BuildDepsStatsScope.fromContext(blazeContext)
+        .ifPresent(stats -> stats.setBazelExitCode(buildResult.exitCode));
+    }
+    return getBepStream(outputFile);
+  }
+
+  @Override
+  public InputStream invokeQuery(BlazeCommand.Builder blazeCommandBuilder) {
+    try {
+      performGuardCheck(project, blazeContext);
+    }
+    catch (ExecutionDeniedException e) {
+      logger.error(e);
+      return null;
+    }
+
+    BlazeCommand blazeCommand = blazeCommandBuilder.build();
+    try (Closer closer = Closer.create()) {
+      Path tempFile =
+        Files.createTempFile(
+          String.format("intellij-bazel-%s-", blazeCommand.getName()), ".stdout");
+      OutputStream out = closer.register(Files.newOutputStream(tempFile));
+      WorkspaceRoot workspaceRoot = WorkspaceRoot.fromProject(project);
+      Function<String, String> rootReplacement =
+        WorkspaceRootReplacement.create(workspaceRoot.path(), blazeCommand);
+      boolean isUnitTestMode = ApplicationManager.getApplication().isUnitTestMode();
+      int retVal =
+        ExternalTask.builder(workspaceRoot)
+          .addBlazeCommand(blazeCommand)
+          .context(blazeContext)
+          .stdout(out)
+          .stderr(
+            LineProcessingOutputStream.of(
+              line -> {
+                line = rootReplacement.apply(line);
+                // errors are expected, so limit logging to info level
+                if (isUnitTestMode) {
+                  // This is essential output in bazel-in-bazel tests if they fail.
+                  System.out.println(line.stripTrailing());
+                }
+                Logger.getInstance(this.getClass()).info(line.stripTrailing());
+                blazeContext.output(PrintOutput.output(line.stripTrailing()));
+                return true;
+              }))
+          .ignoreExitCode(true)
+          .build()
+          .run();
+      SyncQueryStatsScope.fromContext(blazeContext)
+        .ifPresent(stats -> stats.setBazelExitCode(retVal));
+      BazelExitCodeException.throwIfFailed(blazeCommand, retVal, BazelExitCodeException.ThrowOption.ALLOW_PARTIAL_SUCCESS);
+      return new BufferedInputStream(
+        Files.newInputStream(tempFile, StandardOpenOption.DELETE_ON_CLOSE));
+    }
+    catch (IOException | BuildException e) {
+      logger.error(e);
+      return null;
+    }
+  }
+
+  @Override
+  @Nullable
+  public InputStream invokeInfo(BlazeCommand.Builder blazeCommandBuilder) {
+    try {
+      performGuardCheck(project, blazeContext);
+    }
+    catch (ExecutionDeniedException e) {
+      logger.error(e);
+      return null;
+    }
+
+    BlazeCommand blazeCommand = blazeCommandBuilder.build();
+    try (Closer closer = Closer.create()) {
+      Path tmpFile =
+        Files.createTempFile(
+          String.format("intellij-bazel-%s-", blazeCommand.getName()), ".stdout");
+      OutputStream out = closer.register(Files.newOutputStream(tmpFile));
+      OutputStream stderr =
+        closer.register(
+          LineProcessingOutputStream.of(new PrintOutputLineProcessor(blazeContext)));
+      int exitCode =
+        ExternalTask.builder(WorkspaceRoot.fromProject(project))
+          .addBlazeCommand(blazeCommand)
+          .context(blazeContext)
+          .stdout(out)
+          .stderr(stderr)
+          .ignoreExitCode(true)
+          .build()
+          .run();
+      BazelExitCodeException.throwIfFailed(blazeCommand, exitCode);
+      return new BufferedInputStream(
+        Files.newInputStream(tmpFile, StandardOpenOption.DELETE_ON_CLOSE));
+    }
+    catch (IOException | BuildException e) {
+      logger.error(e);
+      return null;
+    }
+  }
+
+  @Override
+  public BuildBinaryType getType() {
+    return this.buildBinaryType;
+  }
+
+  private BuildResult issueBuild(
+    BlazeCommand.Builder blazeCommandBuilder, WorkspaceRoot workspaceRoot, BlazeContext context, File outputFile) {
+    blazeCommandBuilder.addBlazeFlags(BuildEventProtocolUtils.getBuildFlags(outputFile));
+    int retVal =
+      ExternalTask.builder(workspaceRoot)
+        .addBlazeCommand(blazeCommandBuilder.build())
+        .context(context)
+        .stderr(
+          LineProcessingOutputStream.of(
+            BlazeConsoleLineProcessorProvider.getAllStderrLineProcessors(context)))
+        .ignoreExitCode(true)
+        .build()
+        .run();
+    return BuildResult.fromExitCode(retVal);
+  }
+
+  private BuildEventStreamProvider getBepStream(File outputFile) throws BuildResultHelper.GetArtifactsException {
+    try {
+      return BuildEventStreamProvider.fromInputStream(
+        new BufferedInputStream(new FileInputStream(outputFile)));
+    }
+    catch (FileNotFoundException e) {
+      logger.error(e);
+      throw new BuildResultHelper.GetArtifactsException(e.getMessage());
+    }
+  }
+
+  private void performGuardCheck(Project project, BlazeContext context)
+    throws ExecutionDeniedException {
+    try {
+      BazelGuard.checkExtensionsIsExecutionAllowed(project);
+    }
+    catch (ExecutionDeniedException e) {
+      IssueOutput.error(
+          "Can't invoke "
+          + Blaze.buildSystemName(project)
+          + " because the project is not trusted")
+        .submit(context);
+      throw e;
+    }
+  }
+
+  private static String binaryPath(BuildBinaryType binaryType, Project project) {
+    if (binaryType.equals(BuildBinaryType.BLAZE) || binaryType.equals(BuildBinaryType.BLAZE_CUSTOM)) {
+      return BlazeUserSettings.getInstance().getBlazeBinaryPath();
+    }
+    File projectSpecificBinary = null;
+    ProjectViewSet projectView = ProjectViewManager.getInstance(project).getProjectViewSet();
+    if (projectView != null) {
+      projectSpecificBinary = projectView.getScalarValue(BazelBinarySection.KEY).orElse(null);
+    }
+
+    if (projectSpecificBinary != null) {
+      return projectSpecificBinary.getPath();
+    }
+    return BlazeUserSettings.getInstance().getBazelBinaryPath();
+  }
+}

--- a/base/tests/utils/unit/com/google/idea/blaze/base/bazel/BuildSystemProviderWrapper.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/bazel/BuildSystemProviderWrapper.java
@@ -38,7 +38,6 @@ import com.google.idea.blaze.exception.BuildException;
 import com.intellij.openapi.project.Project;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -242,11 +241,6 @@ public class BuildSystemProviderWrapper implements BuildSystemProvider {
       catch (IOException e) {
         throw new BuildException(String.format("Error invoking blaze info with %s", inner.getClass().getSimpleName()), e);
       }
-    }
-
-    @Override
-    public List<String> getBuildFlags() {
-      return inner.getBuildFlags();
     }
 
     @Override

--- a/base/tests/utils/unit/com/google/idea/blaze/base/bazel/FakeBuildInvoker.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/bazel/FakeBuildInvoker.java
@@ -28,7 +28,6 @@ import com.google.idea.blaze.base.command.info.BlazeInfo;
 import com.google.idea.blaze.base.settings.BuildBinaryType;
 import com.google.idea.blaze.base.settings.BuildSystemName;
 import java.io.InputStream;
-import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
@@ -46,7 +45,6 @@ public abstract class FakeBuildInvoker implements BuildInvoker {
       .supportsParallelism(false)
       .buildResultHelperSupplier(() -> null)
       .commandRunner(new FakeBlazeCommandRunner())
-      .buildFlags(ImmutableList.of())
       .buildSystem(FakeBuildSystem.builder(BuildSystemName.Blaze).build());
   }
 
@@ -70,9 +68,6 @@ public abstract class FakeBuildInvoker implements BuildInvoker {
   public InputStream invokeInfo(BlazeCommand.Builder blazeCommandBuilder) {
     return InputStream.nullInputStream();
   }
-
-  @Override
-  public abstract List<String> getBuildFlags();
 
   @Override
   @Nullable
@@ -154,8 +149,6 @@ public abstract class FakeBuildInvoker implements BuildInvoker {
     public abstract Builder buildResultHelperSupplier(Supplier<BuildResultHelper> supplier);
 
     public abstract Builder commandRunner(FakeBlazeCommandRunner runner);
-
-    public abstract Builder buildFlags(java.util.List<String> value);
 
     public abstract Builder buildSystem(BuildSystem buildSystem);
   }


### PR DESCRIPTION
Cherry pick AOSP commit [f4b863f5a6e1b50b3e505cc7d52c521b16a34dec](https://cs.android.com/android-studio/platform/tools/adt/idea/+/f4b863f5a6e1b50b3e505cc7d52c521b16a34dec).

The Blaze and Bazel invokers are pretty much the same, except the binary type and the binary path. Merge them into a single `LocalInvoker` to avoid duplicate code as part of the cleanup.

Prior to cleanup, they were two different classes, but shared the same command runner and the build result helper.

Bug:374906681

Test: n/a
Change-Id: I7a9a570c48191ba6b05e1b5d227fc8a97ebe9398

AOSP: f4b863f5a6e1b50b3e505cc7d52c521b16a34dec
