### PR TITLE
Plugin Transfer: added disclaimer to plugin descriptions

### DIFF
--- a/clwb/src/META-INF/description.html
+++ b/clwb/src/META-INF/description.html
@@ -1,5 +1,9 @@
 <a href="https://bazel.build">Bazel</a> support for CLion.
 
+<p>
+As of July 1, 2025, the Bazel for CLion plugin is actively maintained by JetBrains. This plugin is not offered by nor affiliated with Google. The Bazel trademark and logo are the property of Google LLC.
+</p>
+
 Features:
 <ul>
   <li>Import BUILD files into the IDE.</li>

--- a/ijwb/src/META-INF/description.html
+++ b/ijwb/src/META-INF/description.html
@@ -1,5 +1,12 @@
 <a href="https://bazel.build">Bazel</a> project support.
 
+<p>
+As of July 1, 2025, this plugin is maintained by JetBrains. Maintenance is limited to ensuring compatibility with new versions of the IDE. No new features or bug fixes will be provided. This plugin is not offered by nor affiliated with Google. The Bazel trademark and logo are the property of Google LLC.
+</p>
+<p>
+Bazel support for IntelliJ IDEA, GoLand and PyCharm is now provided by the <a href="https://plugins.jetbrains.com/plugin/22977">new Bazel plugin</a> and actively developed byJetBrains.
+</p>
+
 Features:
 <ul>
   <li>Import BUILD files into the IDE.</li>


### PR DESCRIPTION
The PR adds a disclaimer to plugin descriptions in accordance with the transfer agreement.

