### PR TITLE
[AOSP-pick] Provides libraries via extension point instead of library table

### DIFF
--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -737,6 +737,8 @@
   </projectListeners>
 
   <extensions defaultExtensionNs="com.intellij">
+    <orderEnumerationHandlerFactory implementation="com.google.idea.blaze.base.qsync.QuerySyncBazelOrderEnumeratorHandler$FactoryImpl"/>
+    <additionalLibraryRootsProvider implementation="com.google.idea.blaze.base.qsync.QuerySyncBazelAdditionalLibraryRootsProvider"/>
     <indexedRootsProvider implementation="com.google.idea.blaze.base.project.indexing.WarmUpTriggeringIndexableSetContributor" />
   </extensions>
 

--- a/base/src/com/google/idea/blaze/base/qsync/ProjectLoaderImpl.java
+++ b/base/src/com/google/idea/blaze/base/qsync/ProjectLoaderImpl.java
@@ -264,7 +264,8 @@ public class ProjectLoaderImpl implements ProjectLoader {
         new DependenciesProjectProtoUpdater(
             latestProjectDef,
             projectPathResolver,
-            QuerySync.ATTACH_DEP_SRCJARS::getValue));
+            QuerySync.ATTACH_DEP_SRCJARS::getValue,
+            QuerySync.enableBazelAdditionalLibraryRootsProvider()));
     projectTransformRegistry.add(new CcProjectProtoTransform());
 
     artifactTracker = tracker;

--- a/base/src/com/google/idea/blaze/base/qsync/QuerySync.java
+++ b/base/src/com/google/idea/blaze/base/qsync/QuerySync.java
@@ -21,6 +21,8 @@ import com.google.idea.common.experiments.FeatureRolloutExperiment;
 
 /** Holder class for basic information about querysync, e.g. is it enabled? */
 public class QuerySync {
+  private static final BoolExperiment useAdditionalLibraryProvider =
+    new BoolExperiment("query.sync.use.additional.library.provider", false);
 
   public static final String BUILD_DEPENDENCIES_ACTION_NAME = "Enable analysis";
 
@@ -59,5 +61,10 @@ public class QuerySync {
     else {
       return isLegacyExperimentEnabled() || QuerySyncSettings.getInstance().useQuerySyncBeta();
     }
+  }
+
+  /** Provides library via BazelAdditionalLibraryRootsProvider instead of library table. */
+  public static boolean enableBazelAdditionalLibraryRootsProvider() {
+    return useAdditionalLibraryProvider.getValue();
   }
 }

