### PR TITLE
fix the aspect template for handling language code-gen

### DIFF
--- a/base/src/com/google/idea/blaze/base/sync/aspects/storage/AspectTemplateWriter.kt
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/storage/AspectTemplateWriter.kt
@@ -120,7 +120,7 @@ class AspectTemplateWriter : AspectWriter {
   }
 
   /** This class models a language class to its code-generator rule names. */
-  class LanguageClassRuleNames(val languageClass: LanguageClass, private val ruleNames: List<String>) {
+  class LanguageClassRuleNames(val languageClass: LanguageClass, val ruleNames: List<String>) {
 
     override fun toString(): String {
       return String.format("[%s] -> [%s]", languageClass, ruleNames.joinToString(","))


### PR DESCRIPTION
This model objects appears to have a private member which should be public so that the template is unable to use it.

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Minor change so will not include an issue as well.

# Description of this change

The aspect template file `aspect/code_generator_info.bzl` is expecting to loop though the `rulesNames` but this member variable is private in the Kotlin class `LanguageClassRuleNames` so the template does not work and this is, in turn, preventing the IDE from picking up code-generated sources.