### PR TITLE
Enable CLion headless tests

### DIFF
--- a/clwb/BUILD
+++ b/clwb/BUILD
@@ -198,7 +198,7 @@ test_suite(
     name = "headless_tests",
     tests = [
         ":external_includes_headless_test",
-        # ":llvm_toolchain_headless_test", excluded for now since they are kinda slow
+        ":llvm_toolchain_headless_test",
         ":query_sync_headless_test",
         ":simple_headless_test",
         ":virtual_includes_headless_test",

--- a/clwb/tests/headlesstests/com/google/idea/blaze/clwb/ExecutionTest.java
+++ b/clwb/tests/headlesstests/com/google/idea/blaze/clwb/ExecutionTest.java
@@ -39,7 +39,7 @@ public class ExecutionTest extends ClwbHeadlessTestCase {
     errors.assertNoErrors();
 
     checkRun();
-    // checkTest(); -- java.lang.IllegalArgumentException: Not a valid label, no target name found
+    checkTest();
   }
 
   private void checkRun() throws Exception {

--- a/clwb/tests/headlesstests/com/google/idea/blaze/clwb/base/ClwbHeadlessTestCase.java
+++ b/clwb/tests/headlesstests/com/google/idea/blaze/clwb/base/ClwbHeadlessTestCase.java
@@ -3,7 +3,9 @@ package com.google.idea.blaze.clwb.base;
 import static com.google.common.truth.Truth.assertThat;
 import static junit.framework.Assert.fail;
 
+import com.google.idea.blaze.base.bazel.BazelVersion;
 import com.google.idea.testing.headless.HeadlessTestCase;
+import com.google.idea.testing.headless.ProjectViewBuilder;
 import com.intellij.ide.plugins.PluginManager;
 import com.intellij.openapi.application.PathManager;
 import com.intellij.openapi.extensions.PluginId;
@@ -43,6 +45,12 @@ public class ClwbHeadlessTestCase extends HeadlessTestCase {
     } catch (IOException e) {
       fail("could not create bin path symlink: " + e.getMessage());
     }
+  }
+
+  @Override
+  protected ProjectViewBuilder projectViewText(BazelVersion version) {
+    // required for Bazel 6 integration tests
+    return super.projectViewText(version).addBuildFlag("--cxxopt=-std=c++17");
   }
 
   protected OCWorkspace getWorkspace() {


### PR DESCRIPTION
- Enable llvm integration test, since we paused AOSP picks we can enable these tests again
- Enable further tests for cc_test run configs after the fix in #7609