### PR TITLE
[AOSP-pick] Move RuntimeArtifactCache to base folder

### DIFF
--- a/base/BUILD
+++ b/base/BUILD
@@ -598,6 +598,7 @@ intellij_integration_test_suite(
         "//shared/java/com/google/idea/blaze/common",
         "//shared/java/com/google/idea/blaze/common/artifact",
         "//shared/javatests/com/google/idea/blaze/common:test_utils",
+        "//third_party/java/auto_value",
         "//intellij_platform_sdk:plugin_api",
         "//intellij_platform_sdk:jsr305",
         "//intellij_platform_sdk:plugin_api_for_tests",  # unuseddeps: keep

--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -273,6 +273,8 @@
     <projectService serviceImplementation="com.google.idea.blaze.base.command.info.BlazeInfoProvider"/>
     <projectService serviceImplementation="com.google.idea.blaze.base.model.ExternalWorkspaceDataProvider"/>
     <projectService serviceImplementation="com.google.idea.blaze.base.sync.SyncPhaseCoordinator"/>
+    <projectService serviceInterface="com.google.idea.blaze.base.run.RuntimeArtifactCache"
+                    serviceImplementation="com.google.idea.blaze.base.run.RuntimeArtifactCacheImpl" />
     <projectService serviceInterface="com.google.idea.blaze.base.sync.status.BlazeSyncStatus"
                     serviceImplementation="com.google.idea.blaze.base.sync.status.BlazeSyncStatusImpl"/>
     <projectService serviceImplementation="com.google.idea.blaze.base.sync.libraries.ExternalLibraryManager"/>

--- a/base/src/com/google/idea/blaze/base/run/RuntimeArtifactCache.java
+++ b/base/src/com/google/idea/blaze/base/run/RuntimeArtifactCache.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.idea.blaze.android.run;
+package com.google.idea.blaze.base.run;
 
 import com.google.common.collect.ImmutableList;
 import com.google.idea.blaze.base.scope.BlazeContext;

--- a/base/src/com/google/idea/blaze/base/run/RuntimeArtifactCacheImpl.java
+++ b/base/src/com/google/idea/blaze/base/run/RuntimeArtifactCacheImpl.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.idea.blaze.android.run;
+package com.google.idea.blaze.base.run;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -41,7 +41,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
-final class RuntimeArtifactCacheImpl implements RuntimeArtifactCache {
+public final class RuntimeArtifactCacheImpl implements RuntimeArtifactCache {
   private static final Logger logger = Logger.getInstance(RuntimeArtifactCacheImpl.class);
   private final Map<Label, Map<Path, ProjectProto.ProjectArtifact>> artifactCacheMap = new HashMap<>();
   private final Path runfilesDirectory;

--- a/base/tests/integrationtests/com/google/idea/blaze/base/artifact/TestOutputArtifact.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/artifact/TestOutputArtifact.java
@@ -1,0 +1,68 @@
+package com.google.idea.blaze.base.artifact;
+
+import com.google.auto.value.AutoValue;
+import com.google.idea.blaze.common.artifact.ArtifactState;
+import com.google.idea.blaze.common.artifact.OutputArtifact;
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class TestOutputArtifact implements OutputArtifact {
+
+  public static final TestOutputArtifact EMPTY =
+    new AutoValue_TestOutputArtifact.Builder()
+      .setLength(0)
+      .setDigest("digest")
+      .setArtifactPath(Path.of("path/file"))
+      .setArtifactPathPrefixLength(0)
+      .build();
+
+  public static TestOutputArtifact forDigest(String digest) {
+    return EMPTY.toBuilder().setDigest(digest).build();
+  }
+
+  public static Builder builder() {
+    return EMPTY.toBuilder();
+  }
+
+  @Override
+  public abstract long getLength();
+
+  @Override
+  public BufferedInputStream getInputStream() throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public abstract String getDigest();
+
+  @Override
+  public abstract Path getArtifactPath();
+
+  @Override
+  public abstract int getArtifactPathPrefixLength();
+
+  @Nullable
+  @Override
+  public ArtifactState toArtifactState() {
+    throw new UnsupportedOperationException();
+  }
+
+  public abstract Builder toBuilder();
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    public abstract Builder setLength(long value);
+
+    public abstract Builder setDigest(String value);
+
+    public abstract Builder setArtifactPath(Path value);
+
+    public abstract Builder setArtifactPathPrefixLength(int value);
+
+    public abstract TestOutputArtifact build();
+  }
+}

--- a/base/tests/integrationtests/com/google/idea/blaze/base/run/RuntimeArtifactCacheImplTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/run/RuntimeArtifactCacheImplTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.idea.blaze.android.run;
+package com.google.idea.blaze.base.run;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.util.concurrent.Futures.immediateFailedFuture;
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.io.MoreFiles;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.idea.blaze.base.artifact.TestOutputArtifact;
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.common.Context;
 import com.google.idea.blaze.common.Label;
@@ -34,7 +35,6 @@ import com.google.idea.blaze.common.artifact.ArtifactFetcher;
 import com.google.idea.blaze.common.artifact.BuildArtifactCache;
 import com.google.idea.blaze.common.artifact.BuildArtifactCacheDirectory;
 import com.google.idea.blaze.common.artifact.OutputArtifact;
-import com.google.idea.blaze.common.artifact.TestOutputArtifact;
 import com.google.idea.blaze.exception.BuildException;
 import java.io.IOException;
 import java.nio.file.Files;


### PR DESCRIPTION
Cherry pick AOSP commit [912ea2cbac24299ee601832d2c78eb8e99a171e7](https://cs.android.com/android-studio/platform/tools/adt/idea/+/912ea2cbac24299ee601832d2c78eb8e99a171e7).

STAT (diff to AOSP): 0 insertions(+), 0 deletion(-)

Move RuntimeArtifactCache to base folder to so it maybe used by
LocalFileArtifact. Also add TestOutputArtifact to base folder to use in
tests.

Bug: 385469770
Test: Existing test
Change-Id: I71edc228a951a7d7b20e9f3293089bbdd4719cb3

AOSP: 912ea2cbac24299ee601832d2c78eb8e99a171e7
