### PR TITLE
headless tests: improve error logging

### DIFF
--- a/base/src/com/google/idea/blaze/base/scope/output/IssueOutput.kt
+++ b/base/src/com/google/idea/blaze/base/scope/output/IssueOutput.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 The Bazel Authors. All rights reserved.
+ * Copyright 2025 The Bazel Authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,9 @@ class IssueOutput(
   issue: BuildIssue,
   val kind: MessageEvent.Kind,
 ) : Output, BuildIssue by issue {
+  override fun toString(): String {
+    return "$kind: \"$title\" \"$description\""
+  }
 
   companion object {
     @JvmStatic

--- a/testing/src/com/google/idea/testing/headless/SyncOutput.java
+++ b/testing/src/com/google/idea/testing/headless/SyncOutput.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.idea.testing.headless;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -47,9 +63,8 @@ public class SyncOutput {
     }
 
     builder.append(separator);
-    for (int i = 0; i < issues.size(); i++) {
-      final var issue = issues.get(i) ;
-      builder.append(String.format("%s: %s%n%s%n", issue.getKind(), issue.getTitle(), issue.getDescription()));
+    for (final IssueOutput issue : issues) {
+      builder.append(issue.toString());
     }
     if (issues.isEmpty()) {
       builder.append("No issues during sync\n");
@@ -65,6 +80,6 @@ public class SyncOutput {
         collectLog()
     );
 
-    assertThat(issues).isEmpty();
+    assertWithMessage(message).that(issues).isEmpty();
   }
 }


### PR DESCRIPTION
Truth just prints `toString()` version of asserted elements that does not have required information.

* Let truth print the issue itself
* Also assert with an extra message for debugging purposes