### PR TITLE
Make debugging source mapping optional

### DIFF
--- a/cpp/src/META-INF/blaze-cpp.xml
+++ b/cpp/src/META-INF/blaze-cpp.xml
@@ -60,6 +60,7 @@
                     overrides="true"
     />
     <registryKey defaultValue="false" description="Disable absolute path trimming in debug clang builds" key="bazel.trim.absolute.path.disabled"/>
+    <registryKey defaultValue="true" description="Enable /proc/self/cwd to be mapped to the workspace root" key="bazel.cpp.debug.map_working_dir"/>
     <registryKey defaultValue="true" description="Allow external targets from source directories be imported in" key="bazel.cpp.sync.external.targets.from.directories"/>
     <registryKey defaultValue="false" description="Filter out some incompatible compiler flags (-include)" key="bazel.cpp.sync.workspace.filter.out.incompatible.flags"/>
     <registryKey defaultValue="true" description="Use _cpp_use_get_tool_for_action to get compiler executable" key="bazel.cc.aspect.use_get_tool_for_action"/>


### PR DESCRIPTION

# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: Issue number: https://github.com/bazelbuild/intellij/issues/7663


# Description of this change

ASwB maps /proc/self/cwd -> workspace root which is likely logic specific to Google Forge builds and creates issues for Android Studio  when it tries to resolve sources. It also assumes Linux only builds which is not the case outside google This PR allows to turn off the mapping using the registry key `bazel.cpp.debug.map_working_dir`

