### PR TITLE
[AOSP-pick] Drop outdated experiments

### DIFF
--- a/base/src/com/google/idea/blaze/base/qsync/ProjectLoaderImpl.java
+++ b/base/src/com/google/idea/blaze/base/qsync/ProjectLoaderImpl.java
@@ -297,9 +297,7 @@ public class ProjectLoaderImpl implements ProjectLoader {
             executor,
             createWorkspaceRelativePackageReader(),
             workspaceRoot.path(),
-            handledRules,
-            QuerySync.USE_NEW_RES_DIR_LOGIC::getValue,
-            () -> !QuerySync.EXTRACT_RES_PACKAGES_AT_BUILD_TIME.getValue());
+            handledRules);
     QueryRunner queryRunner = createQueryRunner(buildSystem);
     BazelVersionHandler versionHandler =
         new BazelVersionHandler(buildSystem, buildSystem.getBuildInvoker(project, context));

--- a/base/src/com/google/idea/blaze/base/qsync/QuerySync.java
+++ b/base/src/com/google/idea/blaze/base/qsync/QuerySync.java
@@ -18,7 +18,6 @@ package com.google.idea.blaze.base.qsync;
 import com.google.idea.blaze.base.qsync.settings.QuerySyncSettings;
 import com.google.idea.common.experiments.BoolExperiment;
 import com.google.idea.common.experiments.FeatureRolloutExperiment;
