### PR TITLE
[AOSP-pick] Cache isReadyForAnalysis value

### DIFF
--- a/base/src/com/google/idea/blaze/base/model/primitives/WorkspaceRoot.java
+++ b/base/src/com/google/idea/blaze/base/model/primitives/WorkspaceRoot.java
@@ -100,6 +100,10 @@ public class WorkspaceRoot implements ProtoWrapper<String> {
     return workspacePathFor(file).asPath();
   }
 
+  public Path relativize(Path path) {
+    return workspacePathFor(path.toString()).asPath();
+  }
+
   public @Nullable Path tryRelativize(VirtualFile file) {
     if (!isInWorkspace(file)) {
       return null;

--- a/base/src/com/google/idea/blaze/base/qsync/QuerySyncHighlightingFilter.java
+++ b/base/src/com/google/idea/blaze/base/qsync/QuerySyncHighlightingFilter.java
@@ -36,13 +36,8 @@ public class QuerySyncHighlightingFilter implements HighlightInfoFilter {
     if (psiFile == null) {
       return true;
     }
-    VirtualFile virtualFile = psiFile.getVirtualFile();
-    if (virtualFile == null) {
-      return true;
-    }
-
     if (Blaze.getProjectType(psiFile.getProject()) == ProjectType.QUERY_SYNC) {
-      return QuerySyncManager.getInstance(psiFile.getProject()).isReadyForAnalysis(virtualFile);
+      return QuerySyncManager.getInstance(psiFile.getProject()).isReadyForAnalysis(psiFile);
     } else {
       return true;
     }

--- a/base/src/com/google/idea/blaze/base/qsync/QuerySyncHighlightingSettingProvider.java
+++ b/base/src/com/google/idea/blaze/base/qsync/QuerySyncHighlightingSettingProvider.java
@@ -21,7 +21,7 @@ public class QuerySyncHighlightingSettingProvider extends DefaultHighlightingSet
     }
 
     if (Blaze.getProjectType(project) == BlazeImportSettings.ProjectType.QUERY_SYNC) {
-      if (!QuerySyncManager.getInstance(project).isReadyForAnalysis(psiFile.getVirtualFile())) {
+      if (!QuerySyncManager.getInstance(project).isReadyForAnalysis(psiFile)) {
         return FileHighlightingSetting.ESSENTIAL;
       } else {
         return FileHighlightingSetting.FORCE_HIGHLIGHTING;

--- a/base/src/com/google/idea/blaze/base/qsync/QuerySyncManager.java
+++ b/base/src/com/google/idea/blaze/base/qsync/QuerySyncManager.java
@@ -63,6 +63,8 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.ModificationTracker;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
+import com.intellij.psi.util.CachedValueProvider;
+import com.intellij.psi.util.CachedValuesManager;
 import com.intellij.serviceContainer.NonInjectable;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -528,11 +530,20 @@ public class QuerySyncManager implements Disposable {
         taskOrigin);
   }
 
-  public boolean isReadyForAnalysis(VirtualFile virtualFile) {
-    if (loadedProject == null) {
-      return false;
+  public boolean isReadyForAnalysis(PsiFile psiFile) {
+    VirtualFile virtualFile = psiFile.getVirtualFile();
+    if (virtualFile == null) {
+      return true;
     }
-    return loadedProject.isReadyForAnalysis(virtualFile);
+    return CachedValuesManager.getCachedValue(psiFile, () -> {
+      boolean result;
+      if (loadedProject == null) {
+        result = false;
+      } else {
+        result = loadedProject.isReadyForAnalysis(virtualFile.toNioPath());
+      }
+      return CachedValueProvider.Result.create(result, getProjectModificationTracker());
+    });
   }
 
   /**

--- a/base/src/com/google/idea/blaze/base/qsync/QuerySyncProject.java
+++ b/base/src/com/google/idea/blaze/base/qsync/QuerySyncProject.java
@@ -437,9 +437,8 @@ public class QuerySyncProject {
     }
   }
 
-  public boolean isReadyForAnalysis(VirtualFile virtualFile) {
-    Path p = virtualFile.getFileSystem().getNioPath(virtualFile);
-    if (p == null || !p.startsWith(workspaceRoot.path())) {
+  public boolean isReadyForAnalysis(Path path) {
+    if (path == null || !path.startsWith(workspaceRoot.path())) {
       // Not in the workspace.
       // p == null can occur if the file is a zip entry.
       return true;
@@ -448,7 +447,7 @@ public class QuerySyncProject {
     Set<Label> pendingTargets =
         snapshotHolder
             .getCurrent()
-            .map(s -> s.getPendingTargets(workspaceRoot.relativize(virtualFile)))
+            .map(s -> s.getPendingTargets(workspaceRoot.relativize(path)))
             .orElse(ImmutableSet.of());
     return pendingTargets.isEmpty();
   }

--- a/base/src/com/google/idea/blaze/base/qsync/QuerySyncTrafficLightRendererContributor.java
+++ b/base/src/com/google/idea/blaze/base/qsync/QuerySyncTrafficLightRendererContributor.java
@@ -55,7 +55,7 @@ public class QuerySyncTrafficLightRendererContributor implements TrafficLightRen
         if (virtualFile == null) {
           return super.getStatus();
         }
-        if (QuerySyncManager.getInstance(psiFile.getProject()).isReadyForAnalysis(virtualFile)) {
+        if (QuerySyncManager.getInstance(psiFile.getProject()).isReadyForAnalysis(psiFile)) {
           return super.getStatus();
         }
         return new AnalyzerStatus(


### PR DESCRIPTION
Cherry pick AOSP commit [30e4bc247ac12fdd9d655a86461e998a99f1a59a](https://cs.android.com/android-studio/platform/tools/adt/idea/+/30e4bc247ac12fdd9d655a86461e998a99f1a59a).

STAT (diff to AOSP): 5 insertions(+), 0 deletion(-)

in the `CachedValuesManger` per `PsiFile`.

The new underlying implementation won't prebuilt results and it will
traverse graph each time. Although it is much faster than pre-building
all values upfront it is not free.

Bug: 397354312
Test: existing
Change-Id: I73a2db794174caf9f52408042e204e7933d14746

AOSP: 30e4bc247ac12fdd9d655a86461e998a99f1a59a
