### PR TITLE
[AOSP-pick] Update getLocalFiles method to support RuntimeArtifactCache usage

### DIFF
--- a/aswb/src/com/google/idea/blaze/android/run/NativeSymbolFinder.java
+++ b/aswb/src/com/google/idea/blaze/android/run/NativeSymbolFinder.java
@@ -20,6 +20,9 @@ import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
 import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.intellij.openapi.extensions.ExtensionPointName;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.Project;
+
 import java.io.File;
 
 /** Configures Blaze build to output native symbols and obtains symbol file paths. */
@@ -32,5 +35,5 @@ public interface NativeSymbolFinder {
 
   /** Returns native symbol files present in build output. */
   public ImmutableList<File> getNativeSymbolsForBuild(
-      BlazeContext context, Label label, BuildResultHelper buildResultHelper);
+      Project project, BlazeContext context, Label label, BuildResultHelper buildResultHelper);
 }

--- a/aswb/src/com/google/idea/blaze/android/run/runner/FullApkBuildStep.java
+++ b/aswb/src/com/google/idea/blaze/android/run/runner/FullApkBuildStep.java
@@ -228,7 +228,7 @@ public class FullApkBuildStep implements ApkBuildStep {
           nativeSymbolFinderList.stream()
               .flatMap(
                   finder ->
-                      finder.getNativeSymbolsForBuild(context, label, buildResultHelper).stream())
+                      finder.getNativeSymbolsForBuild(project, context, label, buildResultHelper).stream())
               .collect(ImmutableList.toImmutableList());
       deployInfo =
           deployInfoHelper.extractDeployInfoAndInvalidateManifests(

--- a/aswb/tests/integrationtests/com/google/idea/blaze/android/functional/FullApkBuildStepIntegrationTest.java
+++ b/aswb/tests/integrationtests/com/google/idea/blaze/android/functional/FullApkBuildStepIntegrationTest.java
@@ -244,7 +244,7 @@ public class FullApkBuildStepIntegrationTest extends BlazeAndroidIntegrationTest
     File lib = new File("/path/to/symbol");
     File altLib = new File("/path/to/alt/symbol");
     ImmutableList<File> symbolFiles = ImmutableList.of(lib, altLib);
-    when(mockSymbolFinder.getNativeSymbolsForBuild(any(), any(), any())).thenReturn(symbolFiles);
+    when(mockSymbolFinder.getNativeSymbolsForBuild(any(), any(), any(), any())).thenReturn(symbolFiles);
 
     BlazeAndroidDeployInfo mockDeployInfo = mock(BlazeAndroidDeployInfo.class);
     File apkFile = new File("/path/to/apk");
@@ -336,7 +336,7 @@ public class FullApkBuildStepIntegrationTest extends BlazeAndroidIntegrationTest
     File lib = new File("/path/to/symbol");
     File altLib = new File("/path/to/alt/symbol");
     ImmutableList<File> symbolFiles = ImmutableList.of(lib, altLib);
-    when(mockSymbolFinder.getNativeSymbolsForBuild(any(), any(), any())).thenReturn(symbolFiles);
+    when(mockSymbolFinder.getNativeSymbolsForBuild(any(), any(), any(), any())).thenReturn(symbolFiles);
 
     // Return fake deploy info proto and mocked deploy info data object.
     BlazeAndroidDeployInfo mockDeployInfo = mock(BlazeAndroidDeployInfo.class);

--- a/base/src/com/google/idea/blaze/base/command/buildresult/LocalFileArtifact.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/LocalFileArtifact.java
@@ -19,8 +19,11 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.google.common.collect.ImmutableList;
 import com.google.idea.blaze.base.io.FileOperationProvider;
+import com.google.idea.blaze.base.scope.BlazeContext;
+import com.google.idea.blaze.common.Label;
 import com.google.idea.blaze.common.artifact.BlazeArtifact;
 import com.google.idea.blaze.common.artifact.OutputArtifact;
+import com.intellij.openapi.project.Project;
 import java.io.File;
 import java.util.Collection;
 
@@ -33,7 +36,8 @@ public interface LocalFileArtifact extends BlazeArtifact {
    * <p>Some callers will only ever accept local outputs (e.g. when debugging, and making use of
    * runfiles directories).
    */
-  static ImmutableList<File> getLocalFiles(Collection<? extends OutputArtifact> artifacts) {
+  static ImmutableList<File> getLocalFiles(Label target, Collection<? extends OutputArtifact> artifacts, BlazeContext context,
+                                           Project project) {
     return artifacts.stream()
         .filter(a -> a instanceof LocalFileArtifact)
         .map(a -> ((LocalFileArtifact) a).getFile())

--- a/base/tests/unittests/com/google/idea/blaze/base/command/buildresult/BuildEventProtocolOutputReaderTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/command/buildresult/BuildEventProtocolOutputReaderTest.java
@@ -45,23 +45,27 @@ import com.google.idea.blaze.base.model.primitives.GenericBlazeRules.RuleTypes;
 import com.google.idea.blaze.base.model.primitives.Kind;
 import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.qsync.settings.QuerySyncSettings;
+import com.google.idea.blaze.base.run.RuntimeArtifactCache;
 import com.google.idea.blaze.base.run.testlogs.BlazeTestResult;
 import com.google.idea.blaze.base.run.testlogs.BlazeTestResult.TestStatus;
 import com.google.idea.blaze.base.run.testlogs.BlazeTestResults;
+import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.common.artifact.OutputArtifact;
 import com.google.idea.common.experiments.ExperimentService;
 import com.google.idea.common.experiments.MockExperimentService;
 import com.intellij.openapi.extensions.impl.ExtensionPointImpl;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.InputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
-import org.jetbrains.annotations.NotNull;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -83,6 +87,19 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
   @Parameter public boolean useOldFormatFileUri = false;
 
   @Rule public TemporaryFolder tmpFolder = new TemporaryFolder();
+  private BlazeContext context;
+
+  private static class TestRuntimeArtifactCache implements RuntimeArtifactCache {
+    @Override
+    public ImmutableList<Path> fetchArtifacts(
+      com.google.idea.blaze.common.Label label,
+      List<? extends OutputArtifact> artifacts,
+      BlazeContext context) {
+      return artifacts.stream()
+        .map(a -> Paths.get(a.getBazelOutRelativePath()))
+        .collect(toImmutableList());
+    }
+  }
 
   @Override
   protected void initTest(Container applicationServices, Container projectServices) {
@@ -93,14 +110,17 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
     applicationServices.register(Kind.ApplicationState.class, new Kind.ApplicationState());
     applicationServices.register(ExperimentService.class, new MockExperimentService());
     applicationServices.register(QuerySyncSettings.class, new QuerySyncSettings());
+    projectServices.register(RuntimeArtifactCache.class, new TestRuntimeArtifactCache());
 
     ExtensionPointImpl<OutputArtifactParser> parserEp =
         registerExtensionPoint(OutputArtifactParser.EP_NAME, OutputArtifactParser.class);
     parserEp.registerExtension(new LocalFileParser());
+    context = BlazeContext.create();
   }
 
   @Test
   public void parseAllOutputs_singleTargetEvents_returnsAllOutputs() throws Exception {
+    var label = "//some:target";
     ImmutableList<String> filePaths =
         ImmutableList.of(
             "/usr/local/lib/File.py", "/usr/bin/python2.7", "/usr/local/home/script.sh");
@@ -109,14 +129,14 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
             configuration("config-id", "k8-opt"),
             setOfFiles(filePaths, "set-id"),
             targetComplete(
-                "//some:target",
+                label,
                 "config-id",
                 ImmutableList.of(outputGroup("name", ImmutableList.of("set-id")))));
 
     List<OutputArtifact> parsedFilenames =
         BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)), null).getAllOutputArtifactsForTesting();
 
-    assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
+    assertThat(LocalFileArtifact.getLocalFiles(com.google.idea.blaze.common.Label.of(label), parsedFilenames, context, getProject()))
         .containsExactlyElementsIn(filePaths.stream().map(File::new).toArray())
         .inOrder();
   }
