### PR TITLE
[AOSP-pick] Query sync cache invalidator

### DIFF
--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -238,7 +238,6 @@
     <postStartupActivity implementation="com.google.idea.blaze.base.project.OpenProjectViewStartupActivity"/>
     <moduleRendererFactory implementation="com.google.idea.blaze.base.ui.BlazeModuleRendererFactory" order="first"/>
 
-
     <toolWindow id="Blaze"
         anchor="bottom"
         secondary="false"
@@ -398,6 +397,7 @@
     <notificationGroup displayType="BALLOON" id="AddToProject" />
     <notificationGroup displayType="STICKY_BALLOON" id="QuerySyncPromo" />
     <notificationGroup displayType="BALLOON" id="QuerySyncBuild" />
+    <cachesInvalidator implementation="com.google.idea.blaze.base.qsync.action.ResetQuerySyncAction$CacheInvalidator"/>
     <registryKey defaultValue="false" description="Disable auto import of bazel projects" key="bazel.auto.import.disabled"/>
     <registryKey defaultValue="false" description="Allow to have optional imports in project view" key="bazel.projectview.optional.imports"/>
     <registryKey key="bazel.sync.resolve.virtual.includes"

--- a/base/src/com/google/idea/blaze/base/qsync/QuerySyncProject.java
+++ b/base/src/com/google/idea/blaze/base/qsync/QuerySyncProject.java
@@ -368,12 +368,17 @@ public class QuerySyncProject {
   }
 
   public void resetQuerySyncState(BlazeContext context) throws BuildException {
+    invalidateQuerySyncState(context);
+    fullSync(context);
+  }
+
+  public void invalidateQuerySyncState(BlazeContext context) throws BuildException {
     try {
       artifactTracker.clear();
     } catch (IOException e) {
       throw new BuildException("Failed to clear dependency info", e);
     }
-    fullSync(context);
+    onNewSnapshot(context, QuerySyncProjectSnapshot.EMPTY);
   }
 
   public void build(BlazeContext parentContext, DependencyTracker.DependencyBuildRequest request)

--- a/base/src/com/google/idea/blaze/base/qsync/action/ResetQuerySyncAction.java
+++ b/base/src/com/google/idea/blaze/base/qsync/action/ResetQuerySyncAction.java
@@ -18,20 +18,67 @@ package com.google.idea.blaze.base.qsync.action;
 import com.google.idea.blaze.base.logging.utils.querysync.QuerySyncActionStatsScope;
 import com.google.idea.blaze.base.qsync.QuerySyncManager;
 import com.google.idea.blaze.base.qsync.QuerySyncManager.TaskOrigin;
+import com.google.idea.blaze.base.scope.BlazeContext;
+import com.google.idea.blaze.exception.BuildException;
+import com.intellij.ide.caches.CachesInvalidator;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.DumbAwareAction;
+import com.intellij.openapi.project.ProjectManager;
+import com.intellij.openapi.util.NlsContexts;
+import java.util.Arrays;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * An internal action to clear query sync dependencies, i.e. remove all dependencies from the
  * project.
  */
 public final class ResetQuerySyncAction extends DumbAwareAction {
+  private static final Logger logger = Logger.getInstance(ResetQuerySyncAction.class);
 
   @Override
   public void actionPerformed(@NotNull AnActionEvent e) {
     QuerySyncManager qsm = QuerySyncManager.getInstance(e.getProject());
     qsm.resetQuerySyncState(
         QuerySyncActionStatsScope.create(getClass(), e), TaskOrigin.USER_ACTION);
+  }
+
+  /**
+   * An implementation of {@link com.intellij.ide.caches.CachesInvalidator} for query sync.
+   */
+  public static class CachesInvalidator extends com.intellij.ide.caches.CachesInvalidator   {
+
+    @Override
+    public String getDescription() {
+      return "Reset sync and code analysis state";
+    }
+
+    @Override
+    public String getComment() {
+      return "Completely resets the state of the project structure and disables code analysis in all files";
+    }
+
+    @Override
+    public Boolean optionalCheckboxDefaultValue() {
+      return true;
+    }
+
+    @Override
+    public void invalidateCaches() {
+      Arrays.stream(ProjectManager.getInstance().getOpenProjects())
+        .flatMap(project -> {
+          final var qsm = QuerySyncManager.getInstance(project);
+          return qsm.getLoadedProject().stream();
+        })
+        .forEach(project -> {
+          try {
+            project.invalidateQuerySyncState(BlazeContext.create());
+          }
+          catch (BuildException e) {
+            logger.error(e);
+          }
+        });
+    }
   }
 }

--- a/querysync/java/com/google/idea/blaze/qsync/QuerySyncProjectSnapshot.java
+++ b/querysync/java/com/google/idea/blaze/qsync/QuerySyncProjectSnapshot.java
@@ -54,7 +54,6 @@ import javax.annotation.Nullable;
 @AutoValue
 public abstract class QuerySyncProjectSnapshot {
 
-  @VisibleForTesting
   public static final QuerySyncProjectSnapshot EMPTY =
       builder()
           .graph(BuildGraphData.EMPTY)


### PR DESCRIPTION
Cherry pick AOSP commit [71e593cbc07a254b24f4815d9ae02d51f9c9b7e4](https://cs.android.com/android-studio/platform/tools/adt/idea/+/71e593cbc07a254b24f4815d9ae02d51f9c9b7e4).

Bug: 305956977
Test: n/a (manually only since only integration testing makes sense here)
Change-Id: I6c33643898798e403748849a915278f50c2e9496

AOSP: 71e593cbc07a254b24f4815d9ae02d51f9c9b7e4
