### PR TITLE
[AOSP-pick] Begin splitting build_dependencies_deps.bzl

### DIFF
--- a/aspect/BUILD
+++ b/aspect/BUILD
@@ -66,6 +66,7 @@ aspect_library(
     files = [
         "build_compose_dependencies.bzl",
         "build_dependencies.bzl",
+        "build_dependencies_android_deps.bzl",
         "build_dependencies_deps.bzl",
     ],
     namespace = "aspect/qsync",

--- a/aspect/build_dependencies.bzl
+++ b/aspect/build_dependencies.bzl
@@ -4,12 +4,15 @@
 # to make supporting other versions of bazel easier, by replacing build_dependencies_deps.bzl.
 load(
     ":build_dependencies_deps.bzl",
-    "ANDROID_IDE_INFO",
     "ZIP_TOOL_LABEL",
     _ide_cc_not_validated = "IDE_CC",
     _ide_java_not_validated = "IDE_JAVA",
     _ide_java_proto_not_validated = "IDE_JAVA_PROTO",
     _ide_kotlin_not_validated = "IDE_KOTLIN",
+)
+load(
+    ":build_dependencies_android_deps.bzl",
+    "ANDROID_IDE_INFO",
 )
 
 ALWAYS_BUILD_RULES = "java_proto_library,java_lite_proto_library,java_mutable_proto_library,kt_proto_library_helper,_java_grpc_library,_java_lite_grpc_library,kt_grpc_library_helper,java_stubby_library,kt_stubby_library_helper,aar_import,java_import, j2kt_native_import"

--- a/aspect/build_dependencies_android_deps.bzl
+++ b/aspect/build_dependencies_android_deps.bzl
@@ -1,0 +1,1 @@
+ANDROID_IDE_INFO = None

--- a/aspect/build_dependencies_deps.bzl
+++ b/aspect/build_dependencies_deps.bzl
@@ -8,8 +8,6 @@ load(
 
 ZIP_TOOL_LABEL = "@@bazel_tools//tools/zip:zipper"
 
-ANDROID_IDE_INFO = None
-
 # JAVA
 
 def _get_java_info(target, rule):

--- a/base/src/com/google/idea/blaze/base/qsync/BazelDependencyBuilder.java
+++ b/base/src/com/google/idea/blaze/base/qsync/BazelDependencyBuilder.java
@@ -31,7 +31,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.Sets;
 import com.google.common.io.ByteSource;
-import com.google.common.io.MoreFiles;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.idea.blaze.base.bazel.BazelExitCodeException;
@@ -43,8 +42,6 @@ import com.google.idea.blaze.base.command.BlazeCommand;
 import com.google.idea.blaze.base.command.BlazeCommandName;
 import com.google.idea.blaze.base.command.BlazeFlags;
 import com.google.idea.blaze.base.command.BlazeInvocationContext;
-import com.google.idea.blaze.base.command.buildresult.BuildResultParser;
-import com.google.idea.blaze.base.command.buildresult.bepparser.BuildEventStreamProvider;
 import com.google.idea.blaze.base.logging.utils.querysync.BuildDepsStats;
 import com.google.idea.blaze.base.logging.utils.querysync.BuildDepsStatsScope;
 import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
@@ -57,7 +54,6 @@ import com.google.idea.blaze.base.sync.aspects.storage.AspectRepositoryProvider;
 import com.google.idea.blaze.base.util.VersionChecker;
 import com.google.idea.blaze.base.vcs.BlazeVcsHandlerProvider.BlazeVcsHandler;
 import com.google.idea.blaze.common.Context;
-import com.google.idea.blaze.common.Interners;
 import com.google.idea.blaze.common.Label;
 import com.google.idea.blaze.common.PrintOutput;
 import com.google.idea.blaze.common.artifact.BuildArtifactCache;
@@ -77,14 +73,12 @@ import com.google.idea.common.experiments.BoolExperiment;
 import com.google.idea.common.experiments.StringExperiment;
 import com.google.protobuf.Message;
 import com.google.protobuf.TextFormat;
-import com.intellij.ide.plugins.PluginManager;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.Service;
 import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.openapi.extensions.PluginDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.text.StringUtilRt;
-import com.jgoodies.common.base.Strings;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -315,6 +309,7 @@ public class BazelDependencyBuilder implements DependencyBuilder {
     files.put(Path.of(INVOCATION_FILES_DIR + "/BUILD"), ByteSource.empty());
     files.put(Path.of(INVOCATION_FILES_DIR + "/build_dependencies.bzl"), getBundledAspect("build_dependencies.bzl"));
     files.put(Path.of(INVOCATION_FILES_DIR + "/build_dependencies_deps.bzl"), getBundledAspect("build_dependencies_deps.bzl"));
+    files.put(Path.of(INVOCATION_FILES_DIR + "/build_dependencies_android_deps.bzl"), getBundledAspectAndroidDepsFilePath());
     files.put(Path.of(INVOCATION_FILES_DIR + "/" + aspectFileName), getByteSourceFromString(getBuildDependenciesParametersFileContent(parameters)));
     Optional<String> targetPatternFileWorkspaceRelativeFile;
     if (buildUseTargetPatternFile.getValue()) {
@@ -332,6 +327,9 @@ public class BazelDependencyBuilder implements DependencyBuilder {
         files.build(),
         Label.of(String.format("//" + INVOCATION_FILES_DIR + ":" + aspectFileName)).toString(),
         targetPatternFileWorkspaceRelativeFile);
+  }
+  protected ByteSource getBundledAspectAndroidDepsFilePath() {
+    return getBundledAspect("build_dependencies_android_deps.bzl");
   }
 
   private ByteSource getByteSourceFromString(String content) {

--- a/base/tests/integrationtests/com/google/idea/blaze/base/qsync/BazelDependencyBuilderTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/qsync/BazelDependencyBuilderTest.java
@@ -78,6 +78,12 @@ public class BazelDependencyBuilderTest extends BlazeIntegrationTestCase {
         .toPath()
         .resolve("aspect/build_dependencies_deps.bzl")
         .toString());
+    System.setProperty(
+      "qsync.aspect.build_dependencies_android_deps.bzl.file",
+      getRunfilesWorkspaceRoot()
+        .toPath()
+        .resolve("aspect/build_dependencies_android_deps.bzl")
+        .toString());
     ServiceContainerUtil.registerComponentInstance(ApplicationManager.getApplication(), ExperimentService.class, experimentService,
                                                    getTestRootDisposable());
   }


### PR DESCRIPTION
Cherry pick AOSP commit [bd0efbe2e3df6110c570c56f450283f541ca3121](https://cs.android.com/android-studio/platform/tools/adt/idea/+/bd0efbe2e3df6110c570c56f450283f541ca3121).

STAT (diff to AOSP): 19 insertions(+), 8 deletion(-)

into modules. Move `build_dependencies_android_deps.bzl` without
implementing IDE_ANDROID yet. This "module" will need to get different
implementation in Bazel depending on whether @rules_android are present.

Bug: 383137535
Test: n/a
Change-Id: I8f101452f69ea67222d01999ca20932961d895dd

AOSP: bd0efbe2e3df6110c570c56f450283f541ca3121
