### PR TITLE
[AOSP-pick] Update BepParser to distinguish between aspects

### DIFF
--- a/base/src/com/google/idea/blaze/base/command/buildresult/bepparser/BepParser.kt
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/bepparser/BepParser.kt
@@ -125,24 +125,27 @@ private data class OutputGroupTargetConfigFileSets(
 /**
  * A data structure allowing to associate file set names with output group, targets and configs and allowing to retrieve them efficiently
  * at each level of the hierarchy.
+ *
+ * For each config, the file set names are stored as <aspect, List<file set name>> map to avoid duplicate file set names for the same
+ * config but different aspects. While retrieving, a flatmap for the given config is returned.
  */
 private class OutputGroupTargetConfigFileSetMap {
-  private val data: MutableMap<String, MutableMap<String, MutableMap<String, List<String>>>> = mutableMapOf()
+  private val data: MutableMap<String, MutableMap<String, MutableMap<String, MutableMap<String, List<String>>>>> = mutableMapOf()
 
-  private fun getOutputGroup(outputGroup: String): MutableMap<String, MutableMap<String, List<String>>> {
+  private fun getOutputGroup(outputGroup: String): MutableMap<String, MutableMap<String, MutableMap<String, List<String>>>> {
     return data.computeIfAbsent(outputGroup) { mutableMapOf() }
   }
 
-  private fun getOutputGroupTarget(outputGroup: String, target: String): MutableMap<String, List<String>> {
+  private fun getOutputGroupTarget(outputGroup: String, target: String): MutableMap<String, MutableMap<String, List<String>>> {
     return getOutputGroup(outputGroup).computeIfAbsent(target) { mutableMapOf() }
   }
 
-  private fun getOutputGroupTargetConfig(outputGroup: String, target: String, config: String): List<String> {
-    return getOutputGroupTarget(outputGroup, target)[config] ?: emptyList()
+  private fun getOutputGroupTargetConfig(outputGroup: String, target: String, config: String): MutableMap<String, List<String>> {
+    return getOutputGroupTarget(outputGroup, target).computeIfAbsent(config){mutableMapOf()}
   }
 
-  fun setOutputGroupTargetConfig(outputGroup: String, target: String, config: String, fileSetNames: List<String>) {
-    val previous = getOutputGroupTarget(outputGroup, target).put(config, fileSetNames.toList())
+  fun setOutputGroupTargetConfigAspect(outputGroup: String, target: String, config: String, aspect: String, fileSetNames: List<String>) {
+    val previous = getOutputGroupTargetConfig(outputGroup, target, config).put(aspect, fileSetNames.toList())
     if (previous != null) {
       error("$outputGroup:$target:$config already present")
     }
@@ -153,7 +156,7 @@ private class OutputGroupTargetConfigFileSetMap {
       outputGroup.value.entries.asSequence().flatMap { target ->
         target.value.entries.asSequence().map { config ->
           OutputGroupTargetConfigFileSets(outputGroup.key, target.key,
-                                          config.key, config.value)
+                                          config.key, config.value.entries.flatMap { it.value })
         }
       }
     }
@@ -164,7 +167,7 @@ private class OutputGroupTargetConfigFileSetMap {
     return outputGroupData.entries.asSequence().flatMap { target ->
       target.value.entries.asSequence().map { config ->
         OutputGroupTargetConfigFileSets(outputGroup, target.key,
-                                        config.key, config.value)
+                                        config.key, config.value.entries.flatMap { it.value })
       }
     }
   }
@@ -174,7 +177,7 @@ private class OutputGroupTargetConfigFileSetMap {
     val outputGroupTargetData = outputGroupData[target] ?: return emptySequence()
     return outputGroupTargetData.entries.asSequence().map { config ->
       OutputGroupTargetConfigFileSets(outputGroup, target,
-                                      config.key, config.value)
+                                      config.key, config.value.entries.flatMap { it.value })
     }
   }
 }
@@ -316,11 +319,16 @@ private fun parseBep(stream: BuildEventStreamProvider, nullableInterner: Interne
       TARGET_COMPLETED -> {
         val label = event.id.targetCompleted.label
         val configId = event.id.targetCompleted.configuration.id
+        val aspect = event.id.targetCompleted.aspect
 
         for (o in event.completed.outputGroupList) {
           val fileSetNames = getFileSets(o, interner)
-          state.outputs.setOutputGroupTargetConfig(interner.intern(o.name), interner.intern(label), interner.intern(configId),
-                                                   fileSetNames)
+          state.outputs.setOutputGroupTargetConfigAspect(
+            interner.intern(o.name),
+            interner.intern(label),
+            interner.intern(configId),
+            interner.intern(aspect),
+            fileSetNames)
         }
       }
 


### PR DESCRIPTION
Cherry pick AOSP commit [1154956dcf00e4da4ac14180f38d58e2c38a3c3b](https://cs.android.com/android-studio/platform/tools/adt/idea/+/1154956dcf00e4da4ac14180f38d58e2c38a3c3b).

STAT (diff to AOSP): 0 insertions(+), 0 deletion(-)

For a build (especially with a portable manifest aspect), we may receive
build events with the same output group, target, and config but
different aspects. They need to be distinguished in order to avoid
wrongly hitting the "already present" error on Line 148.

Bug:399949720

Test: existing
Change-Id: I1253be790d7e799fdc1b18741c313b5edaded05c

AOSP: 1154956dcf00e4da4ac14180f38d58e2c38a3c3b
