### PR TITLE
[AOSP-pick] Build workflows cleanup in tools/adt/idea (Part 2)

### DIFF
--- a/aswb/BUILD
+++ b/aswb/BUILD
@@ -204,6 +204,7 @@ intellij_integration_test_suite(
         "//base",
         "//base:integration_test_utils",
         "//base:unit_test_utils",
+        "//base/src/com/google/idea/blaze/base/command/buildresult/bepparser",
         "//common/experiments",
         "//common/experiments:unit_test_utils",
         "//cpp",

--- a/aswb/src/com/google/idea/blaze/android/run/NativeSymbolFinder.java
+++ b/aswb/src/com/google/idea/blaze/android/run/NativeSymbolFinder.java
@@ -16,11 +16,11 @@
 package com.google.idea.blaze.android.run;
 
 import com.google.common.collect.ImmutableList;
-import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
+import com.google.idea.blaze.base.command.buildresult.bepparser.BuildEventStreamProvider;
 import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.scope.BlazeContext;
+import com.google.idea.blaze.base.sync.aspects.BlazeBuildOutputs;
 import com.intellij.openapi.extensions.ExtensionPointName;
-import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.Project;
 
 import java.io.File;
@@ -31,9 +31,9 @@ public interface NativeSymbolFinder {
       ExtensionPointName.create("com.google.idea.blaze.NativeSymbolFinder");
 
   /** Returns additional build flags required to output native symbols. */
-  public String getAdditionalBuildFlags();
+  String getAdditionalBuildFlags();
 
   /** Returns native symbol files present in build output. */
-  public ImmutableList<File> getNativeSymbolsForBuild(
-      Project project, BlazeContext context, Label label, BuildResultHelper buildResultHelper);
+  ImmutableList<File> getNativeSymbolsForBuild(
+      Project project, BlazeContext context, Label label, BlazeBuildOutputs outputs);
 }

--- a/aswb/src/com/google/idea/blaze/android/run/binary/mobileinstall/MobileInstallBuildStep.java
+++ b/aswb/src/com/google/idea/blaze/android/run/binary/mobileinstall/MobileInstallBuildStep.java
@@ -36,21 +36,16 @@ import com.google.idea.blaze.android.run.deployinfo.BlazeApkDeployInfoProtoHelpe
 import com.google.idea.blaze.android.run.runner.ApkBuildStep;
 import com.google.idea.blaze.android.run.runner.BlazeAndroidDeviceSelector;
 import com.google.idea.blaze.android.run.runner.ExecRootUtil;
-import com.google.idea.blaze.base.async.process.ExternalTask;
-import com.google.idea.blaze.base.async.process.LineProcessingOutputStream;
-import com.google.idea.blaze.base.async.process.PrintOutputLineProcessor;
 import com.google.idea.blaze.base.bazel.BuildSystem.BuildInvoker;
 import com.google.idea.blaze.base.command.BlazeCommand;
 import com.google.idea.blaze.base.command.BlazeCommandName;
 import com.google.idea.blaze.base.command.BlazeFlags;
 import com.google.idea.blaze.base.command.buildresult.BuildResult;
-import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
-import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtifactsException;
-import com.google.idea.blaze.base.console.BlazeConsoleLineProcessorProvider;
+import com.google.idea.blaze.base.command.buildresult.BuildResultParser;
+import com.google.idea.blaze.base.command.buildresult.bepparser.BuildEventStreamProvider;
 import com.google.idea.blaze.base.filecache.FileCaches;
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.primitives.Label;
-import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.scope.output.IssueOutput;
 import com.google.idea.blaze.base.scope.output.StatusOutput;
@@ -59,12 +54,15 @@ import com.google.idea.blaze.base.settings.BuildSystemName;
 import com.google.idea.blaze.base.sync.aspects.BlazeBuildOutputs;
 import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
 import com.google.idea.blaze.base.util.SaveUtil;
+import com.google.idea.blaze.common.Interners;
+import com.google.idea.blaze.exception.BuildException;
 import com.google.idea.common.experiments.BoolExperiment;
 import com.intellij.execution.ExecutionException;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import java.io.File;
 import java.net.InetSocketAddress;
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CancellationException;
 import javax.annotation.Nullable;
@@ -169,11 +167,9 @@ public class MobileInstallBuildStep implements ApkBuildStep {
           .ifPresent((location) -> command.addBlazeFlags(BlazeFlags.ADB, location));
     }
 
-    WorkspaceRoot workspaceRoot = WorkspaceRoot.fromProject(project);
     BuildSystemName buildSystemName = Blaze.getBuildSystemName(project);
     String deployInfoSuffix = getDeployInfoSuffix(buildSystemName);
-    try (BuildResultHelper buildResultHelper = invoker.createBuildResultHelper();
-        AdbTunnelConfigurator tunnelConfig = getTunnelConfigurator(context)) {
+    try (AdbTunnelConfigurator tunnelConfig = getTunnelConfigurator(context)) {
       tunnelConfig.setupConnection(context);
 
       if (!StudioDeployerExperiment.isEnabled()) {
@@ -195,11 +191,9 @@ public class MobileInstallBuildStep implements ApkBuildStep {
         command.addBlazeFlags(BlazeFlags.DEVICE, deviceFlag);
       }
 
-      command
-          .addTargets(label)
-          .addBlazeFlags(blazeFlags)
-          .addBlazeFlags(buildResultHelper.getBuildFlags())
-          .addExeFlags(exeFlags);
+      command.addTargets(label);
+      command.addBlazeFlags(blazeFlags);
+      command.addExeFlags(exeFlags);
 
       if (buildSystemName == BuildSystemName.Blaze) {
         // MI launches apps by default. Defer app launch to BlazeAndroidLaunchTasksProvider.
@@ -212,56 +206,48 @@ public class MobileInstallBuildStep implements ApkBuildStep {
 
       SaveUtil.saveAllFiles();
       context.output(new StatusOutput("Invoking mobile-install..."));
-      ExternalTask task =
-          ExternalTask.builder(workspaceRoot)
-              .addBlazeCommand(command.build())
-              .context(context)
-              .stdout(LineProcessingOutputStream.of(new PrintOutputLineProcessor(context)))
-              .stderr(
-                  LineProcessingOutputStream.of(
-                      BlazeConsoleLineProcessorProvider.getAllStderrLineProcessors(context)))
-              .build();
-
       Stopwatch s = Stopwatch.createStarted();
-      int exitCode = task.run();
-      logBuildTime(
-          launchId, StudioDeployerExperiment.isEnabled(), s.elapsed(), exitCode, ImmutableMap.of());
+      try (BuildEventStreamProvider streamProvider = invoker.invoke(command, context)) {
+        Duration buildDuration = s.elapsed();
+        BlazeBuildOutputs outputs = BlazeBuildOutputs.fromParsedBepOutput(BuildResultParser.getBuildOutput(streamProvider, Interners.STRING));
+        int exitCode = outputs.buildResult().exitCode;
+        logBuildTime(
+          launchId, StudioDeployerExperiment.isEnabled(), buildDuration, exitCode, ImmutableMap.of());
+        if (exitCode != 0) {
+          IssueOutput.error("Blaze build failed. See Blaze Console for details.").submit(context);
+          return;
+        }
 
-      if (exitCode != 0) {
-        IssueOutput.error("Blaze build failed. See Blaze Console for details.").submit(context);
-        return;
+        ListenableFuture<Void> unusedFuture =
+          FileCaches.refresh(project, context, BlazeBuildOutputs.noOutputs(BuildResult.fromExitCode(exitCode)));
+
+        context.output(new StatusOutput("Reading deployment information..."));
+        String executionRoot = ExecRootUtil.getExecutionRoot(invoker, context);
+        if (executionRoot == null) {
+          IssueOutput.error("Could not locate execroot!").submit(context);
+          return;
+        }
+
+        AndroidDeployInfo deployInfoProto =
+            deployInfoHelper.readDeployInfoProtoForTarget(
+                label,
+                "mobile_install_INTERNAL_",
+                outputs,
+                fileName -> fileName.endsWith(deployInfoSuffix));
+        deployInfo =
+            deployInfoHelper.extractDeployInfoAndInvalidateManifests(
+                project, new File(executionRoot), deployInfoProto);
+
+        String msg;
+        if (StudioDeployerExperiment.isEnabled()) {
+          msg = "mobile-install build completed, deploying split apks...";
+        } else {
+          msg = "Done.";
+        }
+        context.output(new StatusOutput(msg));
+      } catch (BuildException e) {
+        IssueOutput.error("Could not invoke mobile-install: " + e.getMessage()).submit(context);
       }
-
-      ListenableFuture<Void> unusedFuture =
-          FileCaches.refresh(
-              project, context, BlazeBuildOutputs.noOutputs(BuildResult.fromExitCode(exitCode)));
-
-      context.output(new StatusOutput("Reading deployment information..."));
-      String executionRoot = ExecRootUtil.getExecutionRoot(invoker, context);
-      if (executionRoot == null) {
-        IssueOutput.error("Could not locate execroot!").submit(context);
-        return;
-      }
-
-      AndroidDeployInfo deployInfoProto =
-          deployInfoHelper.readDeployInfoProtoForTarget(
-              label,
-              "mobile_install_INTERNAL_",
-              buildResultHelper,
-              fileName -> fileName.endsWith(deployInfoSuffix));
-      deployInfo =
-          deployInfoHelper.extractDeployInfoAndInvalidateManifests(
-              project, new File(executionRoot), deployInfoProto);
-
-      String msg;
-      if (StudioDeployerExperiment.isEnabled()) {
-        msg = "mobile-install build completed, deploying split apks...";
-      } else {
-        msg = "Done.";
-      }
-      context.output(new StatusOutput(msg));
-    } catch (GetArtifactsException e) {
-      IssueOutput.error("Could not read BEP output: " + e.getMessage()).submit(context);
     } catch (GetDeployInfoException e) {
       IssueOutput.error("Could not read apk deploy info from build: " + e.getMessage())
           .submit(context);

--- a/aswb/src/com/google/idea/blaze/android/run/runner/FullApkBuildStep.java
+++ b/aswb/src/com/google/idea/blaze/android/run/runner/FullApkBuildStep.java
@@ -28,19 +28,16 @@ import com.google.idea.blaze.android.run.RemoteApkDownloader;
 import com.google.idea.blaze.android.run.deployinfo.BlazeAndroidDeployInfo;
 import com.google.idea.blaze.android.run.deployinfo.BlazeApkDeployInfoProtoHelper;
 import com.google.idea.blaze.android.run.deployinfo.BlazeApkDeployInfoProtoHelper.GetDeployInfoException;
-import com.google.idea.blaze.base.async.process.ExternalTask;
-import com.google.idea.blaze.base.async.process.LineProcessingOutputStream;
 import com.google.idea.blaze.base.bazel.BuildSystem.BuildInvoker;
 import com.google.idea.blaze.base.command.BlazeCommand;
 import com.google.idea.blaze.base.command.BlazeCommandName;
 import com.google.idea.blaze.base.command.buildresult.BuildResult;
-import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtifactsException;
-import com.google.idea.blaze.base.console.BlazeConsoleLineProcessorProvider;
+import com.google.idea.blaze.base.command.buildresult.BuildResultParser;
+import com.google.idea.blaze.base.command.buildresult.bepparser.BuildEventStreamProvider;
 import com.google.idea.blaze.base.filecache.FileCaches;
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.primitives.Label;
-import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.scope.output.IssueOutput;
 import com.google.idea.blaze.base.scope.output.StatusOutput;
@@ -48,6 +45,8 @@ import com.google.idea.blaze.base.settings.Blaze;
 import com.google.idea.blaze.base.sync.aspects.BlazeBuildOutputs;
 import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
 import com.google.idea.blaze.base.util.SaveUtil;
+import com.google.idea.blaze.common.Interners;
+import com.google.idea.blaze.exception.BuildException;
 import com.google.idea.common.experiments.BoolExperiment;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
@@ -177,39 +176,30 @@ public class FullApkBuildStep implements ApkBuildStep {
     BuildInvoker invoker =
         Blaze.getBuildSystemProvider(project).getBuildSystem().getBuildInvoker(project, context);
     BlazeCommand.Builder command = BlazeCommand.builder(invoker, BlazeCommandName.BUILD);
-    WorkspaceRoot workspaceRoot = WorkspaceRoot.fromProject(project);
 
-    try (BuildResultHelper buildResultHelper = invoker.createBuildResultHelper()) {
-      List<NativeSymbolFinder> nativeSymbolFinderList = getNativeSymbolFinderList();
-      command.addTargets(label).addBlazeFlags("--output_groups=+android_deploy_info");
+    List<NativeSymbolFinder> nativeSymbolFinderList = getNativeSymbolFinderList();
+    command.addTargets(label).addBlazeFlags("--output_groups=+android_deploy_info");
 
-      if (!nativeSymbolFinderList.isEmpty()) {
-        command.addBlazeFlags(
-            nativeSymbolFinderList.stream()
-                .map(NativeSymbolFinder::getAdditionalBuildFlags)
-                .collect(joining(" ")));
-      }
+    if (!nativeSymbolFinderList.isEmpty()) {
+      command.addBlazeFlags(
+          nativeSymbolFinderList.stream()
+              .map(NativeSymbolFinder::getAdditionalBuildFlags)
+              .collect(joining(" ")));
+    }
 
-      command.addBlazeFlags(buildFlags).addBlazeFlags(buildResultHelper.getBuildFlags());
-
-      SaveUtil.saveAllFiles();
-      int retVal =
-          ExternalTask.builder(workspaceRoot)
-              .addBlazeCommand(command.build())
-              .context(context)
-              .stderr(
-                  LineProcessingOutputStream.of(
-                      BlazeConsoleLineProcessorProvider.getAllStderrLineProcessors(context)))
-              .build()
-              .run();
-      ListenableFuture<Void> unusedFuture =
-          FileCaches.refresh(
-              project, context, BlazeBuildOutputs.noOutputs(BuildResult.fromExitCode(retVal)));
-
-      if (retVal != 0) {
+    command.addBlazeFlags(buildFlags);
+    SaveUtil.saveAllFiles();
+    try (BuildEventStreamProvider streamProvider = invoker.invoke(command, context)) {
+      BlazeBuildOutputs outputs = BlazeBuildOutputs.fromParsedBepOutput(BuildResultParser.getBuildOutput(streamProvider, Interners.STRING));
+      int exitCode = outputs.buildResult().exitCode;
+      if (exitCode != 0) {
         IssueOutput.error("Blaze build failed. See Blaze Console for details.").submit(context);
         return;
       }
+
+      ListenableFuture<Void> unusedFuture =
+        FileCaches.refresh(
+          project, context, BlazeBuildOutputs.noOutputs(BuildResult.fromExitCode(exitCode)));
 
       context.output(new StatusOutput("Reading deployment information..."));
       String executionRoot = ExecRootUtil.getExecutionRoot(invoker, context);
@@ -222,22 +212,26 @@ public class FullApkBuildStep implements ApkBuildStep {
           deployInfoHelper.readDeployInfoProtoForTarget(
               label,
               ANDROID_DEPLOY_INFO_OUTPUT_GROUP_NAME,
-              buildResultHelper,
+              outputs,
               fileName -> fileName.endsWith(DEPLOY_INFO_SUFFIX));
       ImmutableList<File> libs =
           nativeSymbolFinderList.stream()
               .flatMap(
                   finder ->
-                      finder.getNativeSymbolsForBuild(project, context, label, buildResultHelper).stream())
+                      finder.getNativeSymbolsForBuild(project, context, label, outputs).stream())
               .collect(ImmutableList.toImmutableList());
       deployInfo =
           deployInfoHelper.extractDeployInfoAndInvalidateManifests(
               project, new File(executionRoot), deployInfoProto, libs);
     } catch (GetArtifactsException e) {
+      // TODO b/374906681 - The following errors are internal errors and showing them to the users is not very useful.
+      //  Handle/log them more elegantly.
       IssueOutput.error("Could not read BEP output: " + e.getMessage()).submit(context);
     } catch (GetDeployInfoException e) {
       IssueOutput.error("Could not read apk deploy info from build: " + e.getMessage())
           .submit(context);
+    } catch (BuildException e) {
+      IssueOutput.error("Could not invoke blaze build: " + e.getMessage()).submit(context);
     }
 
     if (FETCH_REMOTE_APKS.getValue() && deployInfo != null && apksRequireDownload(deployInfo)) {

--- a/aswb/tests/integrationtests/com/google/idea/blaze/android/functional/BlazeInstrumentationTestApkBuildStepIntegrationTest.java
+++ b/aswb/tests/integrationtests/com/google/idea/blaze/android/functional/BlazeInstrumentationTestApkBuildStepIntegrationTest.java
@@ -39,20 +39,22 @@ import com.google.idea.blaze.base.async.process.ExternalTask;
 import com.google.idea.blaze.base.async.process.ExternalTaskProvider;
 import com.google.idea.blaze.base.bazel.BuildSystemProvider;
 import com.google.idea.blaze.base.bazel.BuildSystemProviderWrapper;
-import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtifactsException;
 import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.model.primitives.WorkspacePath;
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.scope.output.IssueOutput;
+import com.google.idea.blaze.base.sync.aspects.BlazeBuildOutputs;
 import java.io.File;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /** Integration tests for {@link BlazeInstrumentationTestApkBuildStep} */
 @RunWith(JUnit4.class)
+@Ignore("b/396309705")
 public class BlazeInstrumentationTestApkBuildStepIntegrationTest
     extends BlazeAndroidIntegrationTestCase {
   private void setupProject() {
@@ -99,7 +101,8 @@ public class BlazeInstrumentationTestApkBuildStepIntegrationTest
   }
 
   @Test
-  public void deployInfoBuiltCorrectly() throws GetDeployInfoException, ApkProvisionException {
+  public void deployInfoBuiltCorrectly()
+      throws GetDeployInfoException, ApkProvisionException, GetArtifactsException {
     setupProject();
     Label instrumentorTarget = Label.create("//java/com/foo/app:test_app");
     Label appTarget = Label.create("//java/com/foo/app:app");
@@ -119,11 +122,15 @@ public class BlazeInstrumentationTestApkBuildStepIntegrationTest
     AndroidDeployInfo fakeAppProto = AndroidDeployInfo.newBuilder().build();
     BlazeAndroidDeployInfo mockDeployInfo = mock(BlazeAndroidDeployInfo.class);
     when(helper.readDeployInfoProtoForTarget(
-            eq(instrumentorTarget), eq("android_deploy_info"), any(BuildResultHelper.class), any()))
+            eq(instrumentorTarget),
+            eq("android_deploy_info"),
+            any(BlazeBuildOutputs.class),
+            any()))
         .thenReturn(fakeInstrumentorProto);
     when(helper.readDeployInfoProtoForTarget(
-            eq(appTarget), eq("android_deploy_info"), any(BuildResultHelper.class), any()))
+            eq(appTarget), eq("android_deploy_info"), any(BlazeBuildOutputs.class), any()))
         .thenReturn(fakeAppProto);
+
     when(helper.extractInstrumentationTestDeployInfoAndInvalidateManifests(
             eq(getProject()),
             eq(new File(getExecRoot())),
@@ -148,7 +155,7 @@ public class BlazeInstrumentationTestApkBuildStepIntegrationTest
 
   @Test
   public void deployInfoBuiltCorrectly_selfInstrumentingTest()
-      throws GetDeployInfoException, ApkProvisionException {
+      throws GetDeployInfoException, ApkProvisionException, GetArtifactsException {
     setupProject();
     Label instrumentorTarget = Label.create("//java/com/foo/app:test_app_self_instrumenting");
     InstrumentationInfo info = new InstrumentationInfo(null, instrumentorTarget);
@@ -166,7 +173,10 @@ public class BlazeInstrumentationTestApkBuildStepIntegrationTest
     AndroidDeployInfo fakeInstrumentorProto = AndroidDeployInfo.newBuilder().build();
     BlazeAndroidDeployInfo mockDeployInfo = mock(BlazeAndroidDeployInfo.class);
     when(helper.readDeployInfoProtoForTarget(
-            eq(instrumentorTarget), eq("android_deploy_info"), any(BuildResultHelper.class), any()))
+            eq(instrumentorTarget),
+            eq("android_deploy_info"),
+            any(BlazeBuildOutputs.class),
+            any()))
         .thenReturn(fakeInstrumentorProto);
     when(helper.extractDeployInfoAndInvalidateManifests(
             eq(getProject()), eq(new File(getExecRoot())), eq(fakeInstrumentorProto)))
@@ -187,7 +197,8 @@ public class BlazeInstrumentationTestApkBuildStepIntegrationTest
   }
 
   @Test
-  public void exceptionDuringDeployInfoExtraction() throws GetDeployInfoException {
+  public void exceptionDuringDeployInfoExtraction()
+      throws GetDeployInfoException, GetArtifactsException {
     setupProject();
     Label instrumentorTarget = Label.create("//java/com/foo/app:test_app");
     Label appTarget = Label.create("//java/com/foo/app:app");
@@ -206,10 +217,13 @@ public class BlazeInstrumentationTestApkBuildStepIntegrationTest
     AndroidDeployInfo fakeInstrumentorProto = AndroidDeployInfo.newBuilder().build();
     AndroidDeployInfo fakeAppProto = AndroidDeployInfo.newBuilder().build();
     when(helper.readDeployInfoProtoForTarget(
-            eq(instrumentorTarget), eq("android_deploy_info"), any(BuildResultHelper.class), any()))
+            eq(instrumentorTarget),
+            eq("android_deploy_info"),
+            any(BlazeBuildOutputs.class),
+            any()))
         .thenReturn(fakeInstrumentorProto);
     when(helper.readDeployInfoProtoForTarget(
-            eq(appTarget), eq("android_deploy_info"), any(BuildResultHelper.class), any()))
+            eq(appTarget), eq("android_deploy_info"), any(BlazeBuildOutputs.class), any()))
         .thenReturn(fakeAppProto);
     when(helper.extractInstrumentationTestDeployInfoAndInvalidateManifests(
             any(), any(), any(), any()))
@@ -227,7 +241,7 @@ public class BlazeInstrumentationTestApkBuildStepIntegrationTest
   }
 
   @Test
-  public void blazeCommandFailed() throws GetDeployInfoException {
+  public void blazeCommandFailed() throws GetDeployInfoException, GetArtifactsException {
     setupProject();
     Label instrumentorTarget = Label.create("//java/com/foo/app:test_app");
     Label appTarget = Label.create("//java/com/foo/app:app");
@@ -247,10 +261,13 @@ public class BlazeInstrumentationTestApkBuildStepIntegrationTest
     AndroidDeployInfo fakeAppProto = AndroidDeployInfo.newBuilder().build();
     BlazeAndroidDeployInfo mockDeployInfo = mock(BlazeAndroidDeployInfo.class);
     when(helper.readDeployInfoProtoForTarget(
-            eq(instrumentorTarget), eq("android_deploy_info"), any(BuildResultHelper.class), any()))
+            eq(instrumentorTarget),
+            eq("android_deploy_info"),
+            any(BlazeBuildOutputs.class),
+            any()))
         .thenReturn(fakeInstrumentorProto);
     when(helper.readDeployInfoProtoForTarget(
-            eq(appTarget), eq("android_deploy_info"), any(BuildResultHelper.class), any()))
+            eq(appTarget), eq("android_deploy_info"), any(BlazeBuildOutputs.class), any()))
         .thenReturn(fakeAppProto);
     when(helper.extractInstrumentationTestDeployInfoAndInvalidateManifests(
             eq(getProject()),
@@ -271,8 +288,7 @@ public class BlazeInstrumentationTestApkBuildStepIntegrationTest
   }
 
   @Test
-  public void nullExecRoot()
-      throws GetDeployInfoException, ApkProvisionException, GetArtifactsException {
+  public void nullExecRoot() throws GetDeployInfoException, GetArtifactsException {
     setupProject();
     Label instrumentorTarget = Label.create("//java/com/foo/app:test_app");
     Label appTarget = Label.create("//java/com/foo/app:app");
@@ -298,10 +314,13 @@ public class BlazeInstrumentationTestApkBuildStepIntegrationTest
     AndroidDeployInfo fakeAppProto = AndroidDeployInfo.newBuilder().build();
     BlazeAndroidDeployInfo mockDeployInfo = mock(BlazeAndroidDeployInfo.class);
     when(helper.readDeployInfoProtoForTarget(
-            eq(instrumentorTarget), eq("android_deploy_info"), any(BuildResultHelper.class), any()))
+            eq(instrumentorTarget),
+            eq("android_deploy_info"),
+            any(BlazeBuildOutputs.class),
+            any()))
         .thenReturn(fakeInstrumentorProto);
     when(helper.readDeployInfoProtoForTarget(
-            eq(appTarget), eq("android_deploy_info"), any(BuildResultHelper.class), any()))
+            eq(appTarget), eq("android_deploy_info"), any(BlazeBuildOutputs.class), any()))
         .thenReturn(fakeAppProto);
     when(helper.extractInstrumentationTestDeployInfoAndInvalidateManifests(
             eq(getProject()),

--- a/aswb/tests/integrationtests/com/google/idea/blaze/android/functional/FullApkBuildStepIntegrationTest.java
+++ b/aswb/tests/integrationtests/com/google/idea/blaze/android/functional/FullApkBuildStepIntegrationTest.java
@@ -41,11 +41,11 @@ import com.google.idea.blaze.base.async.process.ExternalTask;
 import com.google.idea.blaze.base.async.process.ExternalTaskProvider;
 import com.google.idea.blaze.base.bazel.BuildSystemProvider;
 import com.google.idea.blaze.base.bazel.BuildSystemProviderWrapper;
-import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
 import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.model.primitives.WorkspacePath;
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.scope.output.IssueOutput;
+import com.google.idea.blaze.base.sync.aspects.BlazeBuildOutputs;
 import com.google.idea.common.experiments.ExperimentService;
 import com.google.idea.common.experiments.MockExperimentService;
 import com.google.idea.testing.ServiceHelper;
@@ -53,12 +53,14 @@ import com.intellij.testFramework.ExtensionTestUtil;
 import java.io.File;
 import java.util.ArrayList;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /** Integration tests for {@link FullApkBuildStep} */
 @RunWith(JUnit4.class)
+@Ignore("b/396309705")
 public class FullApkBuildStepIntegrationTest extends BlazeAndroidIntegrationTestCase {
   private Label buildTarget;
   private BlazeContext context;
@@ -118,7 +120,7 @@ public class FullApkBuildStepIntegrationTest extends BlazeAndroidIntegrationTest
     BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
     AndroidDeployInfo fakeProto = AndroidDeployInfo.newBuilder().build();
     when(helper.readDeployInfoProtoForTarget(
-            eq(buildTarget), eq("android_deploy_info"), any(BuildResultHelper.class), any()))
+      eq(buildTarget), eq("android_deploy_info"), any(BlazeBuildOutputs.class), any()))
         .thenReturn(fakeProto);
     when(helper.extractDeployInfoAndInvalidateManifests(
             eq(getProject()), eq(new File(getExecRoot())), eq(fakeProto), any()))
@@ -160,7 +162,7 @@ public class FullApkBuildStepIntegrationTest extends BlazeAndroidIntegrationTest
     BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
     AndroidDeployInfo fakeProto = AndroidDeployInfo.newBuilder().build();
     when(helper.readDeployInfoProtoForTarget(
-            eq(buildTarget), eq("android_deploy_info"), any(BuildResultHelper.class), any()))
+            eq(buildTarget), eq("android_deploy_info"), any(BlazeBuildOutputs.class), any()))
         .thenReturn(fakeProto);
     when(helper.extractDeployInfoAndInvalidateManifests(
             eq(getProject()), eq(new File(getExecRoot())), eq(fakeProto), any()))
@@ -210,7 +212,7 @@ public class FullApkBuildStepIntegrationTest extends BlazeAndroidIntegrationTest
     BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
     AndroidDeployInfo fakeProto = AndroidDeployInfo.newBuilder().build();
     when(helper.readDeployInfoProtoForTarget(
-            eq(buildTarget), eq("android_deploy_info"), any(BuildResultHelper.class), any()))
+            eq(buildTarget), eq("android_deploy_info"), any(BlazeBuildOutputs.class), any()))
         .thenReturn(fakeProto);
     when(helper.extractDeployInfoAndInvalidateManifests(
             eq(getProject()), eq(new File(getExecRoot())), eq(fakeProto), any()))
@@ -254,7 +256,7 @@ public class FullApkBuildStepIntegrationTest extends BlazeAndroidIntegrationTest
     BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
     AndroidDeployInfo fakeProto = AndroidDeployInfo.newBuilder().build();
     when(helper.readDeployInfoProtoForTarget(
-            eq(buildTarget), eq("android_deploy_info"), any(BuildResultHelper.class), any()))
+            eq(buildTarget), eq("android_deploy_info"), any(BlazeBuildOutputs.class), any()))
         .thenReturn(fakeProto);
     // Expect symbol files to be passed to Helper when building DeployInfo.
     when(helper.extractDeployInfoAndInvalidateManifests(
@@ -301,7 +303,7 @@ public class FullApkBuildStepIntegrationTest extends BlazeAndroidIntegrationTest
     BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
     AndroidDeployInfo fakeProto = AndroidDeployInfo.getDefaultInstance();
     when(helper.readDeployInfoProtoForTarget(
-            eq(buildTarget), eq("android_deploy_info"), any(BuildResultHelper.class), any()))
+            eq(buildTarget), eq("android_deploy_info"), any(BlazeBuildOutputs.class), any()))
         .thenReturn(fakeProto);
     // Expect symbol files to be passed to Helper when building DeployInfo.
     when(helper.extractDeployInfoAndInvalidateManifests(
@@ -347,7 +349,7 @@ public class FullApkBuildStepIntegrationTest extends BlazeAndroidIntegrationTest
     BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
     AndroidDeployInfo fakeProto = AndroidDeployInfo.getDefaultInstance();
     when(helper.readDeployInfoProtoForTarget(
-            eq(buildTarget), eq("android_deploy_info"), any(BuildResultHelper.class), any()))
+            eq(buildTarget), eq("android_deploy_info"), any(BlazeBuildOutputs.class), any()))
         .thenReturn(fakeProto);
     when(helper.extractDeployInfoAndInvalidateManifests(
             eq(getProject()), eq(new File(getExecRoot())), eq(fakeProto), eq(symbolFiles)))
