### PR TITLE
Disable expand sync to workings set by default

### DIFF
--- a/base/src/com/google/idea/blaze/base/settings/BlazeUserSettings.java
+++ b/base/src/com/google/idea/blaze/base/settings/BlazeUserSettings.java
@@ -70,7 +70,7 @@ public class BlazeUserSettings implements PersistentStateComponent<BlazeUserSett
   private FocusBehavior showBlazeConsoleOnRun = FocusBehavior.ALWAYS;
   private FocusBehavior showProblemsViewOnRun = FocusBehavior.NEVER;
   private boolean syncStatusPopupShown = false;
-  private boolean expandSyncToWorkingSet = true;
+  private boolean expandSyncToWorkingSet = false;
   private boolean showPerformanceWarnings = false;
   private boolean collapseProjectView = true;
   private boolean useNewSyncView = false;


### PR DESCRIPTION
For me "Expand Sync to Working Set" always causes problems. Let's disable it by default? 