--- a/base/src/com/google/idea/blaze/base/qsync/QuerySyncBazelAdditionalLibraryRootsProvider.java
+++ b/base/src/com/google/idea/blaze/base/qsync/QuerySyncBazelAdditionalLibraryRootsProvider.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2025 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.qsync;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.idea.blaze.base.settings.Blaze;
+import com.google.idea.blaze.base.settings.BlazeImportSettings;
+import com.google.idea.blaze.base.util.UrlUtil;
+import com.google.idea.blaze.qsync.QuerySyncProjectSnapshot;
+import com.google.idea.blaze.qsync.project.ProjectPath;
+import com.google.idea.blaze.qsync.project.ProjectProto;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.AdditionalLibraryRootsProvider;
+import com.intellij.openapi.roots.JavaSyntheticLibrary;
+import com.intellij.openapi.roots.SyntheticLibrary;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.VirtualFileManager;
+import com.intellij.psi.util.CachedValueProvider.Result;
+import com.intellij.psi.util.CachedValuesManager;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Provides all libraries that bazel query sync projects need to depends on. Registers them via these handlers will avoid performance issues
+ * due count of library is too large.
+ */
+public class QuerySyncBazelAdditionalLibraryRootsProvider extends AdditionalLibraryRootsProvider {
+
+
+  @Override
+  public final Collection<SyntheticLibrary> getAdditionalProjectLibraries(Project project) {
+    if (!Blaze.getProjectType(project).equals(BlazeImportSettings.ProjectType.QUERY_SYNC) ||
+        !QuerySync.enableBazelAdditionalLibraryRootsProvider()) {
+      return ImmutableList.of();
+    }
+    return CachedValuesManager.getManager(project).getCachedValue(
+      project,
+      () ->
+        Result.create(getLibs(project),
+                      QuerySyncManager.getInstance(project).getProjectModificationTracker()));
+  }
+
+  private ImmutableSet<SyntheticLibrary> getLibs(Project project) {
+    Optional<QuerySyncProject> loadedProject = QuerySyncManager.getInstance(project).getLoadedProject();
+    Optional<QuerySyncProjectSnapshot> snapshot = QuerySyncManager.getInstance(project).getCurrentSnapshot();
+    if (loadedProject.isEmpty() || snapshot.isEmpty()) {
+      return ImmutableSet.of();
+    }
+    ImmutableSet.Builder<SyntheticLibrary> libs = ImmutableSet.builder();
+    VirtualFileManager virtualFileManager = VirtualFileManager.getInstance();
+    for (ProjectProto.Library libSpec : snapshot.get().project().getLibraryList()) {
+      libs.add(createSyntheticLibrary(Paths.get(project.getBasePath()), virtualFileManager, loadedProject.get().getProjectPathResolver(),
+                                      libSpec));
+    }
+    return libs.build();
+  }
+
+  private SyntheticLibrary createSyntheticLibrary(Path projectBase,
+                                                  VirtualFileManager virtualFileManager,
+                                                  ProjectPath.Resolver projectPathResolver,
+                                                  ProjectProto.Library libSpec) {
+    List<? extends VirtualFile> classJars = libSpec.getClassesJarList().stream()
+      .map(d -> virtualFileManager.findFileByUrl(UrlUtil.pathToIdeaUrl(projectBase.resolve(d.getPath()))))
+      .filter(Objects::nonNull)
+      .distinct()
+      .collect(toImmutableList());
+
+    List<? extends VirtualFile> sourceJars = libSpec.getSourcesList().stream()
+      .filter(ProjectProto.LibrarySource::hasSrcjar)
+      .map(ProjectProto.LibrarySource::getSrcjar)
+      .map(ProjectPath::create)
+      .map(
+        p -> virtualFileManager.findFileByUrl(UrlUtil.pathToUrl(projectPathResolver.resolve(p).toString(), p.innerJarPath())))
+      .filter(Objects::nonNull)
+      .distinct()
+      .collect(toImmutableList());
+    return new JavaSyntheticLibrary(libSpec.getName(), sourceJars, classJars, ImmutableSet.of());
+  }
+
+  public static Collection<SyntheticLibrary> getAdditionalBazelLibraries(Project project) {
+    QuerySyncBazelAdditionalLibraryRootsProvider querySyncBazelAdditionalLibraryRootsProvider =
+      AdditionalLibraryRootsProvider.EP_NAME.findExtension(
+        QuerySyncBazelAdditionalLibraryRootsProvider.class);
+    if (querySyncBazelAdditionalLibraryRootsProvider == null) {
+      throw new IllegalStateException("Cannot load QuerySyncBazelAdditionalLibraryRootsProvider class. Restart the IDE may help.");
+    }
+    return querySyncBazelAdditionalLibraryRootsProvider.getAdditionalProjectLibraries(project);
+  }
+}

