### PR TITLE
[AOSP-pick] Return simple labels instead of TargetTree

### DIFF
--- a/base/src/com/google/idea/blaze/base/model/AspectSyncProjectData.java
+++ b/base/src/com/google/idea/blaze/base/model/AspectSyncProjectData.java
@@ -147,9 +147,9 @@ public final class AspectSyncProjectData implements BlazeProjectData {
   }
 
   @Override
-  public ImmutableList<TargetInfo> targets() {
+  public ImmutableList<Label> targets() {
     return getTargetMap().targets().stream()
-        .map(TargetIdeInfo::toTargetInfo)
+        .map(it -> it.getKey().getLabel())
         .collect(ImmutableList.toImmutableList());
   }
 

--- a/base/src/com/google/idea/blaze/base/model/BlazeProjectData.java
+++ b/base/src/com/google/idea/blaze/base/model/BlazeProjectData.java
@@ -17,7 +17,6 @@ package com.google.idea.blaze.base.model;
 
 import com.google.common.collect.ImmutableList;
 import com.google.idea.blaze.base.command.info.BlazeInfo;
-import com.google.idea.blaze.base.dependencies.TargetInfo;
 import com.google.idea.blaze.base.ideinfo.TargetMap;
 import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.sync.projectview.WorkspaceLanguageSettings;
@@ -36,7 +35,7 @@ public interface BlazeProjectData {
 
   WorkspaceLanguageSettings getWorkspaceLanguageSettings();
 
-  ImmutableList<TargetInfo> targets();
+  ImmutableList<Label> targets();
 
   // TODO: Many of the following methods are aspect-sync specific, and should probably not appear in
   //  this interface.

--- a/base/src/com/google/idea/blaze/base/qsync/QuerySyncProjectData.java
+++ b/base/src/com/google/idea/blaze/base/qsync/QuerySyncProjectData.java
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.idea.blaze.base.bazel.BazelVersion;
 import com.google.idea.blaze.base.command.info.BlazeInfo;
-import com.google.idea.blaze.base.dependencies.TargetInfo;
 import com.google.idea.blaze.base.ideinfo.TargetMap;
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.BlazeVersionData;
@@ -97,8 +96,7 @@ public class QuerySyncProjectData implements BlazeProjectData {
   @Override
   public ProjectTarget getBuildTarget(Label label) {
     return blazeProject
-        .map(QuerySyncProjectSnapshot::getTargetMap)
-        .map(map -> map.get(com.google.idea.blaze.common.Label.of(label.toString())))
+        .map(it -> it.graph().targetMap().get(com.google.idea.blaze.common.Label.of(label.toString())))
         .orElse(null);
   }
 
@@ -117,11 +115,10 @@ public class QuerySyncProjectData implements BlazeProjectData {
   }
 
   @Override
-  public ImmutableList<TargetInfo> targets() {
+  public ImmutableList<Label> targets() {
     if (blazeProject.isPresent()) {
-      return blazeProject.get().getTargetMap().values().stream()
-          .map(TargetInfo::tryFromBuildTarget)
-          .filter(Objects::nonNull)
+      return blazeProject.get().getAllTargets().stream()
+          .map(com.google.idea.blaze.base.model.primitives.Label::create)
           .collect(ImmutableList.toImmutableList());
     }
     return ImmutableList.of();

--- a/base/src/com/google/idea/blaze/base/run/ui/TargetExpressionListUi.java
+++ b/base/src/com/google/idea/blaze/base/run/ui/TargetExpressionListUi.java
@@ -232,7 +232,6 @@ public class TargetExpressionListUi extends JPanel {
 
       if (Blaze.getProjectType(project) == ProjectType.QUERY_SYNC) {
         return projectData.targets().stream()
-            .map(TargetInfo::getLabel)
             .filter(importRoots::importAsSource)
             .map(TargetExpression::toString)
             .collect(toImmutableList());

--- a/plugin_dev/src/com/google/idea/blaze/plugin/IntellijPluginRule.java
+++ b/plugin_dev/src/com/google/idea/blaze/plugin/IntellijPluginRule.java
@@ -18,6 +18,8 @@ package com.google.idea.blaze.plugin;
 import com.google.idea.blaze.base.dependencies.TargetInfo;
 import com.google.idea.blaze.base.model.primitives.GenericBlazeRules.RuleTypes;
 import com.google.idea.blaze.base.model.primitives.Kind;
+import com.google.idea.blaze.base.model.primitives.Label;
+
 import javax.annotation.Nullable;
 
 /** Utility methods for intellij_plugin blaze targets */

--- a/plugin_dev/src/com/google/idea/blaze/plugin/run/BlazeIntellijPluginConfiguration.java
+++ b/plugin_dev/src/com/google/idea/blaze/plugin/run/BlazeIntellijPluginConfiguration.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Ordering;
 import com.google.idea.blaze.base.dependencies.TargetInfo;
+import com.google.idea.blaze.base.ideinfo.TargetIdeInfo;
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.model.primitives.TargetExpression;
@@ -367,7 +368,8 @@ public class BlazeIntellijPluginConfiguration extends LocatableConfigurationBase
     if (projectData == null) {
       return ImmutableSet.of();
     }
-    return projectData.targets().stream()
+    return projectData.getTargetMap().targets().stream()
+        .map(TargetIdeInfo::toTargetInfo)
         .filter(IntellijPluginRule::isPluginTarget)
         .map(info -> info.label)
         .collect(toImmutableSet());

--- a/plugin_dev/src/com/google/idea/blaze/plugin/run/BlazeIntellijPluginConfigurationType.java
+++ b/plugin_dev/src/com/google/idea/blaze/plugin/run/BlazeIntellijPluginConfigurationType.java
@@ -19,6 +19,7 @@ import static java.util.stream.Collectors.toCollection;
 
 import com.google.common.base.Splitter;
 import com.google.idea.blaze.base.dependencies.TargetInfo;
+import com.google.idea.blaze.base.ideinfo.TargetIdeInfo;
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.model.primitives.WorkspaceType;
@@ -140,7 +141,8 @@ public class BlazeIntellijPluginConfigurationType implements ConfigurationType {
       if (projectData == null) {
         return null;
       }
-      return projectData.targets().stream()
+      return projectData.getTargetMap().targets().stream()
+          .map(TargetIdeInfo::toTargetInfo)
           .filter(IntellijPluginRule::isPluginTarget)
           .map(info -> info.label)
           .findFirst()

--- a/python/src/com/google/idea/blaze/python/resolve/provider/AbstractPyImportResolverStrategy.java
+++ b/python/src/com/google/idea/blaze/python/resolve/provider/AbstractPyImportResolverStrategy.java
@@ -55,6 +55,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -185,7 +186,7 @@ public abstract class AbstractPyImportResolverStrategy implements PyImportResolv
       return null;
     }
 
-    for (var target : currentSnapshot.getTargetMap().entrySet()) {
+    for (var target : currentSnapshot.graph().targetMap().entrySet()) {
       List<QualifiedName> importRoots = assembleImportRootsQuerySync(target.getKey(), project);
       for (var source : target.getValue().sourceLabels().get(ProjectTarget.SourceType.REGULAR)) {
         List<QualifiedName> sourceImports = assembleSourceImportsFromImportRoots(importRoots,

--- a/querysync/java/com/google/idea/blaze/qsync/QuerySyncProjectSnapshot.java
+++ b/querysync/java/com/google/idea/blaze/qsync/QuerySyncProjectSnapshot.java
@@ -107,8 +107,9 @@ public abstract class QuerySyncProjectSnapshot {
   }
 
   /** Returns mapping of targets to {@link BuildTarget} */
-  public ImmutableMap<Label, ProjectTarget> getTargetMap() {
-    return graph().targetMap();
+  @Nullable
+  public Collection<Label> getAllTargets() {
+    return graph().allTargets();
   }
 
   @Memoized


### PR DESCRIPTION
Cherry pick AOSP commit [656359f19d35c563b89e58493fce2b32cd6de4dc](https://cs.android.com/android-studio/platform/tools/adt/idea/+/656359f19d35c563b89e58493fce2b32cd6de4dc).

STAT (diff to AOSP): 30 insertions(+), 1 deletion(-)

where possible. These are simpler data structures.

Bug: n/a
Test: n/a
Change-Id: Ib3cd3e303e0016dbe32788f63979f9b71c0dd95a

AOSP: 656359f19d35c563b89e58493fce2b32cd6de4dc
