### PR TITLE
Workaround fix for java project sync without bzlmod for bazel 8+

### DIFF
--- a/base/src/com/google/idea/blaze/base/model/AspectSyncProjectData.java
+++ b/base/src/com/google/idea/blaze/base/model/AspectSyncProjectData.java
@@ -111,8 +111,8 @@ public final class AspectSyncProjectData implements BlazeProjectData {
   public ProjectData.BlazeProjectData toProto() {
     return ProjectData.BlazeProjectData.newBuilder()
         .setTargetData(targetData.toProto())
-        .setBlazeInfo(blazeInfo.toProto())
         .setBlazeVersionData(blazeVersionData.toProto())
+        .setBlazeInfo(blazeInfo.toProto())
         .setWorkspacePathResolver(workspacePathResolver.toProto())
         .setWorkspaceLanguageSettings(workspaceLanguageSettings.toProto())
         .setSyncState(syncState.toProto())

--- a/base/src/com/google/idea/blaze/base/sync/ProjectStateSyncTask.java
+++ b/base/src/com/google/idea/blaze/base/sync/ProjectStateSyncTask.java
@@ -198,6 +198,7 @@ final class ProjectStateSyncTask {
                .setProjectViewSet(projectViewSet)
                .setLanguageSettings(workspaceLanguageSettings)
                .setBlazeVersionData(blazeVersionData)
+               .setBlazeInfo(blazeInfo)
                .setWorkingSet(workingSet)
                .setWorkspacePathResolver(workspacePathResolver)
                .setExternalWorkspaceData(externalWorkspaceData)

--- a/base/src/com/google/idea/blaze/base/sync/SyncProjectState.java
+++ b/base/src/com/google/idea/blaze/base/sync/SyncProjectState.java
@@ -16,6 +16,7 @@
 package com.google.idea.blaze.base.sync;
 
 import com.google.auto.value.AutoValue;
+import com.google.idea.blaze.base.command.info.BlazeInfo;
 import com.google.idea.blaze.base.model.BlazeVersionData;
 import com.google.idea.blaze.base.model.ExternalWorkspaceData;
 import com.google.idea.blaze.base.projectview.ProjectViewSet;
@@ -33,6 +34,8 @@ public abstract class SyncProjectState {
   public abstract WorkspaceLanguageSettings getLanguageSettings();
 
   public abstract BlazeVersionData getBlazeVersionData();
+
+  public abstract BlazeInfo getBlazeInfo();
 
   @Nullable
   public abstract WorkingSet getWorkingSet();
@@ -53,6 +56,8 @@ public abstract class SyncProjectState {
     public abstract Builder setLanguageSettings(WorkspaceLanguageSettings languageSettings);
 
     public abstract Builder setBlazeVersionData(BlazeVersionData blazeVersionData);
+
+    public abstract Builder setBlazeInfo(BlazeInfo blazeInfo);
 
     public abstract Builder setWorkingSet(@Nullable WorkingSet workingSet);
 

--- a/base/src/com/google/idea/blaze/base/sync/aspects/storage/AspectStorageService.kt
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/storage/AspectStorageService.kt
@@ -121,6 +121,7 @@ class AspectStorageService(private val project: Project, private val scope: Coro
       .setWorkspacePathResolver(projectData.workspacePathResolver)
       .setWorkingSet(null)
       .setBlazeVersionData(versionData)
+      .setBlazeInfo(projectData.blazeInfo)
       .build()
 
     prepare(parentCtx, state)

--- a/base/src/com/google/idea/blaze/base/sync/aspects/storage/AspectTemplateWriter.kt
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/storage/AspectTemplateWriter.kt
@@ -16,12 +16,12 @@
 package com.google.idea.blaze.base.sync.aspects.storage
 
 import com.google.common.collect.ImmutableMap
-import com.google.idea.blaze.base.sync.aspects.storage.AspectRepositoryProvider.ASPECT_TEMPLATE_DIRECTORY
 import com.google.idea.blaze.base.model.primitives.LanguageClass
 import com.google.idea.blaze.base.projectview.ProjectViewManager
 import com.google.idea.blaze.base.projectview.ProjectViewSet
 import com.google.idea.blaze.base.sync.SyncProjectState
 import com.google.idea.blaze.base.sync.SyncScope.SyncFailedException
+import com.google.idea.blaze.base.sync.aspects.storage.AspectRepositoryProvider.ASPECT_TEMPLATE_DIRECTORY
 import com.google.idea.blaze.base.sync.codegenerator.CodeGeneratorRuleNameHelper
 import com.google.idea.blaze.base.util.TemplateWriter
 import com.intellij.openapi.project.Project
@@ -102,12 +102,14 @@ class AspectTemplateWriter : AspectWriter {
     val externalWorkspaceData = state.externalWorkspaceData
     val isAtLeastBazel8 = state.blazeVersionData.bazelIsAtLeastVersion(8, 0, 0)
     val isAtLeastBazel9 = state.blazeVersionData.bazelIsAtLeastVersion(9, 0, 0)
+    val isNotBzlmod = state.blazeInfo.starlarkSemantics.contains("enable_bzlmod=false")
+    fun hasRepository(name: String) = externalWorkspaceData?.getByRepoName(name) != null
 
     val isJavaEnabled = activeLanguages.contains(LanguageClass.JAVA) &&
-        (externalWorkspaceData != null && (!isAtLeastBazel8 || externalWorkspaceData.getByRepoName("rules_java") != null))
+        (externalWorkspaceData != null && (!isAtLeastBazel8 || isNotBzlmod || hasRepository("rules_java")))
 
     val isPythonEnabled = activeLanguages.contains(LanguageClass.PYTHON) &&
-        (externalWorkspaceData != null && (!isAtLeastBazel8 || externalWorkspaceData.getByRepoName("rules_python") != null))
+        (externalWorkspaceData != null && (!isAtLeastBazel8 || isNotBzlmod || hasRepository("rules_python")))
 
     return ImmutableMap.of(
       "bazel8OrAbove", if (isAtLeastBazel8) "true" else "false",

--- a/base/src/com/google/idea/blaze/base/sync/aspects/storage/AspectTemplateWriter.kt
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/storage/AspectTemplateWriter.kt
@@ -102,7 +102,7 @@ class AspectTemplateWriter : AspectWriter {
     val externalWorkspaceData = state.externalWorkspaceData
     val isAtLeastBazel8 = state.blazeVersionData.bazelIsAtLeastVersion(8, 0, 0)
     val isAtLeastBazel9 = state.blazeVersionData.bazelIsAtLeastVersion(9, 0, 0)
-    val isNotBzlmod = state.blazeInfo.starlarkSemantics.contains("enable_bzlmod=false")
+    val isNotBzlmod = state.blazeInfo.starlarkSemantics?.contains("enable_bzlmod=false") ?: false
     fun hasRepository(name: String) = externalWorkspaceData?.getByRepoName(name) != null
 
     val isJavaEnabled = activeLanguages.contains(LanguageClass.JAVA) &&

--- a/base/tests/unittests/com/google/idea/blaze/base/sync/BlazeSyncManagerTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/sync/BlazeSyncManagerTest.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Sets;
 import com.google.idea.blaze.base.BlazeTestCase;
 import com.google.idea.blaze.base.bazel.BazelBuildSystemProvider;
 import com.google.idea.blaze.base.bazel.BuildSystemProvider;
+import com.google.idea.blaze.base.command.info.BlazeInfo;
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.BlazeVersionData;
 import com.google.idea.blaze.base.model.ExternalWorkspaceData;
@@ -39,6 +40,7 @@ import com.google.idea.blaze.base.projectview.ProjectViewSet;
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.settings.BlazeImportSettingsManager;
 import com.google.idea.blaze.base.settings.BlazeUserSettings;
+import com.google.idea.blaze.base.settings.BuildSystemName;
 import com.google.idea.blaze.base.sync.projectview.WorkspaceLanguageSettings;
 import com.google.idea.blaze.base.sync.workspace.WorkspacePathResolver;
 import com.google.idea.blaze.base.sync.workspace.WorkspacePathResolverImpl;
@@ -191,6 +193,7 @@ public class BlazeSyncManagerTest extends BlazeTestCase {
         .setLanguageSettings(new WorkspaceLanguageSettings(WorkspaceType.ANDROID, activeLanguages))
         .setProjectViewSet(MockProjectViewManager.getInstance(project).getProjectViewSet())
         .setBlazeVersionData(BlazeVersionData.builder().build())
+        .setBlazeInfo(BlazeInfo.builder().build(BuildSystemName.Blaze))
         .setWorkspacePathResolver(
             new WorkspacePathResolverImpl(WorkspaceRoot.fromProjectSafe(project)))
         .setExternalWorkspaceData(ExternalWorkspaceData.EMPTY)

--- a/base/tests/unittests/com/google/idea/blaze/base/sync/BlazeSyncManagerTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/sync/BlazeSyncManagerTest.java
@@ -31,6 +31,7 @@ import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.BlazeVersionData;
 import com.google.idea.blaze.base.model.ExternalWorkspaceData;
 import com.google.idea.blaze.base.model.MockBlazeProjectDataBuilder;
+import com.google.idea.blaze.base.model.RemoteOutputArtifacts;
 import com.google.idea.blaze.base.model.primitives.LanguageClass;
 import com.google.idea.blaze.base.model.primitives.TargetExpression;
 import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
@@ -193,7 +194,13 @@ public class BlazeSyncManagerTest extends BlazeTestCase {
         .setLanguageSettings(new WorkspaceLanguageSettings(WorkspaceType.ANDROID, activeLanguages))
         .setProjectViewSet(MockProjectViewManager.getInstance(project).getProjectViewSet())
         .setBlazeVersionData(BlazeVersionData.builder().build())
-        .setBlazeInfo(BlazeInfo.builder().build(BuildSystemName.Blaze))
+        .setBlazeInfo(
+            BlazeInfo.createMockBlazeInfo(
+                "/",
+                "/root",
+                "/root/out/bin",
+                "/root/out/gen",
+                "/root/out/testlogs"))
         .setWorkspacePathResolver(
             new WorkspacePathResolverImpl(WorkspaceRoot.fromProjectSafe(project)))
         .setExternalWorkspaceData(ExternalWorkspaceData.EMPTY)


### PR DESCRIPTION
This is a fix for #7432 with a workaround applied to the latest codebase. The main problem was the fact, that we were not setting up `externalWorkspaceData` at all if bzlmod was disabled.

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

