### PR TITLE
fix: Don't assume that Bazel 8 implies bzlmod

### DIFF
--- a/base/src/com/google/idea/blaze/base/sync/aspects/storage/AspectTemplateWriter.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/storage/AspectTemplateWriter.java
@@ -118,11 +118,12 @@ public class AspectTemplateWriter implements AspectWriter {
     // TODO: adapt the logic to query sync
     boolean isQuerySync = projectData.map(BlazeProjectData::isQuerySync).orElse(false);
     var externalWorkspaceData = isQuerySync ? null : projectData.map(BlazeProjectData::getExternalWorkspaceData).orElse(null);
+    var isBzlmod = projectData.map(it -> it.getBlazeInfo().getStarlarkSemantics().contains("enable_bzlmod=true")).orElse(false);
     var isAtLeastBazel8 = projectData.map(it -> it.getBlazeVersionData().bazelIsAtLeastVersion(8, 0, 0)).orElse(false);
     var isJavaEnabled = activeLanguages.contains(LanguageClass.JAVA) &&
-            (isQuerySync || (externalWorkspaceData != null && (!isAtLeastBazel8 || externalWorkspaceData.getByRepoName("rules_java") != null)));
+            (isQuerySync || (externalWorkspaceData != null && (!isAtLeastBazel8 || !isBzlmod || externalWorkspaceData.getByRepoName("rules_java") != null)));
     var isPythonEnabled = activeLanguages.contains(LanguageClass.PYTHON) &&
-            (isQuerySync || (externalWorkspaceData != null && (!isAtLeastBazel8 || externalWorkspaceData.getByRepoName("rules_python") != null)));
+            (isQuerySync || (externalWorkspaceData != null && (!isAtLeastBazel8 || !isBzlmod || externalWorkspaceData.getByRepoName("rules_python") != null)));
     return Map.of(
             "bazel8OrAbove", isAtLeastBazel8 ? "true" : "false",
             "isJavaEnabled", isJavaEnabled ? "true" : "false",


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
  - NOTE: Only conditional/tentative. @LeFrosch expressed interest in possibly merging it in #7432.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #7432 

# Description of this change

Commit 373eb7a8a7b10ac5aa75c29f6f7f2f951790b4ca placed the `isJavaEnabled` aspect template condition behind a guard which verified that the project loaded rules_java.  Unfortunately, the dependency check is implemented in terms of `bazel mod` and so only applies if the project has adopted bzlmod; legacy workspace projects have been left in the cold.

This commit tweaks things slightly by assuming that rules_java and rules_python are available if the project (a) uses Bazel 8+ and (b) does not use bzlmod.  (This is correct because non-bzlmod Bazel 8 injects rules_java and rules_python dependencies into projects via a workspace suffix.[^1])

Fixes #7432.

[^1]: https://github.com/bazelbuild/bazel/blob/7e086c215c3cbaea66a1b795c5393311fea74bd6/src/main/java/com/google/devtools/build/lib/bazel/rules/BUILD#L129-L156
