### PR TITLE
Fix intellij plugin target collection with qsync

### DIFF
--- a/plugin_dev/src/com/google/idea/blaze/plugin/IntellijPluginRule.java
+++ b/plugin_dev/src/com/google/idea/blaze/plugin/IntellijPluginRule.java
@@ -15,21 +15,23 @@
  */
 package com.google.idea.blaze.plugin;
 
-import com.google.idea.blaze.base.dependencies.TargetInfo;
 import com.google.idea.blaze.base.model.primitives.GenericBlazeRules.RuleTypes;
-import com.google.idea.blaze.base.model.primitives.Kind;
-import com.google.idea.blaze.base.model.primitives.Label;
 
+import com.google.idea.blaze.common.BuildTarget;
 import javax.annotation.Nullable;
 
 /** Utility methods for intellij_plugin blaze targets */
 public class IntellijPluginRule {
 
-  public static boolean isPluginTarget(TargetInfo target) {
-    return isPluginTargetKind(target.getKind());
+  public static boolean isPluginTarget(@Nullable BuildTarget target) {
+    if (target == null) {
+      return false;
+    }
+
+    return isPluginTargetKind(target.kind());
   }
 
-  private static boolean isPluginTargetKind(@Nullable Kind kind) {
-    return RuleTypes.INTELLIJ_PLUGIN_DEBUG_TARGET.getKind().equals(kind);
+  private static boolean isPluginTargetKind(String kind) {
+    return RuleTypes.INTELLIJ_PLUGIN_DEBUG_TARGET.getKind().getKindString().equals(kind);
   }
 }

--- a/plugin_dev/src/com/google/idea/blaze/plugin/run/BlazeIntellijPluginConfigurationType.java
+++ b/plugin_dev/src/com/google/idea/blaze/plugin/run/BlazeIntellijPluginConfigurationType.java
@@ -19,7 +19,6 @@ import static java.util.stream.Collectors.toCollection;
 
 import com.google.common.base.Splitter;
 import com.google.idea.blaze.base.dependencies.TargetInfo;
-import com.google.idea.blaze.base.ideinfo.TargetIdeInfo;
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.model.primitives.WorkspaceType;
@@ -74,7 +73,7 @@ public class BlazeIntellijPluginConfigurationType implements ConfigurationType {
       if (target == null) {
         return false;
       }
-      return IntellijPluginRule.isPluginTarget(TargetInfo.builder(label, target.kind()).build());
+      return IntellijPluginRule.isPluginTarget(target);
     }
 
     @Override
@@ -141,10 +140,10 @@ public class BlazeIntellijPluginConfigurationType implements ConfigurationType {
       if (projectData == null) {
         return null;
       }
-      return projectData.getTargetMap().targets().stream()
-          .map(TargetIdeInfo::toTargetInfo)
+      return projectData.targets().stream()
+          .map(projectData::getBuildTarget)
           .filter(IntellijPluginRule::isPluginTarget)
-          .map(info -> info.label)
+          .map(info -> Label.create(info.label()))
           .findFirst()
           .orElse(null);
     }

--- a/querysync/java/com/google/idea/blaze/qsync/BlazeQueryParser.java
+++ b/querysync/java/com/google/idea/blaze/qsync/BlazeQueryParser.java
@@ -92,6 +92,7 @@ public class BlazeQueryParser {
       register(builder, RuleKinds.CC_RULE_KINDS, BlazeQueryParser::visitCcRule);
       register(builder, RuleKinds.PROTO_SOURCE_RULE_KINDS, BlazeQueryParser::visitProtoRule);
       register(builder, RuleKinds.PYTHON_RULE_KINDS, BlazeQueryParser::visitPythonRule);
+      register(builder, RuleKinds.INTELLIJ_PLUGIN, BlazeQueryParser::visitIntellijPluginRule);
       myVisitorsByRuleClass = builder.buildOrThrow();
     }
 
@@ -204,6 +205,10 @@ public class BlazeQueryParser {
     context.output(PrintOutput.log("%-10d Dependencies", javaDeps.size()));
 
     return graph;
+  }
+
+  private void visitIntellijPluginRule(Label label, QueryData.Rule rule, ProjectTarget.Builder targetBuilder) {
+    graphBuilder.allTargetLabelsBuilder().add(label);
   }
 
   private void visitPythonRule(Label label, QueryData.Rule rule, ProjectTarget.Builder targetBuilder) {

--- a/querysync/javatests/com/google/idea/blaze/qsync/query/QuerySpecTest.java
+++ b/querysync/javatests/com/google/idea/blaze/qsync/query/QuerySpecTest.java
@@ -91,9 +91,9 @@ public class QuerySpecTest {
         "_iml_module_", "_java_grpc_library", "_java_lite_grpc_library",
         "_kotlin_library", "android_binary", "android_instrumentation_test", "android_library",
         "android_local_test", "cc_binary", "cc_library", "cc_shared_library", "cc_test",
-        "java_binary", "java_library", "java_lite_proto_library", "java_mutable_proto_library",
-        "java_proto_library", "java_test", "kt_android_library_helper", "kt_jvm_binary",
-        "kt_jvm_library", "kt_jvm_library_helper", "kt_native_library", "proto_library",
+        "intellij_plugin_debug_target", "java_binary", "java_library", "java_lite_proto_library",
+        "java_mutable_proto_library", "java_proto_library", "java_test", "kt_android_library_helper",
+        "kt_jvm_binary", "kt_jvm_library", "kt_jvm_library_helper", "kt_native_library", "proto_library",
         "py_binary", "py_library", "py_test");
 
     QuerySpec qs =

--- a/shared/java/com/google/idea/blaze/common/RuleKinds.java
+++ b/shared/java/com/google/idea/blaze/common/RuleKinds.java
@@ -16,7 +16,6 @@
 package com.google.idea.blaze.common;
 
 import com.google.common.collect.ImmutableSet;
-import java.util.Set;
 
 /** Utility class for information about specific bazel rule kinds (java, cpp, etc.) */
 public final class RuleKinds {
@@ -59,6 +58,9 @@ public final class RuleKinds {
 
   public static final ImmutableSet<String> PYTHON_RULE_KINDS =
           ImmutableSet.of("py_library", "py_binary", "py_test");
+
+  public static final ImmutableSet<String> INTELLIJ_PLUGIN =
+      ImmutableSet.of("intellij_plugin_debug_target");
 
   public static boolean isJava(String ruleClass) {
     return JAVA_RULE_KINDS.contains(ruleClass) || ANDROID_RULE_KINDS.contains(ruleClass);


### PR DESCRIPTION
Fixes regression caused by #7548 that breaks the Bazel IntelliJ Plugin run configuration when using qsync.