### PR TITLE
[AOSP-pick] Enable Kotlin in unit tests

### DIFF
--- a/testing/test_defs.bzl
+++ b/testing/test_defs.bzl
@@ -95,7 +95,12 @@ _generate_test_suite = rule(
 def intellij_unit_test_suite(
         name,
         srcs,
+        deps,
         test_package_root,
+        runtime_deps = [],
+        args = [],
+        friends = [],
+        target_compatible_with = None,
         class_rules = [],
         size = "medium",
         tags = [],
@@ -138,14 +143,27 @@ def intellij_unit_test_suite(
         class_rules = class_rules,
         tags = tags,
     )
+    kt_jvm_library(
+        name = name + ".testlib",
+        srcs = srcs + [suite_class_name],
+        deps = deps,
+        target_compatible_with = target_compatible_with,
+        testonly = 1,
+        #        stdlib = "//testing:lib",
+    )
+
+    # NOTE: Do not replace with `kotlin_test` as it orders classpath in a way
+    #       that puts test dependencies first. Integration tests need plugin
+    #       `'jars` coming first.
     java_test(
         name = name,
         size = size,
-        srcs = srcs + [suite_class_name],
         data = data,
+        tags = tags,
+        args = args,
         jvm_flags = jvm_flags,
         test_class = suite_class,
-        tags = tags,
+        runtime_deps = runtime_deps + [name + ".testlib"],
         **kwargs
     )
 
@@ -266,6 +284,7 @@ def intellij_integration_test_suite(
         jvm_flags = jvm_flags,
         test_class = suite_class,
         runtime_deps = runtime_deps + [name + ".testlib"],
+        target_compatible_with = target_compatible_with,
         **kwargs
     )
 


### PR DESCRIPTION
Cherry pick AOSP commit [7d04735a428ca8515bdaca3f7da08e002e02bcac](https://cs.android.com/android-studio/platform/tools/adt/idea/+/7d04735a428ca8515bdaca3f7da08e002e02bcac).

STAT (diff to AOSP): 1 insertions(+), 4 deletion(-)

similarly to how Koltin works in integration tests

Bug: n/a
Test: n/a
Change-Id: Iaf9854dbf4988eae6a6f18286720f13c74cd3cbe

AOSP: 7d04735a428ca8515bdaca3f7da08e002e02bcac
