### PR TITLE
[AOSP-pick] Store output xml files as OutputArtifact instead of BlazeArtifact in BlazeTestResult

### DIFF
--- a/base/src/com/google/idea/blaze/base/command/buildresult/BuildEventProtocolOutputReader.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/BuildEventProtocolOutputReader.java
@@ -28,7 +28,6 @@ import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.run.testlogs.BlazeTestResult;
 import com.google.idea.blaze.base.run.testlogs.BlazeTestResult.TestStatus;
 import com.google.idea.blaze.base.run.testlogs.BlazeTestResults;
-import com.google.idea.blaze.common.artifact.BlazeArtifact;
 import com.google.idea.blaze.common.artifact.OutputArtifact;
 import com.intellij.util.io.URLUtil;
 import java.io.File;
@@ -103,7 +102,7 @@ public final class BuildEventProtocolOutputReader {
       @Nullable Kind kind,
       BuildEventStreamProtos.TestResult testResult,
       long startTimeMillis) {
-    ImmutableSet<BlazeArtifact> files =
+    ImmutableSet<OutputArtifact> files =
         testResult.getTestActionOutputList().stream()
             .map(
                 file ->
@@ -123,7 +122,7 @@ public final class BuildEventProtocolOutputReader {
   }
 
   @Nullable
-  private static BlazeArtifact parseTestFile(
+  private static OutputArtifact parseTestFile(
       BuildEventStreamProtos.File file,
       Predicate<String> fileFilter,
       long startTimeMillis) {

--- a/base/src/com/google/idea/blaze/base/run/testlogs/BlazeTestResult.java
+++ b/base/src/com/google/idea/blaze/base/run/testlogs/BlazeTestResult.java
@@ -19,7 +19,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
 import com.google.idea.blaze.base.model.primitives.Kind;
 import com.google.idea.blaze.base.model.primitives.Label;
-import com.google.idea.blaze.common.artifact.BlazeArtifact;
+import com.google.idea.blaze.common.artifact.OutputArtifact;
 import javax.annotation.Nullable;
 
 /** The result of a single blaze test action. */
@@ -51,7 +51,7 @@ public abstract class BlazeTestResult {
       Label label,
       @Nullable Kind targetKind,
       TestStatus testStatus,
-      ImmutableSet<? extends BlazeArtifact> outputXmlFiles) {
+      ImmutableSet<? extends OutputArtifact> outputXmlFiles) {
     return new AutoValue_BlazeTestResult(label, targetKind, testStatus, outputXmlFiles);
   }
 
@@ -62,5 +62,5 @@ public abstract class BlazeTestResult {
 
   public abstract TestStatus getTestStatus();
 
-  public abstract ImmutableSet<? extends BlazeArtifact> getOutputXmlFiles();
+  public abstract ImmutableSet<? extends OutputArtifact> getOutputXmlFiles();
 }

--- a/java/src/com/google/idea/blaze/java/run/fastbuild/FastBuildTestResultFinderStrategy.java
+++ b/java/src/com/google/idea/blaze/java/run/fastbuild/FastBuildTestResultFinderStrategy.java
@@ -18,7 +18,7 @@ package com.google.idea.blaze.java.run.fastbuild;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.idea.blaze.base.command.buildresult.SourceArtifact;
+import com.google.idea.blaze.base.command.buildresult.LocalFileOutputArtifact;
 import com.google.idea.blaze.base.model.primitives.Kind;
 import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.run.testlogs.BlazeTestResult;
@@ -26,22 +26,22 @@ import com.google.idea.blaze.base.run.testlogs.BlazeTestResult.TestStatus;
 import com.google.idea.blaze.base.run.testlogs.BlazeTestResultFinderStrategy;
 import com.google.idea.blaze.base.run.testlogs.BlazeTestResults;
 import com.google.idea.blaze.base.scope.BlazeContext;
+import com.google.idea.blaze.common.artifact.OutputArtifact;
 import com.google.idea.blaze.java.fastbuild.FastBuildLogDataScope.FastBuildLogOutput;
-import java.io.File;
 
 final class FastBuildTestResultFinderStrategy implements BlazeTestResultFinderStrategy {
 
   private final Label label;
   private final Kind kind;
-  private final File outputFile;
+  private final LocalFileOutputArtifact outputArtifact;
   private final BlazeContext blazeContext;
   private final Stopwatch timer;
 
   FastBuildTestResultFinderStrategy(
-      Label label, Kind kind, File outputFile, BlazeContext blazeContext) {
+      Label label, Kind kind, LocalFileOutputArtifact outputFile, BlazeContext blazeContext) {
     this.label = label;
     this.kind = kind;
-    this.outputFile = outputFile;
+    this.outputArtifact = outputFile;
     this.blazeContext = blazeContext;
     this.timer = Stopwatch.createStarted();
   }
@@ -58,11 +58,11 @@ final class FastBuildTestResultFinderStrategy implements BlazeTestResultFinderSt
                 label,
                 kind,
                 TestStatus.NO_STATUS,
-                ImmutableSet.of(new SourceArtifact(outputFile)))));
+                  ImmutableSet.of(outputArtifact))));
   }
 
   @Override
   public void deleteTemporaryOutputFiles() {
-    outputFile.delete();
+    outputArtifact.getFile().delete();
   }
 }


### PR DESCRIPTION
Cherry pick AOSP commit [682108b547ddae3227f3de260d237cefcef2bfe6](https://cs.android.com/android-studio/platform/tools/adt/idea/+/682108b547ddae3227f3de260d237cefcef2bfe6).

STAT (diff to AOSP): 0 insertions(+), 11 deletion(-)

Store output xml files as OutputArtifact instead of BlazeArtifact in
BlazeTestResult object as this allows those files to be stored in
RuntimeArtifactCache in later CLs, as RuntimeArtifactCache only stores
OutputArtifact type artifacts.

Bug: 385469770
Test: existing tests
Change-Id: I6f889eeec2f09c96b58229ce1528ca5ec9d4ac91

AOSP: 682108b547ddae3227f3de260d237cefcef2bfe6
