### PR TITLE
[AOSP-pick] Improve BuildInvoker capablities

### DIFF
--- a/aswb/src/com/google/idea/blaze/android/run/runner/BlazeInstrumentationTestApkBuildStep.java
+++ b/aswb/src/com/google/idea/blaze/android/run/runner/BlazeInstrumentationTestApkBuildStep.java
@@ -90,7 +90,7 @@ public class BlazeInstrumentationTestApkBuildStep implements ApkBuildStep {
     BuildInvoker invoker =
         Blaze.getBuildSystemProvider(project)
             .getBuildSystem()
-            .getBuildInvoker(project, ImmutableSet.of(BuildInvoker.Capability.IS_LOCAL));
+            .getBuildInvoker(project, ImmutableSet.of(BuildInvoker.Capability.BUILD_AIT)).orElseThrow();
     BlazeCommand.Builder command = BlazeCommand.builder(invoker, BlazeCommandName.BUILD);
     // TODO(mathewi) we implicitly rely here on the fact that the getBuildInvoker() call above
     //   will always return a local invoker (deployInfoHelper below required that the artifacts

--- a/base/src/com/google/idea/blaze/base/bazel/BazelBuildSystem.java
+++ b/base/src/com/google/idea/blaze/base/bazel/BazelBuildSystem.java
@@ -36,8 +36,8 @@ class BazelBuildSystem implements BuildSystem {
   }
 
   @Override
-  public BuildInvoker getBuildInvoker(Project project, Set<BuildInvoker.Capability> requirements) {
-    return new LocalInvoker(project, this, BuildBinaryType.BAZEL);
+  public Optional<BuildInvoker> getBuildInvoker(Project project, Set<BuildInvoker.Capability> requirements) {
+    return Optional.of(new LocalInvoker(project, this, BuildBinaryType.BAZEL));
   }
 
   @Override

--- a/base/src/com/google/idea/blaze/base/bazel/BuildSystem.java
+++ b/base/src/com/google/idea/blaze/base/bazel/BuildSystem.java
@@ -73,7 +73,26 @@ public interface BuildSystem {
   interface BuildInvoker {
 
     enum Capability {
-      IS_LOCAL, SUPPORTS_CLI, SUPPORTS_PARALLELISM, SUPPORTS_API, SUPPORTS_DBIP
+      /**
+       * Capability to build Android Instrumentation Test APK
+       */
+      BUILD_AIT,
+      /**
+       * Capability to invoke blaze/bazel via CLI
+       */
+      SUPPORT_CLI,
+      /**
+       * Capability to run parallel builds
+       */
+      BUILD_PARALLEL_SHARDS,
+      /**
+       * Capability to run blaze/bazel query command via remote invocation
+       */
+      RUN_REMOTE_QUERIES,
+      /**
+       * Capability to debug Android local test
+       */
+      DEBUG_LOCAL_TEST
     }
 
     default ImmutableSet<Capability> getCapabilities() {
@@ -142,13 +161,13 @@ public interface BuildSystem {
   /**
    * Get a Blaze invoker with desired capabilities.
    */
-  BuildInvoker getBuildInvoker(Project project, Set<BuildInvoker.Capability> requirements);
+  Optional<BuildInvoker> getBuildInvoker(Project project, Set<BuildInvoker.Capability> requirements);
 
   /**
    * Get a Blaze invoker.
    */
   default BuildInvoker getBuildInvoker(Project project) {
-    return getBuildInvoker(project, ImmutableSet.of());
+    return getBuildInvoker(project, ImmutableSet.of()).orElseThrow();
   }
 
   /**
@@ -197,7 +216,7 @@ public interface BuildSystem {
   default BuildInvoker getDefaultInvoker(Project project) {
     if (Blaze.getProjectType(project) != ProjectType.QUERY_SYNC
         && getSyncStrategy(project) == SyncStrategy.PARALLEL) {
-      return getBuildInvoker(project, ImmutableSet.of(BuildInvoker.Capability.SUPPORTS_PARALLELISM));
+      return getBuildInvoker(project, ImmutableSet.of(BuildInvoker.Capability.BUILD_PARALLEL_SHARDS)).orElseThrow();
     }
     return getBuildInvoker(project);
   }

--- a/base/src/com/google/idea/blaze/base/bazel/LocalInvoker.java
+++ b/base/src/com/google/idea/blaze/base/bazel/LocalInvoker.java
@@ -87,7 +87,7 @@ public class LocalInvoker extends AbstractBuildInvoker {
 
   @Override
   public ImmutableSet<Capability> getCapabilities() {
-    return ImmutableSet.of(Capability.IS_LOCAL, Capability.SUPPORTS_CLI);
+    return ImmutableSet.of(Capability.BUILD_AIT, Capability.SUPPORT_CLI, Capability.DEBUG_LOCAL_TEST);
   }
 
   @Override

--- a/base/src/com/google/idea/blaze/base/qsync/BazelQueryRunner.java
+++ b/base/src/com/google/idea/blaze/base/qsync/BazelQueryRunner.java
@@ -66,7 +66,7 @@ public class BazelQueryRunner implements QueryRunner {
     if (PREFER_REMOTE_QUERIES.getValue()) {
       invoker =
           buildSystem
-              .getBuildInvoker(project, ImmutableSet.of(BuildInvoker.Capability.SUPPORTS_API));
+              .getBuildInvoker(project, ImmutableSet.of(BuildInvoker.Capability.RUN_REMOTE_QUERIES)).orElseThrow();
     } else {
       invoker = buildSystem.getDefaultInvoker(project);
     }

--- a/base/src/com/google/idea/blaze/base/sync/BuildPhaseSyncTask.java
+++ b/base/src/com/google/idea/blaze/base/sync/BuildPhaseSyncTask.java
@@ -240,10 +240,10 @@ public final class BuildPhaseSyncTask {
 
     BuildInvoker syncBuildInvoker =
         parallel
-            ? buildSystem.getBuildInvoker(project, ImmutableSet.of(BuildInvoker.Capability.SUPPORTS_PARALLELISM))
+            ? buildSystem.getBuildInvoker(project, ImmutableSet.of(BuildInvoker.Capability.BUILD_PARALLEL_SHARDS)).orElseThrow()
             : defaultInvoker;
     final BlazercMigrator blazercMigrator = new BlazercMigrator(project);
-    if (!syncBuildInvoker.getCapabilities().contains(BuildInvoker.Capability.SUPPORTS_CLI)
+    if (!syncBuildInvoker.getCapabilities().contains(BuildInvoker.Capability.SUPPORT_CLI)
         && blazercMigrator.needMigration()) {
       context.output(
           SummaryOutput.output(Prefix.INFO, "No .blazerc found at workspace root!").log().dedupe());
@@ -259,7 +259,7 @@ public final class BuildPhaseSyncTask {
         .setParallelBuilds(
             syncBuildInvoker
                 .getCapabilities()
-                .contains(BuildInvoker.Capability.SUPPORTS_PARALLELISM));
+                .contains(BuildInvoker.Capability.BUILD_PARALLEL_SHARDS));
 
     BlazeBuildOutputs.Legacy blazeBuildResult =
         getBlazeBuildResult(context, viewSet, shardedTargets, syncBuildInvoker, parallel);

--- a/base/src/com/google/idea/blaze/base/sync/sharding/ShardedTargetList.java
+++ b/base/src/com/google/idea/blaze/base/sync/sharding/ShardedTargetList.java
@@ -98,7 +98,7 @@ public class ShardedTargetList {
     if (shardedTargets.size() == 1) {
       return invocation.apply(shardedTargets.get(0));
     }
-    if (binary.getCapabilities().contains(BuildInvoker.Capability.SUPPORTS_PARALLELISM)
+    if (binary.getCapabilities().contains(BuildInvoker.Capability.BUILD_PARALLEL_SHARDS)
         && invokeParallel) {
       return runInParallel(project, context, invocation);
     }

--- a/base/tests/utils/unit/com/google/idea/blaze/base/bazel/BuildSystemProviderWrapper.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/bazel/BuildSystemProviderWrapper.java
@@ -274,9 +274,9 @@ public class BuildSystemProviderWrapper implements BuildSystemProvider {
     }
 
     @Override
-    public BuildInvoker getBuildInvoker(
+    public Optional<BuildInvoker> getBuildInvoker(
         Project project, Set<BuildInvoker.Capability> requirements) {
-      return new BuildInvokerWrapper(inner.getBuildInvoker(project, requirements));
+      return Optional.of(new BuildInvokerWrapper(inner.getBuildInvoker(project, requirements).orElseThrow()));
     }
 
     @Override

--- a/base/tests/utils/unit/com/google/idea/blaze/base/bazel/FakeBuildSystem.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/bazel/FakeBuildSystem.java
@@ -46,10 +46,10 @@ public abstract class FakeBuildSystem implements BuildSystem {
   public abstract BuildSystemName getName();
 
   @Nullable
-  abstract BuildInvoker getBuildInvoker();
+  abstract Optional<BuildInvoker> getBuildInvoker();
 
   @Override
-  public BuildInvoker getBuildInvoker(Project project, Set<BuildInvoker.Capability> requirements) {
+  public Optional<BuildInvoker> getBuildInvoker(Project project, Set<BuildInvoker.Capability> requirements) {
     return getBuildInvoker();
   }
   @Override

--- a/java/src/com/google/idea/blaze/java/run/BlazeJavaRunProfileState.java
+++ b/java/src/com/google/idea/blaze/java/run/BlazeJavaRunProfileState.java
@@ -21,6 +21,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -115,16 +116,17 @@ public final class BlazeJavaRunProfileState extends BlazeJavaDebuggableRunProfil
   protected ProcessHandler startProcess() throws ExecutionException {
     Project project = getConfiguration().getProject();
     BlazeContext context = BlazeContext.create();
-    BuildInvoker invoker =
-      Blaze.getBuildSystemProvider(project)
-        .getBuildSystem()
-        .getBuildInvoker(
-          project, getExecutorType(), getConfiguration().getTargetKind());
     boolean debuggingLocalTest =
       TargetKindUtil.isLocalTest(getConfiguration().getTargetKind())
       && getExecutorType().isDebugType();
+    ImmutableSet<BuildInvoker.Capability> requirements =
+      debuggingLocalTest ? ImmutableSet.of(BuildInvoker.Capability.DEBUG_LOCAL_TEST) : ImmutableSet.of();
+    BuildInvoker invoker =
+      Blaze.getBuildSystemProvider(project)
+        .getBuildSystem()
+        .getBuildInvoker(project, requirements).orElseThrow();
     if (debuggingLocalTest
-        && !invoker.getCapabilities().contains(BuildInvoker.Capability.SUPPORTS_CLI)) {
+        && !invoker.getCapabilities().contains(BuildInvoker.Capability.SUPPORT_CLI)) {
       return startProcessRunfilesCase(project);
     }
     return startProcessBazelCliCase(invoker, project, context);
@@ -193,7 +195,8 @@ public final class BlazeJavaRunProfileState extends BlazeJavaDebuggableRunProfil
             return consoleView;
           }
         });
-    } else {
+    }
+    else {
       blazeCommand =
         getBlazeCommandBuilder(
           project,
@@ -280,7 +283,8 @@ public final class BlazeJavaRunProfileState extends BlazeJavaDebuggableRunProfil
       int debugPort = handlerState.getDebugPortState().port;
       if (isBinary) {
         command.addExeFlags(debugPortFlag(false, debugPort));
-      } else {
+      }
+      else {
         command.addBlazeFlags(BlazeFlags.JAVA_TEST_DEBUG);
         command.addBlazeFlags(debugPortFlag(true, debugPort));
       }
@@ -380,7 +384,7 @@ public final class BlazeJavaRunProfileState extends BlazeJavaDebuggableRunProfil
           // later. The LocalTestResultFinderStrategy won't work here since it writes/reads the
           // test results to a local file.
           verify(testResultFinderStrategy instanceof BlazeTestResultHolder);
-          ((BlazeTestResultHolder) testResultFinderStrategy).setTestResults(blazeTestResults);
+          ((BlazeTestResultHolder)testResultFinderStrategy).setTestResults(blazeTestResults);
           processHandler.detachProcess();
         }
 
@@ -388,7 +392,7 @@ public final class BlazeJavaRunProfileState extends BlazeJavaDebuggableRunProfil
         public void onFailure(Throwable throwable) {
           context.handleException(throwable.getMessage(), throwable);
           verify(testResultFinderStrategy instanceof BlazeTestResultHolder);
-          ((BlazeTestResultHolder) testResultFinderStrategy)
+          ((BlazeTestResultHolder)testResultFinderStrategy)
             .setTestResults(BlazeTestResults.NO_RESULTS);
           processHandler.detachProcess();
         }
@@ -402,7 +406,7 @@ public final class BlazeJavaRunProfileState extends BlazeJavaDebuggableRunProfil
           if (willBeDestroyed) {
             context.setCancelled();
             verify(testResultFinderStrategy instanceof BlazeTestResultHolder);
-            ((BlazeTestResultHolder) testResultFinderStrategy)
+            ((BlazeTestResultHolder)testResultFinderStrategy)
               .setTestResults(BlazeTestResults.NO_RESULTS);
             processHandler.detachProcess();
           }


### PR DESCRIPTION
Cherry pick AOSP commit [226defcef8928f0846b8fb4346e840b5a2b38864](https://cs.android.com/android-studio/platform/tools/adt/idea/+/226defcef8928f0846b8fb4346e840b5a2b38864).

STAT (diff to AOSP): 0 insertions(+), 0 deletion(-)

The capabilities of a build invoker are used like the hard requirements
by the callers to obtain an appropriate invoker. For example, if a
caller needs to build an android instrumentation test, it calls
getBuildInvoker with a required capability BUILDS_AIT.

This change updates the capabilities in such a way that they represent
what caller requires, instead of what a build system can do.

There is no behavior change in the IDE, the following changes are made
to the capabilities based on what they're used for.
1. IS_LOCAL -> BUILD_AIT.
2. SUPPORTS_PARALLELISM -> BUILD_PARALLEL_SHARDS.
3. SUPPORTS_API -> RUN_REMOTE_QUERIES.
4. SUPPORTS_DBIP -> removed.
5. DEBUG_LOCAL_TEST -> added.

Bug: 374906681
Test: n/a

Change-Id: Id29c1e5eb6e3561552a8edc1e334963da97e2da3

AOSP: 226defcef8928f0846b8fb4346e840b5a2b38864
