### PR TITLE
[AOSP-pick] Isolate kotlin coroutine debugging use case

### DIFF
--- a/base/src/com/google/idea/blaze/base/qsync/QuerySyncProject.java
+++ b/base/src/com/google/idea/blaze/base/qsync/QuerySyncProject.java
@@ -32,7 +32,6 @@ import com.google.idea.blaze.base.logging.utils.querysync.SyncQueryStatsScope;
 import com.google.idea.blaze.base.model.ExternalWorkspaceData;
 import com.google.idea.blaze.base.model.primitives.WorkspacePath;
 import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
-import com.google.idea.blaze.base.projectview.ProjectViewManager;
 import com.google.idea.blaze.base.projectview.ProjectViewSet;
 import com.google.idea.blaze.base.qsync.artifacts.ProjectArtifactStore;
 import com.google.idea.blaze.base.scope.BlazeContext;
@@ -533,15 +532,6 @@ public class QuerySyncProject {
     return snapshotPath.map(path -> !path.resolve(workspaceRelative).toFile().exists());
   }
 
-  /** Returns all external dependencies of a given label */
-  public ImmutableSet<Label> externalDependenciesFor(Label label) {
-    return snapshotHolder
-        .getCurrent()
-        .map(QuerySyncProjectSnapshot::graph)
-        .map(graph -> graph.getTransitiveExternalDependencies(label))
-        .orElse(ImmutableSet.of());
-  }
-
   private void writeToDisk(QuerySyncProjectSnapshot snapshot) throws IOException {
     try (AtomicFileWriter writer = AtomicFileWriter.create(snapshotFilePath)) {
       try (OutputStream zip = new GZIPOutputStream(writer.getOutputStream())) {
@@ -592,5 +582,14 @@ public class QuerySyncProject {
         .putAll(artifactStore.getBugreportFiles())
         .putAll(buildArtifactCache.getBugreportFiles())
         .build();
+  }
+
+  // TODO: b/397649793 - Remove this method when fixed.
+  public boolean dependsOnAnyOf_DO_NOT_USE_BROKEN(Label target, ImmutableSet<Label> deps) {
+    return snapshotHolder
+      .getCurrent()
+      .map(QuerySyncProjectSnapshot::graph)
+      .map(graph -> graph.dependsOnAnyOf_DO_NOT_USE_BROKEN(target, deps))
+      .orElse(false);
   }
 }

--- a/querysync/java/com/google/idea/blaze/qsync/project/BuildGraphData.java
+++ b/querysync/java/com/google/idea/blaze/qsync/project/BuildGraphData.java
@@ -290,6 +290,25 @@ public abstract class BuildGraphData {
     return false;
   }
 
+  // TODO: b/397649793 - Remove this method when fixed.
+  public boolean dependsOnAnyOf_DO_NOT_USE_BROKEN(Label projectTarget, ImmutableSet<Label> deps) {
+    ImmutableList<Label> projectTargetSingleton = ImmutableList.of(projectTarget);
+    final var queue = new ArrayDeque<Label>(projectTargetSingleton);
+    final var seen = new HashSet<>(projectTargetSingleton);
+    while (!queue.isEmpty()) {
+      final var target = queue.remove();
+      if (deps.contains(target)) {
+        return true;
+      }
+      final var targetInfo = targetMap().get(target);
+      if (targetInfo == null) {
+        continue;
+      }
+      queue.addAll(targetInfo.deps().stream().filter(seen::add).toList());
+    }
+    return false;
+  }
+
   private record TargetSearchNode(Label targetLabel, boolean hasDesiredRule) {}
 
   public ImmutableSet<Path> getTargetSources(Label target, SourceType... types) {


### PR DESCRIPTION
Cherry pick AOSP commit [89f52f6b0e05938e4ea778653bc91c0c8dd69f10](https://cs.android.com/android-studio/platform/tools/adt/idea/+/89f52f6b0e05938e4ea778653bc91c0c8dd69f10).

STAT (diff to AOSP): 0 insertions(+), 0 deletion(-)

Note `externalDependenciesFor()` does what it says. It returns external
dependencies of a label but it does not return transitive dependencies.

The replacement methods added in this change do the same, however their
name reflect the intention of these methods, which is different. These
methods are supposed to tell whether a label depends directly or
indirectly on one of the well-known targets. The existing implementation
and its replacement, which is supposed to do the same as the existing
implementation, do not do what is needed, hence the new name.

Bug: 397354312
Test: n/a
Change-Id: Ice510c4199c377011d9aefde406094bb03c265a2

AOSP: 89f52f6b0e05938e4ea778653bc91c0c8dd69f10
