### PR TITLE
Declare BlazeNativeDebuggerAppContextProvider as an extension point for the NDK NativeDebuggerAppContextProvider

### DIFF
--- a/aswb/src/META-INF/ndk_contents.xml
+++ b/aswb/src/META-INF/ndk_contents.xml
@@ -33,4 +33,8 @@
     <androidDebugger implementation="com.google.idea.blaze.android.cppimpl.debug.BlazeNativeAndroidDebugger"/>
   </extensions>
 
+  <extensions defaultExtensionNs="com.android.tools">
+    <ndk.run.NativeDebuggerAppContextProvider implementation="com.google.idea.blaze.android.run.BlazeNativeDebuggerAppContextProvider"/>
+  </extensions>
+
 </idea-plugin>


### PR DESCRIPTION

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

[# Discussion thread for this change](https://bazelbuild.slack.com/archives/C025SBYFC4E/p1741809299854629)

Issue number: https://github.com/bazelbuild/intellij/issues/295

# Description of this change
Native debugging fails with ` No NativeDebuggerAppContext available for com.google.idea.blaze.android.run.BazelApplicationProjectContext` because there are no extension points declared by the plugin. This fixes that issue