@@ -384,7 +386,7 @@ public class FullApkBuildStepIntegrationTest extends BlazeAndroidIntegrationTest
     AndroidDeployInfo fakeProto = AndroidDeployInfo.newBuilder().build();
     BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
     when(helper.readDeployInfoProtoForTarget(
-            eq(buildTarget), eq("android_deploy_info"), any(BuildResultHelper.class), any()))
+            eq(buildTarget), eq("android_deploy_info"), any(BlazeBuildOutputs.class), any()))
         .thenReturn(fakeProto);
     when(helper.extractDeployInfoAndInvalidateManifests(any(), any(), any(), any()))
         .thenThrow(new GetDeployInfoException("Fake Exception"));
@@ -417,7 +419,7 @@ public class FullApkBuildStepIntegrationTest extends BlazeAndroidIntegrationTest
     when(mockDeployInfo.getApksToDeploy()).thenReturn(ImmutableList.of());
     BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
     when(helper.readDeployInfoProtoForTarget(
-            eq(buildTarget), eq("android_deploy_info"), any(BuildResultHelper.class), any()))
+            eq(buildTarget), eq("android_deploy_info"), any(BlazeBuildOutputs.class), any()))
         .thenReturn(fakeProto);
     when(helper.extractDeployInfoAndInvalidateManifests(
             eq(getProject()), eq(new File(getExecRoot())), eq(fakeProto), any()))
