### PR TITLE
Handle user cancellation more gracefully

### DIFF
--- a/base/src/com/google/idea/blaze/base/buildview/events/AbortedParser.kt
+++ b/base/src/com/google/idea/blaze/base/buildview/events/AbortedParser.kt
@@ -58,6 +58,7 @@ class AbortedParser : BuildEventParser {
       id.hasConfiguredLabel() -> id.configuredLabel.label
       id.hasPattern() -> id.pattern.patternList.firstOrNull()
       id.hasUnstructuredCommandLine() -> null
+      id.hasBuildFinished() -> null
       else -> reportMissingImplementation(id)
     }
   }

--- a/base/src/com/google/idea/blaze/base/sync/SyncPhaseCoordinator.java
+++ b/base/src/com/google/idea/blaze/base/sync/SyncPhaseCoordinator.java
@@ -102,6 +102,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
+import kotlinx.coroutines.JobCancellationException;
 
 /** Manages sync execution, coordinating the possibly-separate build/update phases. */
 public final class SyncPhaseCoordinator {
@@ -881,6 +882,9 @@ public final class SyncPhaseCoordinator {
         return;
       }
       if (cause instanceof SyncCanceledException) {
+        return;
+      }
+      if (cause instanceof JobCancellationException) {
         return;
       }
       if (cause instanceof SyncFailedException) {


### PR DESCRIPTION
Do not log build aborted BEP messages and do not show JobCancelledExceptions in the UI.
