### PR TITLE
Remove redundant overrides of BlazeIntegrationTestCase.buildSystem()

### DIFF
--- a/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/findusages/ExternalWorkspaceFindUsagesTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/findusages/ExternalWorkspaceFindUsagesTest.java
@@ -25,7 +25,6 @@ import com.google.idea.blaze.base.lang.buildfile.psi.StringLiteral;
 import com.google.idea.blaze.base.lang.buildfile.psi.util.PsiUtils;
 import com.google.idea.blaze.base.lang.buildfile.search.FindUsages;
 import com.google.idea.blaze.base.model.primitives.WorkspacePath;
-import com.google.idea.blaze.base.settings.BuildSystemName;
 import com.intellij.psi.PsiReference;
 import java.util.Arrays;
 import java.util.stream.Collectors;
@@ -36,11 +35,6 @@ import org.junit.runners.JUnit4;
 /** Test that references to external workspaces appear in 'find usages' results. */
 @RunWith(JUnit4.class)
 public class ExternalWorkspaceFindUsagesTest extends BuildFileIntegrationTestCase {
-
-  @Override
-  protected BuildSystemName buildSystem() {
-    return BuildSystemName.Bazel;
-  }
 
   @Test
   public void testFindUsagesFromWorkspaceFile() {

--- a/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/references/ExternalWorkspaceReferenceTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/references/ExternalWorkspaceReferenceTest.java
@@ -27,7 +27,6 @@ import com.google.idea.blaze.base.lang.buildfile.psi.StringLiteral;
 import com.google.idea.blaze.base.lang.buildfile.psi.util.PsiUtils;
 import com.google.idea.blaze.base.model.ExternalWorkspaceData;
 import com.google.idea.blaze.base.model.primitives.WorkspacePath;
-import com.google.idea.blaze.base.settings.BuildSystemName;
 import com.intellij.psi.PsiFile;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,11 +35,6 @@ import org.junit.runners.JUnit4;
 /** Tests that labels referencing external workspaces are correctly resolved. */
 @RunWith(JUnit4.class)
 public class ExternalWorkspaceReferenceTest extends BuildFileIntegrationTestCase {
-
-  @Override
-  protected BuildSystemName buildSystem() {
-    return BuildSystemName.Bazel;
-  }
 
   @Test
   public void testExternalWorkspaceTargetReference() {

--- a/kotlin/tests/integrationtests/com/google/idea/blaze/kotlin/run/debug/BazelKotlinxCoroutinesLibFinderTest.java
+++ b/kotlin/tests/integrationtests/com/google/idea/blaze/kotlin/run/debug/BazelKotlinxCoroutinesLibFinderTest.java
@@ -28,7 +28,6 @@ import com.google.idea.blaze.base.model.MockBlazeProjectDataManager;
 import com.google.idea.blaze.base.model.primitives.WorkspacePath;
 import com.google.idea.blaze.base.run.BlazeCommandRunConfiguration;
 import com.google.idea.blaze.base.run.producers.BlazeRunConfigurationProducerTestCase;
-import com.google.idea.blaze.base.settings.BuildSystemName;
 import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
 import com.intellij.execution.configurations.RunConfiguration;
 import com.intellij.psi.PsiFile;
@@ -54,11 +53,6 @@ public class BazelKotlinxCoroutinesLibFinderTest extends BlazeRunConfigurationPr
   private TargetIdeInfo kotlinxCoroutinesLibMultipleJars;
 
   private PsiFile mainFile;
-
-  @Override
-  protected BuildSystemName buildSystem() {
-    return BuildSystemName.Bazel;
-  }
 
   @Before
   public final void setup() throws Throwable {

--- a/python/tests/integrationtests/com/google/idea/blaze/python/resolve/provider/BazelPyGenfilesImportResolverStrategyTest.java
+++ b/python/tests/integrationtests/com/google/idea/blaze/python/resolve/provider/BazelPyGenfilesImportResolverStrategyTest.java
@@ -19,7 +19,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.idea.blaze.base.command.info.BlazeInfo;
 import com.google.idea.blaze.base.model.primitives.WorkspacePath;
-import com.google.idea.blaze.base.settings.BuildSystemName;
 import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
 import com.intellij.psi.PsiFile;
 import com.jetbrains.python.psi.PyFile;
@@ -33,11 +32,6 @@ import org.junit.runners.JUnit4;
 /** Test behavior of {@link BazelPyGenfilesImportResolverStrategy}. */
 @RunWith(JUnit4.class)
 public class BazelPyGenfilesImportResolverStrategyTest extends PyImportResolverStrategyTestCase {
-
-  @Override
-  protected BuildSystemName buildSystem() {
-    return BuildSystemName.Bazel;
-  }
 
   @Test
   public void testResolveGenfiles() {

--- a/python/tests/integrationtests/com/google/idea/blaze/python/resolve/provider/BazelPyImportResolverStrategyTest.java
+++ b/python/tests/integrationtests/com/google/idea/blaze/python/resolve/provider/BazelPyImportResolverStrategyTest.java
@@ -25,7 +25,6 @@ import com.google.idea.blaze.base.lang.buildfile.psi.util.PsiUtils;
 import com.google.idea.blaze.base.model.MockBlazeProjectDataBuilder;
 import com.google.idea.blaze.base.model.MockBlazeProjectDataManager;
 import com.google.idea.blaze.base.model.primitives.WorkspacePath;
-import com.google.idea.blaze.base.settings.BuildSystemName;
 import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
 import com.intellij.psi.PsiFile;
 import com.jetbrains.python.codeInsight.imports.AutoImportQuickFix;
@@ -40,11 +39,6 @@ import org.junit.runners.JUnit4;
 /** Test behavior of {@link BazelPyImportResolverStrategy}. */
 @RunWith(JUnit4.class)
 public class BazelPyImportResolverStrategyTest extends PyImportResolverStrategyTestCase {
-
-  @Override
-  protected BuildSystemName buildSystem() {
-    return BuildSystemName.Bazel;
-  }
 
   @Test
   public void testResolveWorkspaceImport() {

--- a/scala/tests/integrationtests/com/google/idea/blaze/scala/run/producers/DeployableJarRunConfigurationProducerTest.java
+++ b/scala/tests/integrationtests/com/google/idea/blaze/scala/run/producers/DeployableJarRunConfigurationProducerTest.java
@@ -25,7 +25,6 @@ import com.google.idea.blaze.base.model.MockBlazeProjectDataManager;
 import com.google.idea.blaze.base.model.primitives.TargetExpression;
 import com.google.idea.blaze.base.model.primitives.WorkspacePath;
 import com.google.idea.blaze.base.run.producers.BlazeRunConfigurationProducerTestCase;
-import com.google.idea.blaze.base.settings.BuildSystemName;
 import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
 import com.intellij.execution.application.ApplicationConfiguration;
 import com.intellij.execution.configurations.RunConfiguration;
@@ -39,11 +38,6 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class DeployableJarRunConfigurationProducerTest
     extends BlazeRunConfigurationProducerTestCase {
-
-  @Override
-  protected BuildSystemName buildSystem() {
-    return BuildSystemName.Bazel;
-  }
 
   @Before
   public final void suppressNativeProducers() {


### PR DESCRIPTION
This is a small refactor of integration tests that has no effect on their execution. `BuildSystemName.Bazel` has been the default since 330f255dd3a06fd5133b9d6884e86572506f7f3a, and we will probably never run any tests for Blaze at all.