### PR TITLE
Implement `BuildToolModuleHandler` for Scala Projects to register Bazel Imported Scala Projects

### DIFF
--- a/scala/src/META-INF/blaze-scala.xml
+++ b/scala/src/META-INF/blaze-scala.xml
@@ -18,8 +18,4 @@
     <SyncPlugin implementation="com.google.idea.blaze.scala.sync.AlwaysPresentScalaSyncPlugin"/>
     <TargetKindProvider implementation="com.google.idea.blaze.scala.ScalaBlazeRules"/>
   </extensions>
-
-  <extensions defaultExtensionNs="org.jetbrains.sbt">
-    <buildToolModuleHandler implementation="com.google.idea.blaze.scala.BlazeScalaBuildToolModuleHandler"/>
-  </extensions>
 </idea-plugin>

--- a/scala/src/META-INF/blaze-scala.xml
+++ b/scala/src/META-INF/blaze-scala.xml
@@ -18,4 +18,8 @@
     <SyncPlugin implementation="com.google.idea.blaze.scala.sync.AlwaysPresentScalaSyncPlugin"/>
     <TargetKindProvider implementation="com.google.idea.blaze.scala.ScalaBlazeRules"/>
   </extensions>
+
+  <extensions defaultExtensionNs="org.jetbrains.sbt">
+    <buildToolModuleHandler implementation="com.google.idea.blaze.scala.BlazeScalaBuildToolModuleHandler"/>
+  </extensions>
 </idea-plugin>

--- a/scala/src/META-INF/scala-contents.xml
+++ b/scala/src/META-INF/scala-contents.xml
@@ -42,4 +42,8 @@
         implementation="com.google.idea.blaze.scala.run.producers.GenerateDeployableJarTaskProvider"/>
     <postStartupActivity implementation="com.google.idea.blaze.scala.run.producers.NonBlazeProducerSuppressor"/>
   </extensions>
+
+  <extensions defaultExtensionNs="org.jetbrains.sbt">
+    <buildToolModuleHandler implementation="com.google.idea.blaze.scala.BlazeScalaBuildToolModuleHandler"/>
+  </extensions>
 </idea-plugin>

--- a/scala/src/com/google/idea/blaze/scala/BlazeScalaBuildToolModuleHandler.java
+++ b/scala/src/com/google/idea/blaze/scala/BlazeScalaBuildToolModuleHandler.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.scala;
+
+import com.google.idea.blaze.base.settings.Blaze;
+import com.intellij.openapi.module.Module;
+import org.jetbrains.sbt.project.BuildToolModuleHandler;
+
+/**
+ * Implementation of BuildToolModuleHandler for Bazel Scala projects.
+ * Indicates when a Scala module is handled by the Bazel build system.
+ */
+public class BlazeScalaBuildToolModuleHandler implements BuildToolModuleHandler {
+  
+  @Override
+  public boolean handles(Module module) {
+    return Blaze.isBlazeProject(module.getProject());
+  }
+}


### PR DESCRIPTION
# Checklist

- [x] I have filed an issue about this change and discussed potential changes with the maintainers.
- [x] I have received the approval from the maintainers to make this change.
- [X] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: https://github.com/bazelbuild/intellij/issues/7703

# Description of this change

Use `BuildToolModuleHandler` API to register that the project is already imported via Bazel.

## Before the change
![image](https://github.com/user-attachments/assets/6b10efb1-616d-46ee-af61-822cea39dae4)

## After the change
![image](https://github.com/user-attachments/assets/c02670c8-38b1-4775-9972-52e773788b95)