--- a/base/src/com/google/idea/blaze/base/qsync/QuerySyncBazelOrderEnumeratorHandler.java
+++ b/base/src/com/google/idea/blaze/base/qsync/QuerySyncBazelOrderEnumeratorHandler.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2025 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.qsync;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.idea.blaze.base.sync.data.BlazeDataStorage.WORKSPACE_MODULE_NAME;
+import static com.google.idea.blaze.qsync.deps.ProjectProtoUpdateOperation.JAVA_DEPS_LIB_NAME;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.idea.blaze.base.settings.Blaze;
+import com.google.idea.blaze.base.settings.BlazeImportSettings;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.LibraryOrSdkOrderEntry;
+import com.intellij.openapi.roots.OrderEnumerationHandler;
+import com.intellij.openapi.roots.OrderRootType;
+import com.intellij.openapi.roots.SyntheticLibrary;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.util.CachedValueProvider.Result;
+import com.intellij.psi.util.CachedValuesManager;
+import java.util.Collection;
+
+/**
+ * Provides all libraries that quer sync workspace module need to depends on. Registers them via these handlers will avoid performance
+ * issues due count of library is too large.
+ */
+public class QuerySyncBazelOrderEnumeratorHandler extends OrderEnumerationHandler {
+  private final Project project;
+
+  public static final class FactoryImpl extends OrderEnumerationHandler.Factory {
+    @Override
+    public boolean isApplicable(Module module) {
+      return Blaze.getProjectType(module.getProject()).equals(BlazeImportSettings.ProjectType.QUERY_SYNC) &&
+             module.getName().equals(WORKSPACE_MODULE_NAME) &&
+             QuerySync.enableBazelAdditionalLibraryRootsProvider();
+    }
+
+    @Override
+    public OrderEnumerationHandler createHandler(Module module) {
+      return new QuerySyncBazelOrderEnumeratorHandler(module);
+    }
+  }
+
+  public QuerySyncBazelOrderEnumeratorHandler(Module module) {
+    project = module.getProject();
+  }
+
+  @Override
+  public boolean addCustomRootsForLibraryOrSdk(LibraryOrSdkOrderEntry forOrderEntry, OrderRootType type, Collection<String> urls) {
+    if (!forOrderEntry.getPresentableName().equals(JAVA_DEPS_LIB_NAME)) {
+      return false;
+    }
+    return urls.addAll(getRoots(project, type));
+  }
+
+  private static ImmutableSet<String> getRoots(Project project, OrderRootType type) {
+    if (!type.equals(OrderRootType.CLASSES) && !type.equals(OrderRootType.SOURCES)) {
+      return ImmutableSet.of();
+    }
+    return QuerySyncBazelAdditionalLibraryRootsProvider.getAdditionalBazelLibraries(project).stream()
+      .map(type.equals(OrderRootType.CLASSES) ? SyntheticLibrary::getBinaryRoots : SyntheticLibrary::getSourceRoots)
+      .flatMap(Collection::stream)
+      .map(
+        VirtualFile::getUrl).collect(toImmutableSet());
+  }
+}

--- a/querysync/java/com/google/idea/blaze/qsync/DependenciesProjectProtoUpdater.java
+++ b/querysync/java/com/google/idea/blaze/qsync/DependenciesProjectProtoUpdater.java
@@ -53,7 +53,8 @@ public class DependenciesProjectProtoUpdater implements ProjectProtoTransform {
   public DependenciesProjectProtoUpdater(
       ProjectDefinition projectDefinition,
       ProjectPath.Resolver pathResolver,
-      Supplier<Boolean> attachDepsSrcjarsExperiment) {
+      Supplier<Boolean> attachDepsSrcjarsExperiment,
+      boolean enableBazelAdditionalLibraryRootsProvider) {
     // Require empty package prefixes for srcjar inner paths, since the ultimate consumer of these
     // paths does not support setting a package prefix (see `Library.ModifiableModel.addRoot`).
     PackageStatementParser packageReader = new PackageStatementParser();
@@ -61,7 +62,7 @@ public class DependenciesProjectProtoUpdater implements ProjectProtoTransform {
 
     ImmutableList.Builder<ProjectProtoUpdateOperation> updateOperations =
         ImmutableList.<ProjectProtoUpdateOperation>builder()
-            .add(new AddCompiledJavaDeps())
+            .add(new AddCompiledJavaDeps(enableBazelAdditionalLibraryRootsProvider))
             .add(
                 new AddProjectGenSrcJars(
                     projectDefinition,
@@ -75,10 +76,11 @@ public class DependenciesProjectProtoUpdater implements ProjectProtoTransform {
           new AddDependencySrcJars(
               projectDefinition,
               pathResolver,
-              srcJarInnerPathFinder));
+              srcJarInnerPathFinder,
+              enableBazelAdditionalLibraryRootsProvider));
       updateOperations.add(
           new AddDependencyGenSrcsJars(
-              projectDefinition, new SrcJarPackageRootsExtractor(srcJarInnerPathFinder)));
+            projectDefinition, new SrcJarPackageRootsExtractor(srcJarInnerPathFinder), enableBazelAdditionalLibraryRootsProvider));
     }
     this.updateOperations = updateOperations.build();
   }

