### PR TITLE
Remove exclusive flag from headless tests

### DIFF
--- a/testing/test_defs.bzl
+++ b/testing/test_defs.bzl
@@ -322,7 +322,7 @@ def bazel_integration_tests(name, env = None, tags = None, last_green = True, **
     parallel.
     """
     env = env or {}
-    tags = tags or ["exclusive"]
+    tags = tags or []
 
     for version in bazel_binaries.versions.all:
         if version == "last_green" and not last_green:


### PR DESCRIPTION
The exclusive flag was introduced so that Bazel does not run into any resource issues. Let's see if it can be removed, because this might reduce test runtime.
