### PR TITLE
[AOSP-pick] Always build af_internal_soyinfo_generator rules

### DIFF
--- a/querysync/java/com/google/idea/blaze/qsync/BlazeQueryParser.java
+++ b/querysync/java/com/google/idea/blaze/qsync/BlazeQueryParser.java
@@ -50,6 +50,7 @@ public class BlazeQueryParser {
       "_java_grpc_library",
       "_java_lite_grpc_library",
       "aar_import",
+      "af_internal_soyinfo_generator",
       "java_import",
       "java_lite_proto_library",
       "java_mutable_proto_library",


### PR DESCRIPTION
Cherry pick AOSP commit [133ee094d73cc103011cf0d670fc54e1751a7741](https://cs.android.com/android-studio/platform/tools/adt/idea/+/133ee094d73cc103011cf0d670fc54e1751a7741).

STAT (diff to AOSP): 0 insertions(+), 0 deletion(-)

Bug: 372665804
Test: Not applicable
Change-Id: I23200566f9384b004d40576ab7434d7b5add0f20

AOSP: 133ee094d73cc103011cf0d670fc54e1751a7741