--- a/querysync/java/com/google/idea/blaze/qsync/deps/BUILD
+++ b/querysync/java/com/google/idea/blaze/qsync/deps/BUILD
@@ -11,6 +11,7 @@ kt_jvm_library(
     ],
     deps = [
         ":artifact_tracker_state_java_proto",
+        "//common/experiments",
         "//querysync/java/com/google/idea/blaze/qsync/artifacts",
         "//querysync/java/com/google/idea/blaze/qsync/cc:cc_compilation_info_java_proto",
         "//querysync/java/com/google/idea/blaze/qsync/java:java_target_info_java_proto",

--- a/querysync/java/com/google/idea/blaze/qsync/deps/ProjectProtoUpdateOperation.java
+++ b/querysync/java/com/google/idea/blaze/qsync/deps/ProjectProtoUpdateOperation.java
@@ -34,7 +34,7 @@ public interface ProjectProtoUpdateOperation {
   ImmutableSet<String> JAVA_ARCHIVE_EXTENSIONS = ImmutableSet.of("jar", "srcjar");
 
   default ImmutableSetMultimap<BuildArtifact, ArtifactMetadata.Extractor<?>> getRequiredArtifacts(
-      TargetBuildInfo forTarget) {
+    TargetBuildInfo forTarget) {
     return ImmutableSetMultimap.of();
   }
 

--- a/querysync/java/com/google/idea/blaze/qsync/java/AddDependencyGenSrcsJars.java
+++ b/querysync/java/com/google/idea/blaze/qsync/java/AddDependencyGenSrcsJars.java
@@ -45,10 +45,13 @@ public class AddDependencyGenSrcsJars implements ProjectProtoUpdateOperation {
   private final ProjectDefinition projectDefinition;
   private final Extractor<SrcJarJavaPackageRoots> srcJarPathsMetadata;
 
+  private final boolean enableBazelAdditionalLibraryRootsProvider;
+
   public AddDependencyGenSrcsJars(
-      ProjectDefinition projectDefinition, Extractor<SrcJarJavaPackageRoots> srcJarPathsMetadata) {
+      ProjectDefinition projectDefinition, Extractor<SrcJarJavaPackageRoots> srcJarPathsMetadata, boolean enableBazelAdditionalLibraryRootsProvider) {
     this.projectDefinition = projectDefinition;
     this.srcJarPathsMetadata = srcJarPathsMetadata;
+    this.enableBazelAdditionalLibraryRootsProvider = enableBazelAdditionalLibraryRootsProvider;
   }
 
   private Stream<BuildArtifact> getDependencyGenSrcJars(TargetBuildInfo target) {
@@ -93,7 +96,7 @@ public class AddDependencyGenSrcsJars implements ProjectProtoUpdateOperation {
                       .map(projectArtifact::withInnerJarPath)
                       .map(ProjectPath::toProto)
                       .map(LibrarySource.newBuilder()::setSrcjar)
-                      .forEach(update.library(JAVA_DEPS_LIB_NAME)::addSources);
+                      .forEach(update.library(enableBazelAdditionalLibraryRootsProvider ? target.label().toString() : JAVA_DEPS_LIB_NAME)::addSources);
                 }
               });
     }

--- a/querysync/java/com/google/idea/blaze/qsync/java/AddDependencySrcJars.java
+++ b/querysync/java/com/google/idea/blaze/qsync/java/AddDependencySrcJars.java
@@ -39,13 +39,17 @@ public class AddDependencySrcJars implements ProjectProtoUpdateOperation {
   private final ProjectPath.Resolver pathResolver;
   private final SrcJarInnerPathFinder srcJarInnerPathFinder;
 
+  private final boolean enableBazelAdditionalLibraryRootsProvider;
+
   public AddDependencySrcJars(
       ProjectDefinition projectDefinition,
       ProjectPath.Resolver pathResolver,
-      SrcJarInnerPathFinder srcJarInnerPathFinder) {
+      SrcJarInnerPathFinder srcJarInnerPathFinder,
+      boolean enableBazelAdditionalLibraryRootsProvider) {
     this.projectDefinition = projectDefinition;
     this.pathResolver = pathResolver;
     this.srcJarInnerPathFinder = srcJarInnerPathFinder;
+    this.enableBazelAdditionalLibraryRootsProvider = enableBazelAdditionalLibraryRootsProvider;
   }
 
   @Override
@@ -72,7 +76,7 @@ public class AddDependencySrcJars implements ProjectProtoUpdateOperation {
             .map(jarPath::withInnerJarPath)
             .map(ProjectPath::toProto)
             .map(LibrarySource.newBuilder()::setSrcjar)
-            .forEach(update.library(JAVA_DEPS_LIB_NAME)::addSources);
+            .forEach(update.library(enableBazelAdditionalLibraryRootsProvider ? target.label().toString() : JAVA_DEPS_LIB_NAME)::addSources);
       }
     }
   }

