### PR TITLE
[AOSP-pick] Fix java_binary debugging

### DIFF
--- a/base/src/com/google/idea/blaze/base/bazel/LocalInvoker.java
+++ b/base/src/com/google/idea/blaze/base/bazel/LocalInvoker.java
@@ -228,6 +228,7 @@ public class LocalInvoker extends AbstractBuildInvoker1 {
         ExternalTask.builder(workspaceRoot)
             .addBlazeCommand(blazeCommandBuilder.build())
             .context(context)
+            .stdout(LineProcessingOutputStream.of(new PrintOutputLineProcessor(context)))
             .stderr(
                 LineProcessingOutputStream.of(
                     BlazeConsoleLineProcessorProvider.getAllStderrLineProcessors(context)))

--- a/base/src/com/google/idea/blaze/base/run/BlazeBeforeRunCommandHelper.java
+++ b/base/src/com/google/idea/blaze/base/run/BlazeBeforeRunCommandHelper.java
@@ -147,7 +147,7 @@ public final class BlazeBeforeRunCommandHelper {
                 BuildSystem.BuildInvoker invoker =
                     Blaze.getBuildSystemProvider(project)
                         .getBuildSystem()
-                        .getDefaultInvoker(project, BlazeContext.create());
+                        .getDefaultInvoker(project, context);
                 try {
                   return invoker.invoke(command, context);
                 } catch (BuildException e) {

--- a/java/src/com/google/idea/blaze/java/run/BlazeJavaRunProfileState.java
+++ b/java/src/com/google/idea/blaze/java/run/BlazeJavaRunProfileState.java
@@ -54,13 +54,13 @@ import com.google.idea.blaze.base.run.testlogs.BlazeTestResultFinderStrategy;
 import com.google.idea.blaze.base.run.testlogs.BlazeTestResultHolder;
 import com.google.idea.blaze.base.run.testlogs.BlazeTestResults;
 import com.google.idea.blaze.base.scope.BlazeContext;
+import com.google.idea.blaze.base.scope.OutputSink;
 import com.google.idea.blaze.base.scope.scopes.IdeaLogScope;
 import com.google.idea.blaze.base.scope.scopes.ProblemsViewScope;
 import com.google.idea.blaze.base.settings.Blaze;
 import com.google.idea.blaze.base.settings.BlazeUserSettings;
+import com.google.idea.blaze.common.PrintOutput;
 import com.google.idea.blaze.java.TargetKindUtil;
-import com.google.idea.blaze.java.run.hotswap.HotSwapCommandBuilder;
-import com.google.idea.blaze.java.run.hotswap.HotSwapUtils;
 import com.intellij.execution.DefaultExecutionResult;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.ExecutionResult;
@@ -75,12 +75,12 @@ import com.intellij.execution.process.ProcessListener;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.runners.ProgramRunner;
 import com.intellij.execution.ui.ConsoleView;
+import com.intellij.execution.ui.ConsoleViewContentType;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.io.FileUtilRt;
 import java.io.File;
-import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
@@ -96,6 +96,7 @@ import org.jetbrains.annotations.NotNull;
 public final class BlazeJavaRunProfileState extends BlazeJavaDebuggableRunProfileState {
   private static final Logger logger = Logger.getInstance(BlazeJavaRunProfileState.class);
   private static final String JAVA_RUNFILES_ENV = "JAVA_RUNFILES=";
+  private static final int BLAZE_INVOCATION_INTERRUPTED_EXIT_CODE = 8;
   private static final String TEST_DIAGNOSTICS_OUTPUT_DIR_ENV = "TEST_DIAGNOSTICS_OUTPUT_DIR=";
   private static final String TEST_SIZE_ENV = "TEST_SIZE=";
   private static final String TEST_TIMEOUT_ENV = "TEST_TIMEOUT=";
@@ -115,13 +116,13 @@ public final class BlazeJavaRunProfileState extends BlazeJavaDebuggableRunProfil
     Project project = getConfiguration().getProject();
     BlazeContext context = BlazeContext.create();
     BuildInvoker invoker =
-        Blaze.getBuildSystemProvider(project)
-            .getBuildSystem()
-            .getBuildInvoker(
-                project, context, getExecutorType(), getConfiguration().getTargetKind());
+      Blaze.getBuildSystemProvider(project)
+        .getBuildSystem()
+        .getBuildInvoker(
+          project, context, getExecutorType(), getConfiguration().getTargetKind());
     boolean debuggingLocalTest =
-        TargetKindUtil.isLocalTest(getConfiguration().getTargetKind())
-            && getExecutorType().isDebugType();
+      TargetKindUtil.isLocalTest(getConfiguration().getTargetKind())
+      && getExecutorType().isDebugType();
     if (debuggingLocalTest
         && !invoker.getCapabilities().contains(BuildInvoker.Capability.SUPPORTS_CLI)) {
       return startProcessRunfilesCase(project);
@@ -132,27 +133,27 @@ public final class BlazeJavaRunProfileState extends BlazeJavaDebuggableRunProfil
   private ProcessHandler startProcessRunfilesCase(Project project) throws ExecutionException {
     File downloadDir = getDownloadDir();
     WorkspaceRoot workspaceRoot =
-        new WorkspaceRoot(
-            new File(downloadDir, WorkspaceRoot.fromProject(project).directory().getName()));
+      new WorkspaceRoot(
+        new File(downloadDir, WorkspaceRoot.fromProject(project).directory().getName()));
     ImmutableList.Builder<String> commandBuilder =
-        ImmutableList.<String>builder()
-            .add("env")
-            .add("-")
-            .add(JAVA_RUNFILES_ENV + downloadDir.getAbsolutePath());
+      ImmutableList.<String>builder()
+        .add("env")
+        .add("-")
+        .add(JAVA_RUNFILES_ENV + downloadDir.getAbsolutePath());
 
     // android_local_tests need additional env variables
     if (TargetKindUtil.isAndroidLocalTest(getConfiguration().getTargetKind())) {
       commandBuilder
-          .add(TEST_TIMEOUT_ENV + "300")
-          .add(TEST_SIZE_ENV + "medium")
-          .add(
-              TEST_DIAGNOSTICS_OUTPUT_DIR_ENV
-                  + downloadDir.getAbsolutePath()
-                  + TEST_DIAGNOSTICS_OUTPUT_DIR);
+        .add(TEST_TIMEOUT_ENV + "300")
+        .add(TEST_SIZE_ENV + "medium")
+        .add(
+          TEST_DIAGNOSTICS_OUTPUT_DIR_ENV
+          + downloadDir.getAbsolutePath()
+          + TEST_DIAGNOSTICS_OUTPUT_DIR);
     }
     commandBuilder
-        .add(getEntryPointScript())
-        .add(debugPortFlag(false, getState(getConfiguration()).getDebugPortState().port));
+      .add(getEntryPointScript())
+      .add(debugPortFlag(false, getState(getConfiguration()).getDebugPortState().port));
     if (TargetKindUtil.isAndroidLocalTest(getConfiguration().getTargetKind())
         && BlazeCommandRunnerExperiments.USE_SINGLEJAR_FOR_DEBUGGING.getValue()) {
       commandBuilder.add("--singlejar");
@@ -161,79 +162,69 @@ public final class BlazeJavaRunProfileState extends BlazeJavaDebuggableRunProfil
   }
 
   private ProcessHandler startProcessBazelCliCase(
-      BuildInvoker invoker, Project project, BlazeContext context) throws ExecutionException {
+    BuildInvoker invoker, Project project, BlazeContext context) {
     BlazeCommand.Builder blazeCommand;
     BlazeTestUiSession testUiSession = null;
     BlazeTestResultFinderStrategy testResultFinderStrategy = new BlazeTestResultHolder();
     if (useTestUi()
         && BlazeTestEventsHandler.targetsSupported(project, getConfiguration().getTargets())) {
       testUiSession =
-          BlazeTestUiSession.create(
-              ImmutableList.<String>builder()
-                  .add("--runs_per_test=1")
-                  .add("--flaky_test_attempts=1")
-                  .build(),
-              testResultFinderStrategy);
+        BlazeTestUiSession.create(
+          ImmutableList.<String>builder()
+            .add("--runs_per_test=1")
+            .add("--flaky_test_attempts=1")
+            .build(),
+          testResultFinderStrategy);
     }
     if (testUiSession != null) {
       blazeCommand =
-          getBlazeCommandBuilder(
-              project,
-              getConfiguration(),
-              testUiSession.getBlazeFlags(),
-              getExecutorType(),
-              kotlinxCoroutinesJavaAgent);
-      final BlazeTestUiSession finalTestUiSession = testUiSession;
+        getBlazeCommandBuilder(
+          project,
+          getConfiguration(),
+          testUiSession.getBlazeFlags(),
+          getExecutorType(),
+          kotlinxCoroutinesJavaAgent);
+      ConsoleView consoleView = SmRunnerUtils.getConsoleView(project, getConfiguration(), getEnvironment().getExecutor(), testUiSession);
+      context.addOutputSink(PrintOutput.class, new WritingOutputSink(consoleView));
       setConsoleBuilder(
-          new TextConsoleBuilderImpl(project) {
-            @Override
-            protected ConsoleView createConsole() {
-              return SmRunnerUtils.getConsoleView(
-                  project, getConfiguration(), getEnvironment().getExecutor(), finalTestUiSession);
-            }
-          });
+        new TextConsoleBuilderImpl(project) {
+          @Override
+          protected ConsoleView createConsole() {
+            return consoleView;
+          }
+        });
     } else {
       blazeCommand =
-          getBlazeCommandBuilder(
-              project,
-              getConfiguration(),
-              ImmutableList.of(),
-              getExecutorType(),
-              kotlinxCoroutinesJavaAgent);
+        getBlazeCommandBuilder(
+          project,
+          getConfiguration(),
+          ImmutableList.of(),
+          getExecutorType(),
+          kotlinxCoroutinesJavaAgent);
     }
     addConsoleFilters(
-        ToolWindowTaskIssueOutputFilter.createWithDefaultParsers(
-            project,
-            WorkspaceRoot.fromProject(project),
-            BlazeInvocationContext.ContextType.RunConfiguration));
+      ToolWindowTaskIssueOutputFilter.createWithDefaultParsers(
+        project,
+        WorkspaceRoot.fromProject(project),
+        BlazeInvocationContext.ContextType.RunConfiguration));
 
-    ImmutableList<String> command;
-    if (HotSwapUtils.canHotSwap(getEnvironment())) {
-      try {
-        command = HotSwapCommandBuilder.getBashCommandsToRunScript(project, blazeCommand);
-      } catch (IOException e) {
-        logger.warn("Failed to create script path. Hot swap will be disabled.", e);
-        command = blazeCommand.build().toList();
-      }
-    } else {
-      command = blazeCommand.build().toList();
-    }
+    //TODO: b/399392908 - Revisit code hot-swapping using HotSwapCommandBuilder
     return getCommandRunnerProcessHandler(invoker, blazeCommand, testResultFinderStrategy, context);
   }
 
   @Override
   public ExecutionResult execute(Executor executor, ProgramRunner<?> runner)
-      throws ExecutionException {
+    throws ExecutionException {
     if (BlazeCommandRunConfigurationRunner.isDebugging(getEnvironment())) {
       new MultiRunDebuggerSessionListener(getEnvironment(), this).startListening();
     }
-    DefaultExecutionResult result = (DefaultExecutionResult) super.execute(executor, runner);
+    DefaultExecutionResult result = (DefaultExecutionResult)super.execute(executor, runner);
     return SmRunnerUtils.attachRerunFailedTestsAction(result);
   }
 
   private boolean useTestUi() {
     BlazeCommandRunConfigurationCommonState state =
-        getConfiguration().getHandlerStateIfType(BlazeCommandRunConfigurationCommonState.class);
+      getConfiguration().getHandlerStateIfType(BlazeCommandRunConfigurationCommonState.class);
     return state != null && BlazeCommandName.TEST.equals(state.getCommandState().getCommand());
   }
 
@@ -243,41 +234,41 @@ public final class BlazeJavaRunProfileState extends BlazeJavaDebuggableRunProfil
 
   @VisibleForTesting
   static BlazeCommand.Builder getBlazeCommandBuilder(
-      Project project,
-      BlazeCommandRunConfiguration configuration,
-      List<String> extraBlazeFlags,
-      ExecutorType executorType,
-      @Nullable String kotlinxCoroutinesJavaAgent) {
+    Project project,
+    BlazeCommandRunConfiguration configuration,
+    List<String> extraBlazeFlags,
+    ExecutorType executorType,
+    @Nullable String kotlinxCoroutinesJavaAgent) {
 
     List<String> blazeFlags = new ArrayList<>(extraBlazeFlags);
 
     ProjectViewSet projectViewSet =
-        Preconditions.checkNotNull(ProjectViewManager.getInstance(project).getProjectViewSet());
+      Preconditions.checkNotNull(ProjectViewManager.getInstance(project).getProjectViewSet());
     BlazeJavaRunConfigState handlerState = getState(configuration);
 
     String binaryPath =
-        handlerState.getBlazeBinaryState().getBlazeBinary() != null
-            ? handlerState.getBlazeBinaryState().getBlazeBinary()
-            : Blaze.getBuildSystemProvider(project).getBinaryPath(project);
+      handlerState.getBlazeBinaryState().getBlazeBinary() != null
+      ? handlerState.getBlazeBinaryState().getBlazeBinary()
+      : Blaze.getBuildSystemProvider(project).getBinaryPath(project);
 
     BlazeCommandName blazeCommand =
-        Preconditions.checkNotNull(handlerState.getCommandState().getCommand());
+      Preconditions.checkNotNull(handlerState.getCommandState().getCommand());
     if (executorType == ExecutorType.COVERAGE) {
       blazeCommand = BlazeCommandName.COVERAGE;
     }
     BlazeCommand.Builder command =
-        BlazeCommand.builder(binaryPath, blazeCommand, project)
-            .addTargets(configuration.getTargets())
-            .addBlazeFlags(
-                BlazeFlags.blazeFlags(
-                    project,
-                    projectViewSet,
-                    blazeCommand,
-                    BlazeContext.create(),
-                    BlazeInvocationContext.runConfigContext(
-                        executorType, configuration.getType(), false)))
-            .addBlazeFlags(blazeFlags)
-            .addBlazeFlags(handlerState.getBlazeFlagsState().getFlagsForExternalProcesses());
+      BlazeCommand.builder(binaryPath, blazeCommand, project)
+        .addTargets(configuration.getTargets())
+        .addBlazeFlags(
+          BlazeFlags.blazeFlags(
+            project,
+            projectViewSet,
+            blazeCommand,
+            BlazeContext.create(),
+            BlazeInvocationContext.runConfigContext(
+              executorType, configuration.getType(), false)))
+        .addBlazeFlags(blazeFlags)
+        .addBlazeFlags(handlerState.getBlazeFlagsState().getFlagsForExternalProcesses());
 
     if (blazeCommand.equals(BlazeCommandName.TEST)) {
       command.addBlazeFlags(handlerState.getUserEnvVarsState().asBlazeTestEnvFlags());
@@ -313,33 +304,36 @@ public final class BlazeJavaRunProfileState extends BlazeJavaDebuggableRunProfil
                     ? GeneralCommandLine.ParentEnvironmentType.CONSOLE
                     : GeneralCommandLine.ParentEnvironmentType.NONE);
     return new ScopedBlazeProcessHandler(
-        project,
-        commandLine,
-        workspaceRoot,
-        new ScopedBlazeProcessHandler.ScopedProcessHandlerDelegate() {
-          @Override
-          public void onBlazeContextStart(BlazeContext context) {
-            context
-                .push(
-                    new ProblemsViewScope(
-                        project, BlazeUserSettings.getInstance().getShowProblemsViewOnRun()))
-                .push(new IdeaLogScope());
-          }
+      project,
+      commandLine,
+      workspaceRoot,
+      new ScopedBlazeProcessHandler.ScopedProcessHandlerDelegate() {
+        @Override
+        public void onBlazeContextStart(BlazeContext context) {
+          context
+            .push(
+              new ProblemsViewScope(
+                project, BlazeUserSettings.getInstance().getShowProblemsViewOnRun()))
+            .push(new IdeaLogScope());
+        }
 
-          @Override
-          public ImmutableList<ProcessListener> createProcessListeners(BlazeContext context) {
-            LineProcessingOutputStream outputStream =
-                LineProcessingOutputStream.of(
-                    BlazeConsoleLineProcessorProvider.getAllStderrLineProcessors(context));
-            return ImmutableList.of(new LineProcessingProcessAdapter(outputStream));
-          }
-        });
+        @Override
+        public ImmutableList<ProcessListener> createProcessListeners(BlazeContext context) {
+          LineProcessingOutputStream outputStream =
+            LineProcessingOutputStream.of(
+              BlazeConsoleLineProcessorProvider.getAllStderrLineProcessors(context));
+          return ImmutableList.of(new LineProcessingProcessAdapter(outputStream));
+        }
+      });
   }
 
   private ProcessHandler getGenericProcessHandler() {
     return new ProcessHandler() {
       @Override
-      protected void destroyProcessImpl() {}
+      protected void destroyProcessImpl() {
+        ApplicationManager.getApplication()
+          .executeOnPooledThread(() -> this.notifyProcessTerminated(BLAZE_INVOCATION_INTERRUPTED_EXIT_CODE));
+      }
 
       @Override
       protected void detachProcessImpl() {
@@ -362,65 +356,66 @@ public final class BlazeJavaRunProfileState extends BlazeJavaDebuggableRunProfil
   //TODO(akhildixit) - the following handler is the same as the one in BlazeCommandGenericRunConfigurationRunner.java.
   // Extract it into a separate class to avoid code duplication.
   private ProcessHandler getCommandRunnerProcessHandler(
-      BuildInvoker invoker,
-      BlazeCommand.Builder blazeCommandBuilder,
-      BlazeTestResultFinderStrategy testResultFinderStrategy,
-      BlazeContext context) {
+    BuildInvoker invoker,
+    BlazeCommand.Builder blazeCommandBuilder,
+    BlazeTestResultFinderStrategy testResultFinderStrategy,
+    BlazeContext context) {
     ProcessHandler processHandler = getGenericProcessHandler();
     ListenableFuture<BlazeTestResults> blazeTestResultsFuture =
-        BlazeExecutor.getInstance()
-            .submit(
-                () -> {
-                  try (BuildEventStreamProvider streamProvider =
-                      invoker.invoke(blazeCommandBuilder, context)) {
-                    return BuildResultParser.getTestResults(streamProvider);
-                  }
-                });
+      BlazeExecutor.getInstance()
+        .submit(
+          () -> {
+            try (BuildEventStreamProvider streamProvider =
+                   invoker.invoke(blazeCommandBuilder, context)) {
+              return BuildResultParser.getTestResults(streamProvider);
+            }
+          });
     Futures.addCallback(
-        blazeTestResultsFuture,
-        new FutureCallback<BlazeTestResults>() {
-          @Override
-          public void onSuccess(BlazeTestResults blazeTestResults) {
-            // The command-runners allow using a remote BES for parsing the test results, so we
-            // use a BlazeTestResultHolder to store the test results for the IDE to find/read
-            // later. The LocalTestResultFinderStrategy won't work here since it writes/reads the
-            // test results to a local file.
-            verify(testResultFinderStrategy instanceof BlazeTestResultHolder);
-            ((BlazeTestResultHolder) testResultFinderStrategy).setTestResults(blazeTestResults);
-            processHandler.detachProcess();
-          }
+      blazeTestResultsFuture,
+      new FutureCallback<BlazeTestResults>() {
+        @Override
+        public void onSuccess(BlazeTestResults blazeTestResults) {
+          // The command-runners allow using a remote BES for parsing the test results, so we
+          // use a BlazeTestResultHolder to store the test results for the IDE to find/read
+          // later. The LocalTestResultFinderStrategy won't work here since it writes/reads the
+          // test results to a local file.
+          verify(testResultFinderStrategy instanceof BlazeTestResultHolder);
+          ((BlazeTestResultHolder) testResultFinderStrategy).setTestResults(blazeTestResults);
+          processHandler.detachProcess();
+        }
 
-          @Override
-          public void onFailure(Throwable throwable) {
-            context.handleException(throwable.getMessage(), throwable);
-            verify(testResultFinderStrategy instanceof BlazeTestResultHolder);
-            ((BlazeTestResultHolder) testResultFinderStrategy)
-                .setTestResults(BlazeTestResults.NO_RESULTS);
-            processHandler.detachProcess();
-          }
-        },
-        BlazeExecutor.getInstance().getExecutor());
+        @Override
+        public void onFailure(Throwable throwable) {
+          context.handleException(throwable.getMessage(), throwable);
+          verify(testResultFinderStrategy instanceof BlazeTestResultHolder);
+          ((BlazeTestResultHolder) testResultFinderStrategy)
+            .setTestResults(BlazeTestResults.NO_RESULTS);
+          processHandler.detachProcess();
+        }
+      },
+      BlazeExecutor.getInstance().getExecutor());
 
     processHandler.addProcessListener(
-        new ProcessAdapter() {
-          @Override
-          public void processWillTerminate(@NotNull ProcessEvent event, boolean willBeDestroyed) {
-            if (willBeDestroyed) {
-              context.setCancelled();
-              verify(testResultFinderStrategy instanceof BlazeTestResultHolder);
-              ((BlazeTestResultHolder) testResultFinderStrategy)
-                  .setTestResults(BlazeTestResults.NO_RESULTS);
-            }
+      new ProcessAdapter() {
+        @Override
+        public void processWillTerminate(@NotNull ProcessEvent event, boolean willBeDestroyed) {
+          if (willBeDestroyed) {
+            context.setCancelled();
+            verify(testResultFinderStrategy instanceof BlazeTestResultHolder);
+            ((BlazeTestResultHolder) testResultFinderStrategy)
+              .setTestResults(BlazeTestResults.NO_RESULTS);
+            processHandler.detachProcess();
           }
-        });
+        }
+      });
     return processHandler;
   }
 
   private File getDownloadDir() {
     String testTargetString = getConfiguration().getSingleTarget().toString();
     return new File(
-        FileUtilRt.getTempDirectory(),
-        testTargetString.substring(testTargetString.lastIndexOf(":") + 1) + ".runfiles");
+      FileUtilRt.getTempDirectory(),
+      testTargetString.substring(testTargetString.lastIndexOf(":") + 1) + ".runfiles");
   }
 
   private static String debugPortFlag(boolean isTest, int port) {
@@ -430,11 +425,32 @@ public final class BlazeJavaRunProfileState extends BlazeJavaDebuggableRunProfil
 
   private String getEntryPointScript() {
     return CharMatcher.is('/')
-        .trimLeadingFrom(getConfiguration().getSingleTarget().toString())
-        .replace(':', '/');
+      .trimLeadingFrom(getConfiguration().getSingleTarget().toString())
+      .replace(':', '/');
   }
 
   private static String testArg(String flag) {
     return "--test_arg=" + flag;
+  }
+
+  //TODO(akhildixit) - the following output sink is the same as the one in BlazeCommandGenericRunConfigurationRunner.java.
+  // Extract it into a separate class to avoid code duplication.
+  private static class WritingOutputSink implements OutputSink<PrintOutput> {
+    private final ConsoleView console;
+
+    public WritingOutputSink(ConsoleView console) {
+      this.console = console;
+    }
+
+    @Override
+    public Propagation onOutput(PrintOutput output) {
+      // Add ANSI support to the console to view colored output
+      console.print(
+        output.getText().replaceAll("\u001B\\[[;\\d]*m", "") + "\n",
+        output.getOutputType() == PrintOutput.OutputType.ERROR
+        ? ConsoleViewContentType.ERROR_OUTPUT
+        : ConsoleViewContentType.NORMAL_OUTPUT);
+      return Propagation.Continue;
+    }
   }
 }

--- a/java/src/com/google/idea/blaze/java/run/hotswap/ClassFileManifestBuilder.java
+++ b/java/src/com/google/idea/blaze/java/run/hotswap/ClassFileManifestBuilder.java
@@ -27,6 +27,7 @@ import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtif
 import com.google.idea.blaze.base.command.buildresult.BuildResultParser;
 import com.google.idea.blaze.base.command.buildresult.LocalFileArtifact;
 import com.google.idea.blaze.base.command.buildresult.bepparser.BuildEventStreamProvider;
+import com.google.idea.blaze.base.command.buildresult.bepparser.ParsedBepOutput;
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.BlazeVersionData;
 import com.google.idea.blaze.base.run.BlazeBeforeRunCommandHelper;
@@ -127,11 +128,9 @@ public class ClassFileManifestBuilder {
     if (progress != null) {
       progress.setCancelWorker(() -> streamProviderFuture.cancel(true));
     }
-    try {
-      BuildResult result =
-          BuildResult.fromExitCode(
-              BuildResultParser.getBuildOutput(streamProviderFuture.get(), Interners.STRING)
-                  .buildResult());
+    try (BuildEventStreamProvider streamProvider = streamProviderFuture.get()) {
+      ParsedBepOutput parsedBepOutput = BuildResultParser.getBuildOutput(streamProvider, Interners.STRING);
+      BuildResult result = BuildResult.fromExitCode(parsedBepOutput.buildResult());
       if (result.status != BuildResult.Status.SUCCESS) {
         throw new ExecutionException("Blaze failure building debug binary");
       }
@@ -139,9 +138,7 @@ public class ClassFileManifestBuilder {
       ImmutableList<File> jars =
           LocalFileArtifact.getLocalFiles(
                   Label.of(Objects.requireNonNull(configuration.getSingleTarget().toString())),
-                  BlazeBuildOutputs.fromParsedBepOutput(
-                          BuildResultParser.getBuildOutput(
-                              streamProviderFuture.get(), Interners.STRING))
+                  BlazeBuildOutputs.fromParsedBepOutput(parsedBepOutput)
                       .getOutputGroupArtifacts(JavaClasspathAspectStrategy.OUTPUT_GROUP),
                   BlazeContext.create(),
                   project)


### PR DESCRIPTION
Cherry pick AOSP commit [3b43602f002a583dec99a57843bb5f4122df7789](https://cs.android.com/android-studio/platform/tools/adt/idea/+/3b43602f002a583dec99a57843bb5f4122df7789).

STAT (diff to AOSP): 4 insertions(+), 9 deletion(-)

1. Updates ClassFileManifestBuilder so that the output is parsed from
the build event stream only once (fixes b/397735292 ).

2. Avoids creating a new BlazeContext in BlazebeforeRunCommandhelper.

3. Adds output sink to the context so that output is printed to the
debug console. Updates the ProcessHandler in BlazeJavaRunProfileState so
that the process terminates when destroyed (fixes b/397869417).

This change along with I3fa6311a269bbc18af9118de81d29d1eb73078f7
disabled Java code hotswapping while debugging, there's a bug
b/399392908 to track re-enabling it.

Bug:397735292
Bug:397869417
Test: n/a
Change-Id: I5932c7c80f1eed2f3487b7fd8560d7bfdbe7a2b6

AOSP: 3b43602f002a583dec99a57843bb5f4122df7789
