### PR TITLE
[AOSP-pick] Build dependencies in the same way

### DIFF
--- a/base/src/com/google/idea/blaze/base/qsync/DependencyTrackerImpl.java
+++ b/base/src/com/google/idea/blaze/base/qsync/DependencyTrackerImpl.java
@@ -19,7 +19,6 @@ import static java.util.stream.Collectors.joining;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimaps;
 import com.google.idea.blaze.base.bazel.BazelExitCode;
 import com.google.idea.blaze.base.logging.utils.querysync.BuildDepsStatsScope;
@@ -92,10 +91,7 @@ public class DependencyTrackerImpl implements DependencyTracker {
       case MULTIPLE_TARGETS:
         return snapshot.graph().computeRequestedTargets(request.targets);
       case WHOLE_PROJECT:
-        return Optional.of(
-            new RequestedTargets(
-                ImmutableSet.copyOf(snapshot.graph().allTargets()),
-                snapshot.graph().projectDeps()));
+        return snapshot.graph().computeRequestedTargets(snapshot.graph().allTargets());
     }
     throw new IllegalArgumentException("Invalid request type: " + request.requestType);
   }

--- a/querysync/java/com/google/idea/blaze/qsync/project/BuildGraphData.java
+++ b/querysync/java/com/google/idea/blaze/qsync/project/BuildGraphData.java
@@ -558,7 +558,7 @@ public abstract class BuildGraphData {
    *     given; the {@link RequestedTargets#expectedDependencyTargets} will be determined by the
    *     {@link #getDependencyTrackingBehaviors(Label)} of the targets given.
    */
-  public Optional<RequestedTargets> computeRequestedTargets(ImmutableSet<Label> projectTargets) {
+  public Optional<RequestedTargets> computeRequestedTargets(Collection<Label> projectTargets) {
     final var externalDeps = new LinkedHashSet<Label>();
     final var seen = new HashSet<>(projectTargets);
     final var queue = new ArrayDeque<Label>(projectTargets);
@@ -575,6 +575,6 @@ public abstract class BuildGraphData {
         queue.addAll(targetInfo.deps().stream().filter(seen::add).toList());
       }
     }
-    return Optional.of(new RequestedTargets(projectTargets, ImmutableSet.copyOf(externalDeps)));
+    return Optional.of(new RequestedTargets(ImmutableSet.copyOf(projectTargets), ImmutableSet.copyOf(externalDeps)));
   }
 }


### PR DESCRIPTION
Cherry pick AOSP commit [c573902363b91b2413036746f2cf66845bd16cb4](https://cs.android.com/android-studio/platform/tools/adt/idea/+/c573902363b91b2413036746f2cf66845bd16cb4).

STAT (diff to AOSP): 0 insertions(+), 0 deletion(-)

regardless of how the targets to build were collected, i.e. build
whole project as if all its targets were selected manually.

Note that this change removes special handling of aliases as they have
not been handled in the non-whole-project case. This may result in code
analysis not being enabled in some targets even after enabling analysis
in the whole project. This will be fixed for all builds by transitioning
to a simplified project graph that only tracks targets of known kinds.

Bug: n/a
Test: existing
Change-Id: Ifae478999feb2b7ea4f98b3a38818cef102891e1

AOSP: c573902363b91b2413036746f2cf66845bd16cb4
