### PR TITLE
feat: support indexing thrift_library

### DIFF
--- a/aspect/intellij_info_impl.bzl
+++ b/aspect/intellij_info_impl.bzl
@@ -253,7 +253,7 @@ def get_aspect_ids(ctx):
 
 def _is_language_specific_proto_library(ctx, target, semantics):
     """Returns True if the target is a proto library with attached language-specific aspect."""
-    if ctx.rule.kind != "proto_library":
+    if ctx.rule.kind != "proto_library" and ctx.rule.kind != "thrift_library":
         return False
     if java_info_in_target(target):
         return True
@@ -494,7 +494,7 @@ def collect_go_info(target, ctx, semantics, ide_info, ide_info_file, output_grou
             library_labels = [stringify_label(ctx.rule.attr.library.label)]
         elif getattr(ctx.rule.attr, "embed", None) != None:
             for library in ctx.rule.attr.embed:
-                if library[IntelliJInfo].kind == "go_source" or library[IntelliJInfo].kind == "go_proto_library":
+                if "intellij-sources-go-outputs" in library[IntelliJInfo].output_groups:
                     l = library[IntelliJInfo].output_groups["intellij-sources-go-outputs"].to_list()
                     sources += l
                     generated += [f for f in l if not f.is_source]

--- a/base/src/com/google/idea/blaze/base/model/primitives/GenericBlazeRules.java
+++ b/base/src/com/google/idea/blaze/base/model/primitives/GenericBlazeRules.java
@@ -27,6 +27,7 @@ public final class GenericBlazeRules implements Kind.Provider {
   /** Generic blaze rule types. */
   public enum RuleTypes {
     PROTO_LIBRARY("proto_library", LanguageClass.GENERIC, RuleType.LIBRARY),
+    THRIFT_LIBRARY("thrift_library", LanguageClass.GENERIC, RuleType.LIBRARY),
     TEST_SUITE("test_suite", LanguageClass.GENERIC, RuleType.TEST),
     INTELLIJ_PLUGIN_DEBUG_TARGET(
         "intellij_plugin_debug_target", LanguageClass.JAVA, RuleType.UNKNOWN),

--- a/golang/src/com/google/idea/blaze/golang/GoBlazeRules.java
+++ b/golang/src/com/google/idea/blaze/golang/GoBlazeRules.java
@@ -37,6 +37,7 @@ public final class GoBlazeRules implements Kind.Provider {
     GO_LIBRARY("go_library", LanguageClass.GO, RuleType.LIBRARY),
     GO_APPENGINE_LIBRARY("go_appengine_library", LanguageClass.GO, RuleType.LIBRARY),
     GO_PROTO_LIBRARY("go_proto_library", LanguageClass.GO, RuleType.LIBRARY),
+    GO_THRIFT_LIBRARY("go_thrift_library", LanguageClass.GO, RuleType.LIBRARY),
     GO_WRAP_CC("go_wrap_cc", LanguageClass.GO, RuleType.UNKNOWN),
     GO_WEB_TEST("go_web_test", LanguageClass.GO, RuleType.TEST);
 

--- a/golang/src/com/google/idea/blaze/golang/resolve/BlazeGoPackage.java
+++ b/golang/src/com/google/idea/blaze/golang/resolve/BlazeGoPackage.java
@@ -125,13 +125,16 @@ public class BlazeGoPackage extends GoPackage {
       Project project, BlazeProjectData projectData, TargetKey targetKey) {
     TargetMap targetMap = projectData.getTargetMap();
     TargetIdeInfo target = targetMap.get(targetKey);
-    if (target == null || target.getKind() != GenericBlazeRules.RuleTypes.PROTO_LIBRARY.getKind()) {
+    if (target == null || !target.getKind().isOneOf(
+            GenericBlazeRules.RuleTypes.PROTO_LIBRARY.getKind(),
+            GenericBlazeRules.RuleTypes.THRIFT_LIBRARY.getKind())
+    ) {
       return targetKey;
     }
     return ReverseDependencyMap.get(project).get(targetKey).stream()
         .map(targetMap::get)
         .filter(Objects::nonNull)
-        .filter(t -> t.getKind() == RuleTypes.GO_PROTO_LIBRARY.getKind())
+        .filter(t -> t.getKind() == RuleTypes.GO_PROTO_LIBRARY.getKind() || t.getKind() == RuleTypes.GO_THRIFT_LIBRARY.getKind())
         .map(TargetIdeInfo::getKey)
         .findFirst()
         .orElse(targetKey);

--- a/querysync/java/com/google/idea/blaze/qsync/BlazeQueryParser.java
+++ b/querysync/java/com/google/idea/blaze/qsync/BlazeQueryParser.java
@@ -91,6 +91,7 @@ public class BlazeQueryParser {
       register(builder, RuleKinds.JAVA_RULE_KINDS, BlazeQueryParser::visitJavaRule);
       register(builder, RuleKinds.CC_RULE_KINDS, BlazeQueryParser::visitCcRule);
       register(builder, RuleKinds.PROTO_SOURCE_RULE_KINDS, BlazeQueryParser::visitProtoRule);
+      register(builder, RuleKinds.THRIFT_SOURCE_RULE_KINDS, BlazeQueryParser::visitProtoRule); // reuse visitProtoRule
       register(builder, RuleKinds.PYTHON_RULE_KINDS, BlazeQueryParser::visitPythonRule);
       register(builder, RuleKinds.INTELLIJ_PLUGIN, BlazeQueryParser::visitIntellijPluginRule);
       myVisitorsByRuleClass = builder.buildOrThrow();

--- a/querysync/javatests/com/google/idea/blaze/qsync/query/QuerySpecTest.java
+++ b/querysync/javatests/com/google/idea/blaze/qsync/query/QuerySpecTest.java
@@ -94,7 +94,7 @@ public class QuerySpecTest {
         "intellij_plugin_debug_target", "java_binary", "java_library", "java_lite_proto_library",
         "java_mutable_proto_library", "java_proto_library", "java_test", "kt_android_library_helper",
         "kt_jvm_binary", "kt_jvm_library", "kt_jvm_library_helper", "kt_native_library", "proto_library",
-        "py_binary", "py_library", "py_test");
+        "py_binary", "py_library", "py_test", "thrift_library");
 
     QuerySpec qs =
       QuerySpec.builder(QuerySpec.QueryStrategy.FILTERING_TO_KNOWN_AND_USED_TARGETS)

--- a/shared/java/com/google/idea/blaze/common/RuleKinds.java
+++ b/shared/java/com/google/idea/blaze/common/RuleKinds.java
@@ -55,6 +55,9 @@ public final class RuleKinds {
   /** Rule kinds that have proto files for sources. */
   public static final ImmutableSet<String> PROTO_SOURCE_RULE_KINDS =
       ImmutableSet.of("proto_library");
+  /** Rule kinds that have thrift files for sources. */
+  public static final ImmutableSet<String> THRIFT_SOURCE_RULE_KINDS =
+          ImmutableSet.of("thrift_library");
 
   public static final ImmutableSet<String> PYTHON_RULE_KINDS =
           ImmutableSet.of("py_library", "py_binary", "py_test");
@@ -75,7 +78,7 @@ public final class RuleKinds {
   }
 
   public static boolean isProtoSource(String ruleClass) {
-    return PROTO_SOURCE_RULE_KINDS.contains(ruleClass);
+    return PROTO_SOURCE_RULE_KINDS.contains(ruleClass) || THRIFT_SOURCE_RULE_KINDS.contains(ruleClass);
   }
 
   public static boolean isPythonSource(String ruleClass) {


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: #7677 

# Description of this change

Basically I just added THRIFT_LIBRARY alongside PROTO_LIBRARY, and `go_thrift_library` alongside `go_proto_library`. Since they both use `library[IntelliJInfo].output_groups["intellij-sources-go-outputs"]` I don't have to change how the index work. I just tell the code to recognize go_thrift_library and re-use `BlazeQueryParser::visitProtoRule` for indexing.