### PR TITLE
[AOSP-pick] Remove getParallelBuildInvoker method

### DIFF
--- a/base/src/com/google/idea/blaze/base/bazel/BazelBuildSystem.java
+++ b/base/src/com/google/idea/blaze/base/bazel/BazelBuildSystem.java
@@ -62,11 +62,6 @@ class BazelBuildSystem implements BuildSystem {
   }
 
   @Override
-  public Optional<BuildInvoker> getParallelBuildInvoker(Project project, BlazeContext context) {
-    return Optional.empty();
-  }
-
-  @Override
   public SyncStrategy getSyncStrategy(Project project) {
     return SyncStrategy.SERIAL;
   }

--- a/base/src/com/google/idea/blaze/base/bazel/BuildSystem.java
+++ b/base/src/com/google/idea/blaze/base/bazel/BuildSystem.java
@@ -185,13 +185,6 @@ public interface BuildSystem {
   }
 
   /**
-   * Get a Blaze invoker that supports multiple calls in parallel, if this build system supports it.
-   *
-   * @return An invoker, or {@code Optional.EMPTY} if parallelism is not supported.
-   */
-  Optional<BuildInvoker> getParallelBuildInvoker(Project project, BlazeContext context);
-
-  /**
    * Return the strategy for remote syncs to be used with this build system.
    */
   SyncStrategy getSyncStrategy(Project project);
@@ -214,11 +207,9 @@ public interface BuildSystem {
   default BuildInvoker getDefaultInvoker(Project project, BlazeContext context) {
     if (Blaze.getProjectType(project) != ProjectType.QUERY_SYNC
         && getSyncStrategy(project) == SyncStrategy.PARALLEL) {
-      return getParallelBuildInvoker(project, context).orElse(getBuildInvoker(project, context));
+      return getBuildInvoker(project, context, ImmutableSet.of(BuildInvoker.Capability.SUPPORTS_PARALLELISM));
     }
-    else {
       return getBuildInvoker(project, context);
-    }
   }
 
   /**

--- a/base/src/com/google/idea/blaze/base/qsync/BazelQueryRunner.java
+++ b/base/src/com/google/idea/blaze/base/qsync/BazelQueryRunner.java
@@ -16,6 +16,7 @@
 package com.google.idea.blaze.base.qsync;
 
 import com.google.common.base.Stopwatch;
+import com.google.common.collect.ImmutableSet;
 import com.google.idea.blaze.base.bazel.BuildSystem;
 import com.google.idea.blaze.base.bazel.BuildSystem.BuildInvoker;
 import com.google.idea.blaze.base.command.BlazeCommand;
@@ -70,8 +71,7 @@ public class BazelQueryRunner implements QueryRunner {
       // become much easier.
       invoker =
           buildSystem
-              .getParallelBuildInvoker(project, context)
-              .orElse(buildSystem.getDefaultInvoker(project, context));
+              .getBuildInvoker(project, context, ImmutableSet.of(BuildInvoker.Capability.SUPPORTS_PARALLELISM));
     } else {
       invoker = buildSystem.getDefaultInvoker(project, context);
     }

--- a/base/src/com/google/idea/blaze/base/sync/BuildPhaseSyncTask.java
+++ b/base/src/com/google/idea/blaze/base/sync/BuildPhaseSyncTask.java
@@ -240,7 +240,7 @@ public final class BuildPhaseSyncTask {
 
     BuildInvoker syncBuildInvoker =
         parallel
-            ? buildSystem.getParallelBuildInvoker(project, context).orElse(defaultInvoker)
+            ? buildSystem.getBuildInvoker(project, context, ImmutableSet.of(BuildInvoker.Capability.SUPPORTS_PARALLELISM))
             : defaultInvoker;
     final BlazercMigrator blazercMigrator = new BlazercMigrator(project);
     if (!syncBuildInvoker.supportsHomeBlazerc() && blazercMigrator.needMigration()) {

--- a/base/tests/utils/unit/com/google/idea/blaze/base/bazel/BuildSystemProviderWrapper.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/bazel/BuildSystemProviderWrapper.java
@@ -322,11 +322,6 @@ public class BuildSystemProviderWrapper implements BuildSystemProvider {
     }
 
     @Override
-    public Optional<BuildInvoker> getParallelBuildInvoker(Project project, BlazeContext context) {
-      return inner.getParallelBuildInvoker(project, context).map(i -> new BuildInvokerWrapper(i));
-    }
-
-    @Override
     public SyncStrategy getSyncStrategy(Project project) {
       if (syncStrategy != null) {
         return syncStrategy;

--- a/base/tests/utils/unit/com/google/idea/blaze/base/bazel/FakeBuildSystem.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/bazel/FakeBuildSystem.java
@@ -58,14 +58,6 @@ public abstract class FakeBuildSystem implements BuildSystem {
   public BuildInvoker getBuildInvoker(Project project, BlazeContext context, Set<BuildInvoker.Capability> requirements) {
     return getBuildInvoker();
   }
-
-  abstract Optional<BuildInvoker> getParallelBuildInvoker();
-
-  @Override
-  public Optional<BuildInvoker> getParallelBuildInvoker(Project project, BlazeContext context) {
-    return getParallelBuildInvoker();
-  }
-
   @Override
   public SyncStrategy getSyncStrategy(Project project) {
     return getSyncStrategy();
@@ -101,10 +93,8 @@ public abstract class FakeBuildSystem implements BuildSystem {
 
     public abstract Builder setBuildInvoker(BuildInvoker value);
 
-    public abstract Builder setParallelBuildInvoker(Optional<BuildInvoker> value);
+    public abstract Builder setSyncStrategy(SyncStrategy value);
 
     public abstract Builder setBazelVersionString(Optional<String> value);
-
-    public abstract Builder setSyncStrategy(SyncStrategy value);
   }
 }


### PR DESCRIPTION
Cherry pick AOSP commit [1c23b04cd4ed55ff931add5a73a8dfbb0f82a058](https://cs.android.com/android-studio/platform/tools/adt/idea/+/1c23b04cd4ed55ff931add5a73a8dfbb0f82a058).

STAT (diff to AOSP): 1 insertions(+), 1 deletion(-)

Removes the getParallelBuildInvoker method from the BuildSystem interface for simplification.

Bug:374906681
Test: n/a
Change-Id: I518da730cca67f23cb23d970d079f35e296cf3f9

AOSP: 1c23b04cd4ed55ff931add5a73a8dfbb0f82a058
