### PR TITLE
Do not mark execution root as dirty

### DIFF
--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -439,6 +439,9 @@
     <registryKey defaultValue="true"
                  description="Enable basic syntax highlighting in Query Sync's 'Analysis Disabled' mode"
                  key="bazel.qsync.enable.basic.highlighting.in.non.analysis.mode"/>
+    <registryKey defaultValue="false"
+                 description="Mark execroot as dirty before refresh after sync"
+                 key="bazel.sync.mark.dirty"/>
     <editorNotificationProvider implementation="com.google.idea.blaze.base.wizard2.BazelNotificationProvider"/>
   </extensions>
 

--- a/base/src/com/google/idea/blaze/base/filecache/FileCaches.java
+++ b/base/src/com/google/idea/blaze/base/filecache/FileCaches.java
@@ -50,7 +50,11 @@ public class FileCaches {
             fileCache.onSync(project, context, projectView, projectData, oldProjectData, syncMode);
           });
     }
-    LocalFileSystem.getInstance().refresh(true);
+
+    // CLion does not use this extension point, this is just an unnecessary refresh there
+    if (!FileCache.EP_NAME.getExtensionList().isEmpty()) {
+      LocalFileSystem.getInstance().refresh(true);
+    }
   }
 
   /**

--- a/clwb/tests/headlesstests/com/google/idea/blaze/clwb/base/ClwbHeadlessTestCase.java
+++ b/clwb/tests/headlesstests/com/google/idea/blaze/clwb/base/ClwbHeadlessTestCase.java
@@ -56,10 +56,7 @@ public abstract class ClwbHeadlessTestCase extends HeadlessTestCase {
     }
   }
 
-  protected void addAllowedVfsRoots(ArrayList<AllowedVfsRoot> roots) {
-    // required because of the mark dirty in com.google.idea.blaze.base.sync.ProjectUpdateSyncTask#refreshVirtualFileSystem
-    roots.add(AllowedVfsRoot.flat(""));
-  }
+  protected void addAllowedVfsRoots(ArrayList<AllowedVfsRoot> roots) { }
 
   @Override
   protected ProjectViewBuilder projectViewText(BazelVersion version) {


### PR DESCRIPTION
Do not mark the execution root as dirty before calling refresh. Foll up for after further investigation #7673.

Results of the investigation:
- Refresh after sync is required to pick up changes from the exec root
- Found an unnecessary refreshe, only refreshing the execution root should be sufficient
- Mark dirty is not required (however, might cause a race condition with the notifier) 