### PR TITLE
[AOSP-pick] Delete unused getFileDependencies()

### DIFF
--- a/querysync/java/com/google/idea/blaze/qsync/project/BuildGraphData.java
+++ b/querysync/java/com/google/idea/blaze/qsync/project/BuildGraphData.java
@@ -397,8 +397,10 @@ public abstract class BuildGraphData {
         .collect(toImmutableSetMultimap(e -> e.getKey(), e -> e.getValue()));
   }
 
-  public ImmutableSet<Label> getTransitiveExternalDependencies(Label target) {
-    return transitiveExternalDeps().get(target);
+  // TODO: solodkyy - Delete this method. This is used in tests only to preserve some useful test code which will be used to test
+  // getExternalDependencies (non-transitive).
+  public ImmutableSet<Label> getTransitiveExternalDependencies(Collection<Label> targets) {
+    return targets.stream().flatMap(it -> transitiveExternalDeps().get(it).stream()).collect(toImmutableSet());
   }
 
   public ImmutableSet<Label> getSourceFileOwners(Path path) {
@@ -420,19 +422,6 @@ public abstract class BuildGraphData {
     return candidates.stream()
         .min(Comparator.comparingInt(label -> targetMap().get(label).deps().size()))
         .orElse(null);
-  }
-
-  @VisibleForTesting
-  @Nullable
-  Set<Label> getFileDependencies(Path path) {
-    ImmutableSet<Label> targets = getSourceFileOwners(path);
-    if (targets == null) {
-      return null;
-    }
-    return targets.stream()
-        .map(this::getTransitiveExternalDependencies)
-        .flatMap(Set::stream)
-        .collect(toImmutableSet());
   }
 
   /** A set of all the targets that show up in java rules 'src' attributes */


### PR DESCRIPTION
Cherry pick AOSP commit [ceacc934f248f3a1fd9a096eb5938f83b1542bca](https://cs.android.com/android-studio/platform/tools/adt/idea/+/ceacc934f248f3a1fd9a096eb5938f83b1542bca).

STAT (diff to AOSP): 7 insertions(+), 13 deletion(-)

and temporarily introduce `getTransitiveExternalDependencies()`
to preserve tests that will be re-used.

Bug: 397354312
Test: n/a
Change-Id: Ie541cc2e6a43914605c2628e0bb4df4ad66fe592

AOSP: ceacc934f248f3a1fd9a096eb5938f83b1542bca
