### PR TITLE
[AOSP-pick] Disable BlazeRenderErrorContributorTest

### DIFF
--- a/aswb/tests/unittests/com/google/idea/blaze/android/rendering/BlazeRenderErrorContributorTest.java
+++ b/aswb/tests/unittests/com/google/idea/blaze/android/rendering/BlazeRenderErrorContributorTest.java
@@ -88,6 +88,7 @@ import org.junit.runners.JUnit4;
 
 /** Unit tests for {@link BlazeRenderErrorContributor}. */
 @RunWith(JUnit4.class)
+@Ignore("b/401277613")
 public class BlazeRenderErrorContributorTest extends BlazeTestCase {
   private static final String BLAZE_BIN = "blaze-out/crosstool/bin";
   private static final String GENERATED_RESOURCES_ERROR = "Generated resources";


### PR DESCRIPTION
Cherry pick AOSP commit [dfbad115042e8fbd75852e8f610ce52497b157e6](https://cs.android.com/android-studio/platform/tools/adt/idea/+/dfbad115042e8fbd75852e8f610ce52497b157e6).

STAT (diff to AOSP): 0 insertions(+), 0 deletion(-)

...temporarily, since it fails with IntelliJ 2025.1.

Bug: 401277613
Test: BlazeRenderErrorContributorTest
Change-Id: If0b766cd919cbb2f1bcb16aa13bb88c76fe8c6b0

AOSP: dfbad115042e8fbd75852e8f610ce52497b157e6
