### PR TITLE
Updated the example Scala project with Bzlmod.

### DIFF
--- a/examples/scala/with_bzlmod/MODULE.bazel
+++ b/examples/scala/with_bzlmod/MODULE.bazel
@@ -10,13 +10,5 @@ scala_deps = use_extension(
     "@rules_scala//scala/extensions:deps.bzl",
     "scala_deps",
 )
-scala_deps.toolchains(
-    scalatest = True,
-)
-
-#TODO Remove when this issue is closed: https://github.com/bazelbuild/rules_scala/issues/1482
-git_override(
-    module_name = "rules_scala",
-    branch = "bzlmod-bazel-8",
-    remote = "https://github.com/mbland/rules_scala.git",
-)
+scala_deps.scala()
+scala_deps.scalatest()


### PR DESCRIPTION
Since the rules_scala version [7.0.0](https://github.com/bazel-contrib/rules_scala/releases/tag/v7.0.0) has been officially released, the repository override is no longer needed.

Fixes #7649.