### PR TITLE
Revert "Return NO_STATUS test result if no tests were run (#7562)"

### DIFF
--- a/base/src/com/google/idea/blaze/base/command/buildresult/BuildEventProtocolOutputReader.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/BuildEventProtocolOutputReader.java
@@ -29,6 +29,10 @@ import com.google.idea.blaze.base.run.testlogs.BlazeTestResult;
 import com.google.idea.blaze.base.run.testlogs.BlazeTestResult.TestStatus;
 import com.google.idea.blaze.base.run.testlogs.BlazeTestResults;
 import com.google.idea.blaze.common.artifact.OutputArtifact;
+import com.intellij.util.io.URLUtil;
+import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -78,19 +82,6 @@ public final class BuildEventProtocolOutputReader {
                   labelToKind.get(label),
                   event.getTestResult(),
                   startTimeMillis));
-          continue;
-        case ACTION_COMPLETED:
-          label = event.getId().getActionCompleted().getLabel();
-          // If no test result is available after action_completed event,
-          // add a NO_STATUS test result.
-          if (results.build().isEmpty()) {
-            results.add(
-              parseTestResult(
-                label,
-                labelToKind.get(label),
-                event.getTestResult(),
-                startTimeMillis));
-          }
           continue;
         default: // continue
       }


### PR DESCRIPTION
Since #7562 introduces #7586 I'd suggest to revert this pick for the release tomorrow. Reverting this commit will reintroduce #472, however I already have an idea how to properly address this issue. 

I'll prepare a proper fix for #472 as part of the next beta release. 