### PR TITLE
CLion: add registry key to allow bazel-bin as header search path

### DIFF
--- a/cpp/src/META-INF/blaze-cpp.xml
+++ b/cpp/src/META-INF/blaze-cpp.xml
@@ -88,6 +88,9 @@
     <registryKey defaultValue="true"
                  description="Use _cpp_use_get_tool_for_action to get compiler executable"
                  key="bazel.cc.aspect.use_get_tool_for_action"/>
+      <registryKey defaultValue="true"
+                   description="Whether to allow bazel-bin as a header search path; directly using bazel-bin as a header search path could cause performance problems"
+                   key="bazel.cpp.sync.allow.bazel.bin.header.search.path"/>
 
     <applicationService serviceInterface="com.google.idea.blaze.cpp.CompilerVersionChecker"
                         serviceImplementation="com.google.idea.blaze.cpp.CompilerVersionCheckerImpl"/>

--- a/cpp/src/com/google/idea/blaze/cpp/HeaderRootTrimmerImpl.kt
+++ b/cpp/src/com/google/idea/blaze/cpp/HeaderRootTrimmerImpl.kt
@@ -114,8 +114,8 @@ private fun collectHeaderRoots(
   val result = mutableListOf<Path>()
   for (directory in possibleDirectories) {
     val add = when {
-      // never allow the bazel-bin as a header search path
-      path.isBazelBin(projectData.blazeInfo) && !allowBazelBin -> false
+      // only allow bazel-bin as a header search path when the registry key is set
+      path.isBazelBin(projectData.blazeInfo) -> allowBazelBin
 
       // if it is not an output directory, there should be now big binary artifacts
       !path.isOutputDirectory(projectData.blazeInfo) -> true

--- a/cpp/src/com/google/idea/blaze/cpp/HeaderRootTrimmerImpl.kt
+++ b/cpp/src/com/google/idea/blaze/cpp/HeaderRootTrimmerImpl.kt
@@ -30,6 +30,7 @@ import com.google.idea.blaze.base.scope.Scope
 import com.google.idea.blaze.base.scope.scopes.TimingScope
 import com.google.idea.blaze.base.sync.workspace.ExecutionRootPathResolver
 import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.util.registry.Registry
 import com.jetbrains.cidr.lang.OCFileTypeHelpers
 import kotlinx.coroutines.*
 import java.io.File
@@ -65,7 +66,7 @@ class HeaderRootTrimmerImpl(private val scope: CoroutineScope) : HeaderRootTrimm
             }
           }
 
-          results.map { it.await() }.forEach(builder::addAll)
+          results.awaitAll().forEach(builder::addAll)
         }
       }.join()
     }
@@ -108,11 +109,13 @@ private fun collectHeaderRoots(
 ): List<Path> {
   val possibleDirectories = executionRootPathResolver.resolveToIncludeDirectories(path).map(File::toPath)
 
+  val allowBazelBin = Registry.`is`("bazel.cpp.sync.allow.bazel.bin.header.search.path")
+
   val result = mutableListOf<Path>()
   for (directory in possibleDirectories) {
     val add = when {
       // never allow the bazel-bin as a header search path
-      path.isBazelBin(projectData.blazeInfo) -> false
+      path.isBazelBin(projectData.blazeInfo) && !allowBazelBin -> false
 
       // if it is not an output directory, there should be now big binary artifacts
       !path.isOutputDirectory(projectData.blazeInfo) -> true


### PR DESCRIPTION
# Discussion thread for this change

Issue number: #7794

# Description of this change
Add a registry flag to allow bazel-bin as a header search path again and enable it by default for now until we find a proper solution.