-import java.util.function.Supplier;
 
 /** Holder class for basic information about querysync, e.g. is it enabled? */
 public class QuerySync {
@@ -27,12 +26,6 @@ public class QuerySync {
 
   private static final FeatureRolloutExperiment ENABLED =
       new FeatureRolloutExperiment("query.sync");
-
-  public static final BoolExperiment USE_NEW_RES_DIR_LOGIC =
-      new BoolExperiment("query.sync.new.resdir.logic", true);
-
-  public static final BoolExperiment EXTRACT_RES_PACKAGES_AT_BUILD_TIME =
-      new BoolExperiment("query.sync.respackages.at.build.time", true);
 
   public static final BoolExperiment ATTACH_DEP_SRCJARS =
       new BoolExperiment("querysync.attach.dep.srcjars", true);

--- a/querysync/java/com/google/idea/blaze/qsync/GraphToProjectConverter.java
+++ b/querysync/java/com/google/idea/blaze/qsync/GraphToProjectConverter.java
@@ -23,7 +23,6 @@ import static java.util.Comparator.comparingInt;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
@@ -48,7 +47,6 @@ import com.google.idea.blaze.qsync.project.BuildGraphData;
 import com.google.idea.blaze.qsync.project.LanguageClassProto.LanguageClass;
 import com.google.idea.blaze.qsync.project.ProjectDefinition;
 import com.google.idea.blaze.qsync.project.ProjectProto;
-import com.google.idea.blaze.qsync.project.ProjectProto.LibraryOrBuilder;
 import com.google.idea.blaze.qsync.project.ProjectProto.ProjectPath.Base;
 import com.google.idea.blaze.qsync.project.ProjectTarget;
 import com.google.idea.blaze.qsync.project.ProjectTarget.SourceType;
@@ -57,7 +55,6 @@ import com.google.idea.blaze.qsync.query.PackageSet;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -87,24 +84,18 @@ public class GraphToProjectConverter {
 
   private final ProjectDefinition projectDefinition;
   private final ListeningExecutorService executor;
-  private final Supplier<Boolean> useNewResDirLogic;
-  private final Supplier<Boolean> guessAndroidResPackages;
 
   public GraphToProjectConverter(
       PackageReader packageReader,
       Path workspaceRoot,
       Context<?> context,
       ProjectDefinition projectDefinition,
-      ListeningExecutorService executor,
-      Supplier<Boolean> useNewResDirLogic,
-      Supplier<Boolean> guessAndroidResPackages) {
+      ListeningExecutorService executor) {
     this.packageReader = packageReader;
     this.fileExistenceCheck = p -> Files.isRegularFile(workspaceRoot.resolve(p));
     this.context = context;
     this.projectDefinition = projectDefinition;
     this.executor = executor;
-    this.useNewResDirLogic = useNewResDirLogic;
-    this.guessAndroidResPackages = guessAndroidResPackages;
   }
 
   @VisibleForTesting
@@ -119,8 +110,6 @@ public class GraphToProjectConverter {
     this.context = context;
     this.projectDefinition = projectDefinition;
     this.executor = executor;
-    this.useNewResDirLogic = Suppliers.ofInstance(true);
-    this.guessAndroidResPackages = Suppliers.ofInstance(false);
   }
 
   /**
@@ -502,36 +491,23 @@ public class GraphToProjectConverter {
         nonJavaSourceFolders(
             graph.getSourceFilesByRuleKindAndType(not(RuleKinds::isJava), SourceType.all()));
     ImmutableSet<Path> androidResDirs;
-    if (useNewResDirLogic.get()) {
-      // Note: according to:
-      //  https://developer.android.com/guide/topics/resources/providing-resources
-      // "Never save resource files directly inside the res/ directory. It causes a compiler error."
-      // This implies that we can safely take the grandparent of each resource file to find the
-      // top level res dir:
-      List<Path> resList = graph.getAndroidResourceFiles();
-      androidResDirs =
-          resList.stream()
-              .map(Path::getParent)
-              .distinct()
-              .map(Path::getParent)
-              .distinct()
-              .collect(toImmutableSet());
-    } else {
-      // TODO(mathewi) Remove this and the corresponding experiment once the logic has been proven.
-      androidResDirs = computeAndroidResourceDirectories(graph.sourceFileLabels());
-    }
+    // Note: according to:
+    //  https://developer.android.com/guide/topics/resources/providing-resources
+    // "Never save resource files directly inside the res/ directory. It causes a compiler error."
+    // This implies that we can safely take the grandparent of each resource file to find the
+    // top level res dir:
+    List<Path> resList = graph.getAndroidResourceFiles();
+    androidResDirs =
+        resList.stream()
+            .map(Path::getParent)
+            .distinct()
+            .map(Path::getParent)
+            .distinct()
+            .collect(toImmutableSet());
     ImmutableSet<String> androidResPackages;
-    if (guessAndroidResPackages.get()) {
-      androidResPackages =
-          computeAndroidSourcePackages(graph.getAndroidSourceFiles(), javaSourceRoots);
-    } else {
-      androidResPackages = ImmutableSet.of();
-    }
+    androidResPackages = ImmutableSet.of();
 
     context.output(PrintOutput.log("%-10d Android resource directories", androidResDirs.size()));
-    if (guessAndroidResPackages.get()) {
-      context.output(PrintOutput.log("%-10d Android resource packages", androidResPackages.size()));
-    }
 
     ProjectProto.Module.Builder workspaceModule =
         ProjectProto.Module.newBuilder()

--- a/querysync/java/com/google/idea/blaze/qsync/SnapshotBuilder.java
+++ b/querysync/java/com/google/idea/blaze/qsync/SnapshotBuilder.java
@@ -39,22 +39,16 @@ public class SnapshotBuilder {
   private final PackageReader workspaceRelativePackageReader;
   private final Path workspaceRoot;
   private final ImmutableSet<String> handledRuleKinds;
-  private final Supplier<Boolean> useNewResDirLogic;
-  private final Supplier<Boolean> guessAndroidResPackages;
 
   public SnapshotBuilder(
       ListeningExecutorService executor,
       PackageReader workspaceRelativePackageReader,
       Path workspaceRoot,
-      ImmutableSet<String> handledRuleKinds,
-      Supplier<Boolean> useNewResDirLogic,
-      Supplier<Boolean> guessAndroidResPackages) {
+      ImmutableSet<String> handledRuleKinds) {
     this.executor = executor;
     this.workspaceRelativePackageReader = workspaceRelativePackageReader;
     this.workspaceRoot = workspaceRoot;
     this.handledRuleKinds = handledRuleKinds;
-    this.useNewResDirLogic = useNewResDirLogic;
-    this.guessAndroidResPackages = guessAndroidResPackages;
   }
 
   /**
@@ -78,9 +72,7 @@ public class SnapshotBuilder {
             effectiveWorkspaceRoot,
             context,
             postQuerySyncData.projectDefinition(),
-            executor,
-            useNewResDirLogic,
-            guessAndroidResPackages);
+            executor);
     QuerySummary querySummary = postQuerySyncData.querySummary();
     BuildGraphData graph = new BlazeQueryParser(querySummary, context, handledRuleKinds).parse();
     Project project =

--- a/querysync/java/com/google/idea/blaze/qsync/util/ProjectSpecBuilder.java
+++ b/querysync/java/com/google/idea/blaze/qsync/util/ProjectSpecBuilder.java
@@ -94,9 +94,7 @@ public class ProjectSpecBuilder {
             workspaceRoot,
             context,
             snapshot.projectDefinition(),
-            executor,
-            Suppliers.ofInstance(true),
-            Suppliers.ofInstance(false));
+            executor);
     System.out.println(TextFormat.printer().printToString(converter.createProject(buildGraph)));
     return context.hasError() ? 1 : 0;
   }


### PR DESCRIPTION
Cherry pick AOSP commit [481bd8c48d97b5bddbe3f8f9983b8b1d8a66e446](https://cs.android.com/android-studio/platform/tools/adt/idea/+/481bd8c48d97b5bddbe3f8f9983b8b1d8a66e446).

STAT (diff to AOSP): 1 insertions(+), 2 deletion(-)

query.sync.new.resdir.logic
query.sync.respackages.at.build.time

These experiments have not been changed recently and have not been
mentioned in bug reports.

Bug: n/a
Test: n/a
Change-Id: Ie753aa0967895e3e90cfeebf6c233f52acd0665b

AOSP: 481bd8c48d97b5bddbe3f8f9983b8b1d8a66e446