@@ -135,6 +155,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
 
   @Test
   public void parseAllOutputs_singleTargetEventsPlusExtras_returnsAllOutputs() throws Exception {
+    var label = "//some:target";
     ImmutableList<String> filePaths =
         ImmutableList.of(
             "/usr/local/lib/Provider.java",
@@ -149,14 +170,14 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
             configuration("config-id", "k8-opt"),
             setOfFiles(filePaths, "set-id"),
             targetComplete(
-                "//some:target",
+                label,
                 "config-id",
                 ImmutableList.of(outputGroup("name", ImmutableList.of("set-id")))));
 
     List<OutputArtifact> parsedFilenames =
         BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)), null).getAllOutputArtifactsForTesting();
 
-    assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
+    assertThat(LocalFileArtifact.getLocalFiles(com.google.idea.blaze.common.Label.of(label), parsedFilenames, context, getProject()))
         .containsExactlyElementsIn(filePaths.stream().map(File::new).toArray())
         .inOrder();
   }
@@ -175,7 +196,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
             "/usr/local/code/ParserTest.java",
             "/usr/local/code/action_output.bzl",
             "/usr/genfiles/BUILD.bazel");
-
+    var label = "//some:target";
     ImmutableList<BuildEvent.Builder> events =
         ImmutableList.of(
             BuildEvent.newBuilder()
@@ -186,7 +207,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
             setOfFiles(fileSet1, "set-1"),
             setOfFiles(fileSet2, "set-2"),
             targetComplete(
-                "//some:target",
+                label,
                 "config-id",
                 ImmutableList.of(
                     outputGroup("name1", ImmutableList.of("set-1")),
@@ -200,13 +221,14 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
     List<OutputArtifact> parsedFilenames =
         BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)), null).getAllOutputArtifactsForTesting();
 
