### PR TITLE
Changed '--noexperimental_run_validations' to '--norun_validations'.

### DIFF
--- a/base/src/com/google/idea/blaze/base/command/BlazeFlags.java
+++ b/base/src/com/google/idea/blaze/base/command/BlazeFlags.java
@@ -59,7 +59,7 @@ public final class BlazeFlags {
 
   // Avoid running validation actions at the end of build. This flag is expected to be set only
   // during syncing projects.
-  public static final String DISABLE_VALIDATIONS = "--noexperimental_run_validations";
+  public static final String DISABLE_VALIDATIONS = "--norun_validations";
 
   // Since query cannot resolve target_compatible_with constraints we try to explicitly build
   // incompatible targets during the sync. This flags allows bazel to skip incompatible targets

--- a/base/src/com/google/idea/blaze/base/qsync/BazelDependencyBuilder.java
+++ b/base/src/com/google/idea/blaze/base/qsync/BazelDependencyBuilder.java
@@ -15,7 +15,6 @@
  */
 package com.google.idea.blaze.base.qsync;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
@@ -281,7 +280,7 @@ public class BazelDependencyBuilder implements DependencyBuilder {
         String.format(
             "--aspects=%1$s%%collect_dependencies,%1$s%%package_dependencies",
             invocationFiles.aspectFileLabel()));
-    querySyncFlags.add("--noexperimental_run_validations");
+    querySyncFlags.add(BlazeFlags.DISABLE_VALIDATIONS);
     querySyncFlags.add("--keep_going");
     querySyncFlags.addAll(
         outputGroups.stream()


### PR DESCRIPTION
This flag has been [renamed](https://blog.bazel.build/2022/01/19/bazel-5.0.html) in Bazel 5.0.