### PR TITLE
[AOSP-pick] No need for special mobile_install invokers

### DIFF
--- a/base/src/com/google/idea/blaze/base/bazel/BazelBuildSystem.java
+++ b/base/src/com/google/idea/blaze/base/bazel/BazelBuildSystem.java
@@ -46,11 +46,6 @@ class BazelBuildSystem implements BuildSystem {
   }
 
   @Override
-  public BuildInvoker getBuildInvoker(Project project, BlazeCommandName command) {
-    return getBuildInvoker(project);
-  }
-
-  @Override
   public SyncStrategy getSyncStrategy(Project project) {
     return SyncStrategy.SERIAL;
   }

--- a/base/src/com/google/idea/blaze/base/bazel/BuildSystem.java
+++ b/base/src/com/google/idea/blaze/base/bazel/BuildSystem.java
@@ -183,17 +183,6 @@ public interface BuildSystem {
   }
 
   /**
-   * Get a Blaze invoker specific to the blaze command.
-   */
-  default BuildInvoker getBuildInvoker(
-    Project project, BlazeCommandName command) {
-    throw new UnsupportedOperationException(
-      String.format(
-        "The getBuildInvoker method specific to a blaze command is not implemented in %s",
-        this.getClass().getSimpleName()));
-  }
-
-  /**
    * Return the strategy for remote syncs to be used with this build system.
    */
   SyncStrategy getSyncStrategy(Project project);

--- a/base/tests/utils/unit/com/google/idea/blaze/base/bazel/BuildSystemProviderWrapper.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/bazel/BuildSystemProviderWrapper.java
@@ -285,12 +285,6 @@ public class BuildSystemProviderWrapper implements BuildSystemProvider {
     }
 
     @Override
-    public BuildInvoker getBuildInvoker(
-        Project project, BlazeCommandName command) {
-      return new BuildInvokerWrapper(inner.getBuildInvoker(project));
-    }
-
-    @Override
     public SyncStrategy getSyncStrategy(Project project) {
       if (syncStrategy != null) {
         return syncStrategy;


### PR DESCRIPTION
Cherry pick AOSP commit [6233a6e18098d592fb42842406b8678ec9e520c0](https://cs.android.com/android-studio/platform/tools/adt/idea/+/6233a6e18098d592fb42842406b8678ec9e520c0).

STAT (diff to AOSP): 0 insertions(+), 0 deletion(-)

as they are only requested in the Bazel mode where the default one is
provided in this case.

Bug: n/a
Test: n/a
Change-Id: I2afb7d844bd7a5873982b87003201457e412f0f8

AOSP: 6233a6e18098d592fb42842406b8678ec9e520c0