--- a/querysync/javatests/com/google/idea/blaze/qsync/java/AddCompiledJavaDepsTest.java
+++ b/querysync/javatests/com/google/idea/blaze/qsync/java/AddCompiledJavaDepsTest.java
@@ -37,75 +37,91 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class AddCompiledJavaDepsTest {
+  @Test
+  public void enable_library_provider_no_deps_built() throws Exception {
+    AddCompiledJavaDeps javaDeps = new AddCompiledJavaDeps(true);
+    no_deps_built(javaDeps);
+  }
 
   @Test
-  public void no_deps_built() throws Exception {
-    ProjectProto.Project original =
-        ProjectProtos.forTestProject(TestData.JAVA_LIBRARY_EXTERNAL_DEP_QUERY);
+  public void disable_library_provider_no_deps_built() throws Exception {
+    AddCompiledJavaDeps javaDeps = new AddCompiledJavaDeps(false);
+    no_deps_built(javaDeps);
+  }
 
-    AddCompiledJavaDeps javaDeps = new AddCompiledJavaDeps();
+  private void no_deps_built(AddCompiledJavaDeps javaDeps) throws Exception {
+    ProjectProto.Project original =
+      ProjectProtos.forTestProject(TestData.JAVA_LIBRARY_EXTERNAL_DEP_QUERY);
 
     ProjectProtoUpdate update =
-        new ProjectProtoUpdate(original, BuildGraphData.EMPTY, new NoopContext());
+      new ProjectProtoUpdate(original, BuildGraphData.EMPTY, new NoopContext());
     javaDeps.update(update, State.EMPTY);
     ProjectProto.Project newProject = update.build();
     assertThat(newProject.getLibraryList()).isEqualTo(original.getLibraryList());
     assertThat(newProject.getModulesList()).isEqualTo(original.getModulesList());
     assertThat(newProject.getArtifactDirectories().getDirectoriesMap().keySet())
-        .containsExactly(".bazel/javadeps");
+      .containsExactly(".bazel/javadeps");
     assertThat(
-        newProject
-            .getArtifactDirectories()
-            .getDirectoriesMap()
-            .get(".bazel/javadeps")
-            .getContentsMap())
-        .isEmpty();
+      newProject
+        .getArtifactDirectories()
+        .getDirectoriesMap()
+        .get(".bazel/javadeps")
+        .getContentsMap())
+      .isEmpty();
   }
 
   @Test
-  public void dep_built() throws Exception {
+  public void enable_library_provider_dep_built() throws Exception {
+    AddCompiledJavaDeps javaDeps = new AddCompiledJavaDeps(true);
+    dep_built(javaDeps,
+              ProjectProto.Library.newBuilder().setName("//java/com/google/common/collect:collect")
+                .addClassesJar(
+                  ProjectProto.JarDirectory.newBuilder().setPath(".bazel/javadeps/build-out/java/com/google/common/collect/libcollect.jar")
+                    .setRecursive(false).build()).build());
+  }
+
+  @Test
+  public void disable_library_provider_dep_built() throws Exception {
+    AddCompiledJavaDeps javaDeps = new AddCompiledJavaDeps(false);
+    dep_built(javaDeps,
+              ProjectProto.Library.newBuilder().setName(".dependencies")
+                .addClassesJar(ProjectProto.JarDirectory.newBuilder().setPath(".bazel/javadeps").setRecursive(true).build()).build());
+  }
+
+  private void dep_built(AddCompiledJavaDeps javaDeps, ProjectProto.Library... expectedLibraries) throws Exception {
     ProjectProto.Project original =
-        ProjectProtos.forTestProject(TestData.JAVA_LIBRARY_EXTERNAL_DEP_QUERY);
+      ProjectProtos.forTestProject(TestData.JAVA_LIBRARY_EXTERNAL_DEP_QUERY);
 
     ArtifactTracker.State artifactState =
-        ArtifactTracker.State.forJavaArtifacts(
-            JavaArtifactInfo.empty(Label.of("//java/com/google/common/collect:collect")).toBuilder()
-                .setJars(
-                    ImmutableList.of(
-                        BuildArtifact.create(
-                            "jardigest",
-                            Path.of("build-out/java/com/google/common/collect/libcollect.jar"),
-                            Label.of("//java/com/google/common/collect:collect"))))
-                .build());
-
-    AddCompiledJavaDeps javaDeps = new AddCompiledJavaDeps();
+      ArtifactTracker.State.forJavaArtifacts(
+        JavaArtifactInfo.empty(Label.of("//java/com/google/common/collect:collect")).toBuilder()
+          .setJars(
+            ImmutableList.of(
+              BuildArtifact.create(
+                "jardigest",
+                Path.of("build-out/java/com/google/common/collect/libcollect.jar"),
+                Label.of("//java/com/google/common/collect:collect"))))
+          .build());
 
     ProjectProtoUpdate update =
-        new ProjectProtoUpdate(original, BuildGraphData.EMPTY, new NoopContext());
+      new ProjectProtoUpdate(original, BuildGraphData.EMPTY, new NoopContext());
     javaDeps.update(update, artifactState);
     ProjectProto.Project newProject = update.build();
-    assertThat(newProject.getLibraryList()).hasSize(1);
-    assertThat(newProject.getLibrary(0).getName()).isEqualTo(".dependencies");
-    assertThat(newProject.getLibrary(0).getClassesJarList())
-        .containsExactly(
-            ProjectProto.JarDirectory.newBuilder()
-                .setPath(".bazel/javadeps")
-                .setRecursive(true)
-                .build());
+    assertThat(newProject.getLibraryList()).containsExactly(expectedLibraries);
     assertThat(newProject.getArtifactDirectories().getDirectoriesMap().keySet())
-        .containsExactly(".bazel/javadeps");
+      .containsExactly(".bazel/javadeps");
     assertThat(
-        newProject
-            .getArtifactDirectories()
-            .getDirectoriesMap()
-            .get(".bazel/javadeps")
-            .getContentsMap())
-        .containsExactly(
-            "build-out/java/com/google/common/collect/libcollect.jar",
-            ProjectProto.ProjectArtifact.newBuilder()
-                .setBuildArtifact(ProjectProto.BuildArtifact.newBuilder().setDigest("jardigest"))
-                .setTransform(ArtifactTransform.COPY)
-                .setTarget("//java/com/google/common/collect:collect")
-                .build());
+      newProject
+        .getArtifactDirectories()
+        .getDirectoriesMap()
+        .get(".bazel/javadeps")
+        .getContentsMap())
+      .containsExactly(
+        "build-out/java/com/google/common/collect/libcollect.jar",
+        ProjectProto.ProjectArtifact.newBuilder()
+          .setBuildArtifact(ProjectProto.BuildArtifact.newBuilder().setDigest("jardigest"))
+          .setTransform(ArtifactTransform.COPY)
+          .setTarget("//java/com/google/common/collect:collect")
+          .build());
   }
 }

