### PR TITLE
fix: replace string with modern providers

### DIFF
--- a/aspect/fast_build_info.bzl
+++ b/aspect/fast_build_info.bzl
@@ -113,11 +113,10 @@ def _fast_build_info_impl(target, ctx):
     if write_output:
         output_file = ctx.actions.declare_file(target.label.name + ".ide-fast-build-info.txt")
         ctx.actions.write(output_file, proto.encode_text(struct_omit_none(**info)))
-        output_files += [output_file]
+        output_files.append(output_file)
 
     output_groups = depset(output_files, transitive = dep_outputs)
-
-    return struct(output_groups = {"ide-fast-build": output_groups})
+    return [OutputGroupInfo(**{"ide-fast-build": output_groups})]
 
 def _get_all_dep_outputs(dep_targets):
     """Get the ide-fast-build output files for all dependencies"""

--- a/aspect/intellij_info_impl.bzl
+++ b/aspect/intellij_info_impl.bzl
@@ -1185,10 +1185,10 @@ def intellij_info_aspect_impl(target, ctx, semantics):
 
     tags = ctx.rule.attr.tags
     if "no-ide" in tags:
-        return struct()
+        return []
 
     if _is_analysis_test(target):
-        return struct()
+        return []
 
     rule_attrs = ctx.rule.attr
 


### PR DESCRIPTION
This is cherrypick of: 15bdabea953ae75a4b38acb0df5dd15981bb0576
PiperOrigin-RevId: 745510931

Strings used to refer to legacy struct providers, which were removed from Bazel.

Legacy struct providers have been deprecated by Bazel. Replacing them with modern providers, will make it possible to simplify and remove legacy handling from Blaze.

The change is a no-op.

More information: https://github.com/bazelbuild/bazel/issues/25836