-    assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
+    assertThat(LocalFileArtifact.getLocalFiles(com.google.idea.blaze.common.Label.of(label), parsedFilenames, context, getProject()))
         .containsExactlyElementsIn(allFiles)
         .inOrder();
   }
 
   @Test
   public void parseAllOutputs_streamWithDuplicateFiles_returnsUniqueOutputs() throws Exception {
+    var label = "//some:target";
     ImmutableList<String> fileSet1 = ImmutableList.of("/usr/out/genfiles/foo.pb.h");
 
     ImmutableList<String> fileSet2 =
@@ -222,7 +244,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
             setOfFiles(fileSet1, "set-1"),
             setOfFiles(fileSet2, "set-2"),
             targetComplete(
-                "//some:target",
+                label,
                 "config-id",
                 ImmutableList.of(
                     outputGroup("name1", ImmutableList.of("set-1")),
@@ -236,7 +258,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
     List<OutputArtifact> parsedFilenames =
         BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)), null).getAllOutputArtifactsForTesting();
 
-    assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
+    assertThat(LocalFileArtifact.getLocalFiles(com.google.idea.blaze.common.Label.of(label), parsedFilenames, context, getProject()))
         .containsExactlyElementsIn(allFiles)
         .inOrder();
   }
@@ -245,7 +267,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
   public void parseArtifactsForTarget_singleTarget_returnsTargetOutputs() throws Exception {
     ImmutableList<String> fileSet =
         ImmutableList.of("/usr/out/genfiles/foo.pb.h", "/usr/out/genfiles/foo.proto.h");
-
+    var label = "//some:target";
     ImmutableList<BuildEvent.Builder> events =
         ImmutableList.of(
             BuildEvent.newBuilder()
@@ -255,7 +277,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
             configuration("config-id", "k8-opt"),
             setOfFiles(fileSet, "set-id"),
             targetComplete(
-                "//some:target",
+                label,
                 "config-id",
                 ImmutableList.of(outputGroup("group-name", ImmutableList.of("set-id")))));
 
@@ -268,13 +290,14 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
               BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)), null).getOutputGroupTargetArtifacts(
                 "group-name", "//some:target");
 
