### PR TITLE
[AOSP-pick] Inline helper and overloaded methods

### DIFF
--- a/base/src/com/google/idea/blaze/base/actions/BlazeCompileFileAction.java
+++ b/base/src/com/google/idea/blaze/base/actions/BlazeCompileFileAction.java
@@ -17,6 +17,7 @@ package com.google.idea.blaze.base.actions;
 
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.idea.blaze.base.build.BlazeBuildService;
 import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.qsync.QuerySyncManager;
@@ -69,14 +70,11 @@ class BlazeCompileFileAction extends BlazeProjectAction {
     }
 
     if (Blaze.getProjectType(project).equals(ProjectType.QUERY_SYNC)) {
-      BuildDependenciesHelper buildDependenciesHelper =
-          new BuildDependenciesHelper(project, DepsBuildType.SELF);
+      BuildDependenciesHelper buildDependenciesHelper = new BuildDependenciesHelper(project, DepsBuildType.SELF);
       buildDependenciesHelper.determineTargetsAndRun(
-          virtualFile,
-          popup -> popup.showCenteredInCurrentWindow(project),
-          labels ->
-              BlazeBuildService.getInstance(project)
-                  .buildFileForLabels(virtualFile.getName(), labels));
+        virtualFile,
+        popup -> popup.showCenteredInCurrentWindow(project),
+        labels -> BlazeBuildService.getInstance(project).buildFileForLabels(virtualFile.getName(), labels), ImmutableSet.of());
       return;
     }
 

--- a/base/src/com/google/idea/blaze/base/qsync/action/BuildDependenciesForOpenFilesAction.java
+++ b/base/src/com/google/idea/blaze/base/qsync/action/BuildDependenciesForOpenFilesAction.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.idea.blaze.base.actions.BlazeProjectAction;
 import com.google.idea.blaze.base.logging.utils.querysync.QuerySyncActionStatsScope;
+import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
 import com.google.idea.blaze.base.qsync.action.BuildDependenciesHelper.DepsBuildType;
 import com.google.idea.blaze.common.Label;
 import com.google.idea.blaze.qsync.project.TargetsToBuild;
@@ -76,18 +77,21 @@ public class BuildDependenciesForOpenFilesAction extends BlazeProjectAction {
       helper.enableAnalysis(disambiguator.unambiguousTargets, querySyncActionStats);
     } else if (ambiguousTargets.size() == 1) {
       // there is a single ambiguous target set. Show the UI to disambiguate it.
+
       TargetsToBuild ambiguousOne = Iterables.getOnlyElement(ambiguousTargets);
+      String displayFileName =
+        WorkspaceRoot.fromProject(project).path().resolve(ambiguousOne.sourceFilePath().orElseThrow()).toString();
       helper.chooseTargetToBuildFor(
-          ambiguousOne.sourceFilePath().orElseThrow(),
-          ambiguousOne,
-          PopupPositioner.showAtMousePointerOrCentered(event),
-          chosen ->
-              helper.enableAnalysis(
-                  ImmutableSet.<Label>builder()
-                      .addAll(disambiguator.unambiguousTargets)
-                      .add(chosen)
-                      .build(),
-                  querySyncActionStats));
+        displayFileName,
+        ambiguousOne,
+        PopupPositioner.showAtMousePointerOrCentered(event),
+        chosen ->
+                helper.enableAnalysis(
+                    ImmutableSet.<Label>builder()
+                        .addAll(disambiguator.unambiguousTargets)
+                        .add(chosen)
+                        .build(),
+                    querySyncActionStats));
     } else {
       logger.warn(
           "Multiple ambiguous target sets for open files; not building them: "

--- a/base/src/com/google/idea/blaze/base/qsync/action/BuildDependenciesHelper.java
+++ b/base/src/com/google/idea/blaze/base/qsync/action/BuildDependenciesHelper.java
@@ -179,11 +179,6 @@ public class BuildDependenciesHelper {
   }
 
   public void determineTargetsAndRun(
-      VirtualFile vf, PopupPositioner positioner, Consumer<ImmutableSet<Label>> consumer) {
-    determineTargetsAndRun(vf, positioner, consumer, ImmutableSet.of());
-  }
-
-  public void determineTargetsAndRun(
       VirtualFile vf,
       PopupPositioner positioner,
       Consumer<ImmutableSet<Label>> consumer,
@@ -231,25 +226,13 @@ public class BuildDependenciesHelper {
   }
 
   public void chooseTargetToBuildFor(
-      Path workspaceRelativePath,
-      TargetsToBuild toBuild,
-      PopupPositioner positioner,
-      Consumer<Label> chosenConsumer) {
-    chooseTargetToBuildFor(
-        WorkspaceRoot.fromProject(project).path().resolve(workspaceRelativePath).toString(),
-        toBuild,
-        positioner,
-        chosenConsumer);
-  }
-
-  public void chooseTargetToBuildFor(
-      String fileName,
+      String displayFileName,
       TargetsToBuild toBuild,
       PopupPositioner positioner,
       Consumer<Label> chosenConsumer) {
     JBPopupFactory factory = JBPopupFactory.getInstance();
     ListPopup popup =
-        factory.createListPopup(SelectTargetPopupStep.create(toBuild, fileName, chosenConsumer));
+        factory.createListPopup(SelectTargetPopupStep.create(toBuild, displayFileName, chosenConsumer));
     positioner.showInCorrectPosition(popup);
   }
 


### PR DESCRIPTION
Cherry pick AOSP commit [27726d3b009cf97835aff9247fc78c80a2effa68](https://cs.android.com/android-studio/platform/tools/adt/idea/+/27726d3b009cf97835aff9247fc78c80a2effa68).

STAT (diff to AOSP): 0 insertions(+), 0 deletion(-)

They make the core code harder to understand.

Helper methods should be added to static-only helper classes or
implemented as Kotlin extension functions.

Bug: 409737053
Test: n/a
Change-Id: Icb8a4efd8a89f0f4fe168a89ece1c33e8bd39c56

AOSP: 27726d3b009cf97835aff9247fc78c80a2effa68
