### PR TITLE
[AOSP-pick] Add/Update getLocalFiles method to support both BlazeArtifact and OutputArtifact type artifacts

### DIFF
--- a/base/src/com/google/idea/blaze/base/command/buildresult/LocalFileArtifact.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/LocalFileArtifact.java
@@ -20,6 +20,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import com.google.common.collect.ImmutableList;
 import com.google.idea.blaze.base.io.FileOperationProvider;
 import com.google.idea.blaze.common.artifact.BlazeArtifact;
+import com.google.idea.blaze.common.artifact.OutputArtifact;
 import java.io.File;
 import java.util.Collection;
 
@@ -32,11 +33,24 @@ public interface LocalFileArtifact extends BlazeArtifact {
    * <p>Some callers will only ever accept local outputs (e.g. when debugging, and making use of
    * runfiles directories).
    */
-  static ImmutableList<File> getLocalFiles(Collection<? extends BlazeArtifact> artifacts) {
+  static ImmutableList<File> getLocalFiles(Collection<? extends OutputArtifact> artifacts) {
     return artifacts.stream()
         .filter(a -> a instanceof LocalFileArtifact)
         .map(a -> ((LocalFileArtifact) a).getFile())
         .collect(toImmutableList());
+  }
+
+  /**
+   * Filters out non-local artifacts for legacy sync as it supports BlazeArtifact.
+   *
+   * <p>Some callers will only ever accept local outputs (e.g. when debugging, and making use of
+   * runfiles directories).
+   */
+  static ImmutableList<File> getLocalFilesForLegacySync(Collection<? extends BlazeArtifact> artifacts) {
+    return artifacts.stream()
+      .filter(a -> a instanceof LocalFileArtifact)
+      .map(a -> ((LocalFileArtifact) a).getFile())
+      .collect(toImmutableList());
   }
 
   File getFile();

--- a/base/src/com/google/idea/blaze/base/sync/aspects/BlazeIdeInterfaceAspectsImpl.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/BlazeIdeInterfaceAspectsImpl.java
@@ -269,7 +269,7 @@ public class BlazeIdeInterfaceAspectsImpl implements BlazeIdeInterface {
     ListenableFuture<?> fetchLocalFilesFuture =
         PrefetchService.getInstance()
             .prefetchFiles(
-                /* files= */ LocalFileArtifact.getLocalFiles(diff.getUpdatedOutputs()),
+                /* files= */ LocalFileArtifact.getLocalFilesForLegacySync(diff.getUpdatedOutputs()),
                 /* refetchCachedFiles= */ true,
                 /* fetchFileTypes= */ false);
     if (!FutureUtil.waitForFuture(context, fetchLocalFilesFuture)

--- a/base/tests/unittests/com/google/idea/blaze/base/command/buildresult/BuildEventProtocolOutputReaderLegacyTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/command/buildresult/BuildEventProtocolOutputReaderLegacyTest.java
@@ -133,7 +133,7 @@ public class BuildEventProtocolOutputReaderLegacyTest extends BlazeTestCase {
         BepParser.parseBepArtifactsForLegacySync(BuildEventStreamProvider.fromInputStream(asInputStream(events)), null)
             .getAllOutputArtifactsForTesting();
 
-    assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
+    assertThat(LocalFileArtifact.getLocalFilesForLegacySync(parsedFilenames))
         .containsExactlyElementsIn(filePaths.stream().map(File::new).toArray())
         .inOrder();
   }
@@ -175,7 +175,7 @@ public class BuildEventProtocolOutputReaderLegacyTest extends BlazeTestCase {
         BepParser.parseBepArtifactsForLegacySync(BuildEventStreamProvider.fromInputStream(asInputStream(events)), null)
             .getAllOutputArtifactsForTesting();
 
-    assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
+    assertThat(LocalFileArtifact.getLocalFilesForLegacySync(parsedFilenames))
         .containsExactlyElementsIn(filePaths.stream().map(File::new).toArray())
         .inOrder();
   }
@@ -220,7 +220,7 @@ public class BuildEventProtocolOutputReaderLegacyTest extends BlazeTestCase {
         BepParser.parseBepArtifactsForLegacySync(BuildEventStreamProvider.fromInputStream(asInputStream(events)), null)
             .getAllOutputArtifactsForTesting();
 
-    assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
+    assertThat(LocalFileArtifact.getLocalFilesForLegacySync(parsedFilenames))
         .containsExactlyElementsIn(allFiles)
         .inOrder();
   }
@@ -257,7 +257,7 @@ public class BuildEventProtocolOutputReaderLegacyTest extends BlazeTestCase {
         BepParser.parseBepArtifactsForLegacySync(BuildEventStreamProvider.fromInputStream(asInputStream(events)), null)
             .getAllOutputArtifactsForTesting();
 
-    assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
+    assertThat(LocalFileArtifact.getLocalFilesForLegacySync(parsedFilenames))
         .containsExactlyElementsIn(allFiles)
         .inOrder();
   }
@@ -289,7 +289,7 @@ public class BuildEventProtocolOutputReaderLegacyTest extends BlazeTestCase {
         getOutputGroupTargetArtifacts(
               BepParser.parseBepArtifactsForLegacySync(BuildEventStreamProvider.fromInputStream(asInputStream(events)), null).fileSets, "group-name", "//some:target");
 
-    assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
+    assertThat(LocalFileArtifact.getLocalFilesForLegacySync(parsedFilenames))
         .containsExactlyElementsIn(allFiles)
         .inOrder();
   }
@@ -329,7 +329,7 @@ public class BuildEventProtocolOutputReaderLegacyTest extends BlazeTestCase {
         getOutputGroupTargetArtifacts(
               BepParser.parseBepArtifactsForLegacySync(BuildEventStreamProvider.fromInputStream(asInputStream(events)), null).fileSets, "group-name", "//some:target");
 
-    assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
+    assertThat(LocalFileArtifact.getLocalFilesForLegacySync(parsedFilenames))
         .containsExactlyElementsIn(allFiles)
         .inOrder();
   }
@@ -375,7 +375,7 @@ public class BuildEventProtocolOutputReaderLegacyTest extends BlazeTestCase {
         getOutputGroupArtifacts(BepParser.parseBepArtifactsForLegacySync(BuildEventStreamProvider.fromInputStream(asInputStream(events)), null).fileSets,
                                      "group-name");
 
-    assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
+    assertThat(LocalFileArtifact.getLocalFilesForLegacySync(parsedFilenames))
         .containsExactlyElementsIn(allFiles)
         .inOrder();
   }
@@ -416,7 +416,7 @@ public class BuildEventProtocolOutputReaderLegacyTest extends BlazeTestCase {
         getOutputGroupArtifacts(BepParser.parseBepArtifactsForLegacySync(BuildEventStreamProvider.fromInputStream(asInputStream(events)), null).fileSets,
                                      "group-1");
 
-    assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
+    assertThat(LocalFileArtifact.getLocalFilesForLegacySync(parsedFilenames))
         .containsExactlyElementsIn(allFiles)
         .inOrder();
   }
@@ -453,7 +453,7 @@ public class BuildEventProtocolOutputReaderLegacyTest extends BlazeTestCase {
     ImmutableList<OutputArtifact> outputs =
         outputData.values().stream().map(d -> d.artifact).collect(toImmutableList());
 
-    assertThat(LocalFileArtifact.getLocalFiles(outputs)).containsExactlyElementsIn(allOutputs);
+    assertThat(LocalFileArtifact.getLocalFilesForLegacySync(outputs)).containsExactlyElementsIn(allOutputs);
   }
 
   private static InputStream asInputStream(BuildEvent.Builder... events) throws Exception {

--- a/base/tests/unittests/com/google/idea/blaze/base/command/buildresult/BuildEventProtocolOutputReaderTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/command/buildresult/BuildEventProtocolOutputReaderTest.java
@@ -585,7 +585,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
   }
 
   private static ImmutableList<File> getOutputXmlFiles(BlazeTestResult result) {
-    return LocalFileArtifact.getLocalFiles(result.getOutputXmlFiles());
+    return LocalFileArtifact.getLocalFilesForLegacySync(result.getOutputXmlFiles());
   }
 
   private static InputStream asInputStream(BuildEvent.Builder... events) throws Exception {

--- a/java/src/com/google/idea/blaze/java/sync/jdeps/JdepsFileReader.java
+++ b/java/src/com/google/idea/blaze/java/sync/jdeps/JdepsFileReader.java
@@ -160,7 +160,7 @@ public class JdepsFileReader {
                 /* outputArtifacts= */ RemoteOutputArtifact.getRemoteArtifacts(outputArtifacts));
     ListenableFuture<?> fetchLocalFilesFuture =
         PrefetchService.getInstance()
-            .prefetchFiles(LocalFileArtifact.getLocalFiles(outputArtifacts), true, false);
+            .prefetchFiles(LocalFileArtifact.getLocalFilesForLegacySync(outputArtifacts), true, false);
     if (!FutureUtil.waitForFuture(
             context, Futures.allAsList(downloadArtifactsFuture, fetchLocalFilesFuture))
         .timed("FetchJdeps", EventType.Prefetching)

--- a/java/src/com/google/idea/blaze/java/sync/source/PackageManifestReader.java
+++ b/java/src/com/google/idea/blaze/java/sync/source/PackageManifestReader.java
@@ -115,7 +115,7 @@ public class PackageManifestReader {
         RemoteArtifactPrefetcher.getInstance().downloadArtifacts(project.getName(), toDownload);
     ListenableFuture<PrefetchStats> fetchLocalFilesFuture =
         PrefetchService.getInstance()
-            .prefetchFiles(LocalFileArtifact.getLocalFiles(diff.getUpdatedOutputs()), true, false);
+            .prefetchFiles(LocalFileArtifact.getLocalFilesForLegacySync(diff.getUpdatedOutputs()), true, false);
 
     if (!FutureUtil.waitForFuture(
             context, Futures.allAsList(fetchRemoteArtifactFuture, fetchLocalFilesFuture))


### PR DESCRIPTION
Cherry pick AOSP commit [ed8535e5178e2f3f0459e7c01de1902fb319d4c5](https://cs.android.com/android-studio/platform/tools/adt/idea/+/ed8535e5178e2f3f0459e7c01de1902fb319d4c5).

STAT (diff to AOSP): 0 insertions(+), 0 deletion(-)

- Add a method getLocalFilesForLegacySync to support processing
  BlazeArtifact artifact types.
- Update existing getLocalFiles method to fetch local files for OutputArtifact type artifacts.
- This will help migrate LocalFileArtifact#getLocalFiles to using RuntimeArtifactCache, which
only supports OutputArtifact (as it expects artifacts to contain a
digest).
- Invokers of the method has been updated based on whether the flow is
  used in LegacySync or QuerySync (Native debugging).

Bug: 385469770
Test: Existing tests for testing old and new methods as their
implementation will only be updated in next CLs.
Change-Id: I6b7ecfd522f086b712c99e90fe30f1b3b3cb7abe

Change-Id: I523e59d72a3c239b234e0112c76b128e2bc19fb7

AOSP: ed8535e5178e2f3f0459e7c01de1902fb319d4c5
