### PR TITLE
[AOSP-pick] Modify signature of getBuildInvoker

### DIFF
--- a/aswb/src/com/google/idea/blaze/android/run/binary/mobileinstall/MobileInstallBuildStep.java
+++ b/aswb/src/com/google/idea/blaze/android/run/binary/mobileinstall/MobileInstallBuildStep.java
@@ -152,7 +152,7 @@ public class MobileInstallBuildStep implements ApkBuildStep {
     BuildInvoker invoker =
         Blaze.getBuildSystemProvider(project)
             .getBuildSystem()
-            .getBuildInvoker(project, context, BlazeCommandName.MOBILE_INSTALL);
+            .getBuildInvoker(project, BlazeCommandName.MOBILE_INSTALL);
     BlazeCommand.Builder command = BlazeCommand.builder(invoker, BlazeCommandName.MOBILE_INSTALL);
 
     if (passAdbArgWithSerialToMi.getValue()) {

--- a/aswb/src/com/google/idea/blaze/android/run/runner/BlazeInstrumentationTestApkBuildStep.java
+++ b/aswb/src/com/google/idea/blaze/android/run/runner/BlazeInstrumentationTestApkBuildStep.java
@@ -90,7 +90,7 @@ public class BlazeInstrumentationTestApkBuildStep implements ApkBuildStep {
     BuildInvoker invoker =
         Blaze.getBuildSystemProvider(project)
             .getBuildSystem()
-            .getBuildInvoker(project, context, ImmutableSet.of(BuildInvoker.Capability.IS_LOCAL));
+            .getBuildInvoker(project, ImmutableSet.of(BuildInvoker.Capability.IS_LOCAL));
     BlazeCommand.Builder command = BlazeCommand.builder(invoker, BlazeCommandName.BUILD);
     // TODO(mathewi) we implicitly rely here on the fact that the getBuildInvoker() call above
     //   will always return a local invoker (deployInfoHelper below required that the artifacts

--- a/aswb/src/com/google/idea/blaze/android/run/runner/ExecRootUtil.java
+++ b/aswb/src/com/google/idea/blaze/android/run/runner/ExecRootUtil.java
@@ -33,7 +33,7 @@ public final class ExecRootUtil {
   public static String getExecutionRoot(BuildInvoker invoker, BlazeContext context)
       throws GetArtifactsException {
     try {
-      return invoker.getBlazeInfo().getExecutionRoot().getAbsolutePath();
+      return invoker.getBlazeInfo(context).getExecutionRoot().getAbsolutePath();
     } catch (SyncFailedException e) {
       IssueOutput.error("Could not obtain exec root from blaze info: " + e.getMessage())
           .submit(context);

--- a/aswb/src/com/google/idea/blaze/android/run/runner/FullApkBuildStep.java
+++ b/aswb/src/com/google/idea/blaze/android/run/runner/FullApkBuildStep.java
@@ -174,7 +174,7 @@ public class FullApkBuildStep implements ApkBuildStep {
     }
 
     BuildInvoker invoker =
-        Blaze.getBuildSystemProvider(project).getBuildSystem().getBuildInvoker(project, context);
+        Blaze.getBuildSystemProvider(project).getBuildSystem().getBuildInvoker(project);
     BlazeCommand.Builder command = BlazeCommand.builder(invoker, BlazeCommandName.BUILD);
 
     List<NativeSymbolFinder> nativeSymbolFinderList = getNativeSymbolFinderList();

--- a/aswb/src/com/google/idea/blaze/android/run/test/BlazeAndroidTestLaunchTask.java
+++ b/aswb/src/com/google/idea/blaze/android/run/test/BlazeAndroidTestLaunchTask.java
@@ -150,7 +150,7 @@ public class BlazeAndroidTestLaunchTask implements BlazeLaunchTask {
                           BlazeCommand.builder(
                                   Blaze.getBuildSystemProvider(project)
                                       .getBuildSystem()
-                                      .getBuildInvoker(project, context),
+                                      .getBuildInvoker(project),
                                   BlazeCommandName.TEST)
                               .addTargets(target);
                       // Build flags must match BlazeBeforeRunTask.
@@ -179,7 +179,7 @@ public class BlazeAndroidTestLaunchTask implements BlazeLaunchTask {
                       BuildSystem.BuildInvoker invoker =
                           Blaze.getBuildSystemProvider(project)
                               .getBuildSystem()
-                              .getBuildInvoker(project, context);
+                              .getBuildInvoker(project);
                       try (BuildEventStreamProvider streamProvider =
                           invoker.invoke(commandBuilder, context)) {
                         ExecutionUtils.println(console, commandBuilder.build() + "\n");

--- a/base/src/com/google/idea/blaze/base/bazel/AbstractBuildInvoker.java
+++ b/base/src/com/google/idea/blaze/base/bazel/AbstractBuildInvoker.java
@@ -51,7 +51,6 @@ import javax.annotation.Nullable;
 public abstract class AbstractBuildInvoker implements BuildInvoker {
 
   protected final Project project;
-  private final BlazeContext blazeContext;
   private final BuildBinaryType binaryType;
   private final String binaryPath;
   private final BuildSystem buildSystem;
@@ -61,13 +60,11 @@ public abstract class AbstractBuildInvoker implements BuildInvoker {
 
   public AbstractBuildInvoker(
       Project project,
-      BlazeContext blazeContext,
       BuildBinaryType binaryType,
       String binaryPath,
       BuildSystem buildSystem,
       BlazeCommandRunner commandRunner) {
     this.project = project;
-    this.blazeContext = blazeContext;
     this.binaryType = binaryType;
     this.binaryPath = binaryPath;
     this.buildSystem = buildSystem;
@@ -123,15 +120,15 @@ public abstract class AbstractBuildInvoker implements BuildInvoker {
 
   @Override
   @Nullable
-  public synchronized BlazeInfo getBlazeInfo() throws SyncFailedException {
+  public synchronized BlazeInfo getBlazeInfo(BlazeContext blazeContext) throws SyncFailedException {
     if (blazeInfo == null) {
-      blazeInfo = getBlazeInfoResult();
+      blazeInfo = getBlazeInfoResult(blazeContext);
     }
     return blazeInfo;
   }
 
-  private BlazeInfo getBlazeInfoResult() throws SyncFailedException {
-    ListenableFuture<BlazeInfo> future = runBlazeInfo();
+  private BlazeInfo getBlazeInfoResult(BlazeContext blazeContext) throws SyncFailedException {
+    ListenableFuture<BlazeInfo> future = runBlazeInfo(blazeContext);
     FutureResult<BlazeInfo> result =
         FutureUtil.waitForFuture(blazeContext, future)
             .timed(buildSystem.getName() + "Info", EventType.BlazeInvocation)
@@ -145,7 +142,7 @@ public abstract class AbstractBuildInvoker implements BuildInvoker {
         String.format("Failed to run `%s info`", getBinaryPath()), result.exception());
   }
 
-  private ListenableFuture<BlazeInfo> runBlazeInfo() {
+  private ListenableFuture<BlazeInfo> runBlazeInfo(BlazeContext blazeContext) {
     ProjectViewSet viewSet = ProjectViewManager.getInstance(project).getProjectViewSet();
     if (viewSet == null) {
       // defer the failure until later when it can be handled more easily:

--- a/base/src/com/google/idea/blaze/base/bazel/BazelBuildSystem.java
+++ b/base/src/com/google/idea/blaze/base/bazel/BazelBuildSystem.java
@@ -22,7 +22,6 @@ import com.google.idea.blaze.base.model.primitives.Kind;
 import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
 import com.google.idea.blaze.base.qsync.BazelQueryRunner;
 import com.google.idea.blaze.base.run.ExecutorType;
-import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.settings.BuildBinaryType;
 import com.google.idea.blaze.base.settings.BuildSystemName;
 import com.intellij.openapi.project.Project;
@@ -37,18 +36,18 @@ class BazelBuildSystem implements BuildSystem {
   }
 
   @Override
-  public BuildInvoker getBuildInvoker(Project project, BlazeContext context, Set<BuildInvoker.Capability> requirements) {
-    return new LocalInvoker(project, context, this, BuildBinaryType.BAZEL);
+  public BuildInvoker getBuildInvoker(Project project, Set<BuildInvoker.Capability> requirements) {
+    return new LocalInvoker(project, this, BuildBinaryType.BAZEL);
   }
 
   @Override
-  public BuildInvoker getBuildInvoker(Project project, BlazeContext context, ExecutorType executorType, Kind targetKind) {
-    return getBuildInvoker(project, context);
+  public BuildInvoker getBuildInvoker(Project project, ExecutorType executorType, Kind targetKind) {
+    return getBuildInvoker(project);
   }
 
   @Override
-  public BuildInvoker getBuildInvoker(Project project, BlazeContext context, BlazeCommandName command) {
-    return getBuildInvoker(project, context);
+  public BuildInvoker getBuildInvoker(Project project, BlazeCommandName command) {
+    return getBuildInvoker(project);
   }
 
   @Override

--- a/base/src/com/google/idea/blaze/base/bazel/BuildSystem.java
+++ b/base/src/com/google/idea/blaze/base/bazel/BuildSystem.java
@@ -114,7 +114,7 @@ public interface BuildSystem {
      */
     String getBinaryPath();
 
-    BlazeInfo getBlazeInfo() throws SyncFailedException;
+    BlazeInfo getBlazeInfo(BlazeContext blazeContext) throws SyncFailedException;
 
     /**
      * Create a {@link BuildResultHelper} instance. This instance must be closed when it is finished
@@ -142,20 +142,20 @@ public interface BuildSystem {
   /**
    * Get a Blaze invoker with desired capabilities.
    */
-  BuildInvoker getBuildInvoker(Project project, BlazeContext context, Set<BuildInvoker.Capability> requirements);
+  BuildInvoker getBuildInvoker(Project project, Set<BuildInvoker.Capability> requirements);
 
   /**
    * Get a Blaze invoker.
    */
-  default BuildInvoker getBuildInvoker(Project project, BlazeContext context) {
-    return getBuildInvoker(project, context, ImmutableSet.of());
+  default BuildInvoker getBuildInvoker(Project project) {
+    return getBuildInvoker(project, ImmutableSet.of());
   }
 
   /**
    * Get a Blaze invoker specific to executor type and run config.
    */
   default BuildInvoker getBuildInvoker(
-    Project project, BlazeContext context, ExecutorType executorType, Kind targetKind) {
+    Project project, ExecutorType executorType, Kind targetKind) {
     throw new UnsupportedOperationException(
       String.format(
         "The getBuildInvoker method specific to executor type and target kind is not"
@@ -167,7 +167,7 @@ public interface BuildSystem {
    * Get a Blaze invoker specific to the blaze command.
    */
   default BuildInvoker getBuildInvoker(
-    Project project, BlazeContext context, BlazeCommandName command) {
+    Project project, BlazeCommandName command) {
     throw new UnsupportedOperationException(
       String.format(
         "The getBuildInvoker method specific to a blaze command is not implemented in %s",
@@ -194,12 +194,12 @@ public interface BuildSystem {
    * Returns the parallel invoker if the sync strategy is PARALLEL and the system supports it;
    * otherwise returns the standard invoker.
    */
-  default BuildInvoker getDefaultInvoker(Project project, BlazeContext context) {
+  default BuildInvoker getDefaultInvoker(Project project) {
     if (Blaze.getProjectType(project) != ProjectType.QUERY_SYNC
         && getSyncStrategy(project) == SyncStrategy.PARALLEL) {
-      return getBuildInvoker(project, context, ImmutableSet.of(BuildInvoker.Capability.SUPPORTS_PARALLELISM));
+      return getBuildInvoker(project, ImmutableSet.of(BuildInvoker.Capability.SUPPORTS_PARALLELISM));
     }
-      return getBuildInvoker(project, context);
+    return getBuildInvoker(project);
   }
 
   /**

--- a/base/src/com/google/idea/blaze/base/bazel/BuildSystemProvider.java
+++ b/base/src/com/google/idea/blaze/base/bazel/BuildSystemProvider.java
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.idea.blaze.base.io.FileOperationProvider;
 import com.google.idea.blaze.base.lang.buildfile.language.semantics.RuleDefinition;
 import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
-import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.settings.BuildSystemName;
 import com.intellij.openapi.extensions.ExtensionPointName;
 import com.intellij.openapi.fileTypes.ExactFileNameMatcher;
@@ -88,7 +87,7 @@ public interface BuildSystemProvider {
    */
   @Deprecated
   default String getBinaryPath(Project project) {
-    return getBuildSystem().getBuildInvoker(project, BlazeContext.create()).getBinaryPath();
+    return getBuildSystem().getBuildInvoker(project).getBinaryPath();
   }
 
   /**
@@ -97,7 +96,7 @@ public interface BuildSystemProvider {
    */
   @Deprecated
   default String getSyncBinaryPath(Project project) {
-    return getBuildSystem().getBuildInvoker(project, BlazeContext.create()).getBinaryPath();
+    return getBuildSystem().getBuildInvoker(project).getBinaryPath();
   }
 
   /**

--- a/base/src/com/google/idea/blaze/base/bazel/LocalInvoker.java
+++ b/base/src/com/google/idea/blaze/base/bazel/LocalInvoker.java
@@ -69,10 +69,9 @@ public class LocalInvoker extends AbstractBuildInvoker1 {
 
   public LocalInvoker(
       Project project,
-      BlazeContext blazeContext,
       BuildSystem buildSystem,
       BuildBinaryType binaryType) {
-    super(project, blazeContext, buildSystem, binaryPath(binaryType, project));
+    super(project, buildSystem, binaryPath(binaryType, project));
     this.buildBinaryType = binaryType;
   }
 

--- a/base/src/com/google/idea/blaze/base/build/BlazeBuildService.java
+++ b/base/src/com/google/idea/blaze/base/build/BlazeBuildService.java
@@ -243,7 +243,7 @@ public class BlazeBuildService {
                     SaveUtil.saveAllFiles();
                     BlazeBuildListener.EP_NAME.extensions().forEach(e -> e.buildStarting(project));
 
-                    BuildInvoker buildInvoker = buildSystem.getBuildInvoker(project, context);
+                    BuildInvoker buildInvoker = buildSystem.getBuildInvoker(project);
 
                     ShardedTargetsResult shardedTargets =
                         BlazeBuildTargetSharder.expandAndShardTargets(

--- a/base/src/com/google/idea/blaze/base/command/info/BlazeInfoProvider.java
+++ b/base/src/com/google/idea/blaze/base/command/info/BlazeInfoProvider.java
@@ -86,7 +86,7 @@ public class BlazeInfoProvider {
             }
             BuildSystem.BuildInvoker buildInvoker = Blaze.getBuildSystemProvider(project)
                     .getBuildSystem()
-                    .getDefaultInvoker(project, context);
+                    .getDefaultInvoker(project);
             logger.debug("Running bazel info");
             blazeInfo = BlazeInfoRunner.getInstance().runBlazeInfo(
                     project,

--- a/base/src/com/google/idea/blaze/base/dependencies/BlazeQueryDirectoryToTargetProvider.java
+++ b/base/src/com/google/idea/blaze/base/dependencies/BlazeQueryDirectoryToTargetProvider.java
@@ -98,11 +98,11 @@ public class BlazeQueryDirectoryToTargetProvider implements DirectoryToTargetPro
     BuildSystem buildSystem = Blaze.getBuildSystemProvider(project).getBuildSystem();
     BlazeCommand.Builder command =
         BlazeCommand.builder(
-                buildSystem.getDefaultInvoker(project, context), BlazeCommandName.QUERY, project)
+                buildSystem.getDefaultInvoker(project), BlazeCommandName.QUERY, project)
             .addBlazeFlags("--output=label_kind")
             .addBlazeFlags("--keep_going")
             .addBlazeFlags(query);
-    BuildInvoker invoker = buildSystem.getDefaultInvoker(project, context);
+    BuildInvoker invoker = buildSystem.getDefaultInvoker(project);
     BlazeQueryLabelKindParser outputProcessor = new BlazeQueryLabelKindParser(t -> true);
     try (InputStream queryResultStream = invoker.invokeQuery(command, context)) {
       new BufferedReader(new InputStreamReader(queryResultStream, UTF_8))

--- a/base/src/com/google/idea/blaze/base/dependencies/BlazeQuerySourceToTargetProvider.java
+++ b/base/src/com/google/idea/blaze/base/dependencies/BlazeQuerySourceToTargetProvider.java
@@ -199,7 +199,7 @@ public class BlazeQuerySourceToTargetProvider implements SourceToTargetProvider 
     Path queryFile = prepareQueryFile(project, rdepsQuery);
     BlazeCommand.Builder command =
         getBlazeCommandBuilder(
-            project, type, "--query_file=" + queryFile.toAbsolutePath(), ImmutableList.of("--output=label_kind"), context);
+            project, type, "--query_file=" + queryFile.toAbsolutePath(), ImmutableList.of("--output=label_kind"));
     try (InputStream queryResultStream = runQuery(project, command, context)) {
       BlazeQueryLabelKindParser blazeQueryLabelKindParser =
           new BlazeQueryLabelKindParser(t -> true);
@@ -248,7 +248,7 @@ public class BlazeQuerySourceToTargetProvider implements SourceToTargetProvider 
       Project project, BlazeContext context, ContextType type, String expr)
       throws BlazeQuerySourceToTargetException {
     BlazeCommand.Builder commandBuilder =
-        getBlazeCommandBuilder(project, type, expr, ImmutableList.of("--output=package"), context);
+        getBlazeCommandBuilder(project, type, expr, ImmutableList.of("--output=package"));
 
     try (InputStream queryResultStream = runQuery(project, commandBuilder, context)) {
       return queryResultStream == null
@@ -269,7 +269,7 @@ public class BlazeQuerySourceToTargetProvider implements SourceToTargetProvider 
       throws BuildException {
     return Blaze.getBuildSystemProvider(project)
         .getBuildSystem()
-        .getDefaultInvoker(project, context)
+        .getDefaultInvoker(project)
         .invokeQuery(blazeCommand, context);
   }
 
@@ -277,15 +277,14 @@ public class BlazeQuerySourceToTargetProvider implements SourceToTargetProvider 
       Project project,
       ContextType type,
       String query,
-      List<String> additionalBlazeFlags,
-      BlazeContext context) {
+      List<String> additionalBlazeFlags) {
     // never use a custom output base for queries during sync
     String outputBaseFlag =
         type == ContextType.Sync
             ? null
             : BlazeQueryOutputBaseProvider.getInstance(project).getOutputBaseFlag();
     BuildInvoker buildInvoker =
-        Blaze.getBuildSystemProvider(project).getBuildSystem().getDefaultInvoker(project, context);
+        Blaze.getBuildSystemProvider(project).getBuildSystem().getDefaultInvoker(project);
     return BlazeCommand.builder(buildInvoker, BlazeCommandName.QUERY, project)
         .addBlazeFlags(additionalBlazeFlags)
         .addBlazeFlags("--keep_going")

--- a/base/src/com/google/idea/blaze/base/lang/buildfile/language/semantics/BuildLanguageSpecProviderImpl.java
+++ b/base/src/com/google/idea/blaze/base/lang/buildfile/language/semantics/BuildLanguageSpecProviderImpl.java
@@ -145,7 +145,7 @@ public class BuildLanguageSpecProviderImpl implements BuildLanguageSpecProvider 
 
   private ListenableFuture<BuildLanguageSpec> fetchBuildLanguageSpec(BlazeContext context) {
     BuildInvoker invoker =
-        Blaze.getBuildSystemProvider(project).getBuildSystem().getDefaultInvoker(project, context);
+        Blaze.getBuildSystemProvider(project).getBuildSystem().getDefaultInvoker(project);
     ListenableFuture<byte[]> future =
         BlazeInfoRunner.getInstance()
             .runBlazeInfoGetBytes(
@@ -168,7 +168,7 @@ public class BuildLanguageSpecProviderImpl implements BuildLanguageSpecProvider 
 
   private ListenableFuture<String> fetchBlazeRelease(BlazeContext context) {
     BuildInvoker invoker =
-        Blaze.getBuildSystemProvider(project).getBuildSystem().getDefaultInvoker(project, context);
+        Blaze.getBuildSystemProvider(project).getBuildSystem().getDefaultInvoker(project);
     ListenableFuture<byte[]> future =
         BlazeInfoRunner.getInstance()
             .runBlazeInfoGetBytes(project, invoker, context, ImmutableList.of(), BlazeInfo.RELEASE);

--- a/base/src/com/google/idea/blaze/base/lang/buildfile/sync/BuildLangSyncPlugin.java
+++ b/base/src/com/google/idea/blaze/base/lang/buildfile/sync/BuildLangSyncPlugin.java
@@ -106,7 +106,7 @@ public class BuildLangSyncPlugin implements BlazeSyncPlugin {
       ProjectViewSet projectViewSet,
       BlazeContext context) {
     BuildInvoker invoker =
-        Blaze.getBuildSystemProvider(project).getBuildSystem().getDefaultInvoker(project, context);
+        Blaze.getBuildSystemProvider(project).getBuildSystem().getDefaultInvoker(project);
     try {
       ListenableFuture<byte[]> future =
           BlazeInfoRunner.getInstance()

--- a/base/src/com/google/idea/blaze/base/model/ExternalWorkspaceDataProvider.java
+++ b/base/src/com/google/idea/blaze/base/model/ExternalWorkspaceDataProvider.java
@@ -128,7 +128,7 @@ public class ExternalWorkspaceDataProvider {
       BuildSystem.BuildInvoker buildInvoker =
           Blaze.getBuildSystemProvider(project)
               .getBuildSystem()
-              .getDefaultInvoker(project, context);
+              .getDefaultInvoker(project);
 
       externalWorkspaceData =
           BlazeModRunner.getInstance()

--- a/base/src/com/google/idea/blaze/base/qsync/BazelAppInspectorBuilder.java
+++ b/base/src/com/google/idea/blaze/base/qsync/BazelAppInspectorBuilder.java
@@ -51,7 +51,7 @@ public class BazelAppInspectorBuilder implements AppInspectorBuilder {
   @Override
   public AppInspectorInfo buildAppInspector(BlazeContext context, Label buildTarget)
       throws BuildException {
-    BuildInvoker invoker = buildSystem.getDefaultInvoker(project, context);
+    BuildInvoker invoker = buildSystem.getDefaultInvoker(project);
     ProjectViewSet projectViewSet = ProjectViewManager.getInstance(project).getProjectViewSet();
     List<String> additionalBlazeFlags =
         BlazeFlags.blazeFlags(

--- a/base/src/com/google/idea/blaze/base/qsync/BazelDependencyBuilder.java
+++ b/base/src/com/google/idea/blaze/base/qsync/BazelDependencyBuilder.java
@@ -207,7 +207,7 @@ public class BazelDependencyBuilder implements DependencyBuilder {
       prepareInvocationFiles(
           context, buildDependenciesBazelInvocationInfo.invocationWorkspaceFiles());
 
-      BuildInvoker invoker = buildSystem.getDefaultInvoker(project, context);
+      BuildInvoker invoker = buildSystem.getDefaultInvoker(project);
 
       Optional<BuildDepsStats.Builder> buildDepsStatsBuilder =
           BuildDepsStatsScope.fromContext(context);

--- a/base/src/com/google/idea/blaze/base/qsync/BazelInfoHandler.java
+++ b/base/src/com/google/idea/blaze/base/qsync/BazelInfoHandler.java
@@ -19,6 +19,7 @@ import static com.google.idea.blaze.base.sync.SyncScope.SyncFailedException;
 
 import com.google.idea.blaze.base.bazel.BuildSystem;
 import com.google.idea.blaze.base.command.info.BlazeInfo;
+import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.exception.BuildException;
 
 public class BazelInfoHandler {
@@ -28,10 +29,10 @@ public class BazelInfoHandler {
     this.buildInvoker = buildInvoker;
   }
 
-  public BlazeInfo getBazelInfo() throws BuildException {
+  public BlazeInfo getBazelInfo(BlazeContext context) throws BuildException {
     // TODO: can we cache the results from handlers?
     try {
-      return buildInvoker.getBlazeInfo();
+      return buildInvoker.getBlazeInfo(context);
     } catch (SyncFailedException e) {
       throw new BuildException("Could not get bazel info", e);
     }

--- a/base/src/com/google/idea/blaze/base/qsync/BazelQueryRunner.java
+++ b/base/src/com/google/idea/blaze/base/qsync/BazelQueryRunner.java
@@ -66,9 +66,9 @@ public class BazelQueryRunner implements QueryRunner {
     if (PREFER_REMOTE_QUERIES.getValue()) {
       invoker =
           buildSystem
-              .getBuildInvoker(project, context, ImmutableSet.of(BuildInvoker.Capability.SUPPORTS_API));
+              .getBuildInvoker(project, ImmutableSet.of(BuildInvoker.Capability.SUPPORTS_API));
     } else {
-      invoker = buildSystem.getDefaultInvoker(project, context);
+      invoker = buildSystem.getDefaultInvoker(project);
     }
     Optional<SyncQueryStats.Builder> syncQueryStatsBuilder =
         SyncQueryStatsScope.fromContext(context);

--- a/base/src/com/google/idea/blaze/base/qsync/BazelRenderJarBuilder.java
+++ b/base/src/com/google/idea/blaze/base/qsync/BazelRenderJarBuilder.java
@@ -75,7 +75,7 @@ public class BazelRenderJarBuilder implements RenderJarBuilder {
   @Override
   public RenderJarInfo buildRenderJar(BlazeContext context, Set<Label> buildTargets)
       throws IOException, BuildException {
-    BuildInvoker invoker = buildSystem.getDefaultInvoker(project, context);
+    BuildInvoker invoker = buildSystem.getDefaultInvoker(project);
     ProjectViewSet projectViewSet = ProjectViewManager.getInstance(project).getProjectViewSet();
     List<String> additionalBlazeFlags =
         BlazeFlags.blazeFlags(

--- a/base/src/com/google/idea/blaze/base/qsync/BazelVersionHandler.java
+++ b/base/src/com/google/idea/blaze/base/qsync/BazelVersionHandler.java
@@ -15,10 +15,10 @@
  */
 package com.google.idea.blaze.base.qsync;
 
-import com.google.auto.value.extension.memoized.Memoized;
 import com.google.idea.blaze.base.bazel.BazelVersion;
 import com.google.idea.blaze.base.bazel.BuildSystem;
 import com.google.idea.blaze.base.bazel.BuildSystem.BuildInvoker;
+import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.sync.SyncScope.SyncFailedException;
 import com.google.idea.blaze.exception.BuildException;
 import java.util.Optional;
@@ -36,17 +36,17 @@ public class BazelVersionHandler {
     this.buildInvoker = buildInvoker;
   }
 
-  public Optional<String> getBazelVersionStr() throws BuildException {
+  public Optional<String> getBazelVersionStr(BlazeContext blazeContext) throws BuildException {
     // TODO: can we cache the results from handlers?
     try {
-      return buildSystem.getBazelVersionString(buildInvoker.getBlazeInfo());
+      return buildSystem.getBazelVersionString(buildInvoker.getBlazeInfo(blazeContext));
     } catch (SyncFailedException e) {
       throw new BuildException("Could not get bazel version", e);
     }
   }
 
-  public BazelVersion getBazelVersion() throws BuildException {
-    return getBazelVersionStr()
+  public BazelVersion getBazelVersion(BlazeContext context) throws BuildException {
+    return getBazelVersionStr(context)
         .map(BazelVersion::parseVersion)
         .orElse(BazelVersion.DEVELOPMENT);
   }

--- a/base/src/com/google/idea/blaze/base/qsync/CandidatePackageFinder.java
+++ b/base/src/com/google/idea/blaze/base/qsync/CandidatePackageFinder.java
@@ -43,7 +43,7 @@ public class CandidatePackageFinder {
 
   public static CandidatePackageFinder create(QuerySyncProject project, Project ideProject) {
     BlazeContext context = BlazeContext.create();
-    BuildInvoker invoker = project.getBuildSystem().getBuildInvoker(ideProject, context);
+    BuildInvoker invoker = project.getBuildSystem().getBuildInvoker(ideProject);
     Path workspacePath = WorkspaceRoot.fromProject(ideProject).path();
     return new CandidatePackageFinder(ideProject, invoker, workspacePath, context);
   }

--- a/base/src/com/google/idea/blaze/base/qsync/ProjectLoaderImpl.java
+++ b/base/src/com/google/idea/blaze/base/qsync/ProjectLoaderImpl.java
@@ -233,8 +233,8 @@ public class ProjectLoaderImpl implements ProjectLoader {
     AppInspectorBuilder appInspectorBuilder = createAppInspectorBuilder(buildSystem);
 
     BlazeInfo blazeInfo =
-        new BazelInfoHandler(buildSystem.getBuildInvoker(project, context))
-            .getBazelInfo();
+        new BazelInfoHandler(buildSystem.getBuildInvoker(project))
+            .getBazelInfo(context);
 
     Path ideProjectBasePath = Paths.get(checkNotNull(project.getBasePath()));
     ProjectPath.Resolver projectPathResolver =
@@ -300,17 +300,17 @@ public class ProjectLoaderImpl implements ProjectLoader {
             handledRules);
     QueryRunner queryRunner = createQueryRunner(buildSystem);
     BazelVersionHandler versionHandler =
-        new BazelVersionHandler(buildSystem, buildSystem.getBuildInvoker(project, context));
+        new BazelVersionHandler(buildSystem, buildSystem.getBuildInvoker(project));
     ProjectQuerier projectQuerier =
         createProjectQuerier(
             projectRefresher,
             queryRunner,
             vcsHandler,
-            new BazelVersionHandler(buildSystem, buildSystem.getBuildInvoker(project, context)));
+            new BazelVersionHandler(buildSystem, buildSystem.getBuildInvoker(project)));
     QuerySyncSourceToTargetMap sourceToTargetMap =
         new QuerySyncSourceToTargetMap(graph, workspaceRoot.path());
     ExternalWorkspaceData externalWorkspaceData = ExternalWorkspaceDataProvider.getInstance(project)
-        .getExternalWorkspaceData(context, projectViewSet, versionHandler.getBazelVersion(), blazeInfo);
+        .getExternalWorkspaceData(context, projectViewSet, versionHandler.getBazelVersion(context), blazeInfo);
     return new QuerySyncProjectDeps(importSettings, workspaceRoot, new WorkspacePathResolverImpl(workspaceRoot), projectViewSet, buildSystem,
                                     workspaceLanguageSettings, latestProjectDef, snapshotFilePath, projectPathResolver, projectTransformRegistry,
                                     graph, artifactCache, artifactTracker, renderJarArtifactTracker, appInspectorArtifactTracker,

--- a/base/src/com/google/idea/blaze/base/qsync/ProjectQuerierImpl.java
+++ b/base/src/com/google/idea/blaze/base/qsync/ProjectQuerierImpl.java
@@ -80,7 +80,7 @@ public class ProjectQuerierImpl implements ProjectQuerier {
 
     RefreshOperation fullQuery =
         projectRefresher.startFullUpdate(
-            context, projectDef, vcsState, bazelVersionProvider.getBazelVersionStr());
+            context, projectDef, vcsState, bazelVersionProvider.getBazelVersionStr(context));
 
     QuerySpec querySpec = fullQuery.getQuerySpec().get();
     return fullQuery.createPostQuerySyncData(queryRunner.runQuery(querySpec, context));
@@ -134,7 +134,7 @@ public class ProjectQuerierImpl implements ProjectQuerier {
 
     Optional<String> bazelVersion = Optional.empty();
     try {
-      bazelVersion = bazelVersionProvider.getBazelVersionStr();
+      bazelVersion = bazelVersionProvider.getBazelVersionStr(context);
     } catch (BuildException e) {
       context.handleExceptionAsWarning("Could not get bazel version", e);
     }

--- a/base/src/com/google/idea/blaze/base/run/BlazeBeforeRunCommandHelper.java
+++ b/base/src/com/google/idea/blaze/base/run/BlazeBeforeRunCommandHelper.java
@@ -147,7 +147,7 @@ public final class BlazeBeforeRunCommandHelper {
                 BuildSystem.BuildInvoker invoker =
                     Blaze.getBuildSystemProvider(project)
                         .getBuildSystem()
-                        .getDefaultInvoker(project, context);
+                        .getDefaultInvoker(project);
                 try {
                   return invoker.invoke(command, context);
                 } catch (BuildException e) {

--- a/base/src/com/google/idea/blaze/base/run/confighandler/BlazeCommandGenericRunConfigurationRunner.java
+++ b/base/src/com/google/idea/blaze/base/run/confighandler/BlazeCommandGenericRunConfigurationRunner.java
@@ -149,8 +149,7 @@ public final class BlazeCommandGenericRunConfigurationRunner
       assert projectViewSet != null;
       BlazeContext context = BlazeContext.create();
       BuildInvoker invoker =
-          Blaze.getBuildSystemProvider(project).getBuildSystem().getBuildInvoker(project, context);
-      WorkspaceRoot workspaceRoot = WorkspaceRoot.fromImportSettings(importSettings);
+          Blaze.getBuildSystemProvider(project).getBuildSystem().getBuildInvoker(project);
       BlazeCommand.Builder blazeCommand =
           getBlazeCommand(
               project,
@@ -159,8 +158,8 @@ public final class BlazeCommandGenericRunConfigurationRunner
               ImmutableList.of(),
               context);
       return isTest()
-          ? getProcessHandlerForTests(project, invoker, blazeCommand, workspaceRoot, context)
-          : getProcessHandlerForNonTests(project, invoker, blazeCommand, workspaceRoot, context);
+          ? getProcessHandlerForTests(project, invoker, blazeCommand, context)
+          : getProcessHandlerForNonTests(project, invoker, blazeCommand, context);
     }
 
     private ProcessHandler getGenericProcessHandler() {
@@ -192,7 +191,6 @@ public final class BlazeCommandGenericRunConfigurationRunner
         Project project,
         BuildInvoker invoker,
         BlazeCommand.Builder blazeCommandBuilder,
-        WorkspaceRoot workspaceRoot,
         BlazeContext context)
         throws ExecutionException {
       ProcessHandler processHandler = getGenericProcessHandler();
@@ -250,7 +248,6 @@ public final class BlazeCommandGenericRunConfigurationRunner
         Project project,
         BuildInvoker invoker,
         BlazeCommand.Builder blazeCommandBuilder,
-        WorkspaceRoot workspaceRoot,
         BlazeContext context) {
       BlazeTestResultFinderStrategy testResultFinderStrategy = new BlazeTestResultHolder();
       BlazeTestUiSession testUiSession = null;

--- a/base/src/com/google/idea/blaze/base/sync/BuildPhaseSyncTask.java
+++ b/base/src/com/google/idea/blaze/base/sync/BuildPhaseSyncTask.java
@@ -194,7 +194,7 @@ public final class BuildPhaseSyncTask {
     buildStats.setTargets(targets);
     notifyBuildStarted(context, syncParams.addProjectViewTargets(), ImmutableList.copyOf(targets));
 
-    BuildInvoker defaultInvoker = buildSystem.getDefaultInvoker(project, context);
+    BuildInvoker defaultInvoker = buildSystem.getDefaultInvoker(project);
 
     ShardedTargetsResult shardedTargetsResult =
         BlazeBuildTargetSharder.expandAndShardTargets(
@@ -240,7 +240,7 @@ public final class BuildPhaseSyncTask {
 
     BuildInvoker syncBuildInvoker =
         parallel
-            ? buildSystem.getBuildInvoker(project, context, ImmutableSet.of(BuildInvoker.Capability.SUPPORTS_PARALLELISM))
+            ? buildSystem.getBuildInvoker(project, ImmutableSet.of(BuildInvoker.Capability.SUPPORTS_PARALLELISM))
             : defaultInvoker;
     final BlazercMigrator blazercMigrator = new BlazercMigrator(project);
     if (!syncBuildInvoker.getCapabilities().contains(BuildInvoker.Capability.SUPPORTS_CLI)
@@ -250,7 +250,7 @@ public final class BuildPhaseSyncTask {
       ApplicationManager.getApplication()
           .invokeAndWait(() -> blazercMigrator.promptAndMigrate(context));
     }
-    resultBuilder.setBlazeInfo(syncBuildInvoker.getBlazeInfo());
+    resultBuilder.setBlazeInfo(syncBuildInvoker.getBlazeInfo(context));
 
     buildStats
         .setSyncSharded(shardedTargets.shardCount() > 1)

--- a/base/src/com/google/idea/blaze/base/sync/ProjectStateSyncTask.java
+++ b/base/src/com/google/idea/blaze/base/sync/ProjectStateSyncTask.java
@@ -214,8 +214,7 @@ final class ProjectStateSyncTask {
                      project,
                      Blaze.getBuildSystemProvider(project)
                          .getBuildSystem()
-                         .getDefaultInvoker(project,
-                             context),
+                         .getDefaultInvoker(project),
                      context,
                      importSettings.getBuildSystem(),
                      syncFlags);

--- a/base/tests/unittests/com/google/idea/blaze/base/sync/sharding/BlazeBuildTargetSharderTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/sync/sharding/BlazeBuildTargetSharderTest.java
@@ -530,7 +530,7 @@ public class BlazeBuildTargetSharderTest extends BlazeTestCase {
 
     @Override
     @Nullable
-    public BlazeInfo getBlazeInfo() {
+    public BlazeInfo getBlazeInfo(BlazeContext blazeContext) {
       return null;
     }
 

--- a/base/tests/utils/unit/com/google/idea/blaze/base/bazel/BuildSystemProviderWrapper.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/bazel/BuildSystemProviderWrapper.java
@@ -236,11 +236,11 @@ public class BuildSystemProviderWrapper implements BuildSystemProvider {
     }
 
     @Override
-    public BlazeInfo getBlazeInfo() throws SyncFailedException {
+    public BlazeInfo getBlazeInfo(BlazeContext blazeContext) throws SyncFailedException {
       if (throwExceptionOnGetBlazeInfo) {
         throw new SyncFailedException();
       }
-      return inner.getBlazeInfo();
+      return inner.getBlazeInfo(blazeContext);
     }
 
     @Override
@@ -275,19 +275,19 @@ public class BuildSystemProviderWrapper implements BuildSystemProvider {
 
     @Override
     public BuildInvoker getBuildInvoker(
-        Project project, BlazeContext context, Set<BuildInvoker.Capability> requirements) {
-      return new BuildInvokerWrapper(inner.getBuildInvoker(project, context, requirements));
+        Project project, Set<BuildInvoker.Capability> requirements) {
+      return new BuildInvokerWrapper(inner.getBuildInvoker(project, requirements));
     }
 
     @Override
-    public BuildInvoker getBuildInvoker(Project project, BlazeContext context) {
-      return new BuildInvokerWrapper(inner.getBuildInvoker(project, context));
+    public BuildInvoker getBuildInvoker(Project project) {
+      return new BuildInvokerWrapper(inner.getBuildInvoker(project));
     }
 
     @Override
     public BuildInvoker getBuildInvoker(
-        Project project, BlazeContext context, BlazeCommandName command) {
-      return new BuildInvokerWrapper(inner.getBuildInvoker(project, context));
+        Project project, BlazeCommandName command) {
+      return new BuildInvokerWrapper(inner.getBuildInvoker(project));
     }
 
     @Override

--- a/base/tests/utils/unit/com/google/idea/blaze/base/bazel/FakeBuildInvoker.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/bazel/FakeBuildInvoker.java
@@ -70,7 +70,9 @@ public abstract class FakeBuildInvoker implements BuildInvoker {
 
   @Override
   @Nullable
-  public abstract BlazeInfo getBlazeInfo();
+  public BlazeInfo getBlazeInfo(BlazeContext blazeContext) {
+    return null;
+  }
 
   @Override
   @MustBeClosed
@@ -144,8 +146,6 @@ public abstract class FakeBuildInvoker implements BuildInvoker {
     public abstract Builder type(BuildBinaryType type);
 
     public abstract Builder binaryPath(String binaryPath);
-
-    public abstract Builder blazeInfo(BlazeInfo blazeInfo);
 
     public abstract Builder buildResultHelperSupplier(Supplier<BuildResultHelper> supplier);
 

--- a/base/tests/utils/unit/com/google/idea/blaze/base/bazel/FakeBuildSystem.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/bazel/FakeBuildSystem.java
@@ -20,7 +20,6 @@ import com.google.idea.blaze.base.command.info.BlazeInfo;
 import com.google.idea.blaze.base.model.BlazeVersionData;
 import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
 import com.google.idea.blaze.base.qsync.BazelQueryRunner;
-import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.settings.BuildSystemName;
 import com.intellij.openapi.project.Project;
 import java.util.Optional;
@@ -50,7 +49,7 @@ public abstract class FakeBuildSystem implements BuildSystem {
   abstract BuildInvoker getBuildInvoker();
 
   @Override
-  public BuildInvoker getBuildInvoker(Project project, BlazeContext context, Set<BuildInvoker.Capability> requirements) {
+  public BuildInvoker getBuildInvoker(Project project, Set<BuildInvoker.Capability> requirements) {
     return getBuildInvoker();
   }
   @Override

--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrLauncher.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrLauncher.java
@@ -114,7 +114,7 @@ public final class BlazeCidrLauncher extends CidrLauncher {
     ImmutableList<String> testHandlerFlags = ImmutableList.of();
     BlazeContext context = BlazeContext.create();
     BuildInvoker invoker =
-        Blaze.getBuildSystemProvider(project).getBuildSystem().getBuildInvoker(project, context);
+        Blaze.getBuildSystemProvider(project).getBuildSystem().getBuildInvoker(project);
     BlazeTestUiSession testUiSession = null;
     if (useTestUi()
         && BlazeTestEventsHandler.targetsSupported(project, configuration.getTargets())) {

--- a/cpp/src/com/google/idea/blaze/cpp/XcodeCompilerSettingsProviderImpl.java
+++ b/cpp/src/com/google/idea/blaze/cpp/XcodeCompilerSettingsProviderImpl.java
@@ -62,7 +62,7 @@ public class XcodeCompilerSettingsProviderImpl implements XcodeCompilerSettingsP
       throws XcodeCompilerSettingsException {
     WorkspaceRoot workspaceRoot = WorkspaceRoot.fromProject(project);
     BuildSystem.BuildInvoker invoker =
-        Blaze.getBuildSystemProvider(project).getBuildSystem().getBuildInvoker(project, context);
+        Blaze.getBuildSystemProvider(project).getBuildSystem().getBuildInvoker(project);
 
     Optional<XcodeAndSdkVersions> xcodeAndSdkVersions = XcodeCompilerSettingsProviderImpl.queryXcodeAndSdkVersions(
         context, 

--- a/gazelle/src/com/google/idea/blaze/gazelle/GazelleSyncListener.java
+++ b/gazelle/src/com/google/idea/blaze/gazelle/GazelleSyncListener.java
@@ -84,7 +84,7 @@ public class GazelleSyncListener implements SyncListener {
       Collection<WorkspacePath> importantDirectories,
       List<String> blazeFlags) {
     BuildSystem.BuildInvoker invoker =
-        Blaze.getBuildSystemProvider(project).getBuildSystem().getBuildInvoker(project, context);
+        Blaze.getBuildSystemProvider(project).getBuildSystem().getBuildInvoker(project);
 
     return GazelleRunner.getInstance()
         .runBlazeGazelle(

--- a/java/src/com/google/idea/blaze/java/fastbuild/FastBuildServiceImpl.java
+++ b/java/src/com/google/idea/blaze/java/fastbuild/FastBuildServiceImpl.java
@@ -397,7 +397,7 @@ final class FastBuildServiceImpl implements FastBuildService, ProjectComponent {
                 project,
                 Blaze.getBuildSystemProvider(project)
                     .getBuildSystem()
-                    .getDefaultInvoker(project, context),
+                    .getDefaultInvoker(project),
                 context,
                 buildSystemName,
                 buildParameters.infoFlags());

--- a/java/src/com/google/idea/blaze/java/run/BlazeJavaRunProfileState.java
+++ b/java/src/com/google/idea/blaze/java/run/BlazeJavaRunProfileState.java
@@ -119,7 +119,7 @@ public final class BlazeJavaRunProfileState extends BlazeJavaDebuggableRunProfil
       Blaze.getBuildSystemProvider(project)
         .getBuildSystem()
         .getBuildInvoker(
-          project, context, getExecutorType(), getConfiguration().getTargetKind());
+          project, getExecutorType(), getConfiguration().getTargetKind());
     boolean debuggingLocalTest =
       TargetKindUtil.isLocalTest(getConfiguration().getTargetKind())
       && getExecutorType().isDebugType();

--- a/java/src/com/google/idea/blaze/java/run/coverage/BlazeCoverageProgramRunner.java
+++ b/java/src/com/google/idea/blaze/java/run/coverage/BlazeCoverageProgramRunner.java
@@ -107,7 +107,7 @@ public class BlazeCoverageProgramRunner extends DefaultProgramRunner {
                         project,
                         Blaze.getBuildSystemProvider(project)
                             .getBuildSystem()
-                            .getDefaultInvoker(project, context),
+                            .getDefaultInvoker(project),
                         context,
                         buildSystemName,
                         infoFlags));

--- a/plugin_dev/src/com/google/idea/blaze/plugin/run/BuildPluginBeforeRunTaskProvider.java
+++ b/plugin_dev/src/com/google/idea/blaze/plugin/run/BuildPluginBeforeRunTaskProvider.java
@@ -201,7 +201,7 @@ public final class BuildPluginBeforeRunTaskProvider
                   BuildInvoker invoker =
                       Blaze.getBuildSystemProvider(project)
                           .getBuildSystem()
-                          .getBuildInvoker(project, context);
+                          .getBuildInvoker(project);
                   try (BuildResultHelper buildResultHelper = invoker.createBuildResultHelper()) {
                     BlazeCommand.Builder command =
                         BlazeCommand.builder(invoker, BlazeCommandName.BUILD, project)


### PR DESCRIPTION
Cherry pick AOSP commit [966bffc99504e46a876cbfb2a99271e055db90f3](https://cs.android.com/android-studio/platform/tools/adt/idea/+/966bffc99504e46a876cbfb2a99271e055db90f3).

STAT (diff to AOSP): 76 insertions(+), 12 deletion(-)

The context passed while creating a BuildInvoker object is no longer
used by the invoker since the new methods to invoke blaze/bazel are in
place. This change removes this unused context parameter.

As a result, the context needs to be passed to getBlazeInfo method,
which also makes it consistent with other methods that invoke blaze and
bazel.

Bug:374906681

Test: Existing tests
Change-Id: Ia7bcf7e012bdcffdba747fa78b58766101dd5b19

AOSP: 966bffc99504e46a876cbfb2a99271e055db90f3
