### PR TITLE
Do not egerly refresh the execroot on import

### DIFF
--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -408,6 +408,7 @@
     <cachesInvalidator implementation="com.google.idea.blaze.base.qsync.action.ResetQuerySyncAction$CachesInvalidator"/>
     <registryKey defaultValue="false" description="Disable auto import of bazel projects" key="bazel.auto.import.disabled"/>
     <registryKey defaultValue="false" description="Allow to have optional imports in project view" key="bazel.projectview.optional.imports"/>
+    <registryKey defaultValue="false" description="Refresh execroot on import" key="blaze.refresh.virtual.filesystem.execroot"/>
     <registryKey key="bazel.sync.resolve.virtual.includes"
                  description="Apply heuristics to detect correct location of headers which are accessed from _virtual_includes during build. (requires re-sync)"
                  defaultValue="true"/>

--- a/base/src/com/google/idea/blaze/base/sync/ProjectUpdateSyncTask.java
+++ b/base/src/com/google/idea/blaze/base/sync/ProjectUpdateSyncTask.java
@@ -73,6 +73,7 @@ import com.intellij.openapi.roots.ContentEntry;
 import com.intellij.openapi.roots.ModifiableRootModel;
 import com.intellij.openapi.roots.ex.ProjectRootManagerEx;
 import com.intellij.openapi.util.io.FileUtil;
+import com.intellij.openapi.util.registry.Registry;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.VirtualFileManager;
@@ -285,6 +286,10 @@ final class ProjectUpdateSyncTask {
 
   private static void refreshVirtualFileSystem(
       BlazeContext context, Project project, BlazeProjectData blazeProjectData) {
+    if (Registry.is("blaze.refresh.virtual.filesystem.execroot")) {
+      return;
+    }
+
     Scope.push(
         context,
         (childContext) -> {


### PR DESCRIPTION
A forced refresh, like:
```java
VfsUtil.markDirtyAndRefresh(
  /* async= */ false, 
  /* recursive= */ true, 
  /* reloadChildren= */ true, 
  root
);
```

Can be very expensive and lead to a modal refresh dialog. Furthermore, the manual refresh should not be necessary, since the VFS should pull changes as necessary. 