### PR TITLE
[AOSP-pick] Remove fetching configMnemonic from BEP event as its calculated from artifact prefix path

### DIFF
--- a/base/tests/unittests/com/google/idea/blaze/base/run/testlogs/LocalBuildEventProtocolTestFinderStrategyTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/run/testlogs/LocalBuildEventProtocolTestFinderStrategyTest.java
@@ -28,8 +28,11 @@ import com.google.idea.blaze.base.command.buildresult.bepparser.BuildEventStream
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtifactsException;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelperBep;
+import com.google.idea.blaze.base.command.buildresult.LocalFileParser;
 import com.google.idea.blaze.base.command.buildresult.bepparser.BuildEventStreamProvider;
 import com.google.idea.blaze.base.command.buildresult.bepparser.BuildEventStreamProvider.BuildEventStreamException;
+import com.google.idea.blaze.base.command.buildresult.bepparser.OutputArtifactParser;
+import com.intellij.openapi.extensions.impl.ExtensionPointImpl;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.testFramework.rules.TempDirectory;
 import java.io.ByteArrayOutputStream;
@@ -47,6 +50,14 @@ import org.junit.runners.JUnit4;
 public class LocalBuildEventProtocolTestFinderStrategyTest extends BlazeTestCase {
 
   @Rule public TempDirectory tempDirectory = new TempDirectory();
+
+  @Override
+  protected void initTest(Container applicationServices, Container projectServices) {
+    super.initTest(applicationServices, projectServices);
+    ExtensionPointImpl<OutputArtifactParser> parserEp =
+      registerExtensionPoint(OutputArtifactParser.EP_NAME, OutputArtifactParser.class);
+    parserEp.registerExtension(new LocalFileParser());
+  }
 
   @Test
   public void testFinder_fileDeletedAfterCleanup() throws GetArtifactsException {


### PR DESCRIPTION
Cherry pick AOSP commit [b5e9e7e11e5cc65423cef425c863fdf4afebe5d8](https://cs.android.com/android-studio/platform/tools/adt/idea/+/b5e9e7e11e5cc65423cef425c863fdf4afebe5d8).

- ag/31040465 calculated configMnemonic in runtime using the artifact
prefix path, so it is no longer required to capture it from the BEP
event.
- It is also no longer required to parse local test files that do not
  have a mnemonic in BEP event as SourceArtifact, because the
  configMnemonic calculated in runtime by ag/31040465 in LocalFileParser.

Bug: 385469770
Test: existing tests
Change-Id: I8f2c8aea91b204d1e5a11ce5e7cc3ed278c4ffc6

AOSP: b5e9e7e11e5cc65423cef425c863fdf4afebe5d8