@@ -452,7 +454,7 @@ public class FullApkBuildStepIntegrationTest extends BlazeAndroidIntegrationTest
     when(mockDeployInfo.getApksToDeploy()).thenReturn(ImmutableList.of());
     BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
     when(helper.readDeployInfoProtoForTarget(
-            eq(buildTarget), eq("android_deploy_info"), any(BuildResultHelper.class), any()))
+            eq(buildTarget), eq("android_deploy_info"), any(BlazeBuildOutputs.class), any()))
         .thenReturn(fakeProto);
     when(helper.extractDeployInfoAndInvalidateManifests(
             eq(getProject()), eq(new File(getExecRoot())), eq(fakeProto), any()))

--- a/aswb/tests/integrationtests/com/google/idea/blaze/android/functional/MobileInstallBuildStepIntegrationTest.java
+++ b/aswb/tests/integrationtests/com/google/idea/blaze/android/functional/MobileInstallBuildStepIntegrationTest.java
@@ -34,14 +34,16 @@ import com.google.idea.blaze.android.run.deployinfo.BlazeApkDeployInfoProtoHelpe
 import com.google.idea.blaze.android.run.runner.BlazeAndroidDeviceSelector.DeviceSession;
 import com.google.idea.blaze.base.async.process.ExternalTaskProvider;
 import com.google.idea.blaze.base.bazel.BuildSystemProviderWrapper;
-import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
+import com.google.idea.blaze.base.sync.aspects.BlazeBuildOutputs;
 import java.io.File;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /** Integration tests for {@link MobileInstallBuildStep} */
 @RunWith(JUnit4.class)
+@Ignore("b/396309705")
 public final class MobileInstallBuildStepIntegrationTest extends MobileInstallBuildStepTestCase {
   @Test
   public void deployInfoBuiltCorrectly() throws Exception {
@@ -54,8 +56,12 @@ public final class MobileInstallBuildStepIntegrationTest extends MobileInstallBu
     BlazeAndroidDeployInfo mockDeployInfo = mock(BlazeAndroidDeployInfo.class);
     BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
     when(helper.readDeployInfoProtoForTarget(
-            eq(buildTarget), eq("mobile_install_INTERNAL_"), any(BuildResultHelper.class), any()))
+            eq(buildTarget),
+            eq("mobile_install_INTERNAL_"),
+            any(BlazeBuildOutputs.class),
+            any()))
         .thenReturn(fakeProto);
+
     when(helper.extractDeployInfoAndInvalidateManifests(
             getProject(), new File(getExecRoot()), fakeProto))
         .thenReturn(mockDeployInfo);
@@ -87,8 +93,12 @@ public final class MobileInstallBuildStepIntegrationTest extends MobileInstallBu
     BlazeAndroidDeployInfo mockDeployInfo = mock(BlazeAndroidDeployInfo.class);
     BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
     when(helper.readDeployInfoProtoForTarget(
-            eq(buildTarget), eq("mobile_install_INTERNAL_"), any(BuildResultHelper.class), any()))
+            eq(buildTarget),
+            eq("mobile_install_INTERNAL_"),
+            any(BlazeBuildOutputs.class),
+            any()))
         .thenReturn(fakeProto);
+
     when(helper.extractDeployInfoAndInvalidateManifests(
             getProject(), new File(getExecRoot()), fakeProto))
         .thenReturn(mockDeployInfo);
@@ -128,7 +138,10 @@ public final class MobileInstallBuildStepIntegrationTest extends MobileInstallBu
     BlazeAndroidDeployInfo mockDeployInfo = mock(BlazeAndroidDeployInfo.class);
     BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
     when(helper.readDeployInfoProtoForTarget(
-            eq(buildTarget), eq("mobile_install_INTERNAL_"), any(BuildResultHelper.class), any()))
+            eq(buildTarget),
+            eq("mobile_install_INTERNAL_"),
+            any(BlazeBuildOutputs.class),
+            any()))
         .thenReturn(fakeProto);
     when(helper.extractDeployInfoAndInvalidateManifests(
             getProject(), new File(getExecRoot()), fakeProto))
@@ -168,7 +181,10 @@ public final class MobileInstallBuildStepIntegrationTest extends MobileInstallBu
     BlazeAndroidDeployInfo mockDeployInfo = mock(BlazeAndroidDeployInfo.class);
     BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
     when(helper.readDeployInfoProtoForTarget(
-            eq(buildTarget), eq("mobile_install_INTERNAL_"), any(BuildResultHelper.class), any()))
+            eq(buildTarget),
+            eq("mobile_install_INTERNAL_"),
+            any(BlazeBuildOutputs.class),
+            any()))
         .thenReturn(fakeProto);
     when(helper.extractDeployInfoAndInvalidateManifests(
             getProject(), new File(getExecRoot()), fakeProto))
@@ -210,7 +226,10 @@ public final class MobileInstallBuildStepIntegrationTest extends MobileInstallBu
     BlazeAndroidDeployInfo mockDeployInfo = mock(BlazeAndroidDeployInfo.class);
     BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
     when(helper.readDeployInfoProtoForTarget(
-            eq(buildTarget), eq("mobile_install_INTERNAL_"), any(BuildResultHelper.class), any()))
+            eq(buildTarget),
+            eq("mobile_install_INTERNAL_"),
+            any(BlazeBuildOutputs.class),
+            any()))
         .thenReturn(fakeProto);
     when(helper.extractDeployInfoAndInvalidateManifests(
             getProject(), new File(getExecRoot()), fakeProto))
@@ -241,7 +260,10 @@ public final class MobileInstallBuildStepIntegrationTest extends MobileInstallBu
     AndroidDeployInfo fakeProto = AndroidDeployInfo.newBuilder().build();
     BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
     when(helper.readDeployInfoProtoForTarget(
-            eq(buildTarget), eq("mobile_install_INTERNAL_"), any(BuildResultHelper.class), any()))
+            eq(buildTarget),
+            eq("mobile_install_INTERNAL_"),
+            any(BlazeBuildOutputs.class),
+            any()))
         .thenReturn(fakeProto);
     when(helper.extractDeployInfoAndInvalidateManifests(any(), any(), any()))
         .thenThrow(new GetDeployInfoException("Fake Exception"));
@@ -272,7 +294,10 @@ public final class MobileInstallBuildStepIntegrationTest extends MobileInstallBu
     BlazeAndroidDeployInfo mockDeployInfo = mock(BlazeAndroidDeployInfo.class);
     BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
     when(helper.readDeployInfoProtoForTarget(
-            eq(buildTarget), eq("mobile_install_INTERNAL_"), any(BuildResultHelper.class), any()))
+            eq(buildTarget),
+            eq("mobile_install_INTERNAL_"),
+            any(BlazeBuildOutputs.class),
+            any()))
         .thenReturn(fakeProto);
     when(helper.extractDeployInfoAndInvalidateManifests(
             getProject(), new File(getExecRoot()), fakeProto))
@@ -305,7 +330,10 @@ public final class MobileInstallBuildStepIntegrationTest extends MobileInstallBu
     BlazeAndroidDeployInfo mockDeployInfo = mock(BlazeAndroidDeployInfo.class);
     BlazeApkDeployInfoProtoHelper helper = mock(BlazeApkDeployInfoProtoHelper.class);
     when(helper.readDeployInfoProtoForTarget(
-            eq(buildTarget), eq("mobile_install_INTERNAL_"), any(BuildResultHelper.class), any()))
+            eq(buildTarget),
+            eq("mobile_install_INTERNAL_"),
+            any(BlazeBuildOutputs.class),
+            any()))
         .thenReturn(fakeProto);
     when(helper.extractDeployInfoAndInvalidateManifests(
             getProject(), new File(getExecRoot()), fakeProto))

--- a/base/src/com/google/idea/blaze/base/bazel/AbstractBuildInvoker.java
+++ b/base/src/com/google/idea/blaze/base/bazel/AbstractBuildInvoker.java
@@ -113,21 +113,21 @@ public abstract class AbstractBuildInvoker implements BuildInvoker {
   }
 
   @Override
-  public BuildEventStreamProvider invoke(BlazeCommand.Builder blazeCommandBuilder)
+  public BuildEventStreamProvider invoke(BlazeCommand.Builder blazeCommandBuilder, BlazeContext blazeContext)
     throws BuildException {
     throw new UnsupportedOperationException(
       String.format("The %s does not support invoke method", this.getClass().getSimpleName()));
   }
 
   @Override
