### PR TITLE
Fixed a typo in the location of JARs which are used by the aspect sync.

### DIFF
--- a/base/src/com/google/idea/blaze/base/sync/aspects/storage/AspectStorageService.kt
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/storage/AspectStorageService.kt
@@ -39,7 +39,7 @@ import java.nio.file.Path
 import java.util.*
 
 private const val ASPECT_TASK_TITLE = "Write Aspects"
-private const val ASPECT_DIRECTORY = "aspects"
+private const val ASPECT_DIRECTORY = "aspect"
 
 private const val BAZEL_IGNORE_FILE = ".bazelignore"
 


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #7470

# Description of this change

This fixes aspect sync for Bazel versions 6.1.0 and newer. See https://github.com/bazelbuild/intellij/issues/7470#issuecomment-2743086423

