### PR TITLE
[AOSP-pick] Migrate querysync library to aswb_library rule

### DIFF
--- a/querysync/java/com/google/idea/blaze/qsync/BUILD.bazel
+++ b/querysync/java/com/google/idea/blaze/qsync/BUILD.bazel
@@ -1,4 +1,6 @@
-java_library(
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
+
+kt_jvm_library(
     name = "qsync",
     srcs = glob(["*.java"]),
     visibility = [

--- a/querysync/java/com/google/idea/blaze/qsync/GraphToProjectConverter.java
+++ b/querysync/java/com/google/idea/blaze/qsync/GraphToProjectConverter.java
@@ -583,6 +583,7 @@ public class GraphToProjectConverter {
     Set<Path> directories = new HashSet<>();
     for (var sourceFile : sourceFiles) {
       if (sourceFile.getName().toString().endsWith(".xml")) {
+        @SuppressWarnings("PathAsIterable")
         List<Path> pathParts = Lists.newArrayList(sourceFile.getName());
         int resPos = pathParts.indexOf(Path.of("res"));
         if (resPos >= 0) {

--- a/querysync/java/com/google/idea/blaze/qsync/artifacts/BUILD
+++ b/querysync/java/com/google/idea/blaze/qsync/artifacts/BUILD
@@ -1,6 +1,6 @@
-load("@rules_java//java:defs.bzl", "java_library")
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
-java_library(
+kt_jvm_library(
     name = "artifacts",
     srcs = glob(["*.java"]),
     visibility = [

--- a/querysync/java/com/google/idea/blaze/qsync/cc/BUILD
+++ b/querysync/java/com/google/idea/blaze/qsync/cc/BUILD
@@ -1,13 +1,13 @@
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 load("@protobuf//bazel:java_proto_library.bzl", "java_proto_library")
 load("@protobuf//bazel:proto_library.bzl", "proto_library")
-load("@rules_java//java:defs.bzl", "java_library")
 
 package(default_visibility = [
     "//querysync:__subpackages__",
     "//javatests/com/google/devtools/intellij/blaze/plugin/aswb:__pkg__",
 ])
 
-java_library(
+kt_jvm_library(
     name = "cc",
     srcs = glob(["*.java"]),
     deps = [

--- a/querysync/java/com/google/idea/blaze/qsync/deps/BUILD
+++ b/querysync/java/com/google/idea/blaze/qsync/deps/BUILD
@@ -1,8 +1,8 @@
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 load("@protobuf//bazel:java_proto_library.bzl", "java_proto_library")
 load("@protobuf//bazel:proto_library.bzl", "proto_library")
-load("@rules_java//java:defs.bzl", "java_library")
 
-java_library(
+kt_jvm_library(
     name = "deps",
     srcs = glob(["*.java"]),
     visibility = [

--- a/querysync/java/com/google/idea/blaze/qsync/deps/NewArtifactTracker.java
+++ b/querysync/java/com/google/idea/blaze/qsync/deps/NewArtifactTracker.java
@@ -60,6 +60,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -257,7 +258,7 @@ public class NewArtifactTracker<C extends Context<C>> implements ArtifactTracker
     if (!failures.isEmpty()) {
       BuildException e =
           new BuildException(
-              String.format("Failed to extract metadata from %d artifacts", failures.size()));
+              String.format(Locale.ROOT, "Failed to extract metadata from %d artifacts", failures.size()));
       failures.forEach(e::addSuppressed);
       throw e;
     }

--- a/querysync/java/com/google/idea/blaze/qsync/java/AddProjectGenSrcs.java
+++ b/querysync/java/com/google/idea/blaze/qsync/java/AddProjectGenSrcs.java
@@ -45,6 +45,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 
 /**
@@ -230,9 +231,9 @@ public class AddProjectGenSrcs implements ProjectProtoUpdateOperation {
         ImmutableList.of(ChronoUnit.DAYS, ChronoUnit.HOURS, ChronoUnit.MINUTES)) {
       long durationInUnits = p.getSeconds() / unit.getDuration().getSeconds();
       if (durationInUnits > 0) {
-        return String.format("%d %s", durationInUnits, unit);
+        return String.format(Locale.ROOT, "%d %s", durationInUnits, unit);
       }
     }
-    return String.format("%d seconds", p.getSeconds());
+    return String.format(Locale.ROOT, "%d seconds", p.getSeconds());
   }
 }

--- a/querysync/java/com/google/idea/blaze/qsync/java/BUILD
+++ b/querysync/java/com/google/idea/blaze/qsync/java/BUILD
@@ -1,6 +1,6 @@
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 load("@protobuf//bazel:java_proto_library.bzl", "java_proto_library")
 load("@protobuf//bazel:proto_library.bzl", "proto_library")
-load("@rules_java//java:defs.bzl", "java_library")
 
 package(default_visibility = [
     "//querysync:__subpackages__",
@@ -23,7 +23,7 @@ java_proto_library(
     deps = [":java_target_info"],
 )
 
-java_library(
+kt_jvm_library(
     name = "java",
     srcs = glob(["*.java"]),
     deps = [

--- a/querysync/java/com/google/idea/blaze/qsync/project/BUILD
+++ b/querysync/java/com/google/idea/blaze/qsync/project/BUILD
@@ -1,6 +1,6 @@
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 load("@protobuf//bazel:java_proto_library.bzl", "java_proto_library")
 load("@protobuf//bazel:proto_library.bzl", "proto_library")
-load("@rules_java//java:defs.bzl", "java_library")
 
 package(default_visibility = [
     "//querysync:__subpackages__",
@@ -55,7 +55,7 @@ java_proto_library(
     deps = [":snapshot_proto"],
 )
 
-java_library(
+kt_jvm_library(
     name = "project",
     srcs = glob(["*.java"]),
     deps = [

--- a/querysync/java/com/google/idea/blaze/qsync/project/BuildGraphData.java
+++ b/querysync/java/com/google/idea/blaze/qsync/project/BuildGraphData.java
@@ -32,7 +32,7 @@ import java.util.Set;
 import javax.annotation.Nullable;
 
 public interface BuildGraphData {
-  @VisibleForTesting BuildGraphData EMPTY = BuildGraphDataImpl.builder().projectDeps(ImmutableSet.of()).build();
+  BuildGraphData EMPTY = BuildGraphDataImpl.builder().projectDeps(ImmutableSet.of()).build();
 
   /**
    * The language classes supported by the query sync.

--- a/querysync/java/com/google/idea/blaze/qsync/project/PostQuerySyncData.java
+++ b/querysync/java/com/google/idea/blaze/qsync/project/PostQuerySyncData.java
@@ -34,7 +34,6 @@ import java.util.Optional;
 @AutoValue
 public abstract class PostQuerySyncData {
 
-  @VisibleForTesting
   public static final PostQuerySyncData EMPTY =
       builder()
           .setProjectDefinition(ProjectDefinition.EMPTY)
@@ -59,7 +58,6 @@ public abstract class PostQuerySyncData {
     return new AutoValue_PostQuerySyncData.Builder();
   }
 
-  @VisibleForTesting
   public abstract Builder toBuilder();
 
   /** Builder for {@link PostQuerySyncData}. */

--- a/querysync/java/com/google/idea/blaze/qsync/query/BUILD
+++ b/querysync/java/com/google/idea/blaze/qsync/query/BUILD
@@ -1,6 +1,6 @@
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 load("@protobuf//bazel:java_proto_library.bzl", "java_proto_library")
 load("@protobuf//bazel:proto_library.bzl", "proto_library")
-load("@rules_java//java:defs.bzl", "java_library")
 
 package(default_visibility = [
     "//querysync:__subpackages__",
@@ -18,7 +18,7 @@ java_proto_library(
     deps = [":querysummary"],
 )
 
-java_library(
+kt_jvm_library(
     name = "query",
     srcs = glob(["*.java"]),
     deps = [


### PR DESCRIPTION
Cherry pick AOSP commit [2b5c5154eeedf6b301ff955c37a564bd71b049e6](https://cs.android.com/android-studio/platform/tools/adt/idea/+/2b5c5154eeedf6b301ff955c37a564bd71b049e6).

STAT (diff to AOSP): 13 insertions(+), 2 deletion(-)

and this way enable Kotlin usage in the `querysync` library.

Also, fix issues detected by Android lint.

Bug: n/a
Test: n/a
Change-Id: I81544bdd6ff64da091b2e98c026cee41328d24f6

AOSP: 2b5c5154eeedf6b301ff955c37a564bd71b049e6