--- a/querysync/javatests/com/google/idea/blaze/qsync/java/AddDependencySrcJarsTest.java
+++ b/querysync/javatests/com/google/idea/blaze/qsync/java/AddDependencySrcJarsTest.java
@@ -21,6 +21,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import com.google.common.collect.ImmutableSet;
 import com.google.idea.blaze.common.Label;
 import com.google.idea.blaze.common.NoopContext;
+import com.google.idea.blaze.exception.BuildException;
 import com.google.idea.blaze.qsync.QuerySyncProjectSnapshot;
 import com.google.idea.blaze.qsync.QuerySyncTestUtils;
 import com.google.idea.blaze.qsync.TestDataSyncRunner;
@@ -30,7 +31,6 @@ import com.google.idea.blaze.qsync.deps.JavaArtifactInfo;
 import com.google.idea.blaze.qsync.deps.ProjectProtoUpdate;
 import com.google.idea.blaze.qsync.project.ProjectPath;
 import com.google.idea.blaze.qsync.project.ProjectProto;
-import com.google.idea.blaze.qsync.project.ProjectProto.Library;
 import com.google.idea.blaze.qsync.project.ProjectProto.ProjectPath.Base;
 import com.google.idea.blaze.qsync.testdata.TestData;
 import java.io.FileOutputStream;