-    assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
+    assertThat(LocalFileArtifact.getLocalFiles(com.google.idea.blaze.common.Label.of(label), parsedFilenames, context, getProject()))
         .containsExactlyElementsIn(allFiles)
         .inOrder();
   }
 
   @Test
   public void parseArtifactsForTarget_twoTargets_returnsCorrectTargetOutputs() throws Exception {
+    var label = "//some:target";
     ImmutableList<String> targetFileSet =
         ImmutableList.of("/usr/out/genfiles/foo.pb.h", "/usr/out/genfiles/foo.proto.h");
     ImmutableList<String> otherTargetFileSet =
@@ -291,7 +314,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
             setOfFiles(targetFileSet, "target-set"),
             setOfFiles(otherTargetFileSet, "other-set"),
             targetComplete(
-                "//some:target",
+                label,
                 "config-id",
                 ImmutableList.of(outputGroup("group-name", ImmutableList.of("target-set")))),
             targetComplete(
@@ -308,7 +331,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
               BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)), null).getOutputGroupTargetArtifacts(
                 "group-name", "//some:target");
 
-    assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
+    assertThat(LocalFileArtifact.getLocalFiles(com.google.idea.blaze.common.Label.of(label), parsedFilenames, context, getProject()))
         .containsExactlyElementsIn(allFiles)
         .inOrder();
   }
@@ -320,7 +343,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
     ImmutableList<String> fileSet2 =
         ImmutableList.of(
             "/usr/local/lib/File.py", "/usr/bin/python2.7", "/usr/local/home/script.sh");
-
+    var label = "//some:target";
     ImmutableList<BuildEvent.Builder> events =
         ImmutableList.of(
             BuildEvent.newBuilder()
@@ -331,7 +354,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
             setOfFiles(fileSet1, "set-1"),
             setOfFiles(fileSet2, "set-2"),
             targetComplete(
-                "//some:target",
+                label,
                 "config-id",
                 ImmutableList.of(outputGroup("group-name", ImmutableList.of("set-1")))),
             targetComplete(
@@ -354,7 +377,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
         BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)), null).getOutputGroupArtifacts(
                                      "group-name");
 
-    assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
+    assertThat(LocalFileArtifact.getLocalFiles(com.google.idea.blaze.common.Label.of(label), parsedFilenames, context, getProject()))
         .containsExactlyElementsIn(allFiles)
         .inOrder();
   }
@@ -367,7 +390,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
     ImmutableList<String> fileSet2 =
         ImmutableList.of(
             "/usr/local/lib/File.py", "/usr/bin/python2.7", "/usr/local/home/script.sh");
-
+    var label = "//some:target";
     ImmutableList<BuildEvent.Builder> events =
         ImmutableList.of(
             BuildEvent.newBuilder()
@@ -378,7 +401,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
             setOfFiles(fileSet1, "set-1"),
             setOfFiles(fileSet2, "set-2"),
             targetComplete(
-                "//some:target",
+                label,
                 "config-id",
                 ImmutableList.of(outputGroup("group-1", ImmutableList.of("set-1")))),
             targetComplete(
@@ -395,7 +418,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
         BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)), null).getOutputGroupArtifacts(
                                      "group-1");
 
-    assertThat(LocalFileArtifact.getLocalFiles(parsedFilenames))
+    assertThat(LocalFileArtifact.getLocalFiles(com.google.idea.blaze.common.Label.of(label), parsedFilenames, context, getProject()))
         .containsExactlyElementsIn(allFiles)
         .inOrder();
   }
@@ -427,7 +450,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
     assertThat(results.perTargetResults.get(label)).hasSize(1);
     BlazeTestResult result = results.perTargetResults.get(label).iterator().next();
     assertThat(result.getTestStatus()).isEqualTo(TestStatus.FAILED);
-    assertThat(getOutputXmlFiles(result))
+    assertThat(getOutputXmlFiles(label, result, context, project))
         .containsExactly(new File("/usr/local/tmp/_cache/test_result.xml"));
   }
 
