### PR TITLE
[AOSP-pick] Token for APK analyzer default APK

### DIFF
--- a/aswb/src/com/google/idea/blaze/android/projectsystem/BazelProjectSystem.java
+++ b/aswb/src/com/google/idea/blaze/android/projectsystem/BazelProjectSystem.java
@@ -95,12 +95,6 @@ public class BazelProjectSystem implements AndroidProjectSystem {
     return true;
   }
 
-  @Nullable
-  @Override
-  public VirtualFile getDefaultApkFile() {
-    return null;
-  }
-
   @Override
   public ProjectSystemBuildManager getBuildManager() {
     return buildManager;


### PR DESCRIPTION
Cherry pick AOSP commit [5c3323ea1aec4860eda8563af1965d8e1df85c74](https://cs.android.com/android-studio/platform/tools/adt/idea/+/5c3323ea1aec4860eda8563af1965d8e1df85c74).

The deleted 'getDefaultApkFile' method from the project system implied
something much more generic than this actually is. Pull out the logic
into a separate token to make it specific to the APK analyzer, and move
the integration tests to be next to the new token.

Bug: 391620143
Bug: 191146142
Test: Moved integration tests.
Change-Id: I4de9fb6c9f0153cdc939de29d5752c90b0428cd7

AOSP: 5c3323ea1aec4860eda8563af1965d8e1df85c74
