### PR TITLE
Add extra flags to fix debugging in Mac OS

### DIFF
--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrRunConfigurationRunner.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrRunConfigurationRunner.java
@@ -115,7 +115,7 @@ public class BlazeCidrRunConfigurationRunner implements BlazeCommandRunConfigura
       flagsBuilder.add("--copt=-fdebug-compilation-dir=" + WorkspaceRoot.fromProject(env.getProject()));
 
       if (SystemInfo.isMac) {
-        flagsBuilder.add("--linkopt=-Wl,-oso_prefix,.");
+        flagsBuilder.add("--linkopt=-Wl,-oso_prefix,.", "--linkopt=-Wl,-reproducible", "--remote_download_all");
       }
     }
 


### PR DESCRIPTION
# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: [`<please reference the issue number or url here>`](https://github.com/bazelbuild/intellij/issues/7824)

# Description of this change
In Mac OS LLDB needs not only the final linked binary but also the intermediate object file. If remote download is set to `minimal` or `top_level` (default) the intermediates will not be fetched for cached builds and setting breakpoints will not work. Additionally, LLDB will compare the timestamp of the binary against the timestamp of the object file and will refuse to load it if they differ. `-repro` fixes this.

see https://github.com/bazelbuild/intellij/issues/7824