@@ -449,7 +472,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
     BlazeTestResult result = results.perTargetResults.get(label).iterator().next();
     assertThat(result.getTargetKind()).isEqualTo(RuleTypes.SH_TEST.getKind());
     assertThat(result.getTestStatus()).isEqualTo(TestStatus.FAILED);
-    assertThat(getOutputXmlFiles(result))
+    assertThat(getOutputXmlFiles(label, result, context, getProject()))
         .containsExactly(new File("/usr/local/tmp/_cache/test_result.xml"));
   }
 
@@ -471,7 +494,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
     BlazeTestResult result = results.perTargetResults.get(label).iterator().next();
     assertThat(result.getTargetKind()).isEqualTo(RuleTypes.SH_TEST.getKind());
     assertThat(result.getTestStatus()).isEqualTo(TestStatus.FAILED);
-    assertThat(getOutputXmlFiles(result))
+    assertThat(getOutputXmlFiles(label, result, context, getProject()))
         .containsExactly(new File("/usr/local/tmp/_cache/test_result.xml"));
   }
 
@@ -494,7 +517,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
     BlazeTestResult result = results.perTargetResults.get(label).iterator().next();
     assertThat(result.getTargetKind()).isEqualTo(RuleTypes.SH_TEST.getKind());
     assertThat(result.getTestStatus()).isEqualTo(TestStatus.FAILED);
-    assertThat(getOutputXmlFiles(result))
+    assertThat(getOutputXmlFiles(label, result, context, getProject()))
         .containsExactly(new File("/usr/local/tmp/_cache/test_result.xml"));
   }
 
@@ -513,7 +536,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
         BuildEventProtocolOutputReader.parseTestResults(BuildEventStreamProvider.fromInputStream(asInputStream(event)));
 
     BlazeTestResult result = results.perTargetResults.get(label).iterator().next();
-    assertThat(getOutputXmlFiles(result))
+    assertThat(getOutputXmlFiles(label, result, context, getProject()))
         .containsExactly(new File("/usr/local/tmp/_cache/test_result.xml"));
   }
 
@@ -547,22 +570,24 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
 
     assertThat(result1.getTestStatus()).isEqualTo(TestStatus.PASSED);
     assertThat(result2.getTestStatus()).isEqualTo(TestStatus.FAILED);
-    assertThat(getOutputXmlFiles(result1))
+    assertThat(getOutputXmlFiles(label, result1, context, getProject()))
         .containsExactly(new File("/usr/local/tmp/_cache/shard1_of_2.xml"));
-    assertThat(getOutputXmlFiles(result2))
+    assertThat(getOutputXmlFiles(label, result2, context, getProject()))
         .containsExactly(new File("/usr/local/tmp/_cache/shard2_of_2.xml"));
   }
 
   @Test
   public void parseTestResults_multipleEvents_returnsAllResults() throws Exception {
+    var label1 = "//java/com/google:Test1";
+    var label2 = "//java/com/google:Test2";
     BuildEvent.Builder test1 =
         testResultEvent(
-            "//java/com/google:Test1",
+            label1,
             BuildEventStreamProtos.TestStatus.PASSED,
             ImmutableList.of("/usr/local/tmp/_cache/test_result.xml"));
     BuildEvent.Builder test2 =
         testResultEvent(
-            "//java/com/google:Test2",
+            label2,
             BuildEventStreamProtos.TestStatus.INCOMPLETE,
             ImmutableList.of("/usr/local/tmp/_cache/second_result.xml"));
 
@@ -575,17 +600,17 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
     BlazeTestResult result1 =
         results.perTargetResults.get(Label.create("//java/com/google:Test1")).iterator().next();
     assertThat(result1.getTestStatus()).isEqualTo(TestStatus.PASSED);
-    assertThat(getOutputXmlFiles(result1))
+    assertThat(getOutputXmlFiles(Label.create(label1), result1, context, getProject()))
         .containsExactly(new File("/usr/local/tmp/_cache/test_result.xml"));
     BlazeTestResult result2 =
         results.perTargetResults.get(Label.create("//java/com/google:Test2")).iterator().next();
     assertThat(result2.getTestStatus()).isEqualTo(TestStatus.INCOMPLETE);
-    assertThat(getOutputXmlFiles(result2))
+    assertThat(getOutputXmlFiles(Label.create(label2), result2, context, getProject()))
         .containsExactly(new File("/usr/local/tmp/_cache/second_result.xml"));
   }
 
