### PR TITLE
[AOSP-pick] Remove analyzeCoordinateCompatiblity from AndroidModuleSystem

### DIFF
--- a/aswb/src/com/google/idea/blaze/android/projectsystem/BlazeModuleSystemBase.java
+++ b/aswb/src/com/google/idea/blaze/android/projectsystem/BlazeModuleSystemBase.java
@@ -396,12 +396,6 @@ abstract class BlazeModuleSystemBase implements AndroidModuleSystem {
   }
 
   @Override
-  public Triple<List<GradleCoordinate>, List<GradleCoordinate>, String>
-      analyzeDependencyCompatibility(List<GradleCoordinate> dependenciesToAdd) {
-    return new Triple<>(ImmutableList.of(), dependenciesToAdd, "");
-  }
-
-  @Override
   @Nullable
   public String getPackageName() {
     return PackageNameUtils.getPackageName(module);


### PR DESCRIPTION
Cherry pick AOSP commit [fed618721adcf20dd73c25ea384a8a4e4370d293](https://cs.android.com/android-studio/platform/tools/adt/idea/+/fed618721adcf20dd73c25ea384a8a4e4370d293).

STAT (diff to AOSP): 1 insertions(+), 1 deletion(-)

Preserve it within the Gradle Module System for the sake of its one
caller using it with the full generality of arbitrary version
additions.

Bug: 279886738
Test: existing
Change-Id: Ie42a07f796e2dc1a5d2926a2e5b2444716803d42

AOSP: fed618721adcf20dd73c25ea384a8a4e4370d293
