### PR TITLE
Use absolute labels for tools in the IntelliJ aspect

### DIFF
--- a/aspect/BUILD
+++ b/aspect/BUILD
@@ -95,7 +95,7 @@ genrule(
     srcs = ["intellij_info.bzl"],
     outs = ["intellij_info_bundled.bzl"],
     cmd = "cat $(SRCS) >$@ && " +
-          "sed -i -e 's,//%s/tools:\" + tool_name,tools/\" + tool_name,g' $@ && " % _dev_aspect_path +
+          "sed -i -e 's,//%s/tools:\" + tool_name,//.ijwb/aspect:tools/\" + tool_name,g' $@ && " % _dev_aspect_path +
           "sed -i -e 's,//%s:flag_hack,:flag_hack,g' $@  && " % _dev_aspect_path +
           "sed -i -e 's,:intellij_info_impl.bzl,:intellij_info_impl_bundled.bzl,g' $@",
 )


### PR DESCRIPTION
This is required for compatibility with Bazel 6.0.0. See https://github.com/bazelbuild/intellij/issues/7470#issuecomment-2743086423

Tested manually on `examples/java/greetings_project` (commit c7a2a83ff681d22fa5b904bd973c91644fcc7aec).
