### PR TITLE
[AOSP-pick] Migrate getSdkManager() to getRepoManager()

### DIFF
--- a/aswb/src/com/google/idea/blaze/android/sdk/BlazeSdkProviderImpl.java
+++ b/aswb/src/com/google/idea/blaze/android/sdk/BlazeSdkProviderImpl.java
@@ -45,7 +45,7 @@ public class BlazeSdkProviderImpl implements BlazeSdkProvider {
     // If so, trigger the construction of an SDK
     ProgressIndicator progress =
         new StudioLoggerProgressIndicator(BlazeSdkProviderImpl.class);
-    androidSdks.tryToChooseSdkHandler().getSdkManager(progress).reloadLocalIfNeeded(progress);
+    androidSdks.tryToChooseSdkHandler().getRepoManager(progress).reloadLocalIfNeeded(progress);
 
     return UIUtil.invokeAndWaitIfNeeded(
         () -> androidSdks.tryToCreate(IdeSdks.getInstance().getAndroidSdkPath(), targetHash));


### PR DESCRIPTION
Cherry pick AOSP commit [3e44a7cc182d0d19ba8167bb938d7265b7f1a2c9](https://cs.android.com/android-studio/platform/tools/adt/idea/+/3e44a7cc182d0d19ba8167bb938d7265b7f1a2c9).

STAT (diff to AOSP): 0 insertions(+), 0 deletion(-)

Or to getRepoManagerAndLoadSynchronously(), if needed.

Bug: 339641500
Test: n/a
Change-Id: I382078a3fb5b7b0524e4302c84ae656964dc9061

AOSP: 3e44a7cc182d0d19ba8167bb938d7265b7f1a2c9
