### PR TITLE
Do not attempt to parse test results from an ACTION_COMPLETED build event if the event isn't associated with any label.

### DIFF
--- a/base/src/com/google/idea/blaze/base/command/buildresult/BuildEventProtocolOutputReader.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/BuildEventProtocolOutputReader.java
@@ -52,13 +52,15 @@ public final class BuildEventProtocolOutputReader {
     ImmutableList.Builder<BlazeTestResult> results = ImmutableList.builder();
     BuildEventStreamProtos.BuildEvent event;
     while ((event = streamProvider.getNext()) != null) {
+      String label;
+      Kind kind;
       switch (event.getId().getIdCase()) {
         case STARTED:
           startTimeMillis = event.getStarted().getStartTimeMillis();
           continue;
         case TARGET_COMPLETED:
-          String label = event.getId().getTargetCompleted().getLabel();
-          Kind kind = parseTargetKind(event.getCompleted().getTargetKind());
+          label = event.getId().getTargetCompleted().getLabel();
+          kind = parseTargetKind(event.getCompleted().getTargetKind());
           if (kind != null) {
             labelToKind.put(label, kind);
           }
@@ -80,6 +82,9 @@ public final class BuildEventProtocolOutputReader {
                   startTimeMillis));
           continue;
         case ACTION_COMPLETED:
+          if(!event.getId().getActionCompleted().hasLabel()) {
+            continue;
+          }
           label = event.getId().getActionCompleted().getLabel();
           // If no test result is available after action_completed event,
           // add a NO_STATUS test result.

--- a/third_party/bazel/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto
+++ b/third_party/bazel/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto
@@ -168,9 +168,9 @@ message BuildEventId {
   message ActionCompletedId {
     string primary_output = 1;
     // Optional, the label of the owner of the action, for reference.
-    string label = 2;
+    optional string label = 2;
     // Optional, the id of the configuration of the action owner.
-    ConfigurationId configuration = 3;
+    optional ConfigurationId configuration = 3;
   }
 
   // Identifier of an event reporting an event associated with an unconfigured


### PR DESCRIPTION
This is a quick fix for #7586. There might be a better way to handle these events, but this seems to be good enough.

# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #7586
# Description of this change