@@ -52,10 +52,12 @@ public class AddDependencySrcJarsTest {
   @Rule public final TemporaryFolder tempDir = new TemporaryFolder();
   private Path workspaceRoot;
   private ProjectPath.Resolver pathResolver;
-
   private final TestDataSyncRunner syncer =
       new TestDataSyncRunner(
           new NoopContext(), QuerySyncTestUtils.PATH_INFERRING_PACKAGE_READER);
+  private final QuerySyncProjectSnapshot original = syncer.sync(TestData.JAVA_LIBRARY_EXTERNAL_DEP_QUERY);
+
+  public AddDependencySrcJarsTest() throws IOException, BuildException { }
 
   @Before
   public void createDirs() throws IOException {
@@ -69,15 +71,28 @@ public class AddDependencySrcJarsTest {
   }
 
   @Test
-  public void no_deps_built() throws Exception {
-    QuerySyncProjectSnapshot original = syncer.sync(TestData.JAVA_LIBRARY_EXTERNAL_DEP_QUERY);
-
+  public void disable_library_provider_no_deps_built() throws Exception {
     AddDependencySrcJars addSrcJars =
-        new AddDependencySrcJars(
-            original.queryData().projectDefinition(),
-            pathResolver,
-            new SrcJarInnerPathFinder(new PackageStatementParser()));
+      new AddDependencySrcJars(
+        original.queryData().projectDefinition(),
+        pathResolver,
+        new SrcJarInnerPathFinder(new PackageStatementParser()),
+        false);
+    no_deps_built(addSrcJars);
+  }
 
+  @Test
+  public void enable_library_provider_no_deps_built() throws Exception {
+    AddDependencySrcJars addSrcJars =
+      new AddDependencySrcJars(
+        original.queryData().projectDefinition(),
+        pathResolver,
+        new SrcJarInnerPathFinder(new PackageStatementParser()),
+        true);
+    no_deps_built(addSrcJars);
+  }
+
+  private void no_deps_built(AddDependencySrcJars addSrcJars) throws Exception {
     ProjectProtoUpdate update =
         new ProjectProtoUpdate(original.project(), original.graph(), new NoopContext());
 
@@ -91,9 +106,44 @@ public class AddDependencySrcJarsTest {
   }
 
   @Test
-  public void external_srcjar_added() throws Exception {
-    QuerySyncProjectSnapshot original = syncer.sync(TestData.JAVA_LIBRARY_EXTERNAL_DEP_QUERY);
+  public void disable_library_provider_external_srcjar_added() throws Exception {
+    AddDependencySrcJars addSrcJars =
+      new AddDependencySrcJars(
+        original.queryData().projectDefinition(),
+        pathResolver,
+        new SrcJarInnerPathFinder(new PackageStatementParser()),
+        false);
+    external_srcjar_added(addSrcJars, ProjectProto.Library.newBuilder().setName(".dependencies")
+      .addSources(ProjectProto.LibrarySource.newBuilder()
+                    .setSrcjar(
+                      ProjectProto.ProjectPath.newBuilder()
+                        .setBase(Base.WORKSPACE)
+                        .setPath("source/path/external.srcjar")
+                        .setInnerPath("root"))
+                    .build())
+      .build());
+  }
 
+  @Test
+  public void enable_library_provider_external_srcjar_added() throws Exception {
+    AddDependencySrcJars addSrcJars =
+      new AddDependencySrcJars(
+        original.queryData().projectDefinition(),
+        pathResolver,
+        new SrcJarInnerPathFinder(new PackageStatementParser()),
+        true);
+    external_srcjar_added(addSrcJars, ProjectProto.Library.newBuilder().setName("//java/com/google/common/collect:collect")
+      .addSources(ProjectProto.LibrarySource.newBuilder()
+                    .setSrcjar(
+                      ProjectProto.ProjectPath.newBuilder()
+                        .setBase(Base.WORKSPACE)
+                        .setPath("source/path/external.srcjar")
+                        .setInnerPath("root"))
+                    .build())
+      .build());
+  }
+
+  private void external_srcjar_added(AddDependencySrcJars addSrcJars, ProjectProto.Library... libraries) throws Exception {
     try (ZipOutputStream zos =
         new ZipOutputStream(
             new FileOutputStream(
@@ -110,12 +160,6 @@ public class AddDependencySrcJarsTest {
                 .setSrcJars(ImmutableSet.of(Path.of("source/path/external.srcjar")))
                 .build());
 
-    AddDependencySrcJars addSrcJars =
-        new AddDependencySrcJars(
-            original.queryData().projectDefinition(),
-            pathResolver,
-            new SrcJarInnerPathFinder(new PackageStatementParser()));
-
     ProjectProtoUpdate update =
         new ProjectProtoUpdate(original.project(), original.graph(), new NoopContext());
 
@@ -123,17 +167,6 @@ public class AddDependencySrcJarsTest {
 
     ProjectProto.Project newProject = update.build();
 
-    assertThat(newProject.getLibraryList()).hasSize(1);
-    Library depsLib = newProject.getLibrary(0);
-    assertThat(depsLib.getName()).isEqualTo(".dependencies");
-    assertThat(depsLib.getSourcesList())
-        .containsExactly(
-            ProjectProto.LibrarySource.newBuilder()
-                .setSrcjar(
-                    ProjectProto.ProjectPath.newBuilder()
-                        .setBase(Base.WORKSPACE)
-                        .setPath("source/path/external.srcjar")
-                        .setInnerPath("root"))
-                .build());
+    assertThat(newProject.getLibraryList()).containsExactly(libraries);
   }
 }


### PR DESCRIPTION
Cherry pick AOSP commit [3f0a86a4e241c4fb46d8340335856b99542df849](https://cs.android.com/android-studio/platform/tools/adt/idea/+/3f0a86a4e241c4fb46d8340335856b99542df849).

STAT (diff to AOSP): 38 insertions(+), 192 deletion(-)

Proivdes libraries and module root via api instead of registering via
library table. When there are too many libraries in library table, it
will lead to peformances issues e.g. rescan in one not cancellable
thread, O(N^2) scanning complexity.

Bug: b/374810387
Test: existing tests
Change-Id: I31c73a06b9e7dea6f82a6ba578ea35119f5a275e

AOSP: 3f0a86a4e241c4fb46d8340335856b99542df849
