### PR TITLE
[AOSP-pick] Update LocalFileArtifact to use RuntimeArtifactCache

### DIFF
--- a/base/src/com/google/idea/blaze/base/command/buildresult/LocalFileArtifact.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/LocalFileArtifact.java
@@ -19,12 +19,14 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.google.common.collect.ImmutableList;
 import com.google.idea.blaze.base.io.FileOperationProvider;
+import com.google.idea.blaze.base.run.RuntimeArtifactCache;
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.common.Label;
 import com.google.idea.blaze.common.artifact.BlazeArtifact;
 import com.google.idea.blaze.common.artifact.OutputArtifact;
 import com.intellij.openapi.project.Project;
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Collection;
 
 /** A file artifact available on the local file system. */
@@ -38,10 +40,8 @@ public interface LocalFileArtifact extends BlazeArtifact {
    */
   static ImmutableList<File> getLocalFiles(Label target, Collection<? extends OutputArtifact> artifacts, BlazeContext context,
                                            Project project) {
-    return artifacts.stream()
-        .filter(a -> a instanceof LocalFileArtifact)
-        .map(a -> ((LocalFileArtifact) a).getFile())
-        .collect(toImmutableList());
+    var runtimeArtifactCache = RuntimeArtifactCache.getInstance(project);
+    return runtimeArtifactCache.fetchArtifacts(target, artifacts.stream().toList(), context).stream().map(Path::toFile).collect(toImmutableList());
   }
 
   /**


### PR DESCRIPTION
Cherry pick AOSP commit [21c61024727b2b5dd0e2c7e171307b3976177a84](https://cs.android.com/android-studio/platform/tools/adt/idea/+/21c61024727b2b5dd0e2c7e171307b3976177a84).

STAT (diff to AOSP): 0 insertions(+), 0 deletion(-)

Update LocalFileArtifact to use RuntimeArtifactCache for storing the
artifacts for QuerySync.

Bug: 385469770
Test: Existing tests updated
Change-Id: If5f8e648f16a58820cf4a40fd58c67c600390182

AOSP: 21c61024727b2b5dd0e2c7e171307b3976177a84