-  private static ImmutableList<File> getOutputXmlFiles(BlazeTestResult result) {
-    return LocalFileArtifact.getLocalFilesForLegacySync(result.getOutputXmlFiles());
+  private static ImmutableList<File> getOutputXmlFiles(Label label, BlazeTestResult result, BlazeContext context, Project project) {
+    return LocalFileArtifact.getLocalFiles(com.google.idea.blaze.common.Label.of(label.toString()), result.getOutputXmlFiles(), context, project);
   }
 
   private static InputStream asInputStream(BuildEvent.Builder... events) throws Exception {

--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrRunConfigurationRunner.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrRunConfigurationRunner.java
@@ -32,6 +32,7 @@ import com.google.idea.blaze.base.run.BlazeBeforeRunCommandHelper;
 import com.google.idea.blaze.base.run.BlazeCommandRunConfiguration;
 import com.google.idea.blaze.base.run.ExecutorType;
 import com.google.idea.blaze.base.run.confighandler.BlazeCommandRunConfigurationRunner;
+import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.sync.aspects.BlazeBuildOutputs;
 import com.google.idea.blaze.base.util.SaveUtil;
 import com.google.idea.blaze.common.Interners;
@@ -173,9 +174,12 @@ public class BlazeCidrRunConfigurationRunner implements BlazeCommandRunConfigura
       try (final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {
         candidateFiles =
             LocalFileArtifact.getLocalFiles(
+                  com.google.idea.blaze.common.Label.of(target.toString()),
                   BlazeBuildOutputs.fromParsedBepOutput(
                     BuildResultParser.getBuildOutput(bepStream, Interners.STRING))
-                      .getOutputGroupTargetArtifacts(DEFAULT_OUTPUT_GROUP_NAME, target.toString() ))
+                      .getOutputGroupTargetArtifacts(DEFAULT_OUTPUT_GROUP_NAME, target.toString() ),
+                  BlazeContext.create(),
+                  env.getProject())
                 .stream()
                 .filter(File::canExecute)
                 .collect(Collectors.toList());

--- a/golang/src/com/google/idea/blaze/golang/run/BlazeGoRunConfigurationRunner.java
+++ b/golang/src/com/google/idea/blaze/golang/run/BlazeGoRunConfigurationRunner.java
@@ -50,6 +50,7 @@ import com.google.idea.blaze.base.run.ExecutorType;
 import com.google.idea.blaze.base.run.confighandler.BlazeCommandGenericRunConfigurationRunner.BlazeCommandRunProfileState;
 import com.google.idea.blaze.base.run.confighandler.BlazeCommandRunConfigurationRunner;
 import com.google.idea.blaze.base.run.state.BlazeCommandRunConfigurationCommonState;
+import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.settings.Blaze;
 import com.google.idea.blaze.base.settings.BuildSystemName;
 import com.google.idea.blaze.base.sync.aspects.BlazeBuildOutputs;
@@ -375,9 +376,12 @@ public class BlazeGoRunConfigurationRunner implements BlazeCommandRunConfigurati
         try (final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {
           candidateFiles =
               LocalFileArtifact.getLocalFiles(
+                   com.google.idea.blaze.common.Label.of(label.toString()),
                    BlazeBuildOutputs.fromParsedBepOutput(
                       BuildResultParser.getBuildOutput(bepStream, Interners.STRING))
-                          .getOutputGroupTargetArtifacts(DEFAULT_OUTPUT_GROUP_NAME, label.toString()))
+                          .getOutputGroupTargetArtifacts(DEFAULT_OUTPUT_GROUP_NAME, label.toString()),
+                      BlazeContext.create(),
+                      env.getProject())
                   .stream()
                   .filter(File::canExecute)
                   .collect(Collectors.toList());

--- a/java/src/com/google/idea/blaze/java/fastbuild/FastBuildServiceImpl.java
+++ b/java/src/com/google/idea/blaze/java/fastbuild/FastBuildServiceImpl.java
@@ -343,6 +343,7 @@ final class FastBuildServiceImpl implements FastBuildService, ProjectComponent {
     try (final var bepStream = resultHelper.getBepStream(Optional.empty())) {
       ImmutableList<File> deployJarArtifacts =
           LocalFileArtifact.getLocalFiles(
+              com.google.idea.blaze.common.Label.of(label.toString()),
               BlazeBuildOutputs.fromParsedBepOutput(
                 BuildResultParser.getBuildOutput(bepStream, Interners.STRING))
                   .getOutputGroupTargetArtifacts(
@@ -350,7 +351,9 @@ final class FastBuildServiceImpl implements FastBuildService, ProjectComponent {
                       aspectStrategy.getAspectOutputGroup())
                   .stream()
                   .filter(artifact -> artifact.getArtifactPath().endsWith(deployJarLabel.targetName().toString()))
-                  .collect(Collectors.toUnmodifiableSet()));
+                  .collect(Collectors.toUnmodifiableSet()),
+              BlazeContext.create(),
+              project);
       checkState(deployJarArtifacts.size() == 1);
       deployJar = deployJarArtifacts.get(0);
     } catch (GetArtifactsException e) {
@@ -360,6 +363,7 @@ final class FastBuildServiceImpl implements FastBuildService, ProjectComponent {
     ImmutableList<File> ideInfoFiles;
     try (final var bepStream = resultHelper.getBepStream(Optional.empty())) {
       ideInfoFiles = LocalFileArtifact.getLocalFiles(
+          com.google.idea.blaze.common.Label.of(label.toString()),
           BlazeBuildOutputs.fromParsedBepOutput(
             BuildResultParser.getBuildOutput(bepStream, Interners.STRING))
               .getOutputGroupArtifacts(
@@ -369,7 +373,9 @@ final class FastBuildServiceImpl implements FastBuildService, ProjectComponent {
                   aspectStrategy.getAspectOutputFilePredicate().test(
                       artifact.getArtifactPath().toString()
                   )
-              ).collect(Collectors.toUnmodifiableSet()));
+              ).collect(Collectors.toUnmodifiableSet()),
+          BlazeContext.create(),
+          project);
     } catch (GetArtifactsException e) {
       throw new RuntimeException("Blaze failure building ide info files: " + e.getMessage());
     }

--- a/java/src/com/google/idea/blaze/java/run/hotswap/ClassFileManifestBuilder.java
+++ b/java/src/com/google/idea/blaze/java/run/hotswap/ClassFileManifestBuilder.java
@@ -35,12 +35,14 @@ import com.google.idea.blaze.base.run.BlazeCommandRunConfiguration;
 import com.google.idea.blaze.base.run.ExecutorType;
 import com.google.idea.blaze.base.run.confighandler.BlazeCommandRunConfigurationRunner;
 import com.google.idea.blaze.base.command.buildresult.BuildResult;
+import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.sync.SyncScope.SyncFailedException;
 import com.google.idea.blaze.base.sync.aspects.BlazeBuildOutputs;
 import com.google.idea.blaze.base.sync.aspects.storage.AspectStorageService;
 import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
 import com.google.idea.blaze.base.util.SaveUtil;
 import com.google.idea.blaze.common.Interners;
+import com.google.idea.blaze.common.Label;
 import com.intellij.debugger.impl.HotSwapProgress;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.RunCanceledByUserException;
@@ -48,6 +50,7 @@ import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Key;
 import java.io.File;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.atomic.AtomicReference;
@@ -147,9 +150,12 @@ public class ClassFileManifestBuilder {
       try (final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {
         jars =
             LocalFileArtifact.getLocalFiles(
+                    Label.of(Objects.requireNonNull(configuration.getSingleTarget().toString())),
                     BlazeBuildOutputs.fromParsedBepOutput(
                             BuildResultParser.getBuildOutput(bepStream, Interners.STRING))
-                        .getOutputGroupArtifacts(JavaClasspathAspectStrategy.OUTPUT_GROUP))
+                        .getOutputGroupArtifacts(JavaClasspathAspectStrategy.OUTPUT_GROUP),
+                    BlazeContext.create(),
+                    project)
                 .stream()
                 .filter(f -> f.getName().endsWith(".jar"))
                 .collect(toImmutableList());

--- a/python/src/com/google/idea/blaze/python/run/BlazePyRunConfigurationRunner.java
+++ b/python/src/com/google/idea/blaze/python/run/BlazePyRunConfigurationRunner.java
@@ -44,6 +44,7 @@ import com.google.idea.blaze.base.run.WithBrowserHyperlinkExecutionException;
 import com.google.idea.blaze.base.run.confighandler.BlazeCommandGenericRunConfigurationRunner.BlazeCommandRunProfileState;
 import com.google.idea.blaze.base.run.confighandler.BlazeCommandRunConfigurationRunner;
 import com.google.idea.blaze.base.run.state.BlazeCommandRunConfigurationCommonState;
+import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.sync.aspects.BlazeBuildOutputs;
 import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
 import com.google.idea.blaze.base.util.ProcessGroupUtil;
@@ -345,10 +346,13 @@ public class BlazePyRunConfigurationRunner implements BlazeCommandRunConfigurati
       try (final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {
         candidateFiles =
             LocalFileArtifact.getLocalFiles(
+                    com.google.idea.blaze.common.Label.of(target.toString()),
                     BlazeBuildOutputs.fromParsedBepOutput(
                             BuildResultParser.getBuildOutput(bepStream, Interners.STRING))
                         .getOutputGroupTargetArtifacts(DEFAULT_OUTPUT_GROUP_NAME, target.toString())
-                        .asList())
+                        .asList(),
+                    BlazeContext.create(),
+                    project)
                 .stream()
                 .filter(File::canExecute)
                 .collect(Collectors.toList());

--- a/scala/src/com/google/idea/blaze/scala/run/producers/GenerateDeployableJarTaskProvider.java
+++ b/scala/src/com/google/idea/blaze/scala/run/producers/GenerateDeployableJarTaskProvider.java
@@ -195,9 +195,12 @@ class GenerateDeployableJarTaskProvider
       List<File> outputs;
       try (final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {
         outputs = LocalFileArtifact.getLocalFiles(
+            com.google.idea.blaze.common.Label.of(target.toString()),
             BlazeBuildOutputs.fromParsedBepOutput(
               BuildResultParser.getBuildOutput(bepStream, Interners.STRING))
-                  .getOutputGroupTargetArtifacts(DEFAULT_OUTPUT_GROUP_NAME, String.format("%s_deploy.jar", target)));
+                  .getOutputGroupTargetArtifacts(DEFAULT_OUTPUT_GROUP_NAME, String.format("%s_deploy.jar", target)),
+            BlazeContext.create(),
+            env.getProject());
       }
 
       if (outputs.isEmpty()) {


### PR DESCRIPTION
Cherry pick AOSP commit [06ee9d025d81da3104feb7efc875d9b61f46a134](https://cs.android.com/android-studio/platform/tools/adt/idea/+/06ee9d025d81da3104feb7efc875d9b61f46a134).

STAT (diff to AOSP): 65 insertions(+), 16 deletion(-)

Add project, target and BlazeContext parameters to getLocalFiles method as they
are required to invoke RuntimeArtifactCache.

Bug: 385469770
Test: Update existing tests and manually test by debugging java_binary
Change-Id: I625b22264bda11fb5fa4010ce0008fceb7cd1188

AOSP: 06ee9d025d81da3104feb7efc875d9b61f46a134
