### PR TITLE
[AOSP-pick] Use the same project definition to load and reload

### DIFF
--- a/base/src/com/google/idea/blaze/base/qsync/ProjectLoader.java
+++ b/base/src/com/google/idea/blaze/base/qsync/ProjectLoader.java
@@ -1,11 +1,32 @@
 package com.google.idea.blaze.base.qsync;
 
+import com.google.idea.blaze.base.bazel.BuildSystem;
+import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
+import com.google.idea.blaze.base.projectview.ProjectViewSet;
 import com.google.idea.blaze.base.scope.BlazeContext;
+import com.google.idea.blaze.base.sync.projectview.WorkspaceLanguageSettings;
 import com.google.idea.blaze.exception.BuildException;
+import com.google.idea.blaze.qsync.project.ProjectDefinition;
 import com.intellij.openapi.util.ModificationTracker;
 import org.jetbrains.annotations.Nullable;
 
 public interface ProjectLoader {
+  /**
+   * A pre-processed definition of a project to be loaded.
+   */
+  record ProjectToLoadDefinition(
+    WorkspaceRoot workspaceRoot,
+    BuildSystem buildSystem,
+    ProjectDefinition definition,
+    ProjectViewSet projectViewSet,
+    WorkspaceLanguageSettings workspaceLanguageSettings) {
+  }
+
+  /**
+   * Loads a project definition from the import settings and the .bazelproject file.
+   */
+  ProjectToLoadDefinition loadProjectDefinition(BlazeContext context) throws BuildException;
+
   @Nullable QuerySyncProject loadProject(BlazeContext context) throws BuildException;
 
   ModificationTracker getProjectModificationTracker();

--- a/base/src/com/google/idea/blaze/base/qsync/QuerySyncManager.java
+++ b/base/src/com/google/idea/blaze/base/qsync/QuerySyncManager.java
@@ -544,7 +544,8 @@ public class QuerySyncManager implements Disposable {
   private boolean projectDefinitionHasChanged(BlazeContext context) throws BuildException {
     // Ensure edits to the project view and any imports have been saved
     SaveUtil.saveAllFiles();
-    return !loadedProject.isDefinitionCurrent(context);
+    final var projectDefinition = loader.loadProjectDefinition(context).definition();
+    return !loadedProject.getProjectDefinition().equals(projectDefinition);
   }
 
   /** Displays error notification popup balloon in IDE. */

--- a/base/src/com/google/idea/blaze/base/qsync/QuerySyncProject.java
+++ b/base/src/com/google/idea/blaze/base/qsync/QuerySyncProject.java
@@ -34,16 +34,12 @@ import com.google.idea.blaze.base.model.primitives.WorkspacePath;
 import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
 import com.google.idea.blaze.base.projectview.ProjectViewManager;
 import com.google.idea.blaze.base.projectview.ProjectViewSet;
-import com.google.idea.blaze.base.projectview.section.Glob;
-import com.google.idea.blaze.base.projectview.section.sections.TestSourceSection;
 import com.google.idea.blaze.base.qsync.artifacts.ProjectArtifactStore;
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.settings.BlazeImportSettings;
 import com.google.idea.blaze.base.sync.SyncListener;
 import com.google.idea.blaze.base.sync.SyncMode;
 import com.google.idea.blaze.base.sync.SyncResult;
-import com.google.idea.blaze.base.sync.projectview.ImportRoots;
-import com.google.idea.blaze.base.sync.projectview.LanguageSupport;
 import com.google.idea.blaze.base.sync.projectview.WorkspaceLanguageSettings;
 import com.google.idea.blaze.base.sync.workspace.WorkspacePathResolver;
 import com.google.idea.blaze.base.targetmaps.SourceToTargetMap;
@@ -115,10 +111,8 @@ public class QuerySyncProject {
   // TODO(mathewi) only one of these two should strictly be necessary:
   private final WorkspacePathResolver workspacePathResolver;
   private final ProjectPath.Resolver projectPathResolver;
-  private final WorkspaceLanguageSettings workspaceLanguageSettings;
   private final QuerySyncSourceToTargetMap sourceToTargetMap;
 
-  private final ProjectViewManager projectViewManager;
   private final BuildSystem buildSystem;
   private final ProjectProtoTransform.Registry projectProtoTransforms;
 
@@ -146,7 +140,6 @@ public class QuerySyncProject {
       ProjectPath.Resolver projectPathResolver,
       WorkspaceLanguageSettings workspaceLanguageSettings,
       QuerySyncSourceToTargetMap sourceToTargetMap,
-      ProjectViewManager projectViewManager,
       BuildSystem buildSystem,
       ProjectProtoTransform.Registry projectProtoTransforms,
       BlazeInfo blazeInfo,
@@ -170,9 +163,7 @@ public class QuerySyncProject {
     this.projectViewSet = projectViewSet;
     this.workspacePathResolver = workspacePathResolver;
     this.projectPathResolver = projectPathResolver;
-    this.workspaceLanguageSettings = workspaceLanguageSettings;
     this.sourceToTargetMap = sourceToTargetMap;
-    this.projectViewManager = projectViewManager;
     this.buildSystem = buildSystem;
     this.projectProtoTransforms = projectProtoTransforms;
     projectData = new QuerySyncProjectData(
@@ -221,10 +212,6 @@ public class QuerySyncProject {
 
   public ProjectArtifactStore getArtifactStore() {
     return artifactStore;
-  }
-
-  public WorkspaceLanguageSettings getWorkspaceLanguageSettings() {
-    return workspaceLanguageSettings;
   }
 
   public ArtifactTracker<?> getArtifactTracker() {
@@ -472,38 +459,6 @@ public class QuerySyncProject {
             .map(s -> s.getPendingTargets(workspaceRoot.relativize(virtualFile)))
             .orElse(ImmutableSet.of());
     return pendingTargets.isEmpty();
-  }
-
-  /**
-   * Reloads the project view and checks it against the stored {@link ProjectDefinition}.
-   *
-   * @return true if the stored {@link ProjectDefinition} matches that derived from the {@link
-   *     ProjectViewSet}
-   */
-  public boolean isDefinitionCurrent(BlazeContext context) throws BuildException {
-    ProjectViewSet projectViewSet =
-        projectViewManager.reloadProjectView(context, workspacePathResolver);
-    ImportRoots importRoots =
-        ImportRoots.builder(workspaceRoot, importSettings.getBuildSystem())
-            .add(projectViewSet)
-            .build();
-    WorkspaceLanguageSettings workspaceLanguageSettings =
-        LanguageSupport.createWorkspaceLanguageSettings(projectViewSet);
-    ImmutableSet<String> testSourceGlobs =
-        projectViewSet.listItems(TestSourceSection.KEY).stream()
-            .map(Glob::toString)
-            .collect(ImmutableSet.toImmutableSet());
-    ProjectDefinition projectDefinition =
-        ProjectDefinition.builder()
-            .setProjectIncludes(importRoots.rootPaths())
-            .setProjectExcludes(importRoots.excludePaths())
-            .setLanguageClasses(
-                LanguageClasses.toQuerySync(workspaceLanguageSettings.getActiveLanguages()))
-            .setTestSources(testSourceGlobs)
-            .setSystemExcludes(importRoots.systemExcludes())
-            .build();
-
-    return this.projectDefinition.equals(projectDefinition);
   }
 
   public Optional<PostQuerySyncData> readSnapshotFromDisk(BlazeContext context) throws IOException {


### PR DESCRIPTION
Cherry pick AOSP commit [6c758baed9cc3d2ed6da03e65a6066db52caadc8](https://cs.android.com/android-studio/platform/tools/adt/idea/+/6c758baed9cc3d2ed6da03e65a6066db52caadc8).

STAT (diff to AOSP): 9 insertions(+), 2 deletion(-)

projects. The ways the project definition is constructed to load a
project and to determine whether it needs to be re-loaded have diverged
and now full query is used with each incremental sync.

Bug: 396605403
Test: n/a (upcoming; requires changes to blaze contexts)
Change-Id: I686d20113979efce7229f2cf6657e3eac559ab24

AOSP: 6c758baed9cc3d2ed6da03e65a6066db52caadc8
