### PR TITLE
[AOSP-pick] Somewhat de-generalize core DependencyManagement

### DIFF
--- a/aswb/src/com/google/idea/blaze/android/projectsystem/BazelAddDestinationMenuToken.java
+++ b/aswb/src/com/google/idea/blaze/android/projectsystem/BazelAddDestinationMenuToken.java
@@ -22,7 +22,7 @@ import com.android.ide.common.repository.GoogleMavenArtifactId;
 import com.android.tools.idea.common.model.NlModel;
 import com.android.tools.idea.naveditor.editor.AddDestinationMenuToken;
 import com.intellij.openapi.module.Module;
-import java.util.List;
+import java.util.Set;
 import org.jetbrains.annotations.NotNull;
 
 /** Blaze implementation of project system tokens for the navigation editor: Add Destination Menu */
@@ -42,9 +42,7 @@ public class BazelAddDestinationMenuToken
     final var unused =
         addDependenciesWithUiConfirmation(
             module,
-            List.of(
-                GoogleMavenArtifactId.ANDROIDX_NAVIGATION_DYNAMIC_FEATURES_FRAGMENT.getCoordinate(
-                    "+")),
+            Set.of(GoogleMavenArtifactId.ANDROIDX_NAVIGATION_DYNAMIC_FEATURES_FRAGMENT),
             true,
             false);
   }

--- a/aswb/src/com/google/idea/blaze/android/projectsystem/BazelNavDesignSurfaceToken.java
+++ b/aswb/src/com/google/idea/blaze/android/projectsystem/BazelNavDesignSurfaceToken.java
@@ -16,16 +16,16 @@
 package com.google.idea.blaze.android.projectsystem;
 
 import static com.android.tools.idea.util.DependencyManagementUtil.addDependenciesWithUiConfirmation;
-import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
-import com.android.ide.common.repository.GradleCoordinate;
+import com.android.ide.common.repository.GoogleMavenArtifactId;
 import com.android.tools.idea.common.model.NlModel;
 import com.android.tools.idea.naveditor.surface.NavDesignSurface;
 import com.android.tools.idea.naveditor.surface.NavDesignSurfaceToken;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.module.Module;
-import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.jetbrains.annotations.NotNull;
 
@@ -35,15 +35,13 @@ public class BazelNavDesignSurfaceToken implements NavDesignSurfaceToken<BazelPr
   public boolean modifyProject(@NotNull BazelProjectSystem projectSystem, @NotNull NlModel model) {
     AtomicBoolean didAdd = new AtomicBoolean(false);
     Module module = model.getModule();
-    List<GradleCoordinate> coordinates =
-        NavDesignSurface.getDependencies(module).stream()
-            .map((a) -> a.getCoordinate("+"))
-            .collect(toImmutableList());
+    Set<GoogleMavenArtifactId> artifacts =
+        NavDesignSurface.getDependencies(module).stream().collect(toImmutableSet());
     Runnable runnable =
         () -> {
           try {
             didAdd.set(
-                addDependenciesWithUiConfirmation(module, coordinates, true, false).isEmpty());
+                addDependenciesWithUiConfirmation(module, artifacts, true, false).isEmpty());
           } catch (Throwable t) {
             Logger.getInstance(NavDesignSurface.class).warn("Failed to add dependencies", t);
             didAdd.set(false);


### PR DESCRIPTION
Cherry pick AOSP commit [7810090c74d7072a8bcc94f4d97c3a34a7a5f617](https://cs.android.com/android-studio/platform/tools/adt/idea/+/7810090c74d7072a8bcc94f4d97c3a34a7a5f617).

STAT (diff to AOSP): 0 insertions(+), 0 deletion(-)

Do not claim to work with arbitrary GradleCoordinates any more:
instead, restrict our domain to the set of artifacts encoded in
GoogleMavenArtifactId (and, specifically, do not allow requesting
specific versions from client code).

This is not a complete solution to the problem that the
DependencyManagement offers interfaces to functionality that it cannot
in general provide, but it's a start, and in particular it removes a
counterintuitive use of GradleCoordinate in the Blaze project system.

Bug: 279149611
Bug: 279886738
Test: existing test adjusted
Change-Id: I40826a43a36818dc6e03fbc6894ed54fb7b3511e

AOSP: 7810090c74d7072a8bcc94f4d97c3a34a7a5f617