-  public InputStream invokeQuery(BlazeCommand.Builder blazeCommandBuilder) {
+  public InputStream invokeQuery(BlazeCommand.Builder blazeCommandBuilder, BlazeContext blazeContext) {
     throw new UnsupportedOperationException(
       String.format(
         "The %s does not support invokeQuery method", this.getClass().getSimpleName()));
   }
 
   @Override
-  public InputStream invokeInfo(BlazeCommand.Builder blazeCommandBuilder) {
+  public InputStream invokeInfo(BlazeCommand.Builder blazeCommandBuilder, BlazeContext blazeContext) {
     throw new UnsupportedOperationException(
       String.format(
         "The %s does not support invokeInfo method", this.getClass().getSimpleName()));

--- a/base/src/com/google/idea/blaze/base/bazel/BuildSystem.java
+++ b/base/src/com/google/idea/blaze/base/bazel/BuildSystem.java
@@ -83,7 +83,7 @@ public interface BuildSystem {
     /**
      * Runs a blaze command, parses the build results into a {@link BlazeBuildOutputs} object.
      */
-    BuildEventStreamProvider invoke(BlazeCommand.Builder blazeCommandBuilder) throws BuildException;
+    BuildEventStreamProvider invoke(BlazeCommand.Builder blazeCommandBuilder, BlazeContext blazeContext) throws BuildException;
 
     /**
      * Runs a blaze query command.
@@ -91,7 +91,7 @@ public interface BuildSystem {
      * @return {@link InputStream} from the stdout of the blaze invocation and null if the query fails
      */
     @MustBeClosed
-    InputStream invokeQuery(BlazeCommand.Builder blazeCommandBuilder) throws BuildException;
+    InputStream invokeQuery(BlazeCommand.Builder blazeCommandBuilder, BlazeContext blazeContext) throws BuildException;
 
     /**
      * Runs a blaze info command.
@@ -99,7 +99,7 @@ public interface BuildSystem {
      * @return {@link InputStream} from the stdout of the blaze invocation and null if blaze info fails
      */
     @MustBeClosed
-    InputStream invokeInfo(BlazeCommand.Builder blazeCommandBuilder) throws BuildException;
+    InputStream invokeInfo(BlazeCommand.Builder blazeCommandBuilder, BlazeContext blazeContext) throws BuildException;
 
     /**
      * Returns the type of this build interface. Used for logging purposes.

--- a/base/src/com/google/idea/blaze/base/bazel/LocalInvoker.java
+++ b/base/src/com/google/idea/blaze/base/bazel/LocalInvoker.java
@@ -102,7 +102,7 @@ public class LocalInvoker extends AbstractBuildInvoker1 {
   }
 
   @Override
-  public BuildEventStreamProvider invoke(BlazeCommand.Builder blazeCommandBuilder)
+  public BuildEventStreamProvider invoke(BlazeCommand.Builder blazeCommandBuilder, BlazeContext blazeContext)
       throws BuildException {
     try {
       performGuardCheck(project, blazeContext);
@@ -113,6 +113,10 @@ public class LocalInvoker extends AbstractBuildInvoker1 {
     BuildResult buildResult =
         issueBuild(
             blazeCommandBuilder, WorkspaceRoot.fromProject(project), blazeContext, outputFile);
+    if (!buildResult.equals(BuildResult.SUCCESS)) {
+      blazeContext.setHasError();
+      IssueOutput.error("Blaze build failed. See Blaze Console for details.").submit(blazeContext);
+    }
     if (blazeCommandBuilder.build().getName().equals(BlazeCommandName.BUILD)) {
       BuildDepsStatsScope.fromContext(blazeContext)
           .ifPresent(stats -> stats.setBazelExitCode(buildResult.exitCode));
@@ -121,7 +125,7 @@ public class LocalInvoker extends AbstractBuildInvoker1 {
   }
 
   @Override
-  public InputStream invokeQuery(BlazeCommand.Builder blazeCommandBuilder) {
+  public InputStream invokeQuery(BlazeCommand.Builder blazeCommandBuilder, BlazeContext blazeContext) {
     try {
       performGuardCheck(project, blazeContext);
     } catch (ExecutionDeniedException e) {
@@ -174,7 +178,7 @@ public class LocalInvoker extends AbstractBuildInvoker1 {
 
   @Override
   @Nullable
-  public InputStream invokeInfo(BlazeCommand.Builder blazeCommandBuilder) {
+  public InputStream invokeInfo(BlazeCommand.Builder blazeCommandBuilder, BlazeContext blazeContext) {
     try {
       performGuardCheck(project, blazeContext);
     } catch (ExecutionDeniedException e) {

--- a/base/src/com/google/idea/blaze/base/command/buildresult/BuildEventProtocolUtils.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/BuildEventProtocolUtils.java
@@ -17,7 +17,9 @@ package com.google.idea.blaze.base.command.buildresult;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
+import com.intellij.openapi.diagnostic.Logger;
 import java.io.File;
+import java.io.IOException;
 import java.util.UUID;
 
 /**
@@ -49,6 +51,12 @@ public final class BuildEventProtocolUtils {
     String suffix = UUID.randomUUID().toString();
     String fileName = "intellij-bep-" + suffix;
     File tempFile = new File(tempDir, fileName);
+    try {
+      var unused = tempFile.createNewFile();
+    } catch (IOException e) {
+      Logger.getInstance(BuildEventProtocolUtils.class)
+          .warn(String.format("could not create a temporary file %s", tempFile.getPath()), e);
+    }
     // Callers should delete this file immediately after use. Add a shutdown hook as well, in case
     // the application exits before then.
     tempFile.deleteOnExit();

--- a/base/src/com/google/idea/blaze/base/command/info/BlazeInfoRunnerImpl.java
+++ b/base/src/com/google/idea/blaze/base/command/info/BlazeInfoRunnerImpl.java
@@ -22,7 +22,6 @@ import com.google.idea.blaze.base.async.executor.BlazeExecutor;
 import com.google.idea.blaze.base.bazel.BuildSystem.BuildInvoker;
 import com.google.idea.blaze.base.command.BlazeCommand;
 import com.google.idea.blaze.base.command.BlazeCommandName;
-import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.settings.BuildSystemName;
 import com.intellij.openapi.project.Project;
@@ -46,11 +45,7 @@ class BlazeInfoRunnerImpl extends BlazeInfoRunner {
               if (keys != null) {
                 builder.addBlazeFlags(keys);
               }
-              try (BuildResultHelper buildResultHelper = invoker.createBuildResultHelper();
-                  InputStream blazeInfoStream =
-                      invoker
-                          .getCommandRunner()
-                          .runBlazeInfo(project, builder, buildResultHelper, context)) {
+              try (InputStream blazeInfoStream = invoker.invokeInfo(builder, context)) {
                 return blazeInfoStream.readAllBytes();
               }
             });

--- a/base/src/com/google/idea/blaze/base/dependencies/BlazeQueryDirectoryToTargetProvider.java
+++ b/base/src/com/google/idea/blaze/base/dependencies/BlazeQueryDirectoryToTargetProvider.java
@@ -24,7 +24,6 @@ import com.google.idea.blaze.base.bazel.BuildSystem;
 import com.google.idea.blaze.base.bazel.BuildSystem.BuildInvoker;
 import com.google.idea.blaze.base.command.BlazeCommand;
 import com.google.idea.blaze.base.command.BlazeCommandName;
-import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
 import com.google.idea.blaze.base.model.primitives.TargetExpression;
 import com.google.idea.blaze.base.model.primitives.WorkspacePath;
 import com.google.idea.blaze.base.query.BlazeQueryLabelKindParser;
@@ -105,9 +104,7 @@ public class BlazeQueryDirectoryToTargetProvider implements DirectoryToTargetPro
             .addBlazeFlags(query);
     BuildInvoker invoker = buildSystem.getDefaultInvoker(project, context);
     BlazeQueryLabelKindParser outputProcessor = new BlazeQueryLabelKindParser(t -> true);
-    try (BuildResultHelper helper = invoker.createBuildResultHelper();
-        InputStream queryResultStream =
-            invoker.getCommandRunner().runQuery(project, command, helper, context)) {
+    try (InputStream queryResultStream = invoker.invokeQuery(command, context)) {
       new BufferedReader(new InputStreamReader(queryResultStream, UTF_8))
           .lines()
           .forEach(outputProcessor::processLine);

--- a/base/src/com/google/idea/blaze/base/dependencies/BlazeQuerySourceToTargetProvider.java
+++ b/base/src/com/google/idea/blaze/base/dependencies/BlazeQuerySourceToTargetProvider.java
@@ -27,7 +27,6 @@ import com.google.idea.blaze.base.bazel.BuildSystem.BuildInvoker;
 import com.google.idea.blaze.base.command.BlazeCommand;
 import com.google.idea.blaze.base.command.BlazeCommandName;
 import com.google.idea.blaze.base.command.BlazeInvocationContext.ContextType;
-import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
 import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.model.primitives.WorkspacePath;
 import com.google.idea.blaze.base.query.BlazeQueryLabelKindParser;
@@ -211,7 +210,7 @@ public class BlazeQuerySourceToTargetProvider implements SourceToTargetProvider 
           .lines()
           .forEach(blazeQueryLabelKindParser::processLine);
       return blazeQueryLabelKindParser.getTargets();
-    } catch (IOException e) {
+    } catch (BuildException | IOException e) {
       throw new BlazeQuerySourceToTargetException("Failed to get target info list", e);
     } finally {
       if (!Registry.is("bazel.sync.keep.query.files")) {
@@ -255,7 +254,7 @@ public class BlazeQuerySourceToTargetProvider implements SourceToTargetProvider 
       return queryResultStream == null
           ? null
           : CharStreams.toString(new InputStreamReader(queryResultStream, UTF_8)).trim();
-    } catch (IOException e) {
+    } catch (BuildException | IOException e) {
       context.output(
           PrintOutput.log(
               String.format("Failed to execute blaze query: %s", e.getCause().getMessage())));
@@ -267,16 +266,11 @@ public class BlazeQuerySourceToTargetProvider implements SourceToTargetProvider 
   @MustBeClosed
   private static InputStream runQuery(
       Project project, BlazeCommand.Builder blazeCommand, BlazeContext context)
-      throws BlazeQuerySourceToTargetException {
-    BuildInvoker invoker =
-        Blaze.getBuildSystemProvider(project).getBuildSystem().getDefaultInvoker(project, context);
-    try (BuildResultHelper buildResultHelper = invoker.createBuildResultHelper()) {
-      return invoker.getCommandRunner().runQuery(project, blazeCommand, buildResultHelper, context);
-    } catch (BuildException e) {
-      context.output(
-          PrintOutput.log(String.format("Failed to execute blaze query: %s", e.getMessage())));
-      throw new BlazeQuerySourceToTargetException(e.getMessage(), e);
-    }
+      throws BuildException {
+    return Blaze.getBuildSystemProvider(project)
+        .getBuildSystem()
+        .getDefaultInvoker(project, context)
+        .invokeQuery(blazeCommand, context);
   }
 
   private static BlazeCommand.Builder getBlazeCommandBuilder(

--- a/base/src/com/google/idea/blaze/base/qsync/BazelAppInspectorBuilder.java
+++ b/base/src/com/google/idea/blaze/base/qsync/BazelAppInspectorBuilder.java
@@ -24,16 +24,17 @@ import com.google.idea.blaze.base.command.BlazeCommand;
 import com.google.idea.blaze.base.command.BlazeCommandName;
 import com.google.idea.blaze.base.command.BlazeFlags;
 import com.google.idea.blaze.base.command.BlazeInvocationContext;
-import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
+import com.google.idea.blaze.base.command.buildresult.BuildResultParser;
+import com.google.idea.blaze.base.command.buildresult.bepparser.BuildEventStreamProvider;
 import com.google.idea.blaze.base.projectview.ProjectViewManager;
 import com.google.idea.blaze.base.projectview.ProjectViewSet;
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.sync.aspects.BlazeBuildOutputs;
+import com.google.idea.blaze.common.Interners;
 import com.google.idea.blaze.common.Label;
 import com.google.idea.blaze.common.artifact.OutputArtifact;
 import com.google.idea.blaze.exception.BuildException;
 import com.intellij.openapi.project.Project;
-import java.io.IOException;
 import java.util.List;
 
 /** An object that knows how to build dependencies for given targets */
@@ -49,28 +50,25 @@ public class BazelAppInspectorBuilder implements AppInspectorBuilder {
 
   @Override
   public AppInspectorInfo buildAppInspector(BlazeContext context, Label buildTarget)
-      throws IOException, BuildException {
+      throws BuildException {
     BuildInvoker invoker = buildSystem.getDefaultInvoker(project, context);
-    try (BuildResultHelper buildResultHelper = invoker.createBuildResultHelper()) {
-      ProjectViewSet projectViewSet = ProjectViewManager.getInstance(project).getProjectViewSet();
-      List<String> additionalBlazeFlags =
-          BlazeFlags.blazeFlags(
-              project,
-              projectViewSet,
-              BlazeCommandName.BUILD,
-              context,
-              BlazeInvocationContext.OTHER_CONTEXT);
-
-      BlazeCommand.Builder builder =
-          BlazeCommand.builder(invoker, BlazeCommandName.BUILD, project)
-              .addBlazeFlags(buildTarget.toString())
-              .addBlazeFlags(buildResultHelper.getBuildFlags())
-              .addBlazeFlags(additionalBlazeFlags);
-
+    ProjectViewSet projectViewSet = ProjectViewManager.getInstance(project).getProjectViewSet();
+    List<String> additionalBlazeFlags =
+        BlazeFlags.blazeFlags(
+            project,
+            projectViewSet,
+            BlazeCommandName.BUILD,
+            context,
+            BlazeInvocationContext.OTHER_CONTEXT);
+    BlazeCommand.Builder builder =
+        BlazeCommand.builder(invoker, BlazeCommandName.BUILD, project)
+            .addBlazeFlags(buildTarget.toString())
+            .addBlazeFlags(additionalBlazeFlags);
+    try (BuildEventStreamProvider streamProvider = invoker.invoke(builder, context)) {
       BlazeBuildOutputs outputs =
-          invoker.getCommandRunner().run(project, builder, buildResultHelper, context, ImmutableMap.of());
+          BlazeBuildOutputs.fromParsedBepOutput(
+              BuildResultParser.getBuildOutput(streamProvider, Interners.STRING));
       BazelExitCodeException.throwIfFailed(builder, outputs.buildResult());
-
       return createAppInspectorInfo(outputs);
     }
   }

--- a/base/src/com/google/idea/blaze/base/qsync/BazelDependencyBuilder.java
+++ b/base/src/com/google/idea/blaze/base/qsync/BazelDependencyBuilder.java
@@ -43,7 +43,8 @@ import com.google.idea.blaze.base.command.BlazeCommand;
 import com.google.idea.blaze.base.command.BlazeCommandName;
 import com.google.idea.blaze.base.command.BlazeFlags;
 import com.google.idea.blaze.base.command.BlazeInvocationContext;
-import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
+import com.google.idea.blaze.base.command.buildresult.BuildResultParser;
+import com.google.idea.blaze.base.command.buildresult.bepparser.BuildEventStreamProvider;
 import com.google.idea.blaze.base.logging.utils.querysync.BuildDepsStats;
 import com.google.idea.blaze.base.logging.utils.querysync.BuildDepsStatsScope;
 import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
@@ -56,6 +57,7 @@ import com.google.idea.blaze.base.sync.aspects.storage.AspectRepositoryProvider;
 import com.google.idea.blaze.base.util.VersionChecker;
 import com.google.idea.blaze.base.vcs.BlazeVcsHandlerProvider.BlazeVcsHandler;
 import com.google.idea.blaze.common.Context;
+import com.google.idea.blaze.common.Interners;
 import com.google.idea.blaze.common.Label;
 import com.google.idea.blaze.common.PrintOutput;
 import com.google.idea.blaze.common.artifact.BuildArtifactCache;
@@ -208,13 +210,14 @@ public class BazelDependencyBuilder implements DependencyBuilder {
       BuildInvoker invoker = buildSystem.getDefaultInvoker(project, context);
 
       Optional<BuildDepsStats.Builder> buildDepsStatsBuilder =
-        BuildDepsStatsScope.fromContext(context);
+          BuildDepsStatsScope.fromContext(context);
       buildDepsStatsBuilder.ifPresent(stats -> stats.setBlazeBinaryType(invoker.getType()));
       BlazeCommand.Builder builder =
-        BlazeCommand.builder(invoker, BlazeCommandName.BUILD, project)
-          .addBlazeFlags(buildDependenciesBazelInvocationInfo.argsAndFlags());
+          BlazeCommand.builder(invoker, BlazeCommandName.BUILD, project)
+              .addBlazeFlags(buildDependenciesBazelInvocationInfo.argsAndFlags());
+
       buildDepsStatsBuilder.ifPresent(
-        stats -> stats.setBuildFlags(builder.build().toArgumentList()));
+          stats -> stats.setBuildFlags(builder.build().toArgumentList()));
       Instant buildTime = Instant.now();
       BlazeBuildOutputs outputs = BazelExecService.instance(project).build(context, builder);
 

--- a/base/src/com/google/idea/blaze/base/qsync/BazelQueryRunner.java
+++ b/base/src/com/google/idea/blaze/base/qsync/BazelQueryRunner.java
@@ -21,8 +21,6 @@ import com.google.idea.blaze.base.bazel.BuildSystem;
 import com.google.idea.blaze.base.bazel.BuildSystem.BuildInvoker;
 import com.google.idea.blaze.base.command.BlazeCommand;
 import com.google.idea.blaze.base.command.BlazeCommandName;
-import com.google.idea.blaze.base.command.BlazeCommandRunner;
-import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
 import com.google.idea.blaze.base.logging.utils.querysync.SyncQueryStats;
 import com.google.idea.blaze.base.logging.utils.querysync.SyncQueryStatsScope;
 import com.google.idea.blaze.base.scope.BlazeContext;
@@ -79,11 +77,9 @@ public class BazelQueryRunner implements QueryRunner {
         SyncQueryStatsScope.fromContext(context);
     syncQueryStatsBuilder.ifPresent(stats -> stats.setBlazeBinaryType(invoker.getType()));
 
-    BlazeCommandRunner commandRunner = invoker.getCommandRunner();
     logger.info(
         String.format(
-            "Running `%.250s` using invoker %s, runner %s",
-            query, invoker.getClass().getSimpleName(), commandRunner.getClass().getSimpleName()));
+            "Running `%.250s` using invoker %s", query, invoker.getClass().getSimpleName()));
 
     BlazeCommand.Builder commandBuilder = BlazeCommand.builder(invoker, BlazeCommandName.QUERY, project);
     commandBuilder.addBlazeFlags(query.getQueryFlags());
@@ -93,7 +89,9 @@ public class BazelQueryRunner implements QueryRunner {
       context.output(PrintOutput.output("Project is empty, not running a query"));
       return QuerySummary.EMPTY;
     }
-    if (commandRunner.getMaxCommandLineLength().map(max -> queryExp.length() > max).orElse(false)) {
+    // TODO b/374906681 - The 130000 figure comes from the command runner. Move it to the invoker
+    // instead of hardcoding.
+    if (queryExp.length() > 130000) {
       // Query is too long, write it to a file.
       Path tmpFile =
           Files.createTempFile(
@@ -109,10 +107,8 @@ public class BazelQueryRunner implements QueryRunner {
 
     syncQueryStatsBuilder.ifPresent(
         stats -> stats.setQueryFlags(commandBuilder.build().toArgumentList()));
-    try (BuildResultHelper buildResultHelper = invoker.createBuildResultHelper();
-        InputStream in =
-            commandRunner.runQuery(project, commandBuilder, buildResultHelper, context)) {
-      QuerySummary querySummary = readFrom(query.queryStrategy(), in, context);
+    try (InputStream queryStream = invoker.invokeQuery(commandBuilder, context)) {
+      QuerySummary querySummary = readFrom(query.queryStrategy(), queryStream, context);
       int packagesWithErrorsCount = querySummary.getPackagesWithErrorsCount();
       context.output(
           PrintOutput.output("Total query time ms: " + timer.elapsed(TimeUnit.MILLISECONDS)));

--- a/base/src/com/google/idea/blaze/base/qsync/BazelRenderJarBuilder.java
+++ b/base/src/com/google/idea/blaze/base/qsync/BazelRenderJarBuilder.java
@@ -34,7 +34,8 @@ import com.google.idea.blaze.base.command.BlazeCommand;
 import com.google.idea.blaze.base.command.BlazeCommandName;
 import com.google.idea.blaze.base.command.BlazeFlags;
 import com.google.idea.blaze.base.command.BlazeInvocationContext;
-import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
+import com.google.idea.blaze.base.command.buildresult.BuildResultParser;
+import com.google.idea.blaze.base.command.buildresult.bepparser.BuildEventStreamProvider;
 import com.google.idea.blaze.base.logging.utils.querysync.QuerySyncActionStatsScope;
 import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
 import com.google.idea.blaze.base.projectview.ProjectViewManager;
@@ -43,6 +44,7 @@ import com.google.idea.blaze.base.qsync.QuerySyncManager.TaskOrigin;
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.sync.aspects.BlazeBuildOutputs;
 import com.google.idea.blaze.base.sync.aspects.storage.AspectRepositoryProvider;
+import com.google.idea.blaze.common.Interners;
 import com.google.idea.blaze.common.Label;
 import com.google.idea.blaze.common.artifact.OutputArtifact;
 import com.google.idea.blaze.exception.BuildException;
@@ -74,30 +76,29 @@ public class BazelRenderJarBuilder implements RenderJarBuilder {
   public RenderJarInfo buildRenderJar(BlazeContext context, Set<Label> buildTargets)
       throws IOException, BuildException {
     BuildInvoker invoker = buildSystem.getDefaultInvoker(project, context);
-    try (BuildResultHelper buildResultHelper = invoker.createBuildResultHelper()) {
-      ProjectViewSet projectViewSet = ProjectViewManager.getInstance(project).getProjectViewSet();
-      List<String> additionalBlazeFlags =
-          BlazeFlags.blazeFlags(
-              project,
-              projectViewSet,
-              BlazeCommandName.BUILD,
-              context,
-              BlazeInvocationContext.OTHER_CONTEXT);
+    ProjectViewSet projectViewSet = ProjectViewManager.getInstance(project).getProjectViewSet();
+    List<String> additionalBlazeFlags =
+        BlazeFlags.blazeFlags(
+            project,
+            projectViewSet,
+            BlazeCommandName.BUILD,
+            context,
+            BlazeInvocationContext.OTHER_CONTEXT);
 
-      String aspectLocation = prepareAspect(context);
-      BlazeCommand.Builder builder =
-          BlazeCommand.builder(invoker, BlazeCommandName.BUILD, project)
-              .addBlazeFlags(buildTargets.stream().map(Label::toString).collect(toImmutableList()))
-              .addBlazeFlags(buildResultHelper.getBuildFlags())
-              .addBlazeFlags(additionalBlazeFlags)
-              .addBlazeFlags(
-                  String.format(
-                      "--aspects=%1$s%%collect_compose_dependencies,%1$s%%package_compose_dependencies",
-                      aspectLocation))
-              .addBlazeFlags("--output_groups=render_jars");
-
+    String aspectLocation = prepareAspect(context);
+    BlazeCommand.Builder builder =
+        BlazeCommand.builder(invoker, BlazeCommandName.BUILD, project)
+            .addBlazeFlags(buildTargets.stream().map(Label::toString).collect(toImmutableList()))
+            .addBlazeFlags(additionalBlazeFlags)
+            .addBlazeFlags(
+                String.format(
+                    "--aspects=%1$s%%collect_compose_dependencies,%1$s%%package_compose_dependencies",
+                    aspectLocation))
+            .addBlazeFlags("--output_groups=render_jars");
+    try (BuildEventStreamProvider streamProvider = invoker.invoke(builder, context)) {
       BlazeBuildOutputs outputs =
-          invoker.getCommandRunner().run(project, builder, buildResultHelper, context, ImmutableMap.of());
+          BlazeBuildOutputs.fromParsedBepOutput(
+              BuildResultParser.getBuildOutput(streamProvider, Interners.STRING));
       BazelExitCodeException.throwIfFailed(builder, outputs.buildResult());
       // Building render jar also involves building the dependencies of the file,
       // (as discussed in b/309154453#comment5). So we also invoke the full QuerySync to build the

--- a/base/src/com/google/idea/blaze/base/qsync/CandidatePackageFinder.java
+++ b/base/src/com/google/idea/blaze/base/qsync/CandidatePackageFinder.java
@@ -24,7 +24,6 @@ import com.google.idea.blaze.base.bazel.BazelExitCodeException;
 import com.google.idea.blaze.base.bazel.BuildSystem.BuildInvoker;
 import com.google.idea.blaze.base.command.BlazeCommand;
 import com.google.idea.blaze.base.command.BlazeCommandName;
-import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
 import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.exception.BuildException;
@@ -108,17 +107,14 @@ public class CandidatePackageFinder {
         BlazeCommand.builder(buildInvoker, BlazeCommandName.QUERY, ideProject)
             .addBlazeFlags("--output", "package")
             .addBlazeFlags("//" + path + "/...");
-    try (BuildResultHelper helper = buildInvoker.createBuildResultHelper()) {
-      try (InputStream queryOut =
-          buildInvoker.getCommandRunner().runQuery(ideProject, command, helper, context)) {
-        return ImmutableList.copyOf(CharStreams.readLines(new InputStreamReader(queryOut, UTF_8)));
-      } catch (BazelExitCodeException exitCodeException) {
-        if (exitCodeException.getExitCode() == BAZEL_QUERY_EXIT_CODE_COMMAND_FAILURE) {
-          // This covers the case that there were no matching packages which is WAI here.
-          return ImmutableList.of();
+    try (InputStream queryOut = buildInvoker.invokeQuery(command, context)) {
+      return ImmutableList.copyOf(CharStreams.readLines(new InputStreamReader(queryOut, UTF_8)));
+    } catch (BazelExitCodeException exitCodeException) {
+      if (exitCodeException.getExitCode() == BAZEL_QUERY_EXIT_CODE_COMMAND_FAILURE) {
+        // This covers the case that there were no matching packages which is WAI here.
+        return ImmutableList.of();
         }
-        throw exitCodeException;
-      }
+      throw exitCodeException;
     } catch (IOException ioe) {
       throw new BuildException(ioe);
     }

--- a/base/src/com/google/idea/blaze/base/run/BlazeBeforeRunCommandHelper.java
+++ b/base/src/com/google/idea/blaze/base/run/BlazeBeforeRunCommandHelper.java
@@ -19,15 +19,12 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.idea.blaze.base.async.executor.ProgressiveTaskWithProgressIndicator;
-import com.google.idea.blaze.base.async.process.ExternalTask;
-import com.google.idea.blaze.base.async.process.LineProcessingOutputStream;
+import com.google.idea.blaze.base.bazel.BuildSystem;
 import com.google.idea.blaze.base.command.BlazeCommand;
 import com.google.idea.blaze.base.command.BlazeCommandName;
 import com.google.idea.blaze.base.command.BlazeFlags;
 import com.google.idea.blaze.base.command.BlazeInvocationContext;
-import com.google.idea.blaze.base.command.buildresult.BuildResult;
-import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
-import com.google.idea.blaze.base.console.BlazeConsoleLineProcessorProvider;
+import com.google.idea.blaze.base.command.buildresult.bepparser.BuildEventStreamProvider;
 import com.google.idea.blaze.base.io.FileOperationProvider;
 import com.google.idea.blaze.base.io.TempDirectoryProvider;
 import com.google.idea.blaze.base.issueparser.BlazeIssueParser;
@@ -44,6 +41,7 @@ import com.google.idea.blaze.base.scope.scopes.ToolWindowScope;
 import com.google.idea.blaze.base.settings.Blaze;
 import com.google.idea.blaze.base.settings.BlazeUserSettings;
 import com.google.idea.blaze.base.toolwindow.Task;
+import com.google.idea.blaze.exception.BuildException;
 import com.intellij.openapi.project.Project;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -69,10 +67,9 @@ public final class BlazeBeforeRunCommandHelper {
    *
    * <p>Runs the blaze command on the targets specified in the given {@code configuration}.
    */
-  public static ListenableFuture<BuildResult> runBlazeCommand(
+  public static ListenableFuture<BuildEventStreamProvider> runBlazeCommand(
       BlazeCommandName commandName,
       BlazeCommandRunConfiguration configuration,
-      BuildResultHelper buildResultHelper,
       List<String> requiredExtraBlazeFlags,
       List<String> overridableExtraBlazeFlags,
       BlazeInvocationContext invocationContext,
@@ -80,7 +77,6 @@ public final class BlazeBeforeRunCommandHelper {
     return runBlazeCommand(
         commandName,
         configuration,
-        buildResultHelper,
         requiredExtraBlazeFlags,
         overridableExtraBlazeFlags,
         invocationContext,
@@ -92,10 +88,9 @@ public final class BlazeBeforeRunCommandHelper {
    * Runs the given blaze command on the given list of {@code targets} instead of retrieving the
    * targets from the run {@code configuration}.
    */
-  public static ListenableFuture<BuildResult> runBlazeCommand(
+  public static ListenableFuture<BuildEventStreamProvider> runBlazeCommand(
       BlazeCommandName commandName,
       BlazeCommandRunConfiguration configuration,
-      BuildResultHelper buildResultHelper,
       List<String> requiredExtraBlazeFlags,
       List<String> overridableExtraBlazeFlags,
       BlazeInvocationContext invocationContext,
@@ -115,9 +110,9 @@ public final class BlazeBeforeRunCommandHelper {
 
     return ProgressiveTaskWithProgressIndicator.builder(project, TASK_TITLE)
         .submitTaskWithResult(
-            new ScopedTask<BuildResult>() {
+            new ScopedTask<BuildEventStreamProvider>() {
               @Override
-              protected BuildResult execute(BlazeContext context) {
+              protected BuildEventStreamProvider execute(BlazeContext context) {
                 context
                     .push(
                         new ToolWindowScope.Builder(
@@ -147,20 +142,17 @@ public final class BlazeBeforeRunCommandHelper {
                                 invocationContext))
                         .addBlazeFlags(
                             handlerState.getBlazeFlagsState().getFlagsForExternalProcesses())
-                        .addBlazeFlags(requiredExtraBlazeFlags)
-                        .addBlazeFlags(buildResultHelper.getBuildFlags());
+                        .addBlazeFlags(requiredExtraBlazeFlags);
 
-                int exitCode =
-                    ExternalTask.builder(workspaceRoot)
-                        .addBlazeCommand(command.build())
-                        .context(context)
-                        .stderr(
-                            LineProcessingOutputStream.of(
-                                BlazeConsoleLineProcessorProvider.getAllStderrLineProcessors(
-                                    context)))
-                        .build()
-                        .run();
-                return BuildResult.fromExitCode(exitCode);
+                BuildSystem.BuildInvoker invoker =
+                    Blaze.getBuildSystemProvider(project)
+                        .getBuildSystem()
+                        .getDefaultInvoker(project, BlazeContext.create());
+                try {
+                  return invoker.invoke(command, context);
+                } catch (BuildException e) {
+                  throw new RuntimeException(e);
+                }
               }
             });
   }

--- a/base/src/com/google/idea/blaze/base/run/confighandler/BlazeCommandGenericRunConfigurationRunner.java
+++ b/base/src/com/google/idea/blaze/base/run/confighandler/BlazeCommandGenericRunConfigurationRunner.java
@@ -29,7 +29,8 @@ import com.google.idea.blaze.base.command.BlazeCommand;
 import com.google.idea.blaze.base.command.BlazeCommandName;
 import com.google.idea.blaze.base.command.BlazeFlags;
 import com.google.idea.blaze.base.command.BlazeInvocationContext;
-import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
+import com.google.idea.blaze.base.command.buildresult.BuildResultParser;
+import com.google.idea.blaze.base.command.buildresult.bepparser.BuildEventStreamProvider;
 import com.google.idea.blaze.base.console.BlazeConsoleLineProcessorProvider;
 import com.google.idea.blaze.base.issueparser.ToolWindowTaskIssueOutputFilter;
 import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
@@ -46,7 +47,6 @@ import com.google.idea.blaze.base.run.state.BlazeCommandRunConfigurationCommonSt
 import com.google.idea.blaze.base.run.testlogs.BlazeTestResultFinderStrategy;
 import com.google.idea.blaze.base.run.testlogs.BlazeTestResultHolder;
 import com.google.idea.blaze.base.run.testlogs.BlazeTestResults;
-import com.google.idea.blaze.base.run.testlogs.LocalBuildEventProtocolTestFinderStrategy;
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.scope.OutputSink;
 import com.google.idea.blaze.base.scope.scopes.IdeaLogScope;
@@ -56,6 +56,7 @@ import com.google.idea.blaze.base.settings.BlazeImportSettings;
 import com.google.idea.blaze.base.settings.BlazeImportSettingsManager;
 import com.google.idea.blaze.base.settings.BlazeUserSettings;
 import com.google.idea.blaze.base.sync.aspects.BlazeBuildOutputs;
+import com.google.idea.blaze.common.Interners;
 import com.google.idea.blaze.common.PrintOutput;
 import com.google.idea.blaze.common.PrintOutput.OutputType;
 import com.intellij.execution.DefaultExecutionResult;
@@ -150,20 +151,16 @@ public final class BlazeCommandGenericRunConfigurationRunner
       BuildInvoker invoker =
           Blaze.getBuildSystemProvider(project).getBuildSystem().getBuildInvoker(project, context);
       WorkspaceRoot workspaceRoot = WorkspaceRoot.fromImportSettings(importSettings);
-      try (BuildResultHelper buildResultHelper = invoker.createBuildResultHelper()) {
-        BlazeCommand.Builder blazeCommand =
-            getBlazeCommand(
-                project,
-                ExecutorType.fromExecutor(getEnvironment().getExecutor()),
-                invoker,
-                ImmutableList.copyOf(buildResultHelper.getBuildFlags()),
-                context);
-        return isTest()
-            ? getProcessHandlerForTests(
-                project, invoker, buildResultHelper, blazeCommand, workspaceRoot, context)
-            : getProcessHandlerForNonTests(
-                project, invoker, buildResultHelper, blazeCommand, workspaceRoot, context);
-      }
+      BlazeCommand.Builder blazeCommand =
+          getBlazeCommand(
+              project,
+              ExecutorType.fromExecutor(getEnvironment().getExecutor()),
+              invoker,
+              ImmutableList.of(),
+              context);
+      return isTest()
+          ? getProcessHandlerForTests(project, invoker, blazeCommand, workspaceRoot, context)
+          : getProcessHandlerForNonTests(project, invoker, blazeCommand, workspaceRoot, context);
     }
 
     private ProcessHandler getGenericProcessHandler() {
@@ -191,51 +188,13 @@ public final class BlazeCommandGenericRunConfigurationRunner
       };
     }
 
-    private ProcessHandler getScopedProcessHandler(
-        Project project, BlazeCommand blazeCommand, WorkspaceRoot workspaceRoot)
-        throws ExecutionException {
-      GeneralCommandLine commandLine = new GeneralCommandLine(blazeCommand.toList());
-      EnvironmentVariablesData envVarState = handlerState.getUserEnvVarsState().getData();
-      commandLine.withEnvironment(envVarState.getEnvs());
-      commandLine.withParentEnvironmentType(
-              envVarState.isPassParentEnvs()
-                      ? GeneralCommandLine.ParentEnvironmentType.CONSOLE
-                      : GeneralCommandLine.ParentEnvironmentType.NONE);
-      return new ScopedBlazeProcessHandler(
-          project,
-          commandLine,
-          workspaceRoot,
-          new ScopedBlazeProcessHandler.ScopedProcessHandlerDelegate() {
-            @Override
-            public void onBlazeContextStart(BlazeContext context) {
-              context
-                  .push(
-                      new ProblemsViewScope(
-                          project, BlazeUserSettings.getInstance().getShowProblemsViewOnRun()))
-                  .push(new IdeaLogScope());
-            }
-
-            @Override
-            public ImmutableList<ProcessListener> createProcessListeners(BlazeContext context) {
-              LineProcessingOutputStream outputStream =
-                  LineProcessingOutputStream.of(
-                      BlazeConsoleLineProcessorProvider.getAllStderrLineProcessors(context));
-              return ImmutableList.of(new LineProcessingProcessAdapter(outputStream));
-            }
-          });
-    }
-
     private ProcessHandler getProcessHandlerForNonTests(
         Project project,
         BuildInvoker invoker,
-        BuildResultHelper buildResultHelper,
         BlazeCommand.Builder blazeCommandBuilder,
         WorkspaceRoot workspaceRoot,
         BlazeContext context)
         throws ExecutionException {
-      if (invoker.getCommandRunner().canUseCli()) {
-        return getScopedProcessHandler(project, blazeCommandBuilder.build(), workspaceRoot);
-      }
       ProcessHandler processHandler = getGenericProcessHandler();
       ConsoleView consoleView = getConsoleBuilder().getConsole();
       context.addOutputSink(PrintOutput.class, new WritingOutputSink(consoleView));
@@ -252,10 +211,13 @@ public final class BlazeCommandGenericRunConfigurationRunner
       ListenableFuture<BlazeBuildOutputs> blazeBuildOutputsListenableFuture =
           BlazeExecutor.getInstance()
               .submit(
-                  () ->
-                      invoker
-                          .getCommandRunner()
-                          .run(project, blazeCommandBuilder, buildResultHelper, context, envVars));
+                  () -> {
+                    try (BuildEventStreamProvider streamProvider =
+                        invoker.invoke(blazeCommandBuilder, context)) {
+                      return BlazeBuildOutputs.fromParsedBepOutput(
+                          BuildResultParser.getBuildOutput(streamProvider, Interners.STRING));
+                    }
+                  });
       Futures.addCallback(
           blazeBuildOutputsListenableFuture,
           new FutureCallback<BlazeBuildOutputs>() {
@@ -287,21 +249,15 @@ public final class BlazeCommandGenericRunConfigurationRunner
     private ProcessHandler getProcessHandlerForTests(
         Project project,
         BuildInvoker invoker,
-        BuildResultHelper buildResultHelper,
         BlazeCommand.Builder blazeCommandBuilder,
         WorkspaceRoot workspaceRoot,
-        BlazeContext context)
-        throws ExecutionException {
-      BlazeTestResultFinderStrategy testResultFinderStrategy =
-          !invoker.getCommandRunner().canUseCli()
-              ? new BlazeTestResultHolder()
-              : new LocalBuildEventProtocolTestFinderStrategy(buildResultHelper);
+        BlazeContext context) {
+      BlazeTestResultFinderStrategy testResultFinderStrategy = new BlazeTestResultHolder();
       BlazeTestUiSession testUiSession = null;
       if (BlazeTestEventsHandler.targetsSupported(project, configuration.getTargets())) {
         testUiSession =
             BlazeTestUiSession.create(
                 ImmutableList.<String>builder()
-                    .addAll(ImmutableList.copyOf(buildResultHelper.getBuildFlags()))
                     .add("--runs_per_test=1")
                     .add("--flaky_test_attempts=1")
                     .build(),
@@ -330,22 +286,13 @@ public final class BlazeCommandGenericRunConfigurationRunner
         for (Map.Entry<String, String> env: envVars.entrySet()) {
           blazeCommandBuilder.addBlazeFlags(BlazeFlags.TEST_ENV, String.format("%s=%s", env.getKey(), env.getValue()));
         }
-
-        return getScopedProcessHandler(project, blazeCommandBuilder.build(), workspaceRoot);
       }
       return getCommandRunnerProcessHandlerForTests(
-              project,
-              invoker,
-              buildResultHelper,
-              blazeCommandBuilder,
-              testResultFinderStrategy,
-              context);
+          invoker, blazeCommandBuilder, testResultFinderStrategy, context);
     }
 
     private ProcessHandler getCommandRunnerProcessHandlerForTests(
-        Project project,
         BuildInvoker invoker,
-        BuildResultHelper buildResultHelper,
         BlazeCommand.Builder blazeCommandBuilder,
         BlazeTestResultFinderStrategy testResultFinderStrategy,
         BlazeContext context) {
@@ -354,10 +301,12 @@ public final class BlazeCommandGenericRunConfigurationRunner
       ListenableFuture<BlazeTestResults> blazeTestResultsFuture =
           BlazeExecutor.getInstance()
               .submit(
-                  () ->
-                      invoker
-                          .getCommandRunner()
-                          .runTest(project, blazeCommandBuilder, buildResultHelper, context, envVars));
+                  () -> {
+                    try (BuildEventStreamProvider streamProvider =
+                        invoker.invoke(blazeCommandBuilder, context)) {
+                      return BuildResultParser.getTestResults(streamProvider);
+                    }
+                  });
       Futures.addCallback(
           blazeTestResultsFuture,
           new FutureCallback<BlazeTestResults>() {

--- a/base/src/com/google/idea/blaze/base/sync/BuildPhaseSyncTask.java
+++ b/base/src/com/google/idea/blaze/base/sync/BuildPhaseSyncTask.java
@@ -243,7 +243,8 @@ public final class BuildPhaseSyncTask {
             ? buildSystem.getBuildInvoker(project, context, ImmutableSet.of(BuildInvoker.Capability.SUPPORTS_PARALLELISM))
             : defaultInvoker;
     final BlazercMigrator blazercMigrator = new BlazercMigrator(project);
-    if (!syncBuildInvoker.supportsHomeBlazerc() && blazercMigrator.needMigration()) {
+    if (!syncBuildInvoker.getCapabilities().contains(BuildInvoker.Capability.SUPPORTS_CLI)
+        && blazercMigrator.needMigration()) {
       context.output(
           SummaryOutput.output(Prefix.INFO, "No .blazerc found at workspace root!").log().dedupe());
       ApplicationManager.getApplication()
@@ -255,7 +256,10 @@ public final class BuildPhaseSyncTask {
         .setSyncSharded(shardedTargets.shardCount() > 1)
         .setShardCount(shardedTargets.shardCount())
         .setShardStats(shardedTargets.shardStats())
-        .setParallelBuilds(syncBuildInvoker.supportsParallelism());
+        .setParallelBuilds(
+            syncBuildInvoker
+                .getCapabilities()
+                .contains(BuildInvoker.Capability.SUPPORTS_PARALLELISM));
 
     BlazeBuildOutputs.Legacy blazeBuildResult =
         getBlazeBuildResult(context, viewSet, shardedTargets, syncBuildInvoker, parallel);

--- a/base/src/com/google/idea/blaze/base/sync/sharding/ShardedTargetList.java
+++ b/base/src/com/google/idea/blaze/base/sync/sharding/ShardedTargetList.java
@@ -98,7 +98,8 @@ public class ShardedTargetList {
     if (shardedTargets.size() == 1) {
       return invocation.apply(shardedTargets.get(0));
     }
-    if (binary.supportsParallelism() && invokeParallel) {
+    if (binary.getCapabilities().contains(BuildInvoker.Capability.SUPPORTS_PARALLELISM)
+        && invokeParallel) {
       return runInParallel(project, context, invocation);
     }
     int progress = 0;

--- a/base/src/com/google/idea/blaze/base/sync/sharding/WildcardTargetExpander.java
+++ b/base/src/com/google/idea/blaze/base/sync/sharding/WildcardTargetExpander.java
@@ -28,7 +28,6 @@ import com.google.idea.blaze.base.command.BlazeFlags;
 import com.google.idea.blaze.base.command.BlazeInvocationContext;
 import com.google.idea.blaze.base.command.buildresult.BuildResult;
 import com.google.idea.blaze.base.command.buildresult.BuildResult.Status;
-import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
 import com.google.idea.blaze.base.model.primitives.TargetExpression;
 import com.google.idea.blaze.base.model.primitives.WildcardTargetPattern;
 import com.google.idea.blaze.base.model.primitives.WorkspacePath;
@@ -228,9 +227,7 @@ public class WildcardTargetExpander {
             : t -> handledRulesPredicate.test(t.ruleType) || explicitTargets.contains(t.label);
 
     BlazeQueryLabelKindParser outputProcessor = new BlazeQueryLabelKindParser(filter);
-    try (BuildResultHelper buildResultHelper = buildBinary.createBuildResultHelper();
-        InputStream queryResultStream =
-            buildBinary.getCommandRunner().runQuery(project, builder, buildResultHelper, context)) {
+    try (InputStream queryResultStream = buildBinary.invokeQuery(builder, context)) {
       verify(queryResultStream != null);
       new BufferedReader(new InputStreamReader(queryResultStream, UTF_8))
           .lines()

--- a/base/tests/unittests/com/google/idea/blaze/base/run/testlogs/LocalBuildEventProtocolTestFinderStrategyTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/run/testlogs/LocalBuildEventProtocolTestFinderStrategyTest.java
@@ -27,7 +27,6 @@ import com.google.idea.blaze.base.command.buildresult.bepparser.BuildEventStream
 import com.google.idea.blaze.base.command.buildresult.bepparser.BuildEventStreamProvider.BuildEventStreamException;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtifactsException;
-import com.google.idea.blaze.base.command.buildresult.BuildResultHelperBep;
 import com.google.idea.blaze.base.command.buildresult.LocalFileParser;
 import com.google.idea.blaze.base.command.buildresult.bepparser.BuildEventStreamProvider;
 import com.google.idea.blaze.base.command.buildresult.bepparser.BuildEventStreamProvider.BuildEventStreamException;
@@ -64,7 +63,7 @@ public class LocalBuildEventProtocolTestFinderStrategyTest extends BlazeTestCase
     File file = tempDirectory.newFile("tmp/bep_output.txt", new byte[0]);
 
     LocalBuildEventProtocolTestFinderStrategy testFinder =
-        new LocalBuildEventProtocolTestFinderStrategy(new BuildResultHelperBep(file));
+        new LocalBuildEventProtocolTestFinderStrategy(file);
     try {
       BlazeTestResults unused = testFinder.findTestResults();
     } finally {
@@ -90,7 +89,7 @@ public class LocalBuildEventProtocolTestFinderStrategyTest extends BlazeTestCase
     File bepOutputFile =
         tempDirectory.newFile("tmp/bep_output.txt", asByteArray(ImmutableList.of(test1, test2)));
     LocalBuildEventProtocolTestFinderStrategy strategy =
-        new LocalBuildEventProtocolTestFinderStrategy(new BuildResultHelperBep(bepOutputFile));
+        new LocalBuildEventProtocolTestFinderStrategy(bepOutputFile);
 
     BlazeTestResults results =
         BuildEventProtocolOutputReader.parseTestResults(

--- a/base/tests/utils/unit/com/google/idea/blaze/base/bazel/BuildSystemProviderWrapper.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/bazel/BuildSystemProviderWrapper.java
@@ -16,6 +16,7 @@
 package com.google.idea.blaze.base.bazel;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.MustBeClosed;
 import com.google.idea.blaze.base.bazel.BuildSystem.BuildInvoker;
 import com.google.idea.blaze.base.bazel.BuildSystem.SyncStrategy;
@@ -36,7 +37,6 @@ import com.google.idea.blaze.base.settings.BuildSystemName;
 import com.google.idea.blaze.base.sync.SyncScope.SyncFailedException;
 import com.google.idea.blaze.exception.BuildException;
 import com.intellij.openapi.project.Project;
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.Optional;
 import java.util.Set;
@@ -192,27 +192,6 @@ public class BuildSystemProviderWrapper implements BuildSystemProvider {
     this.throwExceptionOnGetBlazeInfo = throwExceptionOnGetBlazeInfo;
   }
 
-  /**
-   * Sets the build binary type to be returned by {@code
-   * getBuildSystem().getBuildInvoker().getType()}.
-   *
-   * <p>If not set, or set to {@code null}, the {@link BuildBinaryType} returned will come from the
-   * wrapped instance.
-   */
-  public void setBuildBinaryType(BuildBinaryType type) {
-    buildBinaryType = type;
-  }
-
-  /**
-   * Sets the build binary type to be returned by {@code getBuildSystem().getSyncStrategy()}.
-   *
-   * <p>If not set, or set to {@code null}, the {@link SyncStrategy} returned will come form the
-   * wrapped instance.
-   */
-  public void setSyncStrategy(SyncStrategy strategy) {
-    syncStrategy = strategy;
-  }
-
   class BuildInvokerWrapper implements BuildInvoker {
     private final BuildInvoker inner;
 
@@ -221,31 +200,26 @@ public class BuildSystemProviderWrapper implements BuildSystemProvider {
     }
 
     @Override
-    public BuildEventStreamProvider invoke(BlazeCommand.Builder blazeCommandBuilder)
+    public BuildEventStreamProvider invoke(BlazeCommand.Builder blazeCommandBuilder, BlazeContext blazeContext)
         throws BuildException {
-      return inner.invoke(blazeCommandBuilder);
+      return inner.invoke(blazeCommandBuilder, blazeContext);
     }
 
     @Override
-    public InputStream invokeQuery(BlazeCommand.Builder blazeCommandBuilder) throws BuildException {
-      try (InputStream in = inner.invokeQuery(blazeCommandBuilder)) {
-        return in;
-      } catch (IOException e) {
-        throw new BuildException(
-            String.format("Error invoking blaze query with %s", inner.getClass().getSimpleName()),
-            e);
-      }
+    @MustBeClosed
+    public InputStream invokeQuery(BlazeCommand.Builder blazeCommandBuilder, BlazeContext blazeContext) throws BuildException {
+      return inner.invokeQuery(blazeCommandBuilder, blazeContext);
     }
 
     @Override
-    public InputStream invokeInfo(BlazeCommand.Builder blazeCommandBuilder) throws BuildException {
-      try (InputStream in = inner.invokeInfo(blazeCommandBuilder)) {
-        return in;
-      } catch (IOException e) {
-        throw new BuildException(
-            String.format("Error invoking blaze info with %s", inner.getClass().getSimpleName()),
-            e);
-      }
+    @MustBeClosed
+    public InputStream invokeInfo(BlazeCommand.Builder blazeCommandBuilder, BlazeContext blazeContext) throws BuildException {
+      return inner.invokeInfo(blazeCommandBuilder, blazeContext);
+    }
+
+    @Override
+    public ImmutableSet<Capability> getCapabilities() {
+      return inner.getCapabilities();
     }
 
     @Override
@@ -307,7 +281,7 @@ public class BuildSystemProviderWrapper implements BuildSystemProvider {
     @Override
     public BuildInvoker getBuildInvoker(
         Project project, BlazeContext context, Set<BuildInvoker.Capability> requirements) {
-      return inner.getBuildInvoker(project, context, requirements);
+      return new BuildInvokerWrapper(inner.getBuildInvoker(project, context, requirements));
     }
 
     @Override

--- a/base/tests/utils/unit/com/google/idea/blaze/base/bazel/FakeBuildInvoker.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/bazel/FakeBuildInvoker.java
@@ -25,8 +25,10 @@ import com.google.idea.blaze.base.command.BlazeCommand;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
 import com.google.idea.blaze.base.command.buildresult.bepparser.BuildEventStreamProvider;
 import com.google.idea.blaze.base.command.info.BlazeInfo;
+import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.settings.BuildBinaryType;
 import com.google.idea.blaze.base.settings.BuildSystemName;
+import com.google.idea.blaze.exception.BuildException;
 import java.io.InputStream;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -53,17 +55,17 @@ public abstract class FakeBuildInvoker implements BuildInvoker {
   public abstract String getBinaryPath();
 
   @Override
-  public BuildEventStreamProvider invoke(BlazeCommand.Builder blazeCommandBuilder) {
+  public BuildEventStreamProvider invoke(BlazeCommand.Builder blazeCommandBuilder, BlazeContext blazeContext) {
     return fakeBuildEventStreamProvider();
   }
 
   @Override
-  public InputStream invokeQuery(BlazeCommand.Builder blazeCommandBuilder) {
+  public InputStream invokeQuery(BlazeCommand.Builder blazeCommandBuilder, BlazeContext blazeContext) throws BuildException {
     return InputStream.nullInputStream();
   }
 
   @Override
-  public InputStream invokeInfo(BlazeCommand.Builder blazeCommandBuilder) {
+  public InputStream invokeInfo(BlazeCommand.Builder blazeCommandBuilder, BlazeContext blazeContext) {
     return InputStream.nullInputStream();
   }
 
@@ -85,7 +87,7 @@ public abstract class FakeBuildInvoker implements BuildInvoker {
     return getBuildResultHelperSupplier().get();
   }
 
-  abstract Supplier<BuildResultHelper> getBuildResultHelperSupplier();
+  protected abstract Supplier<BuildResultHelper> getBuildResultHelperSupplier();
 
   @Override
   public abstract FakeBlazeCommandRunner getCommandRunner();

--- a/clwb/BUILD
+++ b/clwb/BUILD
@@ -76,6 +76,7 @@ java_library(
     visibility = ["//clwb:__subpackages__"],
     deps = [
         "//base",
+        "//base/src/com/google/idea/blaze/base/command/buildresult/bepparser",
         "//clwb/sdkcompat",
         "//common/actions",
         "//common/experiments",

--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrLauncher.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrLauncher.java
@@ -24,6 +24,7 @@ import com.google.idea.blaze.base.command.BlazeCommandName;
 import com.google.idea.blaze.base.command.BlazeFlags;
 import com.google.idea.blaze.base.command.BlazeInvocationContext;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
+import com.google.idea.blaze.base.command.buildresult.BuildResultHelperBep;
 import com.google.idea.blaze.base.console.BlazeConsoleLineProcessorProvider;
 import com.google.idea.blaze.base.issueparser.ToolWindowTaskIssueOutputFilter;
 import com.google.idea.blaze.base.logging.EventLoggingService;
@@ -118,6 +119,10 @@ public final class BlazeCidrLauncher extends CidrLauncher {
     if (useTestUi()
         && BlazeTestEventsHandler.targetsSupported(project, configuration.getTargets())) {
       try (BuildResultHelper buildResultHelper = invoker.createBuildResultHelper()) {
+        if (!(buildResultHelper instanceof BuildResultHelperBep)) {
+          throw new ExecutionException("Build result helper not supported");
+        }
+        File outputFile = ((BuildResultHelperBep) buildResultHelper).getOutputFile();
         testUiSession =
             BlazeTestUiSession.create(
                 ImmutableList.<String>builder()
@@ -125,7 +130,7 @@ public final class BlazeCidrLauncher extends CidrLauncher {
                     .add("--flaky_test_attempts=1")
                     .addAll(buildResultHelper.getBuildFlags())
                     .build(),
-                new LocalBuildEventProtocolTestFinderStrategy(buildResultHelper));
+                new LocalBuildEventProtocolTestFinderStrategy(outputFile));
       }
     }
     if (testUiSession != null) {

--- a/golang/BUILD
+++ b/golang/BUILD
@@ -25,6 +25,7 @@ java_library(
     visibility = GOLANG_PACKAGES_VISIBILITY,
     deps = [
         "//base",
+        "//base/src/com/google/idea/blaze/base/command/buildresult/bepparser",
         "//common/experiments",
         "//common/util:transactions",
         "//intellij_platform_sdk:jsr305",

--- a/java/BUILD
+++ b/java/BUILD
@@ -43,6 +43,7 @@ java_library(
     deps = [
         ":fast_build_javac_interface",
         "//base",
+        "//base/src/com/google/idea/blaze/base/command/buildresult/bepparser",
         "//common/actions",
         "//common/experiments",
         "//common/settings",

--- a/java/src/com/google/idea/blaze/java/run/BlazeJavaRunProfileState.java
+++ b/java/src/com/google/idea/blaze/java/run/BlazeJavaRunProfileState.java
@@ -15,10 +15,16 @@
  */
 package com.google.idea.blaze.java.run;
 
+import static com.google.common.base.Verify.verify;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.idea.blaze.base.async.executor.BlazeExecutor;
 import com.google.idea.blaze.base.async.process.LineProcessingOutputStream;
 import com.google.idea.blaze.base.bazel.BuildSystem.BuildInvoker;
 import com.google.idea.blaze.base.command.BlazeCommand;
@@ -26,7 +32,8 @@ import com.google.idea.blaze.base.command.BlazeCommandName;
 import com.google.idea.blaze.base.command.BlazeCommandRunnerExperiments;
 import com.google.idea.blaze.base.command.BlazeFlags;
 import com.google.idea.blaze.base.command.BlazeInvocationContext;
-import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
+import com.google.idea.blaze.base.command.buildresult.BuildResultParser;
+import com.google.idea.blaze.base.command.buildresult.bepparser.BuildEventStreamProvider;
 import com.google.idea.blaze.base.console.BlazeConsoleLineProcessorProvider;
 import com.google.idea.blaze.base.issueparser.ToolWindowTaskIssueOutputFilter;
 import com.google.idea.blaze.base.model.primitives.Kind;
@@ -43,7 +50,9 @@ import com.google.idea.blaze.base.run.smrunner.BlazeTestEventsHandler;
 import com.google.idea.blaze.base.run.smrunner.BlazeTestUiSession;
 import com.google.idea.blaze.base.run.smrunner.SmRunnerUtils;
 import com.google.idea.blaze.base.run.state.BlazeCommandRunConfigurationCommonState;
-import com.google.idea.blaze.base.run.testlogs.LocalBuildEventProtocolTestFinderStrategy;
+import com.google.idea.blaze.base.run.testlogs.BlazeTestResultFinderStrategy;
+import com.google.idea.blaze.base.run.testlogs.BlazeTestResultHolder;
+import com.google.idea.blaze.base.run.testlogs.BlazeTestResults;
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.scope.scopes.IdeaLogScope;
 import com.google.idea.blaze.base.scope.scopes.ProblemsViewScope;
@@ -59,20 +68,25 @@ import com.intellij.execution.Executor;
 import com.intellij.execution.configuration.EnvironmentVariablesData;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.filters.TextConsoleBuilderImpl;
+import com.intellij.execution.process.ProcessAdapter;
+import com.intellij.execution.process.ProcessEvent;
 import com.intellij.execution.process.ProcessHandler;
 import com.intellij.execution.process.ProcessListener;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.runners.ProgramRunner;
 import com.intellij.execution.ui.ConsoleView;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.io.FileUtilRt;
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A Blaze run configuration set up with an executor, program runner, and other settings, ready to
@@ -99,23 +113,20 @@ public final class BlazeJavaRunProfileState extends BlazeJavaDebuggableRunProfil
   @Override
   protected ProcessHandler startProcess() throws ExecutionException {
     Project project = getConfiguration().getProject();
-
+    BlazeContext context = BlazeContext.create();
     BuildInvoker invoker =
         Blaze.getBuildSystemProvider(project)
             .getBuildSystem()
             .getBuildInvoker(
-                project,
-                BlazeContext.create(),
-                getExecutorType(),
-                getConfiguration().getTargetKind());
-    BlazeTestUiSession testUiSession = null;
+                project, context, getExecutorType(), getConfiguration().getTargetKind());
     boolean debuggingLocalTest =
         TargetKindUtil.isLocalTest(getConfiguration().getTargetKind())
             && getExecutorType().isDebugType();
-    if (debuggingLocalTest && !invoker.getCommandRunner().canUseCli()) {
+    if (debuggingLocalTest
+        && !invoker.getCapabilities().contains(BuildInvoker.Capability.SUPPORTS_CLI)) {
       return startProcessRunfilesCase(project);
     }
-    return startProcessBazelCliCase(invoker, project, testUiSession);
+    return startProcessBazelCliCase(invoker, project, context);
   }
 
   private ProcessHandler startProcessRunfilesCase(Project project) throws ExecutionException {
@@ -150,21 +161,19 @@ public final class BlazeJavaRunProfileState extends BlazeJavaDebuggableRunProfil
   }
 
   private ProcessHandler startProcessBazelCliCase(
-      BuildInvoker invoker, Project project, BlazeTestUiSession testUiSession)
-      throws ExecutionException {
+      BuildInvoker invoker, Project project, BlazeContext context) throws ExecutionException {
     BlazeCommand.Builder blazeCommand;
-    try (BuildResultHelper buildResultHelper = invoker.createBuildResultHelper()) {
-      if (useTestUi()
-          && BlazeTestEventsHandler.targetsSupported(project, getConfiguration().getTargets())) {
-        testUiSession =
-            BlazeTestUiSession.create(
-                ImmutableList.<String>builder()
-                    .add("--runs_per_test=1")
-                    .add("--flaky_test_attempts=1")
-                    .addAll(buildResultHelper.getBuildFlags())
-                    .build(),
-                new LocalBuildEventProtocolTestFinderStrategy(buildResultHelper));
-      }
+    BlazeTestUiSession testUiSession = null;
+    BlazeTestResultFinderStrategy testResultFinderStrategy = new BlazeTestResultHolder();
+    if (useTestUi()
+        && BlazeTestEventsHandler.targetsSupported(project, getConfiguration().getTargets())) {
+      testUiSession =
+          BlazeTestUiSession.create(
+              ImmutableList.<String>builder()
+                  .add("--runs_per_test=1")
+                  .add("--flaky_test_attempts=1")
+                  .build(),
+              testResultFinderStrategy);
     }
     if (testUiSession != null) {
       blazeCommand =
@@ -209,7 +218,7 @@ public final class BlazeJavaRunProfileState extends BlazeJavaDebuggableRunProfil
     } else {
       command = blazeCommand.build().toList();
     }
-    return getScopedProcessHandler(project, command, WorkspaceRoot.fromProject(project));
+    return getCommandRunnerProcessHandler(invoker, blazeCommand, testResultFinderStrategy, context);
   }
 
   @Override
@@ -325,6 +334,86 @@ public final class BlazeJavaRunProfileState extends BlazeJavaDebuggableRunProfil
             return ImmutableList.of(new LineProcessingProcessAdapter(outputStream));
           }
         });
+  }
+
+  private ProcessHandler getGenericProcessHandler() {
+    return new ProcessHandler() {
+      @Override
+      protected void destroyProcessImpl() {}
+
+      @Override
+      protected void detachProcessImpl() {
+        ApplicationManager.getApplication().executeOnPooledThread(this::notifyProcessDetached);
+      }
+
+      @Override
+      public boolean detachIsDefault() {
+        return false;
+      }
+
+      @Nullable
+      @Override
+      public OutputStream getProcessInput() {
+        return null;
+      }
+    };
+  }
+
+  //TODO(akhildixit) - the following handler is the same as the one in BlazeCommandGenericRunConfigurationRunner.java.
+  // Extract it into a separate class to avoid code duplication.
+  private ProcessHandler getCommandRunnerProcessHandler(
+      BuildInvoker invoker,
+      BlazeCommand.Builder blazeCommandBuilder,
+      BlazeTestResultFinderStrategy testResultFinderStrategy,
+      BlazeContext context) {
+    ProcessHandler processHandler = getGenericProcessHandler();
+    ListenableFuture<BlazeTestResults> blazeTestResultsFuture =
+        BlazeExecutor.getInstance()
+            .submit(
+                () -> {
+                  try (BuildEventStreamProvider streamProvider =
+                      invoker.invoke(blazeCommandBuilder, context)) {
+                    return BuildResultParser.getTestResults(streamProvider);
+                  }
+                });
+    Futures.addCallback(
+        blazeTestResultsFuture,
+        new FutureCallback<BlazeTestResults>() {
+          @Override
+          public void onSuccess(BlazeTestResults blazeTestResults) {
+            // The command-runners allow using a remote BES for parsing the test results, so we
+            // use a BlazeTestResultHolder to store the test results for the IDE to find/read
+            // later. The LocalTestResultFinderStrategy won't work here since it writes/reads the
+            // test results to a local file.
+            verify(testResultFinderStrategy instanceof BlazeTestResultHolder);
+            ((BlazeTestResultHolder) testResultFinderStrategy).setTestResults(blazeTestResults);
+            processHandler.detachProcess();
+          }
+
+          @Override
+          public void onFailure(Throwable throwable) {
+            context.handleException(throwable.getMessage(), throwable);
+            verify(testResultFinderStrategy instanceof BlazeTestResultHolder);
+            ((BlazeTestResultHolder) testResultFinderStrategy)
+                .setTestResults(BlazeTestResults.NO_RESULTS);
+            processHandler.detachProcess();
+          }
+        },
+        BlazeExecutor.getInstance().getExecutor());
+
+    processHandler.addProcessListener(
+        new ProcessAdapter() {
+          @Override
+          public void processWillTerminate(@NotNull ProcessEvent event, boolean willBeDestroyed) {
+            if (willBeDestroyed) {
+              context.setCancelled();
+              verify(testResultFinderStrategy instanceof BlazeTestResultHolder);
+              ((BlazeTestResultHolder) testResultFinderStrategy)
+                  .setTestResults(BlazeTestResults.NO_RESULTS);
+            }
+          }
+        });
+    return processHandler;
   }
 
   private File getDownloadDir() {

--- a/java/src/com/google/idea/blaze/java/run/hotswap/ClassFileManifestBuilder.java
+++ b/java/src/com/google/idea/blaze/java/run/hotswap/ClassFileManifestBuilder.java
@@ -23,11 +23,10 @@ import com.google.idea.blaze.base.command.BlazeCommandName;
 import com.google.idea.blaze.base.command.BlazeInvocationContext;
 import com.google.idea.blaze.base.command.buildresult.BuildResult;
 import com.google.idea.blaze.base.command.buildresult.BuildResultParser;
-import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtifactsException;
-import com.google.idea.blaze.base.command.buildresult.BuildResultHelperProvider;
 import com.google.idea.blaze.base.command.buildresult.BuildResultParser;
 import com.google.idea.blaze.base.command.buildresult.LocalFileArtifact;
+import com.google.idea.blaze.base.command.buildresult.bepparser.BuildEventStreamProvider;
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.BlazeVersionData;
 import com.google.idea.blaze.base.run.BlazeBeforeRunCommandHelper;
@@ -51,7 +50,6 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Key;
 import java.io.File;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
@@ -116,58 +114,55 @@ public class ClassFileManifestBuilder {
     }
 
     SaveUtil.saveAllFiles();
-    // Explicitly create a local build helper because the logic below assumes the JARs to be present
-    // locally
-    try (BuildResultHelper buildResultHelper =
-        BuildResultHelperProvider.createForLocalBuild(project)) {
+    ListenableFuture<BuildEventStreamProvider> streamProviderFuture =
+        BlazeBeforeRunCommandHelper.runBlazeCommand(
+            BlazeCommandName.BUILD,
+            configuration,
+            aspectStrategy.getBuildFlags(versionData, project),
+            ImmutableList.of(),
+            BlazeInvocationContext.runConfigContext(
+                ExecutorType.fromExecutor(env.getExecutor()), configuration.getType(), true),
+            "Building debug binary");
 
-      ListenableFuture<BuildResult> buildOperation =
-          BlazeBeforeRunCommandHelper.runBlazeCommand(
-              BlazeCommandName.BUILD,
-              configuration,
-              buildResultHelper,
-              aspectStrategy.getBuildFlags(versionData, project),
-              ImmutableList.of(),
-              BlazeInvocationContext.runConfigContext(
-                  ExecutorType.fromExecutor(env.getExecutor()), configuration.getType(), true),
-              "Building debug binary");
+    if (progress != null) {
+      progress.setCancelWorker(() -> streamProviderFuture.cancel(true));
+    }
+    try {
+      BuildResult result =
+          BuildResult.fromExitCode(
+              BuildResultParser.getBuildOutput(streamProviderFuture.get(), Interners.STRING)
+                  .buildResult());
+      if (result.status != BuildResult.Status.SUCCESS) {
+        throw new ExecutionException("Blaze failure building debug binary");
+      }
 
-      if (progress != null) {
-        progress.setCancelWorker(() -> buildOperation.cancel(true));
-      }
-      try {
-        BuildResult result = buildOperation.get();
-        if (result.status != BuildResult.Status.SUCCESS) {
-          throw new ExecutionException("Blaze failure building debug binary");
-        }
-      } catch (InterruptedException | CancellationException e) {
-        buildOperation.cancel(true);
-        throw new RunCanceledByUserException();
-      } catch (java.util.concurrent.ExecutionException e) {
-        throw new ExecutionException(e);
-      }
-      ImmutableList<File> jars;
-      try (final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {
-        jars =
-            LocalFileArtifact.getLocalFiles(
-                    Label.of(Objects.requireNonNull(configuration.getSingleTarget().toString())),
-                    BlazeBuildOutputs.fromParsedBepOutput(
-                            BuildResultParser.getBuildOutput(bepStream, Interners.STRING))
-                        .getOutputGroupArtifacts(JavaClasspathAspectStrategy.OUTPUT_GROUP),
-                    BlazeContext.create(),
-                    project)
-                .stream()
-                .filter(f -> f.getName().endsWith(".jar"))
-                .collect(toImmutableList());
-      } catch (GetArtifactsException e) {
-        throw new ExecutionException("Failed to get debug binary: " + e.getMessage());
-      }
+      ImmutableList<File> jars =
+          LocalFileArtifact.getLocalFiles(
+                  Label.of(Objects.requireNonNull(configuration.getSingleTarget().toString())),
+                  BlazeBuildOutputs.fromParsedBepOutput(
+                          BuildResultParser.getBuildOutput(
+                              streamProviderFuture.get(), Interners.STRING))
+                      .getOutputGroupArtifacts(JavaClasspathAspectStrategy.OUTPUT_GROUP),
+                  BlazeContext.create(),
+                  project)
+              .stream()
+              .filter(f -> f.getName().endsWith(".jar"))
+              .collect(toImmutableList());
+
       ClassFileManifest oldManifest = getManifest(env);
       ClassFileManifest newManifest = ClassFileManifest.build(jars, oldManifest);
       env.getCopyableUserData(MANIFEST_KEY).set(newManifest);
+
       return oldManifest != null
           ? ClassFileManifest.modifiedClasses(oldManifest, newManifest)
           : null;
+    } catch (InterruptedException | CancellationException e) {
+      streamProviderFuture.cancel(true);
+      throw new RunCanceledByUserException();
+    } catch (java.util.concurrent.ExecutionException e) {
+      throw new ExecutionException(e);
+    } catch (GetArtifactsException e) {
+      throw new ExecutionException("Unable to parse build output from build event stream", e);
     }
   }
 }

--- a/python/BUILD
+++ b/python/BUILD
@@ -24,6 +24,7 @@ java_library(
     visibility = PYTHON_PACKAGES_VISIBILITY,
     deps = [
         "//base",
+        "//base/src/com/google/idea/blaze/base/command/buildresult/bepparser",
         "//common/experiments",
         "//common/util:transactions",
         "//proto:proto_deps",

--- a/python/src/com/google/idea/blaze/python/run/BlazePyRunConfigurationRunner.java
+++ b/python/src/com/google/idea/blaze/python/run/BlazePyRunConfigurationRunner.java
@@ -20,15 +20,16 @@ import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.Uninterruptibles;
 import com.google.idea.blaze.base.command.BlazeCommandName;
 import com.google.idea.blaze.base.command.BlazeFlags;
 import com.google.idea.blaze.base.command.BlazeInvocationContext;
 import com.google.idea.blaze.base.command.buildresult.BuildResult;
-import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtifactsException;
-import com.google.idea.blaze.base.command.buildresult.BuildResultHelperProvider;
 import com.google.idea.blaze.base.command.buildresult.BuildResultParser;
 import com.google.idea.blaze.base.command.buildresult.LocalFileArtifact;
+import com.google.idea.blaze.base.command.buildresult.bepparser.BuildEventStreamProvider;
+import com.google.idea.blaze.base.command.buildresult.bepparser.ParsedBepOutput;
 import com.google.idea.blaze.base.ideinfo.PyIdeInfo;
 import com.google.idea.blaze.base.ideinfo.TargetIdeInfo;
 import com.google.idea.blaze.base.ideinfo.TargetKey;
@@ -83,7 +84,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -179,8 +179,7 @@ public class BlazePyRunConfigurationRunner implements BlazeCommandRunConfigurati
 
         @Override
         protected ConsoleView createAndAttachConsole(
-            Project project, ProcessHandler processHandler, Executor executor)
-            throws ExecutionException {
+            Project project, ProcessHandler processHandler, Executor executor) {
           ConsoleView consoleView = createConsoleBuilder(project, getSdk()).getConsole();
           consoleView.addMessageFilter(createUrlFilter(processHandler));
 
@@ -315,52 +314,36 @@ public class BlazePyRunConfigurationRunner implements BlazeCommandRunConfigurati
     }
 
     SaveUtil.saveAllFiles();
-    // Explicitly depend on local build helper because the debuggable binary is expected to be
-    // present locally
-    try (BuildResultHelper buildResultHelper =
-        BuildResultHelperProvider.createForLocalBuild(project)) {
+    ListenableFuture<BuildEventStreamProvider> streamProviderFuture =
+        BlazeBeforeRunCommandHelper.runBlazeCommand(
+            BlazeCommandName.BUILD,
+            configuration,
+            BlazePyDebugHelper.getAllBlazeDebugFlags(configuration.getProject(), target),
+            ImmutableList.of(),
+            BlazeInvocationContext.runConfigContext(
+                ExecutorType.fromExecutor(env.getExecutor()), configuration.getType(), true),
+            "Building debug binary");
 
-      ListenableFuture<BuildResult> buildOperation =
-          BlazeBeforeRunCommandHelper.runBlazeCommand(
-              BlazeCommandName.BUILD,
-              configuration,
-              buildResultHelper,
-              BlazePyDebugHelper.getAllBlazeDebugFlags(configuration.getProject(), target),
-              ImmutableList.of(),
-              BlazeInvocationContext.runConfigContext(
-                  ExecutorType.fromExecutor(env.getExecutor()), configuration.getType(), true),
-              "Building debug binary");
-
-      try {
-        BuildResult result = buildOperation.get();
-        if (result.status != BuildResult.Status.SUCCESS) {
-          throw new ExecutionException("Blaze failure building debug binary");
-        }
-      } catch (InterruptedException | CancellationException e) {
-        buildOperation.cancel(true);
-        throw new RunCanceledByUserException();
-      } catch (java.util.concurrent.ExecutionException e) {
-        throw new ExecutionException(e);
+    try {
+      BuildEventStreamProvider streamProvider =
+          Uninterruptibles.getUninterruptibly(streamProviderFuture);
+      ParsedBepOutput parsedBepOutput =
+          BuildResultParser.getBuildOutput(streamProvider, Interners.STRING);
+      BuildResult result = BuildResult.fromExitCode(parsedBepOutput.buildResult());
+      if (result.status != BuildResult.Status.SUCCESS) {
+        throw new ExecutionException("Blaze failure building debug binary");
       }
-      List<File> candidateFiles;
-      try (final var bepStream = buildResultHelper.getBepStream(Optional.empty())) {
-        candidateFiles =
-            LocalFileArtifact.getLocalFiles(
-                    com.google.idea.blaze.common.Label.of(target.toString()),
-                    BlazeBuildOutputs.fromParsedBepOutput(
-                            BuildResultParser.getBuildOutput(bepStream, Interners.STRING))
-                        .getOutputGroupTargetArtifacts(DEFAULT_OUTPUT_GROUP_NAME, target.toString())
-                        .asList(),
-                    BlazeContext.create(),
-                    project)
-                .stream()
-                .filter(File::canExecute)
-                .collect(Collectors.toList());
-      } catch (GetArtifactsException e) {
-        throw new ExecutionException(
-            String.format(
-                "Failed to get output artifacts when building %s: %s", target, e.getMessage()));
-      }
+      List<File> candidateFiles =
+          LocalFileArtifact.getLocalFiles(
+                  com.google.idea.blaze.common.Label.of(target.toString()),
+                  BlazeBuildOutputs.fromParsedBepOutput(parsedBepOutput)
+                      .getOutputGroupTargetArtifacts(DEFAULT_OUTPUT_GROUP_NAME, target.toString())
+                      .asList(),
+                  BlazeContext.create(),
+                  project)
+              .stream()
+              .filter(File::canExecute)
+              .collect(Collectors.toList());
       if (candidateFiles.isEmpty()) {
         throw new ExecutionException(
             String.format("No output artifacts found when building %s", target));
@@ -375,6 +358,13 @@ public class BlazePyRunConfigurationRunner implements BlazeCommandRunConfigurati
       }
       LocalFileSystem.getInstance().refreshIoFiles(ImmutableList.of(file));
       return new PyExecutionInfo(file, args);
+    } catch (CancellationException e) {
+      streamProviderFuture.cancel(true);
+      throw new RunCanceledByUserException();
+    } catch (java.util.concurrent.ExecutionException | GetArtifactsException e) {
+      throw new ExecutionException(
+          String.format(
+              "Failed to get output artifacts when building %s: %s", target, e.getMessage()), e);
     }
   }
 


### PR DESCRIPTION
Cherry pick AOSP commit [1fd9e1e590e1ff78e2e4566fefbdbb3f4d6d8c01](https://cs.android.com/android-studio/platform/tools/adt/idea/+/1fd9e1e590e1ff78e2e4566fefbdbb3f4d6d8c01).

STAT (diff to AOSP): 208 insertions(+), 88 deletion(-)

This cleanup change is purely a refactor and the IDE behavior or the user experience is not expected to change in any way.

1. Migrate all callers of the blaze/bazel builds to using the new build invokers. The callers will now use the `LocalInvoker`, `RabbitBlazeInvoker`, and the `BuildApiBlazeInvoker` as needed.

2. To invoke blaze/bazel, they now use `invoke`, `invokeInfo`, and `invokeQuery` methods instead of the old `run`, `runTest`, `runQuery` etc. These methods take in the BlazeContext as a parameter, so the context used while creating the invoker is no longer used (it'll be removed in the next CLs). The new methods directly return the `BuildEventStreamProvider`. As a result, the `CommandRunner` and the `BuildResultHelper` abstractions are no longer used.

3. Most of the unit tests and integration tests are updated as necessary to be able to test the new invokers, except some integration tests. Since the invoker methods now return a stream that cannot be consumed more than once, we parse it to construct the build outputs within the apk build steps. This is the main reason some tests break and it needs more changes to make them work. They are currently marked as ignored with a TODO. See b/396309705 .

4. In the subsequent CL, the unused code will be deleted. This includes several abstract classes and interfaces, local test finder strategy, and a few tests.

Bug:374906681
Test: n/a
Change-Id: I3fa6311a269bbc18af9118de81d29d1eb73078f7

AOSP: 1fd9e1e590e1ff78e2e4566fefbdbb3f4d6d8c01
