### PR TITLE
[AOSP-pick] Return NO_STATUS test result if no tests were run

### DIFF
--- a/base/src/com/google/idea/blaze/base/command/buildresult/BuildEventProtocolOutputReader.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/BuildEventProtocolOutputReader.java
@@ -29,10 +29,6 @@ import com.google.idea.blaze.base.run.testlogs.BlazeTestResult;
 import com.google.idea.blaze.base.run.testlogs.BlazeTestResult.TestStatus;
 import com.google.idea.blaze.base.run.testlogs.BlazeTestResults;
 import com.google.idea.blaze.common.artifact.OutputArtifact;
-import com.intellij.util.io.URLUtil;
-import java.io.File;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -82,6 +78,19 @@ public final class BuildEventProtocolOutputReader {
                   labelToKind.get(label),
                   event.getTestResult(),
                   startTimeMillis));
+          continue;
+        case ACTION_COMPLETED:
+          label = event.getId().getActionCompleted().getLabel();
+          // If no test result is available after action_completed event,
+          // add a NO_STATUS test result.
+          if (results.build().isEmpty()) {
+            results.add(
+              parseTestResult(
+                label,
+                labelToKind.get(label),
+                event.getTestResult(),
+                startTimeMillis));
+          }
           continue;
         default: // continue
       }


### PR DESCRIPTION
Cherry pick AOSP commit [a3305d03303e897f3f00f6dd7e4578d04fedce81](https://cs.android.com/android-studio/platform/tools/adt/idea/+/a3305d03303e897f3f00f6dd7e4578d04fedce81).

STAT (diff to AOSP): 0 insertions(+), 0 deletion(-)

The BES does not send a TEST_RESULT event if the tests were not run (for
reasons such as build failures). Consequently, ASwB displays an
incorrect `All tests passed` message to the user.

This change isn't ideal, but works towards fixing this by adding a
`NO_STATUS` test result while parsing the BEP.

Bug: 400687547
Test: n/a

Change-Id: Ie2b694506515e80df6b3bcc4d33b1f3d5e7f8a5e

AOSP: a3305d03303e897f3f00f6dd7e4578d04fedce81
