### PR TITLE
Draft: Add support for rule executable_jar

### DIFF
--- a/java/src/com/google/idea/blaze/java/JavaBlazeRules.java
+++ b/java/src/com/google/idea/blaze/java/JavaBlazeRules.java
@@ -31,6 +31,7 @@ public final class JavaBlazeRules implements Kind.Provider {
 
   /** Java-specific blaze rules. */
   public enum RuleTypes {
+    EXECUTABLE_JAR("executable_jar", LanguageClass.JAVA, RuleType.BINARY),
     JAVA_LIBRARY("java_library", LanguageClass.JAVA, RuleType.LIBRARY),
     JAVA_TEST("java_test", LanguageClass.JAVA, RuleType.TEST),
     JAVA_JUNIT5_TEST("java_junit5_test", LanguageClass.JAVA, RuleType.TEST),

--- a/java/src/com/google/idea/blaze/java/sync/source/JavaLikeLanguage.java
+++ b/java/src/com/google/idea/blaze/java/sync/source/JavaLikeLanguage.java
@@ -96,6 +96,7 @@ public interface JavaLikeLanguage {
     @Override
     public ImmutableSet<Kind> getDebuggableKinds() {
       return ImmutableSet.of(
+          JavaBlazeRules.RuleTypes.EXECUTABLE_JAR.getKind(),
           JavaBlazeRules.RuleTypes.JAVA_BINARY.getKind(),
           JavaBlazeRules.RuleTypes.JAVA_TEST.getKind(),
           JavaBlazeRules.RuleTypes.JAVA_TEST_SUITE.getKind());


### PR DESCRIPTION
I'm trying to add support for the `executable_jar` [rule](https://github.com/joca-bt/extra_rules_java/blob/master/docs/executable_jar.md). While these changes add support for debugging from BUILD files, the gutter on source files doesn't recognize the target.

![image](https://github.com/user-attachments/assets/12309d06-fc4e-44f9-b989-7398e990a99b)

Would you be so kind to point me in the right direction to add this functionality?

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`