### PR TITLE
Use scoped process handler in BlazeCommandGenericRunConfigurationRunner

### DIFF
--- a/base/src/com/google/idea/blaze/base/run/confighandler/BlazeCommandGenericRunConfigurationRunner.java
+++ b/base/src/com/google/idea/blaze/base/run/confighandler/BlazeCommandGenericRunConfigurationRunner.java
@@ -142,7 +142,7 @@ public final class BlazeCommandGenericRunConfigurationRunner
               ImmutableList.of(),
               context);
       return isTest()
-          ? getProcessHandlerForTests(project, invoker, blazeCommand, workspaceRoot, context)
+          ? getProcessHandlerForTests(project, blazeCommand, workspaceRoot, context)
           : getScopedProcessHandler(project, blazeCommand.build(), workspaceRoot);
     }
 
@@ -185,7 +185,6 @@ public final class BlazeCommandGenericRunConfigurationRunner
 
     private ProcessHandler getProcessHandlerForTests(
         Project project,
-        BuildInvoker invoker,
         BlazeCommand.Builder blazeCommandBuilder,
         WorkspaceRoot workspaceRoot,
         BlazeContext context
@@ -221,6 +220,8 @@ public final class BlazeCommandGenericRunConfigurationRunner
 
       addConsoleFilters(consoleFilters.toArray(new Filter[0]));
 
+      // When running `bazel test`, bazel will not forward the environment to the tests themselves -- we need to use
+      // the --test_env flag for that. Therefore, we convert all the env vars to --test_env flags here.
       for (Map.Entry<String, String> env : handlerState.getUserEnvVarsState().getData().getEnvs().entrySet()) {
         blazeCommandBuilder.addBlazeFlags(BlazeFlags.TEST_ENV, String.format("%s=%s", env.getKey(), env.getValue()));
       }

--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrLauncher.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrLauncher.java
@@ -118,6 +118,8 @@ public final class BlazeCidrLauncher extends CidrLauncher {
     BlazeTestUiSession testUiSession = null;
     if (useTestUi()
         && BlazeTestEventsHandler.targetsSupported(project, configuration.getTargets())) {
+
+      // TODO: the result helper is closed before the command is executed, this is useless
       try (BuildResultHelper buildResultHelper = invoker.createBuildResultHelper()) {
         if (!(buildResultHelper instanceof BuildResultHelperBep)) {
           throw new ExecutionException("Build result helper not supported");


### PR DESCRIPTION
Follow up for: #7622

Revert to previous behaviour of using the ScopedProcess Handler in the BlazeCommandGenericRunConfigurationRunner and remove support for the generic process handler.

FYI, the entire logic with BuildResultHelperBep and LocalBuildEventProtocolTestFinderStrategy is pretty messy. The result helper is closed before the strategy is executed, causing all the 'could not delete BEP file' warnings. This needs a proper refactor later.