### PR TITLE
[AOSP-pick] Set test experiment for merged aars and jars to false

### DIFF
--- a/aswb/BUILD
+++ b/aswb/BUILD
@@ -88,6 +88,8 @@ java_library(
         "//base",
         "//base:integration_test_utils",
         "//base:unit_test_utils",
+        "//common/experiments",
+        "//common/experiments:unit_test_utils",
         "//cpp",
         "//java",
         "//shared:artifact",

--- a/aswb/tests/utils/integration/com/google/idea/blaze/android/MobileInstallBuildStepTestCase.java
+++ b/aswb/tests/utils/integration/com/google/idea/blaze/android/MobileInstallBuildStepTestCase.java
@@ -40,6 +40,9 @@ import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.model.primitives.WorkspacePath;
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.scope.output.IssueOutput;
+import com.google.idea.common.experiments.BoolExperiment;
+import com.google.idea.common.experiments.ExperimentService;
+import com.google.idea.common.experiments.MockExperimentService;
 import com.intellij.openapi.project.Project;
 import com.intellij.ui.SimpleColoredComponent;
 import java.util.EnumSet;
@@ -67,6 +70,9 @@ public class MobileInstallBuildStepTestCase extends BlazeAndroidIntegrationTestC
         "  //java/com/foo/app:app",
         "android_sdk_platform: android-27");
     MockSdkUtil.registerSdk(workspace, "27");
+    MockExperimentService experimentService = new MockExperimentService();
+    registerApplicationComponent(ExperimentService.class, experimentService);
+    experimentService.setExperiment(new BoolExperiment("blaze.android.merge.libs", true), false);
 
     workspace.createFile(
         new WorkspacePath("java/com/foo/app/MainActivity.java"),


### PR DESCRIPTION
Cherry pick AOSP commit [c79ba65b65bf7825b38fb73d616321dc88b0046b](https://cs.android.com/android-studio/platform/tools/adt/idea/+/c79ba65b65bf7825b38fb73d616321dc88b0046b).

This experiment is being removed and thus set to true in the code,
but this test depends on this flag being false.

Bug: 391569121
Test: //tools/adt.idea/aswb/aswb:integration_tests
Change-Id: I56cd0a1835a4a07d9f3bb5f210bf2bfbbee424cf

AOSP: c79ba65b65bf7825b38fb73d616321dc88b0046b
