### PR TITLE
[AOSP-pick] Extract out GetArtifactsException from BuildResultHelper

### DIFF
--- a/base/src/com/google/idea/blaze/base/bazel/LocalInvoker.java
+++ b/base/src/com/google/idea/blaze/base/bazel/LocalInvoker.java
@@ -28,6 +28,7 @@ import com.google.idea.blaze.base.command.WorkspaceRootReplacement;
 import com.google.idea.blaze.base.command.buildresult.BuildEventProtocolUtils;
 import com.google.idea.blaze.base.command.buildresult.BuildResult;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
+import com.google.idea.blaze.base.command.buildresult.GetArtifactsException;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelperBep;
 import com.google.idea.blaze.base.command.buildresult.bepparser.BuildEventStreamProvider;
 import com.google.idea.blaze.base.console.BlazeConsoleLineProcessorProvider;
@@ -228,13 +229,13 @@ public class LocalInvoker extends AbstractBuildInvoker {
   }
 
   private BuildEventStreamProvider getBepStream(File outputFile)
-      throws BuildResultHelper.GetArtifactsException {
+    throws GetArtifactsException {
     try {
       return BuildEventStreamProvider.fromInputStream(
           new BufferedInputStream(new FileInputStream(outputFile)));
     } catch (FileNotFoundException e) {
       logger.error(e);
-      throw new BuildResultHelper.GetArtifactsException(e.getMessage());
+      throw new GetArtifactsException(e.getMessage());
     }
   }
 

--- a/base/src/com/google/idea/blaze/base/command/CommandLineBlazeCommandRunner.java
+++ b/base/src/com/google/idea/blaze/base/command/CommandLineBlazeCommandRunner.java
@@ -26,7 +26,7 @@ import com.google.idea.blaze.base.bazel.BazelExitCodeException.ThrowOption;
 import com.google.idea.blaze.base.command.buildresult.BuildResult;
 import com.google.idea.blaze.base.command.buildresult.BuildResult.Status;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
-import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtifactsException;
+import com.google.idea.blaze.base.command.buildresult.GetArtifactsException;
 import com.google.idea.blaze.base.command.buildresult.BuildResultParser;
 import com.google.idea.blaze.base.command.buildresult.bepparser.ParsedBepOutput;
 import com.google.idea.blaze.base.command.mod.BlazeModException;

--- a/base/src/com/google/idea/blaze/base/command/buildresult/BuildResultHelper.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/BuildResultHelper.java
@@ -78,34 +78,4 @@ public interface BuildResultHelper extends AutoCloseable {
 
   @Override
   void close();
-
-  /** Indicates a failure to get artifact information */
-  class GetArtifactsException extends BuildException {
-    public GetArtifactsException(Throwable cause) {
-      super(cause);
-    }
-
-    public GetArtifactsException(String message) {
-      super(message);
-    }
-
-    public GetArtifactsException(String message, Throwable cause) {
-      super(message, cause);
-    }
-  }
-
-  /** Indicates a failure to get artifact information */
-  class GetFlagsException extends Exception {
-    public GetFlagsException(String message, Throwable cause) {
-      super(message, cause);
-    }
-
-    public GetFlagsException(String message) {
-      super(message);
-    }
-
-    public GetFlagsException(Throwable cause) {
-      super(cause);
-    }
-  }
 }

--- a/base/src/com/google/idea/blaze/base/command/buildresult/BuildResultParser.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/BuildResultParser.java
@@ -43,12 +43,13 @@ public final class BuildResultParser {
    */
   public static ParsedBepOutput getBuildOutput(
     BuildEventStreamProvider bepStream, Interner<String> stringInterner)
-    throws BuildResultHelper.GetArtifactsException {
+    throws GetArtifactsException {
     try {
       return BepParser.parseBepArtifacts(bepStream, stringInterner);
-    } catch (BuildEventStreamProvider.BuildEventStreamException e) {
+    }
+    catch (BuildEventStreamProvider.BuildEventStreamException e) {
       BuildResultHelper.logger.error(e);
-      throw new BuildResultHelper.GetArtifactsException(String.format(
+      throw new GetArtifactsException(String.format(
         "Failed to parse bep for build id: %s: %s", bepStream.getId(), e.getMessage()));
     }
   }
@@ -63,12 +64,13 @@ public final class BuildResultParser {
    */
   public static ParsedBepOutput.Legacy getBuildOutputForLegacySync(
     BuildEventStreamProvider bepStream, Interner<String> stringInterner)
-    throws BuildResultHelper.GetArtifactsException {
+    throws GetArtifactsException {
     try {
       return BepParser.parseBepArtifactsForLegacySync(bepStream, stringInterner);
-    } catch (BuildEventStreamProvider.BuildEventStreamException e) {
+    }
+    catch (BuildEventStreamProvider.BuildEventStreamException e) {
       BuildResultHelper.logger.error(e);
-      throw new BuildResultHelper.GetArtifactsException(String.format(
+      throw new GetArtifactsException(String.format(
         "Failed to parse bep for build id: %s: %s", bepStream.getId(), e.getMessage()));
     }
   }
@@ -77,24 +79,13 @@ public final class BuildResultParser {
    * Parses BEP stream and returns the corresponding {@link BlazeTestResults}. May
    * only be called once on a given stream.
    */
-  public static BlazeTestResults getTestResults(BuildEventStreamProvider bepStream) throws BuildResultHelper.GetArtifactsException {
-    try  {
-      return BuildEventProtocolOutputReader.parseTestResults(bepStream);
-    } catch (BuildEventStreamProvider.BuildEventStreamException e) {
-      BuildResultHelper.logger.warn(e);
-      throw new BuildResultHelper.GetArtifactsException(
-        String.format("Failed to parse bep for build id: %s", bepStream.getId()), e);
-    }
-  }
-
-  /**
-   * Parses the BEP stream and collects all build flags used. Return all flags that pass filters
-   */
-  public static BuildFlags getBlazeFlags(BuildEventStreamProvider bepStream) throws BuildResultHelper.GetFlagsException {
+  public static BlazeTestResults getTestResults(BuildEventStreamProvider bepStream) throws GetArtifactsException {
     try {
-      return BuildFlags.parseBep(bepStream);
-    } catch (BuildEventStreamProvider.BuildEventStreamException e) {
-      throw new BuildResultHelper.GetFlagsException(
+      return BuildEventProtocolOutputReader.parseTestResults(bepStream);
+    }
+    catch (BuildEventStreamProvider.BuildEventStreamException e) {
+      BuildResultHelper.logger.warn(e);
+      throw new GetArtifactsException(
         String.format("Failed to parse bep for build id: %s", bepStream.getId()), e);
     }
   }
@@ -109,12 +100,12 @@ public final class BuildResultParser {
       BuildEventStreamProvider bepStream,
       Interner<String> stringInterner,
       String label)
-      throws BuildResultHelper.GetArtifactsException {
+      throws GetArtifactsException {
     final var parsedBepOutput = getBuildOutput(bepStream, stringInterner);
 
     final var result = BuildResult.fromExitCode(parsedBepOutput.buildResult());
     if (result.status != BuildResult.Status.SUCCESS) {
-      throw new BuildResultHelper.GetArtifactsException(
+      throw new GetArtifactsException(
           String.format("Failed to parse bep for build id: %s", bepStream.getId()));
     }
 
@@ -130,7 +121,7 @@ public final class BuildResultParser {
         .collect(ImmutableList.toImmutableList());
 
     if (artifacts.isEmpty()) {
-      throw new BuildResultHelper.GetArtifactsException(
+      throw new GetArtifactsException(
           String.format("No output artifacts found for build id: %s", bepStream.getId()));
     }
 

--- a/base/src/com/google/idea/blaze/base/command/buildresult/GetArtifactsException.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/GetArtifactsException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.command.buildresult;
+
+import com.google.idea.blaze.exception.BuildException;
+
+/**
+ * Indicates a failure to get artifact information
+ */
+public class GetArtifactsException extends BuildException {
+  public GetArtifactsException(Throwable cause) {
+    super(cause);
+  }
+
+  public GetArtifactsException(String message) {
+    super(message);
+  }
+
+  public GetArtifactsException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/base/src/com/google/idea/blaze/base/run/smrunner/BlazeXmlToTestEventsConverter.java
+++ b/base/src/com/google/idea/blaze/base/run/smrunner/BlazeXmlToTestEventsConverter.java
@@ -20,7 +20,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtifactsException;
+import com.google.idea.blaze.base.command.buildresult.GetArtifactsException;
 import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.primitives.Kind;
 import com.google.idea.blaze.base.model.primitives.Label;

--- a/base/src/com/google/idea/blaze/base/run/testlogs/BlazeTestResultFinderStrategy.java
+++ b/base/src/com/google/idea/blaze/base/run/testlogs/BlazeTestResultFinderStrategy.java
@@ -15,7 +15,7 @@
  */
 package com.google.idea.blaze.base.run.testlogs;
 
-import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtifactsException;
+import com.google.idea.blaze.base.command.buildresult.GetArtifactsException;
 
 /** A strategy for locating results from 'blaze test' invocation (e.g. output XML files). */
 public interface BlazeTestResultFinderStrategy {

--- a/base/src/com/google/idea/blaze/base/run/testlogs/LocalBuildEventProtocolTestFinderStrategy.java
+++ b/base/src/com/google/idea/blaze/base/run/testlogs/LocalBuildEventProtocolTestFinderStrategy.java
@@ -15,7 +15,7 @@
  */
 package com.google.idea.blaze.base.run.testlogs;
 
-import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtifactsException;
+import com.google.idea.blaze.base.command.buildresult.GetArtifactsException;
 import com.google.idea.blaze.base.command.buildresult.BuildResultParser;
 import com.google.idea.blaze.base.command.buildresult.bepparser.BuildEventStreamProvider;
 import com.intellij.openapi.diagnostic.Logger;

--- a/base/tests/unittests/com/google/idea/blaze/base/run/testlogs/LocalBuildEventProtocolTestFinderStrategyTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/run/testlogs/LocalBuildEventProtocolTestFinderStrategyTest.java
@@ -26,7 +26,7 @@ import com.google.idea.blaze.base.command.buildresult.BuildEventProtocolOutputRe
 import com.google.idea.blaze.base.command.buildresult.bepparser.BuildEventStreamProvider;
 import com.google.idea.blaze.base.command.buildresult.bepparser.BuildEventStreamProvider.BuildEventStreamException;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
-import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtifactsException;
+import com.google.idea.blaze.base.command.buildresult.GetArtifactsException;
 import com.google.idea.blaze.base.command.buildresult.LocalFileParser;
 import com.google.idea.blaze.base.command.buildresult.bepparser.BuildEventStreamProvider;
 import com.google.idea.blaze.base.command.buildresult.bepparser.BuildEventStreamProvider.BuildEventStreamException;

--- a/base/tests/utils/unit/com/google/idea/blaze/base/bazel/FakeBlazeCommandRunner.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/bazel/FakeBlazeCommandRunner.java
@@ -20,7 +20,7 @@ import com.google.idea.blaze.base.command.BlazeCommand;
 import com.google.idea.blaze.base.command.BlazeCommandRunner;
 import com.google.idea.blaze.base.command.buildresult.BuildResult;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
-import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtifactsException;
+import com.google.idea.blaze.base.command.buildresult.GetArtifactsException;
 import com.google.idea.blaze.base.command.buildresult.BuildResultParser;
 import com.google.idea.blaze.base.command.info.BlazeInfoException;
 import com.google.idea.blaze.base.command.mod.BlazeModException;

--- a/base/tests/utils/unit/com/google/idea/blaze/base/bazel/FakeBuildResultHelperBep.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/bazel/FakeBuildResultHelperBep.java
@@ -26,6 +26,7 @@ import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos;
 import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.BuildEventId.BuildFinishedId;
 import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.BuildEventId.BuildStartedId;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
+import com.google.idea.blaze.base.command.buildresult.GetArtifactsException;
 import com.google.idea.blaze.base.command.buildresult.bepparser.BuildEventStreamProvider;
 import java.util.List;
 import java.util.Optional;

--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrRunConfigurationRunner.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrRunConfigurationRunner.java
@@ -19,7 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.idea.blaze.base.command.BlazeCommandName;
 import com.google.idea.blaze.base.command.BlazeInvocationContext;
-import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtifactsException;
+import com.google.idea.blaze.base.command.buildresult.GetArtifactsException;
 import com.google.idea.blaze.base.command.buildresult.BuildResultParser;
 import com.google.idea.blaze.base.command.buildresult.bepparser.BuildEventStreamProvider;
 import com.google.idea.blaze.base.model.primitives.Label;

--- a/golang/src/com/google/idea/blaze/golang/run/BlazeGoRunConfigurationRunner.java
+++ b/golang/src/com/google/idea/blaze/golang/run/BlazeGoRunConfigurationRunner.java
@@ -34,7 +34,7 @@ import com.google.idea.blaze.base.command.BlazeInvocationContext;
 import com.google.idea.blaze.base.command.buildresult.BuildResult;
 import com.google.idea.blaze.base.command.buildresult.BuildResult.Status;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
-import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtifactsException;
+import com.google.idea.blaze.base.command.buildresult.GetArtifactsException;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelperProvider;
 import com.google.idea.blaze.base.command.buildresult.BuildResultParser;
 import com.google.idea.blaze.base.command.buildresult.LocalFileArtifact;

--- a/java/src/com/google/idea/blaze/java/fastbuild/FastBuildServiceImpl.java
+++ b/java/src/com/google/idea/blaze/java/fastbuild/FastBuildServiceImpl.java
@@ -33,7 +33,7 @@ import com.google.idea.blaze.base.command.BlazeInvocationContext;
 import com.google.idea.blaze.base.command.buildresult.BuildResult;
 import com.google.idea.blaze.base.command.buildresult.BuildResult.Status;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
-import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtifactsException;
+import com.google.idea.blaze.base.command.buildresult.GetArtifactsException;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelperProvider;
 import com.google.idea.blaze.base.command.buildresult.BuildResultParser;
 import com.google.idea.blaze.base.command.buildresult.LocalFileArtifact;
@@ -80,7 +80,6 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkState;

--- a/java/src/com/google/idea/blaze/java/run/hotswap/ClassFileManifestBuilder.java
+++ b/java/src/com/google/idea/blaze/java/run/hotswap/ClassFileManifestBuilder.java
@@ -23,7 +23,7 @@ import com.google.idea.blaze.base.command.BlazeCommandName;
 import com.google.idea.blaze.base.command.BlazeInvocationContext;
 import com.google.idea.blaze.base.command.buildresult.BuildResult;
 import com.google.idea.blaze.base.command.buildresult.BuildResultParser;
-import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtifactsException;
+import com.google.idea.blaze.base.command.buildresult.GetArtifactsException;
 import com.google.idea.blaze.base.command.buildresult.BuildResultParser;
 import com.google.idea.blaze.base.command.buildresult.LocalFileArtifact;
 import com.google.idea.blaze.base.command.buildresult.bepparser.BuildEventStreamProvider;

--- a/plugin_dev/src/com/google/idea/blaze/plugin/run/BlazeIntellijPluginDeployer.java
+++ b/plugin_dev/src/com/google/idea/blaze/plugin/run/BlazeIntellijPluginDeployer.java
@@ -27,7 +27,7 @@ import com.google.common.io.Files;
 import com.google.devtools.intellij.plugin.IntellijPluginTargetDeployInfo.IntellijPluginDeployFile;
 import com.google.devtools.intellij.plugin.IntellijPluginTargetDeployInfo.IntellijPluginDeployInfo;
 import com.google.idea.blaze.base.async.executor.BlazeExecutor;
-import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtifactsException;
+import com.google.idea.blaze.base.command.buildresult.GetArtifactsException;
 import com.google.idea.blaze.base.sync.aspects.BlazeBuildOutputs;
 import com.google.idea.blaze.common.artifact.OutputArtifact;
 import com.google.idea.common.experiments.BoolExperiment;

--- a/plugin_dev/src/com/google/idea/blaze/plugin/run/BuildPluginBeforeRunTaskProvider.java
+++ b/plugin_dev/src/com/google/idea/blaze/plugin/run/BuildPluginBeforeRunTaskProvider.java
@@ -26,7 +26,7 @@ import com.google.idea.blaze.base.command.BlazeFlags;
 import com.google.idea.blaze.base.command.BlazeInvocationContext;
 import com.google.idea.blaze.base.command.BlazeInvocationContext.ContextType;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
-import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtifactsException;
+import com.google.idea.blaze.base.command.buildresult.GetArtifactsException;
 import com.google.idea.blaze.base.experiments.ExperimentScope;
 import com.google.idea.blaze.base.filecache.FileCaches;
 import com.google.idea.blaze.base.issueparser.BlazeIssueParser;

--- a/python/src/com/google/idea/blaze/python/run/BlazePyRunConfigurationRunner.java
+++ b/python/src/com/google/idea/blaze/python/run/BlazePyRunConfigurationRunner.java
@@ -23,7 +23,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.idea.blaze.base.command.BlazeCommandName;
 import com.google.idea.blaze.base.command.BlazeFlags;
 import com.google.idea.blaze.base.command.BlazeInvocationContext;
-import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtifactsException;
+import com.google.idea.blaze.base.command.buildresult.GetArtifactsException;
 import com.google.idea.blaze.base.command.buildresult.BuildResultParser;
 import com.google.idea.blaze.base.command.buildresult.bepparser.BuildEventStreamProvider;
 import com.google.idea.blaze.base.ideinfo.PyIdeInfo;

--- a/scala/src/com/google/idea/blaze/scala/run/producers/GenerateDeployableJarTaskProvider.java
+++ b/scala/src/com/google/idea/blaze/scala/run/producers/GenerateDeployableJarTaskProvider.java
@@ -26,7 +26,7 @@ import com.google.idea.blaze.base.command.BlazeFlags;
 import com.google.idea.blaze.base.command.BlazeInvocationContext;
 import com.google.idea.blaze.base.command.buildresult.BuildResult;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
-import com.google.idea.blaze.base.command.buildresult.BuildResultHelper.GetArtifactsException;
+import com.google.idea.blaze.base.command.buildresult.GetArtifactsException;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelperProvider;
 import com.google.idea.blaze.base.command.buildresult.BuildResultParser;
 import com.google.idea.blaze.base.command.buildresult.LocalFileArtifact;


### PR DESCRIPTION
Cherry pick AOSP commit [1b413f38e00ac9d4533b66012cec51bd81ff700b](https://cs.android.com/android-studio/platform/tools/adt/idea/+/1b413f38e00ac9d4533b66012cec51bd81ff700b).

STAT (diff to AOSP): 54 insertions(+), 20 deletion(-)

The BuildResultHelper abstraction is no longer used post-cleanup, and
will be deleted. The GetArtifactsException that currently is inside the
interface is used, so this change extracts it out into a separate class.

Bug:374906681

Test: existing tests
Change-Id: Ic89a342707a3b1b562fcfcc03f2260956a726eb8

AOSP: 1b413f38e00ac9d4533b66012cec51bd81ff700b
