### PR TITLE
[AOSP-pick] Fix deletion of all files in artifact directory

### DIFF
--- a/querysync/java/com/google/idea/blaze/qsync/artifacts/ArtifactDirectoryUpdate.java
+++ b/querysync/java/com/google/idea/blaze/qsync/artifacts/ArtifactDirectoryUpdate.java
@@ -264,7 +264,7 @@ public class ArtifactDirectoryUpdate {
     try (final var fileStream = Files.walk(root)) {
       final var dot = Path.of("."); // Path.of("abc").startsWith(Path.of("")) does not work but with "./abc" and "./" it does.
       final var wanted = contents.getContentsMap().keySet().stream().map(dot::resolve);
-      final var present = fileStream.map(root::relativize).filter(it -> !root.equals(it)).map(dot::resolve);
+      final var present = fileStream.map(root::relativize).map(dot::resolve).filter(it -> !dot.equals(it));
       toDelete = computeFilesToDelete(present, wanted);
     }
     for (Path p : Lists.reverse(toDelete)) {


### PR DESCRIPTION
Cherry pick AOSP commit [9e010cda99cb3deaca4e9ae1a69e695988c0d929](https://cs.android.com/android-studio/platform/tools/adt/idea/+/9e010cda99cb3deaca4e9ae1a69e695988c0d929).

STAT (diff to AOSP): 0 insertions(+), 0 deletion(-)

A path like `/some/path/.` cannot be deleted even though
`/some/path/./dir` can be. Also, the artifact directory itself should
not be deleted anyway.

Bug: n/a
Test: caught by tests in upcoming changes
Change-Id: I716a7f80ca9af89ab94518253af201e36945e8d8

AOSP: 9e010cda99cb3deaca4e9ae1a69e695988c0d929
