### PR TITLE
[AOSP-pick] Separate storage and logic in BuildGraphData

### DIFF
--- a/base/src/com/google/idea/blaze/base/qsync/ProjectStatsLogger.java
+++ b/base/src/com/google/idea/blaze/base/qsync/ProjectStatsLogger.java
@@ -64,10 +64,10 @@ public class ProjectStatsLogger implements QuerySyncProjectListener {
                           .map(WorkspacePath::asPath)
                           .collect(toImmutableSet()))
                   .setProjectTargetCount(instance.graph().allTargets().size())
-                  .setExternalDependencyCount(instance.graph().projectDeps().size());
+                  .setExternalDependencyCount(instance.graph().getExternalDependencyCount());
               scope
                   .getDependenciesInfoStatsBuilder()
-                  .setTargetMapSize(instance.graph().targetMap().size())
+                  .setTargetMapSize(instance.graph().getTargetMapSizeForStatsOnly())
                   .setLibraryCount(instance.project().getLibraryCount())
                   .setJarCount(
                       instance.artifactState().targets().stream()

--- a/base/src/com/google/idea/blaze/base/qsync/QuerySyncProjectData.java
+++ b/base/src/com/google/idea/blaze/base/qsync/QuerySyncProjectData.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.idea.blaze.base.bazel.BazelVersion;
 import com.google.idea.blaze.base.command.info.BlazeInfo;
+import com.google.idea.blaze.base.dependencies.TargetInfo;
 import com.google.idea.blaze.base.ideinfo.TargetMap;
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.BlazeVersionData;
@@ -96,7 +97,7 @@ public class QuerySyncProjectData implements BlazeProjectData {
   @Override
   public ProjectTarget getBuildTarget(Label label) {
     return blazeProject
-        .map(it -> it.graph().targetMap().get(com.google.idea.blaze.common.Label.of(label.toString())))
+        .map(it -> it.graph().getProjectTarget(com.google.idea.blaze.common.Label.of(label.toString())))
         .orElse(null);
   }
 

--- a/base/src/com/google/idea/blaze/base/qsync/action/BuildDependenciesForProjectAction.java
+++ b/base/src/com/google/idea/blaze/base/qsync/action/BuildDependenciesForProjectAction.java
@@ -65,7 +65,7 @@ public class BuildDependenciesForProjectAction extends BlazeProjectAction {
       return;
     }
 
-    int externalDeps = snapshot.graph().projectDeps().size();
+    int externalDeps = snapshot.graph().getExternalDependencyCount();
     logger.warn("Total external deps: " + externalDeps);
     if (externalDeps > EXTERNAL_DEPS_WARNING_THRESHOLD) {
       if (!new WarningDialog(project).showAndGet()) {

--- a/java/src/com/google/idea/blaze/java/run/producers/JavaBinaryContextProvider.java
+++ b/java/src/com/google/idea/blaze/java/run/producers/JavaBinaryContextProvider.java
@@ -138,7 +138,7 @@ public class JavaBinaryContextProvider implements BinaryContextProvider {
 
     ImmutableSet<ProjectTarget> binaryTargets =
         targetOwners.stream()
-            .map(label -> buildGraphData.targetMap().get(label))
+            .map(buildGraphData::getProjectTarget)
             .filter(Objects::nonNull)
             .filter(t -> t.kind().equals("java_binary"))
             .collect(toImmutableSet());

--- a/python/src/com/google/idea/blaze/python/resolve/provider/AbstractPyImportResolverStrategy.java
+++ b/python/src/com/google/idea/blaze/python/resolve/provider/AbstractPyImportResolverStrategy.java
@@ -186,9 +186,9 @@ public abstract class AbstractPyImportResolverStrategy implements PyImportResolv
       return null;
     }
 
-    for (var target : currentSnapshot.graph().targetMap().entrySet()) {
-      List<QualifiedName> importRoots = assembleImportRootsQuerySync(target.getKey(), project);
-      for (var source : target.getValue().sourceLabels().get(ProjectTarget.SourceType.REGULAR)) {
+    for (var target : currentSnapshot.graph().allTargets()) {
+      List<QualifiedName> importRoots = assembleImportRootsQuerySync(target, project);
+      for (var source : currentSnapshot.graph().getProjectTarget(target).sourceLabels().get(ProjectTarget.SourceType.REGULAR)) {
         List<QualifiedName> sourceImports = assembleSourceImportsFromImportRoots(importRoots,
                 fromRelativePath(source.toFilePath().toString()));
         var file = workspaceRoot.path().resolve(source.toFilePath());

--- a/querysync/java/com/google/idea/blaze/qsync/BUILD.bazel
+++ b/querysync/java/com/google/idea/blaze/qsync/BUILD.bazel
@@ -21,6 +21,7 @@ java_library(
         "//shared:vcs",
         "//third_party/java/auto_value",
         "@com_google_guava_guava//jar",
+        "@jetbrains_annotations//jar",
         "@protobuf//:protobuf_java",
         "@error_prone_annotations//jar",
     ],

--- a/querysync/java/com/google/idea/blaze/qsync/GraphToProjectConverter.java
+++ b/querysync/java/com/google/idea/blaze/qsync/GraphToProjectConverter.java
@@ -565,17 +565,11 @@ public class GraphToProjectConverter {
       workspaceModule.addContentEntries(contentEntry);
     }
 
-    ImmutableSet.Builder<LanguageClass> activeLanguages = ImmutableSet.builder();
-    if (graph.targetMap().values().stream().map(ProjectTarget::kind).anyMatch(RuleKinds::isJava)) {
-      activeLanguages.add(LanguageClass.LANGUAGE_CLASS_JVM);
-    }
-    if (graph.targetMap().values().stream().map(ProjectTarget::kind).anyMatch(RuleKinds::isCc)) {
-      activeLanguages.add(LanguageClass.LANGUAGE_CLASS_CC);
-    }
+    final var activeLanguages = graph.getActiveLanguages();
 
     return ProjectProto.Project.newBuilder()
         .addModules(workspaceModule)
-        .addAllActiveLanguages(activeLanguages.build())
+        .addAllActiveLanguages(activeLanguages.stream().map(it -> it.protoValue).toList())
         .build();
   }
 

--- a/querysync/java/com/google/idea/blaze/qsync/cc/CcWorkspaceBuilder.java
+++ b/querysync/java/com/google/idea/blaze/qsync/cc/CcWorkspaceBuilder.java
@@ -141,14 +141,14 @@ public class CcWorkspaceBuilder {
   }
 
   private void visitTarget(Label label, CcCompilationInfo target) {
-    if (!graph.targetMap().containsKey(label)) {
+    ProjectTarget projectTarget = graph.getProjectTarget(label);
+    if (projectTarget == null) {
       // This target is no longer present in the project. Ignore it.
       // We should really clean up the dependency cache itself to remove any artifacts relating to
       // no-longer-present targets, but that will be a lot more work. For now, just ensure we don't
       // crash.
       return;
     }
-    ProjectTarget projectTarget = Preconditions.checkNotNull(graph.targetMap().get(label));
 
     CcToolchain toolchain = ccDependenciesInfo.toolchainInfoMap().get(target.toolchainId());
 

--- a/querysync/java/com/google/idea/blaze/qsync/cc/ConfigureCcCompilation.java
+++ b/querysync/java/com/google/idea/blaze/qsync/cc/ConfigureCcCompilation.java
@@ -136,7 +136,7 @@ public class ConfigureCcCompilation {
   }
 
   private void visitTarget(CcCompilationInfo ccInfo, DependencyBuildContext buildContext) {
-    ProjectTarget projectTarget = update.buildGraph().targetMap().get(ccInfo.target());
+    ProjectTarget projectTarget = update.buildGraph().getProjectTarget(ccInfo.target());
     if (projectTarget == null) {
       // This target is no longer present in the project. Ignore it.
       // We should really clean up the dependency cache itself to remove any artifacts relating to

--- a/querysync/java/com/google/idea/blaze/qsync/project/BuildGraphDataImpl.java
+++ b/querysync/java/com/google/idea/blaze/qsync/project/BuildGraphDataImpl.java
@@ -20,6 +20,7 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.ImmutableSetMultimap.toImmutableSetMultimap;
 import static java.util.Arrays.stream;
 
+import com.google.auto.value.AutoBuilder;
 import com.google.auto.value.AutoValue;
 import com.google.auto.value.extension.memoized.Memoized;
 import com.google.common.annotations.VisibleForTesting;
@@ -67,15 +68,25 @@ import javax.annotation.Nullable;
  * <p>This class is immutable. A new instance of it will be created every time there is any change
  * to the project structure.
  */
-@AutoValue
-public abstract class BuildGraphDataImpl implements BuildGraphData {
+public record BuildGraphDataImpl(Storage storage) implements BuildGraphData {
+
+  @Override
+  @Nullable
+  public ProjectTarget getProjectTarget(Label label) {
+    return storage.targetMap().get(label);
+  }
+
+  @Override
+  public Collection<Label> allTargets() {
+    return storage.allTargets();
+  }
 
   /** A set of all the BUILD files */
   @Memoized
   @Override
   public PackageSet packages() {
     PackageSet.Builder packages = new PackageSet.Builder();
-    for (Label sourceFile : sourceFileLabels()) {
+    for (Label sourceFile : storage.sourceFileLabels()) {
       if (sourceFile.getName().equals(Path.of("BUILD")) || sourceFile.getName().equals(Path.of("BUILD.bazel"))) {
         // TODO: b/334110669 - support Bazel workspaces.
         packages.add(sourceFile.getPackage());
@@ -113,7 +124,7 @@ public abstract class BuildGraphDataImpl implements BuildGraphData {
     if (sourceFileLabel.isEmpty()) {
       return Optional.empty();
     }
-    if (sourceFileLabels().contains(sourceFileLabel.get())) {
+    if (storage.sourceFileLabels().contains(sourceFileLabel.get())) {
       return sourceFileLabel;
     }
     return Optional.empty();
@@ -131,7 +142,7 @@ public abstract class BuildGraphDataImpl implements BuildGraphData {
   @Override
   public DepsGraph<Label> depsGraph() {
     DepsGraph.Builder<Label> builder = new DepsGraph.Builder<>();
-    targetMap().values().stream().forEach(target ->
+    storage.targetMap().values().stream().forEach(target ->
         builder.add(target.label(), ImmutableSet.<Label>builder().addAll(target.deps()).addAll(target.runtimeDeps()).build()));
     return builder.build();
   }
@@ -145,12 +156,12 @@ public abstract class BuildGraphDataImpl implements BuildGraphData {
     ImmutableSet.Builder<Label> directRdeps = ImmutableSet.builder();
     directRdeps.addAll(targets);
     for (Label target : targets) {
-      ImmutableSet<QuerySyncLanguage> targetLanguages = targetMap().get(target).languages();
+      ImmutableSet<QuerySyncLanguage> targetLanguages = storage.targetMap().get(target).languages();
       // filter the rdeps based on the languages, removing those that don't have a common
       // language. This ensures we don't follow reverse deps of (e.g.) a java target depending on
       // a cc target.
       depsGraph().rdeps(target).stream()
-          .filter(d -> !Collections.disjoint(targetMap().get(d).languages(), targetLanguages))
+          .filter(d -> !Collections.disjoint(storage.targetMap().get(d).languages(), targetLanguages))
           .forEach(directRdeps::add);
     }
     return directRdeps.build();
@@ -177,7 +188,7 @@ public abstract class BuildGraphDataImpl implements BuildGraphData {
     while (!toVisit.isEmpty()) {
       Label next = toVisit.remove();
       if (visited.add(next)) {
-        ProjectTarget target = targetMap().get(next);
+        ProjectTarget target = storage.targetMap().get(next);
         if (target != null && ruleKinds.contains(target.kind())) {
           result.add(target);
         } else {
@@ -206,7 +217,7 @@ public abstract class BuildGraphDataImpl implements BuildGraphData {
     }
 
     return Streams.stream(Traverser.forGraph(depsGraph()::rdeps).breadthFirst(targetOwners))
-        .map(label -> targetMap().get(label))
+        .map(label -> storage.targetMap().get(label))
         .filter(Objects::nonNull)
         .collect(toImmutableSet());
   }
@@ -231,7 +242,7 @@ public abstract class BuildGraphDataImpl implements BuildGraphData {
       return false;
     }
 
-    ImmutableMap<Label, ProjectTarget> targetMap = targetMap();
+    ImmutableMap<Label, ProjectTarget> targetMap = storage.targetMap();
 
     // Do a BFS up the dependency graph, looking both at the labels and the set of rule kinds
     // we've found so far at any given point.
@@ -281,7 +292,7 @@ public abstract class BuildGraphDataImpl implements BuildGraphData {
       if (deps.contains(target)) {
         return true;
       }
-      final var targetInfo = targetMap().get(target);
+      final var targetInfo = storage.targetMap().get(target);
       if (targetInfo == null) {
         continue;
       }
@@ -294,11 +305,11 @@ public abstract class BuildGraphDataImpl implements BuildGraphData {
 
   @Override
   public ImmutableSet<Path> getTargetSources(Label target, SourceType... types) {
-    return Optional.ofNullable(targetMap().get(target)).stream()
+    return Optional.ofNullable(storage.targetMap().get(target)).stream()
         .map(ProjectTarget::sourceLabels)
         .flatMap(m -> stream(types).map(m::get))
         .flatMap(Set::stream)
-        .filter(sourceFileLabels()::contains) // filter out generated sources
+        .filter(storage.sourceFileLabels()::contains) // filter out generated sources
         .map(Label::toFilePath)
         .collect(toImmutableSet());
   }
@@ -310,30 +321,54 @@ public abstract class BuildGraphDataImpl implements BuildGraphData {
     return getClass().getSimpleName() + "@" + Integer.toHexString(System.identityHashCode(this));
   }
 
-  public static Builder builder() {
-    return new AutoValue_BuildGraphDataImpl.Builder();
-  }
+  /**
+   * Build graph data in one place.
+   */
+  public record Storage(ImmutableSet<Label> sourceFileLabels,
+                        ImmutableMap<Label, ProjectTarget> targetMap,
+                        ImmutableSet<Label> projectDeps,
+                        TargetTree allTargets) {
 
-  /** Builder for {@link BuildGraphDataImpl}. */
-  @AutoValue.Builder
-  public abstract static class Builder {
+    public Storage(ImmutableSet<Label> sourceFileLabels, ImmutableMap<Label, ProjectTarget> targetMap,
+                   ImmutableSet<Label> projectDeps, ImmutableSet<Label> allTargetLabels) {
+      this(sourceFileLabels, targetMap, projectDeps, getTargetTree(allTargetLabels));
+    }
 
-    public abstract ImmutableSet.Builder<Label> sourceFileLabelsBuilder();
+    private static TargetTree getTargetTree(ImmutableSet<Label> allTargets) {
+      TargetTree.Builder treeBuilder = TargetTree.builder();
+      for (Label target : allTargets) {
+        treeBuilder.add(target);
+      }
+      return treeBuilder.build();
+    }
 
-    public abstract ImmutableMap.Builder<Label, ProjectTarget> targetMapBuilder();
+    public static Builder builder() {
+      return new AutoBuilder_BuildGraphDataImpl_Storage_Builder();
+    }
 
-    public abstract Builder projectDeps(Set<Label> value);
+    /**
+     * Builder for {@link BuildGraphDataImpl}.
+     */
+    @AutoBuilder(ofClass = Storage.class)
+    public abstract static class Builder {
 
-    public abstract TargetTree.Builder allTargetsBuilder();
+      public abstract ImmutableSet.Builder<Label> sourceFileLabelsBuilder();
 
-    abstract BuildGraphDataImpl autoBuild();
+      public abstract ImmutableMap.Builder<Label, ProjectTarget> targetMapBuilder();
 
-    public final BuildGraphData build() {
-      BuildGraphData result = autoBuild();
-      // these are memoized, but we choose to pay the cost of building it now so that it's done at
-      // sync time rather than later on.
-      ImmutableSetMultimap<Label, Label> unused = result.sourceOwners();
-      return result;
+      public abstract Builder projectDeps(Set<Label> value);
+
+      public abstract ImmutableSet.Builder<Label> allTargetLabelsBuilder();
+
+      abstract Storage autoBuild();
+
+      public final BuildGraphDataImpl build() {
+        final var result = new BuildGraphDataImpl(autoBuild());
+        // these are memoized, but we choose to pay the cost of building it now so that it's done at
+        // sync time rather than later on.
+        ImmutableSetMultimap<Label, Label> unused = result.sourceOwners();
+        return result;
+      }
     }
   }
 
@@ -365,7 +400,7 @@ public abstract class BuildGraphDataImpl implements BuildGraphData {
   @Memoized
   @Override
   public ImmutableSetMultimap<Label, Label> sourceOwners() {
-    return targetMap().values().stream()
+    return storage.targetMap().values().stream()
         .flatMap(
             t -> t.sourceLabels().values().stream().map(src -> new SimpleEntry<>(src, t.label())))
         .collect(toImmutableSetMultimap(e -> e.getKey(), e -> e.getValue()));
@@ -391,7 +426,7 @@ public abstract class BuildGraphDataImpl implements BuildGraphData {
   @Override
   public Label selectLabelWithLeastDeps(Collection<Label> candidates) {
     return candidates.stream()
-        .min(Comparator.comparingInt(label -> targetMap().get(label).deps().size()))
+        .min(Comparator.comparingInt(label -> storage.targetMap().get(label).deps().size()))
         .orElse(null);
   }
 
@@ -432,7 +467,7 @@ public abstract class BuildGraphDataImpl implements BuildGraphData {
 
   private ImmutableSet<Label> sourcesByRuleKindAndType(
       Predicate<String> ruleKindPredicate, SourceType... sourceTypes) {
-    return targetMap().values().stream()
+    return storage.targetMap().values().stream()
         .filter(t -> ruleKindPredicate.test(t.kind()))
         .map(ProjectTarget::sourceLabels)
         .flatMap(srcs -> stream(sourceTypes).map(srcs::get))
@@ -441,7 +476,7 @@ public abstract class BuildGraphDataImpl implements BuildGraphData {
   }
 
   private List<Path> pathListFromSourceFileLabelsOnly(Collection<Label> labels) {
-    return labels.stream().filter(sourceFileLabels()::contains).map(Label::toFilePath).collect(toImmutableList());
+    return labels.stream().filter(storage.sourceFileLabels()::contains).map(Label::toFilePath).collect(toImmutableList());
   }
 
   /**
@@ -461,7 +496,7 @@ public abstract class BuildGraphDataImpl implements BuildGraphData {
   /** Returns a list of custom_package fields that used by current project. */
   @Override
   public ImmutableSet<String> getAllCustomPackages() {
-    return targetMap().values().stream()
+    return storage.targetMap().values().stream()
         .map(ProjectTarget::customPackage)
         .flatMap(Optional::stream)
         .collect(toImmutableSet());
@@ -487,9 +522,9 @@ public abstract class BuildGraphDataImpl implements BuildGraphData {
   public TargetsToBuild getProjectTargets(Context<?> context, Path workspaceRelativePath) {
     if (workspaceRelativePath.endsWith("BUILD") || workspaceRelativePath.endsWith("BUILD.bazel")) {
       Path packagePath = workspaceRelativePath.getParent();
-      return TargetsToBuild.targetGroup(allTargets().get(packagePath));
+      return TargetsToBuild.targetGroup(storage.allTargets().get(packagePath));
     } else {
-      TargetTree targets = allTargets().getSubpackages(workspaceRelativePath);
+      TargetTree targets = storage.allTargets().getSubpackages(workspaceRelativePath);
       if (!targets.isEmpty()) {
         // this will only be non-empty for directories
         return TargetsToBuild.targetGroup(targets);
@@ -520,14 +555,14 @@ public abstract class BuildGraphDataImpl implements BuildGraphData {
   @Override
   public ImmutableSet<QuerySyncLanguage> getTargetLanguages(ImmutableSet<Label> targets) {
     return targets.stream()
-        .map(targetMap()::get)
+        .map(storage.targetMap()::get)
         .map(ProjectTarget::languages)
         .reduce((a, b) -> Sets.union(a, b).immutableCopy())
         .orElse(ImmutableSet.of());
   }
 
   /**
-   * Traversed the dependency graph starting from {@code projectTargets} and returns the first level of dependencies which are either not in
+   * Traverses the dependency graph starting from {@code projectTargets} and returns the first level of dependencies which are either not in
    * the project scope or must be built as they are not directly supported by the IDE.
    */
   @Override
@@ -537,8 +572,8 @@ public abstract class BuildGraphDataImpl implements BuildGraphData {
     final var queue = new ArrayDeque<Label>(projectTargets);
     while (!queue.isEmpty()) {
       final var target = queue.remove();
-      final var targetInfo = targetMap().get(target);
-      if (targetInfo == null || projectDeps().contains(target)) {
+      final var targetInfo = storage.targetMap().get(target);
+      if (targetInfo == null || storage().projectDeps().contains(target)) {
         // External dependency.
         externalDeps.add(target);
         continue;
@@ -551,7 +586,17 @@ public abstract class BuildGraphDataImpl implements BuildGraphData {
     return externalDeps;
   }
 
- /**
+  @Override
+  public int getExternalDependencyCount() {
+    return storage.projectDeps().size();
+  }
+
+  @Override
+  public int getTargetMapSizeForStatsOnly() {
+    return storage.targetMap().size();
+  }
+
+  /**
    * Calculates the {@link RequestedTargets} for a project target.
    *
    * @return Requested targets. The {@link RequestedTargets#buildTargets()} will match the parameter
@@ -562,5 +607,29 @@ public abstract class BuildGraphDataImpl implements BuildGraphData {
  public RequestedTargets computeRequestedTargets(Collection<Label> projectTargets) {
     final var externalDeps = getExternalDependencies(projectTargets);
     return new RequestedTargets(ImmutableSet.copyOf(projectTargets), ImmutableSet.copyOf(externalDeps));
+  }
+
+  @Override
+  public void outputStats(Context<?> context) {
+    context.output(PrintOutput.log("%-10d Source files", storage.sourceFileLabels().size()));
+    context.output(PrintOutput.log("%-10d Java sources", javaSources().size()));
+    context.output(PrintOutput.log("%-10d Packages", packages().size()));
+    context.output(PrintOutput.log("%-10d External dependencies", storage.projectDeps().size()));
+  }
+
+  @Override
+  public ImmutableSet<QuerySyncLanguage> getActiveLanguages() {
+    ImmutableSet.Builder<QuerySyncLanguage> activeLanguages = ImmutableSet.builder();
+    if (storage.targetMap().values().stream().map(ProjectTarget::kind).anyMatch(RuleKinds::isJava)) {
+      activeLanguages.add(QuerySyncLanguage.JVM);
+    }
+    if (storage.targetMap().values().stream().map(ProjectTarget::kind).anyMatch(RuleKinds::isCc)) {
+      activeLanguages.add(QuerySyncLanguage.CC);
+    }
+    return activeLanguages.build();
+  }
+
+  public static Storage.Builder builder() {
+    return Storage.builder();
   }
 }

--- a/querysync/javatests/com/google/idea/blaze/qsync/project/BUILD
+++ b/querysync/javatests/com/google/idea/blaze/qsync/project/BUILD
@@ -4,8 +4,8 @@ load("//:build-visibility.bzl", "DEFAULT_TEST_VISIBILITY")
 package(default_visibility = DEFAULT_TEST_VISIBILITY)
 
 java_test(
-    name = "BuildGraphDataTest",
-    srcs = ["BuildGraphDataTest.java"],
+    name = "BuildGraphDataImplTest",
+    srcs = ["BuildGraphDataImplTest.java"],
     tags = [
         "notap",
     ],

--- a/querysync/javatests/com/google/idea/blaze/qsync/testdata/BuildGraphs.java
+++ b/querysync/javatests/com/google/idea/blaze/qsync/testdata/BuildGraphs.java
@@ -29,7 +29,7 @@ public class BuildGraphs {
 
   private BuildGraphs() {}
 
-  public static BuildGraphData forTestProject(TestData project) throws IOException {
-    return new BlazeQueryParser(getQuerySummary(project), NOOP_CONTEXT, ImmutableSet.of()).parse();
+  public static BuildGraphDataImpl forTestProject(TestData project) throws IOException {
+    return new BlazeQueryParser(getQuerySummary(project), NOOP_CONTEXT, ImmutableSet.of()).parseForTesting();
   }
 }


### PR DESCRIPTION
Cherry pick AOSP commit [3ebf215d7d36b00bf458042525892a7751211f03](https://cs.android.com/android-studio/platform/tools/adt/idea/+/3ebf215d7d36b00bf458042525892a7751211f03).

STAT (diff to AOSP): 25 insertions(+), 32 deletion(-)

Bug: n/a
Test: n/a
Change-Id: I40ea0fcc4fda3680a4248aa836be7a5e050ae675

AOSP: 3ebf215d7d36b00bf458042525892a7751211f03
