### PR TITLE
[AOSP-pick] Delete unused variant of getBuildInvoker()

### DIFF
--- a/base/src/com/google/idea/blaze/base/bazel/BazelBuildSystem.java
+++ b/base/src/com/google/idea/blaze/base/bazel/BazelBuildSystem.java
@@ -41,11 +41,6 @@ class BazelBuildSystem implements BuildSystem {
   }
 
   @Override
-  public BuildInvoker getBuildInvoker(Project project, ExecutorType executorType, Kind targetKind) {
-    return getBuildInvoker(project);
-  }
-
-  @Override
   public SyncStrategy getSyncStrategy(Project project) {
     return SyncStrategy.SERIAL;
   }

--- a/base/src/com/google/idea/blaze/base/bazel/BuildSystem.java
+++ b/base/src/com/google/idea/blaze/base/bazel/BuildSystem.java
@@ -171,18 +171,6 @@ public interface BuildSystem {
   }
 
   /**
-   * Get a Blaze invoker specific to executor type and run config.
-   */
-  default BuildInvoker getBuildInvoker(
-    Project project, ExecutorType executorType, Kind targetKind) {
-    throw new UnsupportedOperationException(
-      String.format(
-        "The getBuildInvoker method specific to executor type and target kind is not"
-        + " implemented in %s",
-        this.getClass().getSimpleName()));
-  }
-
-  /**
    * Return the strategy for remote syncs to be used with this build system.
    */
   SyncStrategy getSyncStrategy(Project project);


### PR DESCRIPTION
Cherry pick AOSP commit [54b229050bff65aa93116357b756b9a38bc4688c](https://cs.android.com/android-studio/platform/tools/adt/idea/+/54b229050bff65aa93116357b756b9a38bc4688c).

STAT (diff to AOSP): 0 insertions(+), 0 deletion(-)

Bug: n/a
Test: n/a
Change-Id: I1627c7a2aaedae582e8dc75d4ebea64d713cafa3

AOSP: 54b229050bff65aa93116357b756b9a38bc4688c
