### PR TITLE
Highlighting support for binary operators and augmented assignments in BUILD files.

### DIFF
--- a/base/src/com/google/idea/blaze/base/lang/buildfile/lexer/BuildLexerBase.java
+++ b/base/src/com/google/idea/blaze/base/lang/buildfile/lexer/BuildLexerBase.java
@@ -54,6 +54,9 @@ public class BuildLexerBase {
           .put('*', TokenKind.STAR_EQUALS)
           .put('/', TokenKind.SLASH_EQUALS)
           .put('%', TokenKind.PERCENT_EQUALS)
+          .put('^', TokenKind.CARET_EQUALS)
+          .put('&', TokenKind.AMPERSAND_EQUALS)
+          .put('|', TokenKind.PIPE_EQUALS)
           .build();
 
   private final LexerMode mode;

--- a/base/src/com/google/idea/blaze/base/lang/buildfile/lexer/BuildLexerBase.java
+++ b/base/src/com/google/idea/blaze/base/lang/buildfile/lexer/BuildLexerBase.java
@@ -810,6 +810,12 @@ public class BuildLexerBase {
         case '|':
           addToken(TokenKind.PIPE, pos - 1, pos);
           break;
+        case '^':
+          addToken(TokenKind.CARET, pos - 1, pos);
+          break;
+        case '&':
+          addToken(TokenKind.AMPERSAND, pos - 1, pos);
+          break;
         case '=':
           addToken(TokenKind.EQUALS, pos - 1, pos);
           break;

--- a/base/src/com/google/idea/blaze/base/lang/buildfile/lexer/BuildLexerBase.java
+++ b/base/src/com/google/idea/blaze/base/lang/buildfile/lexer/BuildLexerBase.java
@@ -772,10 +772,28 @@ public class BuildLexerBase {
           popParen();
           break;
         case '>':
-          addToken(TokenKind.GREATER, pos - 1, pos);
+          if (lookaheadIs(0, '>') && lookaheadIs(1, '=')) {
+            addToken(TokenKind.GREATER_GREATER_EQUALS, pos - 1, pos + 2);
+            pos += 2;
+          } else if (lookaheadIs(0, '>')) {
+            addToken(TokenKind.GREATER_GREATER, pos - 1, pos + 1);
+            pos++;
+          } else {
+            // >= is handled by tokenizeTwoChars.
+            addToken(TokenKind.GREATER, pos - 1, pos);
+          }
           break;
         case '<':
-          addToken(TokenKind.LESS, pos - 1, pos);
+          if (lookaheadIs(0, '<') && lookaheadIs(1, '=')) {
+            addToken(TokenKind.LESS_LESS_EQUALS, pos - 1, pos + 2);
+            pos += 2;
+          } else if (lookaheadIs(0, '<')) {
+            addToken(TokenKind.LESS_LESS, pos - 1, pos + 1);
+            pos++;
+          } else {
+            // <= is handled by tokenizeTwoChars.
+            addToken(TokenKind.LESS, pos - 1, pos);
+          }
           break;
         case ':':
           addToken(TokenKind.COLON, pos - 1, pos);

--- a/base/src/com/google/idea/blaze/base/lang/buildfile/lexer/TokenKind.java
+++ b/base/src/com/google/idea/blaze/base/lang/buildfile/lexer/TokenKind.java
@@ -77,6 +77,9 @@ public enum TokenKind {
   SLASH_EQUALS("/="),
   SLASH_SLASH_EQUALS("//="),
   PERCENT_EQUALS("%="),
+  AMPERSAND_EQUALS("&="),
+  PIPE_EQUALS("|="),
+  CARET_EQUALS("^="),
   RAISE("raise"),
   RBRACE("}"),
   RBRACKET("]"),
@@ -139,5 +142,6 @@ public enum TokenKind {
 
   public static final ImmutableSet<TokenKind> AUGMENTED_ASSIGNMENT_OPS =
       ImmutableSet.of(
-          PLUS_EQUALS, MINUS_EQUALS, STAR_EQUALS, SLASH_EQUALS, SLASH_SLASH_EQUALS, PERCENT_EQUALS);
+          PLUS_EQUALS, MINUS_EQUALS, STAR_EQUALS, SLASH_EQUALS, SLASH_SLASH_EQUALS, PERCENT_EQUALS,
+              AMPERSAND_EQUALS, PIPE_EQUALS, CARET_EQUALS);
 }

--- a/base/src/com/google/idea/blaze/base/lang/buildfile/lexer/TokenKind.java
+++ b/base/src/com/google/idea/blaze/base/lang/buildfile/lexer/TokenKind.java
@@ -80,6 +80,8 @@ public enum TokenKind {
   AMPERSAND_EQUALS("&="),
   PIPE_EQUALS("|="),
   CARET_EQUALS("^="),
+  GREATER_GREATER_EQUALS(">>="),
+  LESS_LESS_EQUALS("<<="),
   RAISE("raise"),
   RBRACE("}"),
   RBRACKET("]"),
@@ -88,6 +90,8 @@ public enum TokenKind {
   SEMI(";"),
   SLASH("/"),
   SLASH_SLASH("//"),
+  GREATER_GREATER(">>"),
+  LESS_LESS("<<"),
   STAR("*"),
   STAR_STAR("**"),
   STRING("string"),
@@ -136,6 +140,8 @@ public enum TokenKind {
           PERCENT,
           SLASH,
           SLASH_SLASH,
+          GREATER_GREATER,
+          LESS_LESS,
           PLUS,
           PIPE,
           STAR);
@@ -143,5 +149,5 @@ public enum TokenKind {
   public static final ImmutableSet<TokenKind> AUGMENTED_ASSIGNMENT_OPS =
       ImmutableSet.of(
           PLUS_EQUALS, MINUS_EQUALS, STAR_EQUALS, SLASH_EQUALS, SLASH_SLASH_EQUALS, PERCENT_EQUALS,
-              AMPERSAND_EQUALS, PIPE_EQUALS, CARET_EQUALS);
+              AMPERSAND_EQUALS, PIPE_EQUALS, CARET_EQUALS, GREATER_GREATER_EQUALS, LESS_LESS_EQUALS);
 }

--- a/base/src/com/google/idea/blaze/base/lang/buildfile/lexer/TokenKind.java
+++ b/base/src/com/google/idea/blaze/base/lang/buildfile/lexer/TokenKind.java
@@ -69,7 +69,9 @@ public enum TokenKind {
   DEDENT("dedent"),
   PASS("pass"),
   PERCENT("%"),
+  AMPERSAND("&"),
   PIPE("|"),
+  CARET("^"),
   PLUS("+"),
   PLUS_EQUALS("+="),
   MINUS_EQUALS("-="),
@@ -143,7 +145,9 @@ public enum TokenKind {
           GREATER_GREATER,
           LESS_LESS,
           PLUS,
+          AMPERSAND,
           PIPE,
+          CARET,
           STAR);
 
   public static final ImmutableSet<TokenKind> AUGMENTED_ASSIGNMENT_OPS =

--- a/base/src/com/google/idea/blaze/base/lang/buildfile/parser/ExpressionParsing.java
+++ b/base/src/com/google/idea/blaze/base/lang/buildfile/parser/ExpressionParsing.java
@@ -77,6 +77,8 @@ public class ExpressionParsing extends Parsing {
               TokenKind.IN,
               TokenKind.NOT_IN),
           EnumSet.of(TokenKind.PIPE),
+          EnumSet.of(TokenKind.CARET),
+          EnumSet.of(TokenKind.AMPERSAND),
           EnumSet.of(TokenKind.LESS_LESS, TokenKind.GREATER_GREATER),
           EnumSet.of(TokenKind.MINUS, TokenKind.PLUS),
           EnumSet.of(TokenKind.SLASH, TokenKind.SLASH_SLASH, TokenKind.STAR, TokenKind.PERCENT));

--- a/base/src/com/google/idea/blaze/base/lang/buildfile/parser/ExpressionParsing.java
+++ b/base/src/com/google/idea/blaze/base/lang/buildfile/parser/ExpressionParsing.java
@@ -59,8 +59,8 @@ public class ExpressionParsing extends Parsing {
       ImmutableSet.of(TokenKind.EOF, TokenKind.RPAREN, TokenKind.SEMI, TokenKind.NEWLINE);
 
   /**
-   * Highest precedence goes last. Based on:
-   * http://docs.python.org/2/reference/expressions.html#operator-precedence
+   * Highest precedence goes last. Based on
+   * <a href="http://docs.python.org/2/reference/expressions.html#operator-precedence">Python 2 specification</a>.
    */
   private static final ImmutableList<EnumSet<TokenKind>> OPERATOR_PRECEDENCE =
       ImmutableList.of(
@@ -77,6 +77,7 @@ public class ExpressionParsing extends Parsing {
               TokenKind.IN,
               TokenKind.NOT_IN),
           EnumSet.of(TokenKind.PIPE),
+          EnumSet.of(TokenKind.LESS_LESS, TokenKind.GREATER_GREATER),
           EnumSet.of(TokenKind.MINUS, TokenKind.PLUS),
           EnumSet.of(TokenKind.SLASH, TokenKind.SLASH_SLASH, TokenKind.STAR, TokenKind.PERCENT));
 

--- a/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/parser/BuildParserTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/parser/BuildParserTest.java
@@ -54,12 +54,13 @@ public class BuildParserTest extends BuildFileIntegrationTestCase {
   @Test
   public void testAugmentedAssign() throws Exception {
     //See https://starlark-lang.org/spec.html#augmented-assignments
-    //TODO support >>= and <<=
     assertThat(parse("x += 1")).isEqualTo("aug_assign(reference, int)");
     assertThat(parse("x -= 1")).isEqualTo("aug_assign(reference, int)");
     assertThat(parse("x *= 1")).isEqualTo("aug_assign(reference, int)");
     assertThat(parse("x /= 1")).isEqualTo("aug_assign(reference, int)");
     assertThat(parse("x //= 1")).isEqualTo("aug_assign(reference, int)");
+    assertThat(parse("x >>= 1")).isEqualTo("aug_assign(reference, int)");
+    assertThat(parse("x <<= 1")).isEqualTo("aug_assign(reference, int)");
     assertThat(parse("x %= 1")).isEqualTo("aug_assign(reference, int)");
     assertThat(parse("x &= 1")).isEqualTo("aug_assign(reference, int)");
     assertThat(parse("x |= 1")).isEqualTo("aug_assign(reference, int)");
@@ -113,8 +114,10 @@ public class BuildParserTest extends BuildFileIntegrationTestCase {
   }
 
   @Test
-  public void testSlashSlashOperator() {
+  public void testTwoCharOperators() {
     assertThat(parse("6 // 1")).isEqualTo("binary_op(int, int)");
+    assertThat(parse("6 << 1")).isEqualTo("binary_op(int, int)");
+    assertThat(parse("6 >> 1")).isEqualTo("binary_op(int, int)");
     assertNoErrors();
   }
 

--- a/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/parser/BuildParserTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/parser/BuildParserTest.java
@@ -114,6 +114,20 @@ public class BuildParserTest extends BuildFileIntegrationTestCase {
   }
 
   @Test
+  public void testBinaryOperators() {
+    // See https://starlark-lang.org/spec.html#binary-operators
+    assertThat(parse("6 + 1")).isEqualTo("binary_op(int, int)");
+    assertThat(parse("6 - 1")).isEqualTo("binary_op(int, int)");
+    assertThat(parse("6 * 1")).isEqualTo("binary_op(int, int)");
+    assertThat(parse("6 / 1")).isEqualTo("binary_op(int, int)");
+    assertThat(parse("6 % 1")).isEqualTo("binary_op(int, int)");
+    assertThat(parse("6 & 1")).isEqualTo("binary_op(int, int)");
+    assertThat(parse("6 | 1")).isEqualTo("binary_op(int, int)");
+    assertThat(parse("6 ^ 1")).isEqualTo("binary_op(int, int)");
+    assertNoErrors();
+  }
+
+  @Test
   public void testTwoCharOperators() {
     assertThat(parse("6 // 1")).isEqualTo("binary_op(int, int)");
     assertThat(parse("6 << 1")).isEqualTo("binary_op(int, int)");

--- a/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/parser/BuildParserTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/lang/buildfile/parser/BuildParserTest.java
@@ -53,12 +53,17 @@ public class BuildParserTest extends BuildFileIntegrationTestCase {
 
   @Test
   public void testAugmentedAssign() throws Exception {
+    //See https://starlark-lang.org/spec.html#augmented-assignments
+    //TODO support >>= and <<=
     assertThat(parse("x += 1")).isEqualTo("aug_assign(reference, int)");
     assertThat(parse("x -= 1")).isEqualTo("aug_assign(reference, int)");
     assertThat(parse("x *= 1")).isEqualTo("aug_assign(reference, int)");
     assertThat(parse("x /= 1")).isEqualTo("aug_assign(reference, int)");
     assertThat(parse("x //= 1")).isEqualTo("aug_assign(reference, int)");
     assertThat(parse("x %= 1")).isEqualTo("aug_assign(reference, int)");
+    assertThat(parse("x &= 1")).isEqualTo("aug_assign(reference, int)");
+    assertThat(parse("x |= 1")).isEqualTo("aug_assign(reference, int)");
+    assertThat(parse("x ^= 1")).isEqualTo("aug_assign(reference, int)");
     assertNoErrors();
   }
 


### PR DESCRIPTION
Supported operators: `& ^ >> << &= ^= |= >>= <<=`

Fixes #7733.