### PR TITLE
[AOSP-pick] Skip throwing UnsupportedOperationException to avoid crash

### DIFF
--- a/aswb/src/com/android/tools/idea/rendering/tokens/BazelBuildSystemFilePreviewServices.java
+++ b/aswb/src/com/android/tools/idea/rendering/tokens/BazelBuildSystemFilePreviewServices.java
@@ -67,9 +67,7 @@ public class BazelBuildSystemFilePreviewServices
 
   @Override
   public void subscribeBuildListener(Project project,
-                                     Disposable parentDisposable, BuildListener listener) {
-    throw new UnsupportedOperationException();
-  }
+                                     Disposable parentDisposable, BuildListener listener) {}
 
   @Override
   public BuildTargets getBuildTargets() {


### PR DESCRIPTION
Cherry pick AOSP commit [1260875b8b38a76ccb436c819d791bbd317b686e](https://cs.android.com/android-studio/platform/tools/adt/idea/+/1260875b8b38a76ccb436c819d791bbd317b686e).

STAT (diff to AOSP): 0 insertions(+), 0 deletion(-)

Bug: 400656413
Test: Existing
Change-Id: I61df7c7bb4d2f2d3c2557e2e7643c817bd964cc3

AOSP: 1260875b8b38a76ccb436c819d791bbd317b686e
