### PR TITLE
CLion: release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,96 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release Version'
+        required: true
+        type: string
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        product: [clion-oss-latest-stable, clion-oss-oldest-stable]
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bazel
+        uses: bazel-contrib/setup-bazel@0.15.0
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}
+          repository-cache: true
+
+      - name: Update version.bzl
+        run: |
+          bazel build //intellij_platform_sdk:build_name --define=ij_product=${{ matrix.product }}
+          echo "VERSION = '$(cat bazel-bin/intellij_platform_sdk/build_name.txt)-${{ inputs.version }}'" > version.bzl
+
+      - name: Build Plugin Zip
+        run: bazel build //clwb:clwb_bazel_zip --define=ij_product=${{ matrix.product }}
+
+      - name: Rename Plugin Zip
+        run: |
+          mkdir out
+          mv bazel-bin/clwb/clwb_bazel.zip out/$(cat bazel-bin/intellij_platform_sdk/build_name.txt).zip
+
+      - name: Upload Plugin Zip
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.product }}
+          path: "out/*.zip"
+          retention-days: 1
+
+  gh-release:
+    needs: build
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download Latest Plugin Zip
+        uses: actions/download-artifact@v4
+        with:
+          name: clion-oss-latest-stable
+
+      - name: Download Oldest Plugin Zip
+        uses: actions/download-artifact@v4
+        with:
+          name: clion-oss-oldest-stable
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: "*.zip"
+          tag_name: ${{ inputs.version }}
+          name: "CLwB Release ${{ inputs.version }}"
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  jb-release:
+    needs: build
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download Latest Plugin Zip
+        uses: actions/download-artifact@v4
+        with:
+          name: clion-oss-latest-stable
+
+      - name: Download Oldest Plugin Zip
+        uses: actions/download-artifact@v4
+        with:
+          name: clion-oss-oldest-stable
+
+      - name: Upload Releases
+        run: |
+          find . -type f -name "*.zip" -exec curl -i --header "Authorization: Bearer ${{ secrets.MARKETPLACE_TOKEN }}" -F pluginId=9554 -F file=@{} -F isHidden=true -F channel=stable https://plugins.jetbrains.com/plugin/uploadPlugin \;

--- a/intellij_platform_sdk/BUILD
+++ b/intellij_platform_sdk/BUILD
@@ -14,7 +14,9 @@ load(
 load(
     ":build_defs.bzl",
     "select_from_plugin_api_directory",
+    "select_build_name"
 )
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
 
 package(default_visibility = INTELLIJ_PLUGINS_VISIBILITY)
 
@@ -540,4 +542,10 @@ filegroup(
         clion = [":application_info_json"],
         intellij = [":application_info_json"],
     ),
+)
+
+write_file(
+    name = "build_name",
+    out = "build_name.txt",
+    content = select_build_name(),
 )

--- a/intellij_platform_sdk/build_defs.bzl
+++ b/intellij_platform_sdk/build_defs.bzl
@@ -254,6 +254,15 @@ def select_from_plugin_api_version_directory(params):
 
     return _do_select_for_plugin_api(params)
 
+def select_build_name():
+    """Returns a select for name of the current build target, e.g. clion-2025.2"""
+
+    params = dict()
+    for ij_product, value in DIRECT_IJ_PRODUCTS.items():
+        params[ij_product] = ["%s-%s" % (value.ide, value.version)]
+
+    return _do_select_for_plugin_api(params)
+
 def get_versions_to_build(product):
     """"Returns a set of unique product version aliases to test and build during regular release process.
 


### PR DESCRIPTION
Adds a GitHub action that can be manually triggered to create a new release. The action does the following:
- Build clion-oss-latest-stable
- Build clion-oss-oldest-stable
- Create a new release on GitHub including the tag
- Upload the zip files to the market place

The zip files are uploaded with the hidden flag, so they have to be manually promoted on the marketplace after verification.

