### PR TITLE
[AOSP-pick] Warm-up the working directory only

### DIFF
--- a/base/src/com/google/idea/blaze/base/project/indexing/FileSystemWarmUpService.kt
+++ b/base/src/com/google/idea/blaze/base/project/indexing/FileSystemWarmUpService.kt
@@ -26,6 +26,7 @@ import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ModuleRootManagerEx
+import com.intellij.openapi.vfs.VFileProperty
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.platform.backend.observation.ActivityKey
 import com.intellij.platform.backend.observation.trackActivity
@@ -130,6 +131,7 @@ class FileSystemWarmUpService(val project: Project, val coroutineScope: Coroutin
         }
         when {
           !file.isInLocalFileSystem -> return@readAction arrayOf()
+          file.`is`(VFileProperty.SYMLINK) -> return@readAction arrayOf()
           file.exists() && file.isDirectory -> file.children
           else -> {
             file.fileType


### PR DESCRIPTION
Cherry pick AOSP commit [a07f8d93a38ff78d995cb37e3591752357a42e2f](https://cs.android.com/android-studio/platform/tools/adt/idea/+/a07f8d93a38ff78d995cb37e3591752357a42e2f).

STAT (diff to AOSP): 0 insertions(+), 0 deletion(-)

Prevent the VFS warm-up service escape the working directory by
following symlinks. It may pollute the VFS with unneeded files.

Bug: n/a
Test: n/a
Change-Id: I79a8df3b45f59ce2eb80886f4c1a0085bcd02693

AOSP: a07f8d93a38ff78d995cb37e3591752357a42e2f
