### PR TITLE
[AOSP-pick] Support storing multiple kinds of artifacts in RuntimeArtifactCache

### DIFF
--- a/base/src/com/google/idea/blaze/base/command/buildresult/LocalFileArtifact.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/LocalFileArtifact.java
@@ -20,6 +20,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import com.google.common.collect.ImmutableList;
 import com.google.idea.blaze.base.io.FileOperationProvider;
 import com.google.idea.blaze.base.run.RuntimeArtifactCache;
+import com.google.idea.blaze.base.run.RuntimeArtifactKind;
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.common.Label;
 import com.google.idea.blaze.common.artifact.BlazeArtifact;
@@ -29,7 +30,9 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.Collection;
 
-/** A file artifact available on the local file system. */
+/**
+ * A file artifact available on the local file system.
+ */
 public interface LocalFileArtifact extends BlazeArtifact {
 
   /**
@@ -39,9 +42,11 @@ public interface LocalFileArtifact extends BlazeArtifact {
    * runfiles directories).
    */
   static ImmutableList<File> getLocalFiles(Label target, Collection<? extends OutputArtifact> artifacts, BlazeContext context,
-                                           Project project) {
+                                           Project project, RuntimeArtifactKind artifactKind) {
     var runtimeArtifactCache = RuntimeArtifactCache.getInstance(project);
-    return runtimeArtifactCache.fetchArtifacts(target, artifacts.stream().toList(), context).stream().map(Path::toFile).collect(toImmutableList());
+    return runtimeArtifactCache.fetchArtifacts(target, artifacts.stream().toList(), context, artifactKind).stream()
+      .map(Path::toFile)
+      .collect(toImmutableList());
   }
 
   /**
@@ -53,7 +58,7 @@ public interface LocalFileArtifact extends BlazeArtifact {
   static ImmutableList<File> getLocalFilesForLegacySync(Collection<? extends BlazeArtifact> artifacts) {
     return artifacts.stream()
       .filter(a -> a instanceof LocalFileArtifact)
-      .map(a -> ((LocalFileArtifact) a).getFile())
+      .map(a -> ((LocalFileArtifact)a).getFile())
       .collect(toImmutableList());
   }
 

--- a/base/src/com/google/idea/blaze/base/run/RuntimeArtifactCache.java
+++ b/base/src/com/google/idea/blaze/base/run/RuntimeArtifactCache.java
@@ -35,5 +35,5 @@ public interface RuntimeArtifactCache {
    * build.
    */
   ImmutableList<Path> fetchArtifacts(
-      Label target, List<? extends OutputArtifact> artifacts, BlazeContext context);
+      Label target, List<? extends OutputArtifact> artifacts, BlazeContext context, RuntimeArtifactKind artifactKind);
 }

--- a/base/src/com/google/idea/blaze/base/run/RuntimeArtifactCacheImpl.java
+++ b/base/src/com/google/idea/blaze/base/run/RuntimeArtifactCacheImpl.java
@@ -32,6 +32,7 @@ import com.google.idea.blaze.qsync.project.ProjectProto;
 import com.google.idea.blaze.qsync.project.ProjectProto.ProjectArtifact;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Pair;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -43,7 +44,7 @@ import java.util.concurrent.ExecutionException;
 
 public final class RuntimeArtifactCacheImpl implements RuntimeArtifactCache {
   private static final Logger logger = Logger.getInstance(RuntimeArtifactCacheImpl.class);
-  private final Map<Label, Map<Path, ProjectProto.ProjectArtifact>> artifactCacheMap = new HashMap<>();
+  private final Map<Pair<Label, RuntimeArtifactKind>,  Map<Path, ProjectArtifact>> artifactCacheMap = new HashMap<>();
   private final Path runfilesDirectory;
   private static final String SEPARATOR_DIR_NAME = "_";
   private final BuildArtifactCache buildArtifactCache;
@@ -67,20 +68,21 @@ public final class RuntimeArtifactCacheImpl implements RuntimeArtifactCache {
 
   @Override
   public ImmutableList<Path> fetchArtifacts(
-      Label target, List<? extends OutputArtifact> artifacts, BlazeContext context) {
+      Label target, List<? extends OutputArtifact> artifacts, BlazeContext context, RuntimeArtifactKind artifactKind) {
+    var targetKind = Pair.create(target, artifactKind);
     final var artifactsCachedFuture =
         buildArtifactCache.addAll(artifacts.stream().collect(toImmutableList()), context);
-    artifactCacheMap.put(target, buildArtifactLayout(target, artifacts));
+    artifactCacheMap.put(targetKind, buildArtifactLayout(target, artifacts));
     final var artifactDirectoryContents = buildArtifactDirectoryContents(artifactCacheMap);
     waitForArtifacts(artifactsCachedFuture);
     updateArtifactDirectory(artifactDirectoryContents);
 
-    return resolveArtifactLayoutPaths(target, artifactCacheMap.get(target).keySet());
+    return resolveArtifactLayoutPaths(target, artifactKind, artifactCacheMap.get(targetKind).keySet());
   }
 
-  private ImmutableList<Path> resolveArtifactLayoutPaths(Label target, Set<Path> artifactPaths) {
+  private ImmutableList<Path> resolveArtifactLayoutPaths(Label target, RuntimeArtifactKind artifactKind, Set<Path> artifactPaths) {
     return artifactPaths.stream()
-        .map(artifactPath -> runfilesDirectory.resolve(getArtifactLocalPath(target, artifactPath)))
+        .map(artifactPath -> runfilesDirectory.resolve(getArtifactLocalPath(target, artifactKind, artifactPath)))
         .collect(toImmutableList());
   }
 
@@ -129,15 +131,15 @@ public final class RuntimeArtifactCacheImpl implements RuntimeArtifactCache {
    * path -> project artifact.
    */
   private static ProjectProto.ArtifactDirectoryContents buildArtifactDirectoryContents(
-      Map<Label, Map<Path, ProjectProto.ProjectArtifact>> artifacts) {
+      Map<Pair<Label, RuntimeArtifactKind>, Map<Path, ProjectProto.ProjectArtifact>> artifacts) {
     final var artifactDirectoryContents = ProjectProto.ArtifactDirectoryContents.newBuilder();
     for (final var entry : artifacts.entrySet()) {
-      final var target = entry.getKey();
+      final var key = entry.getKey();
       for (final var artifactPathAndDigest : entry.getValue().entrySet()) {
         final var artifactPath = artifactPathAndDigest.getKey();
         final var artifact = artifactPathAndDigest.getValue();
         artifactDirectoryContents.putContents(
-            getArtifactLocalPath(target, artifactPath).toString(), artifact);
+            getArtifactLocalPath(key.first, key.second, artifactPath).toString(), artifact);
       }
     }
     return artifactDirectoryContents.build();
@@ -147,7 +149,7 @@ public final class RuntimeArtifactCacheImpl implements RuntimeArtifactCache {
    * Generates the local artifact path from the target and artifact path. Local Artifact path ->
    * Target + SEPARATOR_DIR_NAME + artifactPath.
    */
-  public static Path getArtifactLocalPath(Label target, Path artifactPath) {
-    return target.toFilePath().resolve(Path.of(SEPARATOR_DIR_NAME)).resolve(artifactPath);
+  public static Path getArtifactLocalPath(Label target, RuntimeArtifactKind artifactKind, Path artifactPath) {
+    return target.toFilePath().resolve(Path.of(artifactKind.name())).resolve(Path.of(SEPARATOR_DIR_NAME)).resolve(artifactPath);
   }
 }

--- a/base/src/com/google/idea/blaze/base/run/RuntimeArtifactKind.java
+++ b/base/src/com/google/idea/blaze/base/run/RuntimeArtifactKind.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.run;
+
+public enum RuntimeArtifactKind {
+  APK(".apk"),
+  SYMBOL_FILE(".so"),
+  JAR(".jar");
+
+  public final String extension;
+
+  private RuntimeArtifactKind(String extension) {
+    this.extension = extension;
+  }
+}

--- a/base/tests/integrationtests/com/google/idea/blaze/base/run/RuntimeArtifactCacheImplTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/run/RuntimeArtifactCacheImplTest.java
@@ -82,15 +82,15 @@ public class RuntimeArtifactCacheImplTest {
     Label target = Label.of("//some/label:target");
     List<Path> paths =
         runtimeArtifactCache.fetchArtifacts(
-            target, ImmutableList.of(artifact1, artifact2), BlazeContext.create());
+            target, ImmutableList.of(artifact1, artifact2), BlazeContext.create(), RuntimeArtifactKind.JAR);
     assertThat(paths)
         .containsExactly(
             runfilesDirectory.resolve(
                 RuntimeArtifactCacheImpl.getArtifactLocalPath(
-                    target, Path.of("out/test1.jar"))),
+                  target, RuntimeArtifactKind.JAR, Path.of("out/test1.jar"))),
             runfilesDirectory.resolve(
                 RuntimeArtifactCacheImpl.getArtifactLocalPath(
-                    target, Path.of("out/test2.jar"))));
+                  target, RuntimeArtifactKind.JAR, Path.of("out/test2.jar"))));
     assertThat(Files.readAllBytes(paths.get(0))).isEqualTo("abc".getBytes());
     assertThat(Files.readAllBytes(paths.get(1))).isEqualTo("def".getBytes());
     assertThat(testArtifactFetcher.getCopiedArtifacts()).isEqualTo(List.of(artifact1, artifact2));
@@ -112,7 +112,7 @@ public class RuntimeArtifactCacheImplTest {
       .build();
     Label target = Label.of("//some/label:target");
     assertThrows(IllegalStateException.class, () -> runtimeArtifactCache.fetchArtifacts(
-      target, ImmutableList.of(artifact1, artifact2), BlazeContext.create()));
+      target, ImmutableList.of(artifact1, artifact2), BlazeContext.create(), RuntimeArtifactKind.JAR));
   }
 
   private BuildArtifactCacheDirectory createBuildArtifactCache(RuntimeArtifactCacheImplTest.TestArtifactFetcher artifactFetcher) throws

--- a/base/tests/unittests/com/google/idea/blaze/base/command/buildresult/BuildEventProtocolOutputReaderTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/command/buildresult/BuildEventProtocolOutputReaderTest.java
@@ -46,6 +46,7 @@ import com.google.idea.blaze.base.model.primitives.Kind;
 import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.qsync.settings.QuerySyncSettings;
 import com.google.idea.blaze.base.run.RuntimeArtifactCache;
+import com.google.idea.blaze.base.run.RuntimeArtifactKind;
 import com.google.idea.blaze.base.run.testlogs.BlazeTestResult;
 import com.google.idea.blaze.base.run.testlogs.BlazeTestResult.TestStatus;
 import com.google.idea.blaze.base.run.testlogs.BlazeTestResults;
@@ -74,13 +75,15 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
-/** Unit tests for {@link BuildEventProtocolOutputReader}. */
+/**
+ * Unit tests for {@link BuildEventProtocolOutputReader}.
+ */
 @RunWith(Parameterized.class)
 public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
 
   @Parameters
   public static ImmutableList<Object[]> data() {
-    return ImmutableList.of(new Object[] {true}, new Object[] {false});
+    return ImmutableList.of(new Object[]{true}, new Object[]{false});
   }
 
   // BEP file URI format changed from 'file://[abs_path]' to 'file:[abs_path]'
@@ -94,7 +97,8 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
     public ImmutableList<Path> fetchArtifacts(
       com.google.idea.blaze.common.Label label,
       List<? extends OutputArtifact> artifacts,
-      BlazeContext context) {
+      BlazeContext context,
+      RuntimeArtifactKind artifactKind) {
       return artifacts.stream()
         .map(a -> Paths.get(a.getBazelOutRelativePath()))
         .collect(toImmutableList());
@@ -105,7 +109,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
   protected void initTest(Container applicationServices, Container projectServices) {
     super.initTest(applicationServices, projectServices);
     ExtensionPointImpl<Kind.Provider> ep =
-        registerExtensionPoint(Kind.Provider.EP_NAME, Kind.Provider.class);
+      registerExtensionPoint(Kind.Provider.EP_NAME, Kind.Provider.class);
     ep.registerExtension(new GenericBlazeRules());
     applicationServices.register(Kind.ApplicationState.class, new Kind.ApplicationState());
     applicationServices.register(ExperimentService.class, new MockExperimentService());
@@ -113,7 +117,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
     projectServices.register(RuntimeArtifactCache.class, new TestRuntimeArtifactCache());
 
     ExtensionPointImpl<OutputArtifactParser> parserEp =
-        registerExtensionPoint(OutputArtifactParser.EP_NAME, OutputArtifactParser.class);
+      registerExtensionPoint(OutputArtifactParser.EP_NAME, OutputArtifactParser.class);
     parserEp.registerExtension(new LocalFileParser());
     context = BlazeContext.create();
   }
@@ -122,33 +126,35 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
   public void parseAllOutputs_singleTargetEvents_returnsAllOutputs() throws Exception {
     var label = "//some:target";
     ImmutableList<String> filePaths =
-        ImmutableList.of(
-            "/usr/local/lib/File.py", "/usr/bin/python2.7", "/usr/local/home/script.sh");
+      ImmutableList.of(
+        "/usr/local/lib/File.py", "/usr/bin/python2.7", "/usr/local/home/script.sh");
     ImmutableList<BuildEvent.Builder> events =
-        ImmutableList.of(
-            configuration("config-id", "k8-opt"),
-            setOfFiles(filePaths, "set-id"),
-            targetComplete(
-                label,
-                "config-id",
-                ImmutableList.of(outputGroup("name", ImmutableList.of("set-id")))));
+      ImmutableList.of(
+        configuration("config-id", "k8-opt"),
+        setOfFiles(filePaths, "set-id"),
+        targetComplete(
+          label,
+          "config-id",
+          ImmutableList.of(outputGroup("name", ImmutableList.of("set-id")))));
 
     List<OutputArtifact> parsedFilenames =
-        BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)), null).getAllOutputArtifactsForTesting();
+      BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)), null).getAllOutputArtifactsForTesting();
 
-    assertThat(LocalFileArtifact.getLocalFiles(com.google.idea.blaze.common.Label.of(label), parsedFilenames, context, getProject()))
-        .containsExactlyElementsIn(filePaths.stream().map(File::new).toArray())
-        .inOrder();
+    assertThat(LocalFileArtifact.getLocalFiles(com.google.idea.blaze.common.Label.of(label), parsedFilenames, context, getProject(),
+                                               RuntimeArtifactKind.JAR))
+      .containsExactlyElementsIn(filePaths.stream().map(File::new).toArray())
+      .inOrder();
   }
 
   @Test
   public void parseAllOutputs_nonFileEvent_returnsEmptyList() throws Exception {
     BuildEvent.Builder targetFinishedEvent =
-        BuildEvent.newBuilder()
-            .setCompleted(BuildEventStreamProtos.TargetComplete.getDefaultInstance());
+      BuildEvent.newBuilder()
+        .setCompleted(BuildEventStreamProtos.TargetComplete.getDefaultInstance());
 
     List<OutputArtifact> parsedFilenames =
-        BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(targetFinishedEvent)), null).getAllOutputArtifactsForTesting();
+      BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(targetFinishedEvent)), null)
+        .getAllOutputArtifactsForTesting();
 
     assertThat(parsedFilenames).isEmpty();
   }
@@ -157,73 +163,76 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
   public void parseAllOutputs_singleTargetEventsPlusExtras_returnsAllOutputs() throws Exception {
     var label = "//some:target";
     ImmutableList<String> filePaths =
-        ImmutableList.of(
-            "/usr/local/lib/Provider.java",
-            "/usr/local/home/Executor.java",
-            "/google/code/script.sh");
+      ImmutableList.of(
+        "/usr/local/lib/Provider.java",
+        "/usr/local/home/Executor.java",
+        "/google/code/script.sh");
     ImmutableList<BuildEvent.Builder> events =
-        ImmutableList.of(
-            BuildEvent.newBuilder()
-                .setStarted(BuildEventStreamProtos.BuildStarted.getDefaultInstance()),
-            BuildEvent.newBuilder()
-                .setProgress(BuildEventStreamProtos.Progress.getDefaultInstance()),
-            configuration("config-id", "k8-opt"),
-            setOfFiles(filePaths, "set-id"),
-            targetComplete(
-                label,
-                "config-id",
-                ImmutableList.of(outputGroup("name", ImmutableList.of("set-id")))));
+      ImmutableList.of(
+        BuildEvent.newBuilder()
+          .setStarted(BuildEventStreamProtos.BuildStarted.getDefaultInstance()),
+        BuildEvent.newBuilder()
+          .setProgress(BuildEventStreamProtos.Progress.getDefaultInstance()),
+        configuration("config-id", "k8-opt"),
+        setOfFiles(filePaths, "set-id"),
+        targetComplete(
+          label,
+          "config-id",
+          ImmutableList.of(outputGroup("name", ImmutableList.of("set-id")))));
 
     List<OutputArtifact> parsedFilenames =
-        BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)), null).getAllOutputArtifactsForTesting();
+      BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)), null).getAllOutputArtifactsForTesting();
 
-    assertThat(LocalFileArtifact.getLocalFiles(com.google.idea.blaze.common.Label.of(label), parsedFilenames, context, getProject()))
-        .containsExactlyElementsIn(filePaths.stream().map(File::new).toArray())
-        .inOrder();
+    assertThat(LocalFileArtifact.getLocalFiles(com.google.idea.blaze.common.Label.of(label), parsedFilenames, context, getProject(),
+                                               RuntimeArtifactKind.JAR))
+      .containsExactlyElementsIn(filePaths.stream().map(File::new).toArray())
+      .inOrder();
   }
 
   @Test
   public void parseAllOutputs_singleTargetWithMultipleFileSets_returnsAllOutputs()
-      throws Exception {
+    throws Exception {
     ImmutableList<String> fileSet1 =
-        ImmutableList.of(
-            "/usr/local/lib/Provider.java",
-            "/usr/local/home/Executor.java",
-            "/google/code/script.sh");
+      ImmutableList.of(
+        "/usr/local/lib/Provider.java",
+        "/usr/local/home/Executor.java",
+        "/google/code/script.sh");
 
     ImmutableList<String> fileSet2 =
-        ImmutableList.of(
-            "/usr/local/code/ParserTest.java",
-            "/usr/local/code/action_output.bzl",
-            "/usr/genfiles/BUILD.bazel");
+      ImmutableList.of(
+        "/usr/local/code/ParserTest.java",
+        "/usr/local/code/action_output.bzl",
+        "/usr/genfiles/BUILD.bazel");
     var label = "//some:target";
     ImmutableList<BuildEvent.Builder> events =
-        ImmutableList.of(
-            BuildEvent.newBuilder()
-                .setStarted(BuildEventStreamProtos.BuildStarted.getDefaultInstance()),
-            BuildEvent.newBuilder()
-                .setProgress(BuildEventStreamProtos.Progress.getDefaultInstance()),
-            configuration("config-id", "k8-opt"),
-            setOfFiles(fileSet1, "set-1"),
-            setOfFiles(fileSet2, "set-2"),
-            targetComplete(
-                label,
-                "config-id",
-                ImmutableList.of(
-                    outputGroup("name1", ImmutableList.of("set-1")),
-                    outputGroup("name2", ImmutableList.of("set-2")))));
+      ImmutableList.of(
+        BuildEvent.newBuilder()
+          .setStarted(BuildEventStreamProtos.BuildStarted.getDefaultInstance()),
+        BuildEvent.newBuilder()
+          .setProgress(BuildEventStreamProtos.Progress.getDefaultInstance()),
+        configuration("config-id", "k8-opt"),
+        setOfFiles(fileSet1, "set-1"),
+        setOfFiles(fileSet2, "set-2"),
+        targetComplete(
+          label,
+          "config-id",
+          ImmutableList.of(
+            outputGroup("name1", ImmutableList.of("set-1")),
+            outputGroup("name2", ImmutableList.of("set-2")))));
 
     ImmutableList<File> allFiles =
-        ImmutableList.<String>builder().addAll(fileSet1).addAll(fileSet2).build().stream()
-            .map(File::new)
-            .collect(toImmutableList());
+      ImmutableList.<String>builder().addAll(fileSet1).addAll(fileSet2).build().stream()
+        .map(File::new)
+        .collect(toImmutableList());
 
     List<OutputArtifact> parsedFilenames =
-        BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)), null).getAllOutputArtifactsForTesting();
+      BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)), null)
+        .getAllOutputArtifactsForTesting();
 
-    assertThat(LocalFileArtifact.getLocalFiles(com.google.idea.blaze.common.Label.of(label), parsedFilenames, context, getProject()))
-        .containsExactlyElementsIn(allFiles)
-        .inOrder();
+    assertThat(LocalFileArtifact.getLocalFiles(com.google.idea.blaze.common.Label.of(label), parsedFilenames, context, getProject(),
+                                               RuntimeArtifactKind.JAR))
+      .containsExactlyElementsIn(allFiles)
+      .inOrder();
   }
 
   @Test
@@ -232,206 +241,216 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
     ImmutableList<String> fileSet1 = ImmutableList.of("/usr/out/genfiles/foo.pb.h");
 
     ImmutableList<String> fileSet2 =
-        ImmutableList.of("/usr/out/genfiles/foo.pb.h", "/usr/out/genfiles/foo.proto.h");
+      ImmutableList.of("/usr/out/genfiles/foo.pb.h", "/usr/out/genfiles/foo.proto.h");
 
     ImmutableList<BuildEvent.Builder> events =
-        ImmutableList.of(
-            BuildEvent.newBuilder()
-                .setStarted(BuildEventStreamProtos.BuildStarted.getDefaultInstance()),
-            BuildEvent.newBuilder()
-                .setProgress(BuildEventStreamProtos.Progress.getDefaultInstance()),
-            configuration("config-id", "k8-opt"),
-            setOfFiles(fileSet1, "set-1"),
-            setOfFiles(fileSet2, "set-2"),
-            targetComplete(
-                label,
-                "config-id",
-                ImmutableList.of(
-                    outputGroup("name1", ImmutableList.of("set-1")),
-                    outputGroup("name2", ImmutableList.of("set-2")))));
+      ImmutableList.of(
+        BuildEvent.newBuilder()
+          .setStarted(BuildEventStreamProtos.BuildStarted.getDefaultInstance()),
+        BuildEvent.newBuilder()
+          .setProgress(BuildEventStreamProtos.Progress.getDefaultInstance()),
+        configuration("config-id", "k8-opt"),
+        setOfFiles(fileSet1, "set-1"),
+        setOfFiles(fileSet2, "set-2"),
+        targetComplete(
+          label,
+          "config-id",
+          ImmutableList.of(
+            outputGroup("name1", ImmutableList.of("set-1")),
+            outputGroup("name2", ImmutableList.of("set-2")))));
 
     ImmutableList<File> allFiles =
-        ImmutableSet.of("/usr/out/genfiles/foo.pb.h", "/usr/out/genfiles/foo.proto.h").stream()
-            .map(File::new)
-            .collect(toImmutableList());
+      ImmutableSet.of("/usr/out/genfiles/foo.pb.h", "/usr/out/genfiles/foo.proto.h").stream()
+        .map(File::new)
+        .collect(toImmutableList());
 
     List<OutputArtifact> parsedFilenames =
-        BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)), null).getAllOutputArtifactsForTesting();
+      BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)), null)
+        .getAllOutputArtifactsForTesting();
 
-    assertThat(LocalFileArtifact.getLocalFiles(com.google.idea.blaze.common.Label.of(label), parsedFilenames, context, getProject()))
-        .containsExactlyElementsIn(allFiles)
-        .inOrder();
+    assertThat(LocalFileArtifact.getLocalFiles(com.google.idea.blaze.common.Label.of(label), parsedFilenames, context, getProject(),
+                                               RuntimeArtifactKind.JAR))
+      .containsExactlyElementsIn(allFiles)
+      .inOrder();
   }
 
   @Test
   public void parseArtifactsForTarget_singleTarget_returnsTargetOutputs() throws Exception {
     ImmutableList<String> fileSet =
-        ImmutableList.of("/usr/out/genfiles/foo.pb.h", "/usr/out/genfiles/foo.proto.h");
+      ImmutableList.of("/usr/out/genfiles/foo.pb.h", "/usr/out/genfiles/foo.proto.h");
     var label = "//some:target";
     ImmutableList<BuildEvent.Builder> events =
-        ImmutableList.of(
-            BuildEvent.newBuilder()
-                .setStarted(BuildEventStreamProtos.BuildStarted.getDefaultInstance()),
-            BuildEvent.newBuilder()
-                .setProgress(BuildEventStreamProtos.Progress.getDefaultInstance()),
-            configuration("config-id", "k8-opt"),
-            setOfFiles(fileSet, "set-id"),
-            targetComplete(
-                label,
-                "config-id",
-                ImmutableList.of(outputGroup("group-name", ImmutableList.of("set-id")))));
+      ImmutableList.of(
+        BuildEvent.newBuilder()
+          .setStarted(BuildEventStreamProtos.BuildStarted.getDefaultInstance()),
+        BuildEvent.newBuilder()
+          .setProgress(BuildEventStreamProtos.Progress.getDefaultInstance()),
+        configuration("config-id", "k8-opt"),
+        setOfFiles(fileSet, "set-id"),
+        targetComplete(
+          label,
+          "config-id",
+          ImmutableList.of(outputGroup("group-name", ImmutableList.of("set-id")))));
 
     ImmutableList<File> allFiles =
-        ImmutableSet.of("/usr/out/genfiles/foo.pb.h", "/usr/out/genfiles/foo.proto.h").stream()
-            .map(File::new)
-            .collect(toImmutableList());
+      ImmutableSet.of("/usr/out/genfiles/foo.pb.h", "/usr/out/genfiles/foo.proto.h").stream()
+        .map(File::new)
+        .collect(toImmutableList());
 
     List<OutputArtifact> parsedFilenames =
-              BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)), null).getOutputGroupTargetArtifacts(
-                "group-name", "//some:target");
+      BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)), null)
+        .getOutputGroupTargetArtifacts(
+        "group-name", "//some:target");
 
-    assertThat(LocalFileArtifact.getLocalFiles(com.google.idea.blaze.common.Label.of(label), parsedFilenames, context, getProject()))
-        .containsExactlyElementsIn(allFiles)
-        .inOrder();
+    assertThat(LocalFileArtifact.getLocalFiles(com.google.idea.blaze.common.Label.of(label), parsedFilenames, context, getProject(),
+                                               RuntimeArtifactKind.JAR))
+      .containsExactlyElementsIn(allFiles)
+      .inOrder();
   }
 
   @Test
   public void parseArtifactsForTarget_twoTargets_returnsCorrectTargetOutputs() throws Exception {
     var label = "//some:target";
     ImmutableList<String> targetFileSet =
-        ImmutableList.of("/usr/out/genfiles/foo.pb.h", "/usr/out/genfiles/foo.proto.h");
+      ImmutableList.of("/usr/out/genfiles/foo.pb.h", "/usr/out/genfiles/foo.proto.h");
     ImmutableList<String> otherTargetFileSet =
-        ImmutableList.of(
-            "/usr/local/lib/File.py", "/usr/bin/python2.7", "/usr/local/home/script.sh");
+      ImmutableList.of(
+        "/usr/local/lib/File.py", "/usr/bin/python2.7", "/usr/local/home/script.sh");
 
     ImmutableList<BuildEvent.Builder> events =
-        ImmutableList.of(
-            BuildEvent.newBuilder()
-                .setStarted(BuildEventStreamProtos.BuildStarted.getDefaultInstance()),
-            BuildEvent.newBuilder()
-                .setProgress(BuildEventStreamProtos.Progress.getDefaultInstance()),
-            configuration("config-id", "k8-opt"),
-            setOfFiles(targetFileSet, "target-set"),
-            setOfFiles(otherTargetFileSet, "other-set"),
-            targetComplete(
-                label,
-                "config-id",
-                ImmutableList.of(outputGroup("group-name", ImmutableList.of("target-set")))),
-            targetComplete(
-                "//other:target",
-                "config-id",
-                ImmutableList.of(outputGroup("group-name", ImmutableList.of("other-set")))));
+      ImmutableList.of(
+        BuildEvent.newBuilder()
+          .setStarted(BuildEventStreamProtos.BuildStarted.getDefaultInstance()),
+        BuildEvent.newBuilder()
+          .setProgress(BuildEventStreamProtos.Progress.getDefaultInstance()),
+        configuration("config-id", "k8-opt"),
+        setOfFiles(targetFileSet, "target-set"),
+        setOfFiles(otherTargetFileSet, "other-set"),
+        targetComplete(
+          label,
+          "config-id",
+          ImmutableList.of(outputGroup("group-name", ImmutableList.of("target-set")))),
+        targetComplete(
+          "//other:target",
+          "config-id",
+          ImmutableList.of(outputGroup("group-name", ImmutableList.of("other-set")))));
 
     ImmutableList<File> allFiles =
-        ImmutableSet.of("/usr/out/genfiles/foo.pb.h", "/usr/out/genfiles/foo.proto.h").stream()
-            .map(File::new)
-            .collect(toImmutableList());
+      ImmutableSet.of("/usr/out/genfiles/foo.pb.h", "/usr/out/genfiles/foo.proto.h").stream()
+        .map(File::new)
+        .collect(toImmutableList());
 
     List<OutputArtifact> parsedFilenames =
-              BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)), null).getOutputGroupTargetArtifacts(
-                "group-name", "//some:target");
+      BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)), null)
+        .getOutputGroupTargetArtifacts(
+        "group-name", "//some:target");
 
-    assertThat(LocalFileArtifact.getLocalFiles(com.google.idea.blaze.common.Label.of(label), parsedFilenames, context, getProject()))
-        .containsExactlyElementsIn(allFiles)
-        .inOrder();
+    assertThat(LocalFileArtifact.getLocalFiles(com.google.idea.blaze.common.Label.of(label), parsedFilenames, context, getProject(),
+                                               RuntimeArtifactKind.JAR))
+      .containsExactlyElementsIn(allFiles)
+      .inOrder();
   }
 
   @Test
   public void parseAllArtifactsInOutputGroups_oneGroup_returnsAllOutputs() throws Exception {
     ImmutableList<String> fileSet1 =
-        ImmutableList.of("/usr/out/genfiles/foo.pb.h", "/usr/out/genfiles/foo.proto.h");
+      ImmutableList.of("/usr/out/genfiles/foo.pb.h", "/usr/out/genfiles/foo.proto.h");
     ImmutableList<String> fileSet2 =
-        ImmutableList.of(
-            "/usr/local/lib/File.py", "/usr/bin/python2.7", "/usr/local/home/script.sh");
+      ImmutableList.of(
+        "/usr/local/lib/File.py", "/usr/bin/python2.7", "/usr/local/home/script.sh");
     var label = "//some:target";
     ImmutableList<BuildEvent.Builder> events =
-        ImmutableList.of(
-            BuildEvent.newBuilder()
-                .setStarted(BuildEventStreamProtos.BuildStarted.getDefaultInstance()),
-            BuildEvent.newBuilder()
-                .setProgress(BuildEventStreamProtos.Progress.getDefaultInstance()),
-            configuration("config-id", "k8-opt"),
-            setOfFiles(fileSet1, "set-1"),
-            setOfFiles(fileSet2, "set-2"),
-            targetComplete(
-                label,
-                "config-id",
-                ImmutableList.of(outputGroup("group-name", ImmutableList.of("set-1")))),
-            targetComplete(
-                "//other:target",
-                "config-id",
-                ImmutableList.of(outputGroup("group-name", ImmutableList.of("set-2")))));
+      ImmutableList.of(
+        BuildEvent.newBuilder()
+          .setStarted(BuildEventStreamProtos.BuildStarted.getDefaultInstance()),
+        BuildEvent.newBuilder()
+          .setProgress(BuildEventStreamProtos.Progress.getDefaultInstance()),
+        configuration("config-id", "k8-opt"),
+        setOfFiles(fileSet1, "set-1"),
+        setOfFiles(fileSet2, "set-2"),
+        targetComplete(
+          label,
+          "config-id",
+          ImmutableList.of(outputGroup("group-name", ImmutableList.of("set-1")))),
+        targetComplete(
+          "//other:target",
+          "config-id",
+          ImmutableList.of(outputGroup("group-name", ImmutableList.of("set-2")))));
 
     ImmutableList<File> allFiles =
-        ImmutableSet.of(
-                "/usr/out/genfiles/foo.pb.h",
-                "/usr/out/genfiles/foo.proto.h",
-                "/usr/local/lib/File.py",
-                "/usr/bin/python2.7",
-                "/usr/local/home/script.sh")
-            .stream()
-            .map(File::new)
-            .collect(toImmutableList());
+      ImmutableSet.of(
+          "/usr/out/genfiles/foo.pb.h",
+          "/usr/out/genfiles/foo.proto.h",
+          "/usr/local/lib/File.py",
+          "/usr/bin/python2.7",
+          "/usr/local/home/script.sh")
+        .stream()
+        .map(File::new)
+        .collect(toImmutableList());
 
     List<OutputArtifact> parsedFilenames =
-        BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)), null).getOutputGroupArtifacts(
-                                     "group-name");
+      BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)), null)
+        .getOutputGroupArtifacts(
+        "group-name");
 
-    assertThat(LocalFileArtifact.getLocalFiles(com.google.idea.blaze.common.Label.of(label), parsedFilenames, context, getProject()))
-        .containsExactlyElementsIn(allFiles)
-        .inOrder();
+    assertThat(LocalFileArtifact.getLocalFiles(com.google.idea.blaze.common.Label.of(label), parsedFilenames, context, getProject(),
+                                               RuntimeArtifactKind.JAR))
+      .containsExactlyElementsIn(allFiles)
+      .inOrder();
   }
 
   @Test
   public void parseAllArtifactsInOutputGroups_oneOfTwoGroups_returnsCorrectOutputs()
-      throws Exception {
+    throws Exception {
     ImmutableList<String> fileSet1 =
-        ImmutableList.of("/usr/out/genfiles/foo.pb.h", "/usr/out/genfiles/foo.proto.h");
+      ImmutableList.of("/usr/out/genfiles/foo.pb.h", "/usr/out/genfiles/foo.proto.h");
     ImmutableList<String> fileSet2 =
-        ImmutableList.of(
-            "/usr/local/lib/File.py", "/usr/bin/python2.7", "/usr/local/home/script.sh");
+      ImmutableList.of(
+        "/usr/local/lib/File.py", "/usr/bin/python2.7", "/usr/local/home/script.sh");
     var label = "//some:target";
     ImmutableList<BuildEvent.Builder> events =
-        ImmutableList.of(
-            BuildEvent.newBuilder()
-                .setStarted(BuildEventStreamProtos.BuildStarted.getDefaultInstance()),
-            BuildEvent.newBuilder()
-                .setProgress(BuildEventStreamProtos.Progress.getDefaultInstance()),
-            configuration("config-id", "k8-opt"),
-            setOfFiles(fileSet1, "set-1"),
-            setOfFiles(fileSet2, "set-2"),
-            targetComplete(
-                label,
-                "config-id",
-                ImmutableList.of(outputGroup("group-1", ImmutableList.of("set-1")))),
-            targetComplete(
-                "//other:target",
-                "config-id",
-                ImmutableList.of(outputGroup("group-2", ImmutableList.of("set-2")))));
+      ImmutableList.of(
+        BuildEvent.newBuilder()
+          .setStarted(BuildEventStreamProtos.BuildStarted.getDefaultInstance()),
+        BuildEvent.newBuilder()
+          .setProgress(BuildEventStreamProtos.Progress.getDefaultInstance()),
+        configuration("config-id", "k8-opt"),
+        setOfFiles(fileSet1, "set-1"),
+        setOfFiles(fileSet2, "set-2"),
+        targetComplete(
+          label,
+          "config-id",
+          ImmutableList.of(outputGroup("group-1", ImmutableList.of("set-1")))),
+        targetComplete(
+          "//other:target",
+          "config-id",
+          ImmutableList.of(outputGroup("group-2", ImmutableList.of("set-2")))));
 
     ImmutableList<File> allFiles =
-        ImmutableSet.of("/usr/out/genfiles/foo.pb.h", "/usr/out/genfiles/foo.proto.h").stream()
-            .map(File::new)
-            .collect(toImmutableList());
+      ImmutableSet.of("/usr/out/genfiles/foo.pb.h", "/usr/out/genfiles/foo.proto.h").stream()
+        .map(File::new)
+        .collect(toImmutableList());
 
     List<OutputArtifact> parsedFilenames =
-        BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)), null).getOutputGroupArtifacts(
-                                     "group-1");
+      BepParser.parseBepArtifacts(BuildEventStreamProvider.fromInputStream(asInputStream(events)), null)
+        .getOutputGroupArtifacts(
+        "group-1");
 
-    assertThat(LocalFileArtifact.getLocalFiles(com.google.idea.blaze.common.Label.of(label), parsedFilenames, context, getProject()))
-        .containsExactlyElementsIn(allFiles)
-        .inOrder();
+    assertThat(LocalFileArtifact.getLocalFiles(com.google.idea.blaze.common.Label.of(label), parsedFilenames, context, getProject(),
+                                               RuntimeArtifactKind.JAR))
+      .containsExactlyElementsIn(allFiles)
+      .inOrder();
   }
 
   @Test
   public void testStatusEnum_handlesAllProtoEnumValues() {
     ImmutableSet<String> protoValues =
-        EnumSet.allOf(BuildEventStreamProtos.TestStatus.class).stream()
-            .map(Enum::name)
-            .filter(name -> !name.equals(BuildEventStreamProtos.TestStatus.UNRECOGNIZED.name()))
-            .collect(toImmutableSet());
+      EnumSet.allOf(BuildEventStreamProtos.TestStatus.class).stream()
+        .map(Enum::name)
+        .filter(name -> !name.equals(BuildEventStreamProtos.TestStatus.UNRECOGNIZED.name()))
+        .collect(toImmutableSet());
     ImmutableSet<String> handledValues =
-        EnumSet.allOf(TestStatus.class).stream().map(Enum::name).collect(toImmutableSet());
+      EnumSet.allOf(TestStatus.class).stream().map(Enum::name).collect(toImmutableSet());
 
     assertThat(protoValues).containsExactlyElementsIn(handledValues);
   }
@@ -444,26 +463,26 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
     BuildEvent.Builder event = testResultEvent(label.toString(), status, filePaths);
 
     BlazeTestResults results =
-        BuildEventProtocolOutputReader.parseTestResults(BuildEventStreamProvider.fromInputStream(asInputStream(event)));
+      BuildEventProtocolOutputReader.parseTestResults(BuildEventStreamProvider.fromInputStream(asInputStream(event)));
 
     assertThat(results.perTargetResults.keySet()).containsExactly(label);
     assertThat(results.perTargetResults.get(label)).hasSize(1);
     BlazeTestResult result = results.perTargetResults.get(label).iterator().next();
     assertThat(result.getTestStatus()).isEqualTo(TestStatus.FAILED);
     assertThat(getOutputXmlFiles(label, result, context, project))
-        .containsExactly(new File("/usr/local/tmp/_cache/test_result.xml"));
+      .containsExactly(new File("/usr/local/tmp/_cache/test_result.xml"));
   }
 
   @Test
   public void parseTestResults_singleTestEventWithTargetConfigured_resultsIncludeTargetKind()
-      throws Exception {
+    throws Exception {
     Label label = Label.create("//java/com/google:unit_tests");
     BuildEventStreamProtos.TestStatus status = BuildEventStreamProtos.TestStatus.FAILED;
     ImmutableList<String> filePaths = ImmutableList.of("/usr/local/tmp/_cache/test_result.xml");
     InputStream events =
-        asInputStream(
-            targetConfiguredEvent(label.toString(), "sh_test rule"),
-            testResultEvent(label.toString(), status, filePaths));
+      asInputStream(
+        targetConfiguredEvent(label.toString(), "sh_test rule"),
+        testResultEvent(label.toString(), status, filePaths));
 
     BlazeTestResults results = BuildEventProtocolOutputReader.parseTestResults(BuildEventStreamProvider.fromInputStream(events));
 
@@ -473,19 +492,19 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
     assertThat(result.getTargetKind()).isEqualTo(RuleTypes.SH_TEST.getKind());
     assertThat(result.getTestStatus()).isEqualTo(TestStatus.FAILED);
     assertThat(getOutputXmlFiles(label, result, context, getProject()))
-        .containsExactly(new File("/usr/local/tmp/_cache/test_result.xml"));
+      .containsExactly(new File("/usr/local/tmp/_cache/test_result.xml"));
   }
 
   @Test
   public void parseTestResults_singleTestEventWithTargetCompleted_resultsIncludeTargetKind()
-      throws Exception {
+    throws Exception {
     Label label = Label.create("//java/com/google:unit_tests");
     BuildEventStreamProtos.TestStatus status = BuildEventStreamProtos.TestStatus.FAILED;
     ImmutableList<String> filePaths = ImmutableList.of("/usr/local/tmp/_cache/test_result.xml");
     InputStream events =
-        asInputStream(
-            targetCompletedEvent(label.toString(), "sh_test rule"),
-            testResultEvent(label.toString(), status, filePaths));
+      asInputStream(
+        targetCompletedEvent(label.toString(), "sh_test rule"),
+        testResultEvent(label.toString(), status, filePaths));
 
     BlazeTestResults results = BuildEventProtocolOutputReader.parseTestResults(BuildEventStreamProvider.fromInputStream(events));
 
@@ -495,20 +514,20 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
     assertThat(result.getTargetKind()).isEqualTo(RuleTypes.SH_TEST.getKind());
     assertThat(result.getTestStatus()).isEqualTo(TestStatus.FAILED);
     assertThat(getOutputXmlFiles(label, result, context, getProject()))
-        .containsExactly(new File("/usr/local/tmp/_cache/test_result.xml"));
+      .containsExactly(new File("/usr/local/tmp/_cache/test_result.xml"));
   }
 
   @Test
   public void parseTestResults_multipleTargetKindSources_resultsIncludeCorrectTargetKind()
-      throws Exception {
+    throws Exception {
     Label label = Label.create("//java/com/google:unit_tests");
     BuildEventStreamProtos.TestStatus status = BuildEventStreamProtos.TestStatus.FAILED;
     ImmutableList<String> filePaths = ImmutableList.of("/usr/local/tmp/_cache/test_result.xml");
     InputStream events =
-        asInputStream(
-            targetConfiguredEvent(label.toString(), "sh_test rule"),
-            targetCompletedEvent(label.toString(), "sh_test rule"),
-            testResultEvent(label.toString(), status, filePaths));
+      asInputStream(
+        targetConfiguredEvent(label.toString(), "sh_test rule"),
+        targetCompletedEvent(label.toString(), "sh_test rule"),
+        testResultEvent(label.toString(), status, filePaths));
 
     BlazeTestResults results = BuildEventProtocolOutputReader.parseTestResults(BuildEventStreamProvider.fromInputStream(events));
 
@@ -518,7 +537,7 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
     assertThat(result.getTargetKind()).isEqualTo(RuleTypes.SH_TEST.getKind());
     assertThat(result.getTestStatus()).isEqualTo(TestStatus.FAILED);
     assertThat(getOutputXmlFiles(label, result, context, getProject()))
-        .containsExactly(new File("/usr/local/tmp/_cache/test_result.xml"));
+      .containsExactly(new File("/usr/local/tmp/_cache/test_result.xml"));
   }
 
   @Test
@@ -526,40 +545,40 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
     Label label = Label.create("//java/com/google:unit_tests");
     BuildEventStreamProtos.TestStatus status = BuildEventStreamProtos.TestStatus.FAILED;
     ImmutableList<String> filePaths =
-        ImmutableList.of(
-            "/usr/local/tmp/_cache/test_result.xml",
-            "/usr/local/tmp/_cache/test_result.log",
-            "/usr/local/tmp/other_output_file");
+      ImmutableList.of(
+        "/usr/local/tmp/_cache/test_result.xml",
+        "/usr/local/tmp/_cache/test_result.log",
+        "/usr/local/tmp/other_output_file");
     BuildEvent.Builder event = testResultEvent(label.toString(), status, filePaths);
 
     BlazeTestResults results =
-        BuildEventProtocolOutputReader.parseTestResults(BuildEventStreamProvider.fromInputStream(asInputStream(event)));
+      BuildEventProtocolOutputReader.parseTestResults(BuildEventStreamProvider.fromInputStream(asInputStream(event)));
 
     BlazeTestResult result = results.perTargetResults.get(label).iterator().next();
     assertThat(getOutputXmlFiles(label, result, context, getProject()))
-        .containsExactly(new File("/usr/local/tmp/_cache/test_result.xml"));
+      .containsExactly(new File("/usr/local/tmp/_cache/test_result.xml"));
   }
 
   @Test
   public void parseTestResults_singleTargetWithMultipleEvents_returnsTestResults()
-      throws Exception {
+    throws Exception {
     Label label = Label.create("//java/com/google:unit_tests");
 
     ImmutableList<BuildEvent.Builder> events =
-        ImmutableList.of(
-            configuration("config-id", "k8-opt"),
-            targetComplete(label.toString(), "config-id", ImmutableList.of()),
-            testResultEvent(
-                label.toString(),
-                BuildEventStreamProtos.TestStatus.PASSED,
-                ImmutableList.of("/usr/local/tmp/_cache/shard1_of_2.xml")),
-            testResultEvent(
-                label.toString(),
-                BuildEventStreamProtos.TestStatus.FAILED,
-                ImmutableList.of("/usr/local/tmp/_cache/shard2_of_2.xml")));
+      ImmutableList.of(
+        configuration("config-id", "k8-opt"),
+        targetComplete(label.toString(), "config-id", ImmutableList.of()),
+        testResultEvent(
+          label.toString(),
+          BuildEventStreamProtos.TestStatus.PASSED,
+          ImmutableList.of("/usr/local/tmp/_cache/shard1_of_2.xml")),
+        testResultEvent(
+          label.toString(),
+          BuildEventStreamProtos.TestStatus.FAILED,
+          ImmutableList.of("/usr/local/tmp/_cache/shard2_of_2.xml")));
 
     BlazeTestResults results =
-        BuildEventProtocolOutputReader.parseTestResults(BuildEventStreamProvider.fromInputStream(asInputStream(events)));
+      BuildEventProtocolOutputReader.parseTestResults(BuildEventStreamProvider.fromInputStream(asInputStream(events)));
 
     ImmutableCollection<BlazeTestResult> targetResults = results.perTargetResults.get(label);
     assertThat(targetResults).hasSize(2);
@@ -571,9 +590,9 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
     assertThat(result1.getTestStatus()).isEqualTo(TestStatus.PASSED);
     assertThat(result2.getTestStatus()).isEqualTo(TestStatus.FAILED);
     assertThat(getOutputXmlFiles(label, result1, context, getProject()))
-        .containsExactly(new File("/usr/local/tmp/_cache/shard1_of_2.xml"));
+      .containsExactly(new File("/usr/local/tmp/_cache/shard1_of_2.xml"));
     assertThat(getOutputXmlFiles(label, result2, context, getProject()))
-        .containsExactly(new File("/usr/local/tmp/_cache/shard2_of_2.xml"));
+      .containsExactly(new File("/usr/local/tmp/_cache/shard2_of_2.xml"));
   }
 
   @Test
@@ -581,36 +600,37 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
     var label1 = "//java/com/google:Test1";
     var label2 = "//java/com/google:Test2";
     BuildEvent.Builder test1 =
-        testResultEvent(
-            label1,
-            BuildEventStreamProtos.TestStatus.PASSED,
-            ImmutableList.of("/usr/local/tmp/_cache/test_result.xml"));
+      testResultEvent(
+        label1,
+        BuildEventStreamProtos.TestStatus.PASSED,
+        ImmutableList.of("/usr/local/tmp/_cache/test_result.xml"));
     BuildEvent.Builder test2 =
-        testResultEvent(
-            label2,
-            BuildEventStreamProtos.TestStatus.INCOMPLETE,
-            ImmutableList.of("/usr/local/tmp/_cache/second_result.xml"));
+      testResultEvent(
+        label2,
+        BuildEventStreamProtos.TestStatus.INCOMPLETE,
+        ImmutableList.of("/usr/local/tmp/_cache/second_result.xml"));
 
     BlazeTestResults results =
-        BuildEventProtocolOutputReader.parseTestResults(BuildEventStreamProvider.fromInputStream(asInputStream(test1, test2)));
+      BuildEventProtocolOutputReader.parseTestResults(BuildEventStreamProvider.fromInputStream(asInputStream(test1, test2)));
 
     assertThat(results.perTargetResults).hasSize(2);
     assertThat(results.perTargetResults.get(Label.create("//java/com/google:Test1"))).hasSize(1);
     assertThat(results.perTargetResults.get(Label.create("//java/com/google:Test2"))).hasSize(1);
     BlazeTestResult result1 =
-        results.perTargetResults.get(Label.create("//java/com/google:Test1")).iterator().next();
+      results.perTargetResults.get(Label.create("//java/com/google:Test1")).iterator().next();
     assertThat(result1.getTestStatus()).isEqualTo(TestStatus.PASSED);
     assertThat(getOutputXmlFiles(Label.create(label1), result1, context, getProject()))
-        .containsExactly(new File("/usr/local/tmp/_cache/test_result.xml"));
+      .containsExactly(new File("/usr/local/tmp/_cache/test_result.xml"));
     BlazeTestResult result2 =
-        results.perTargetResults.get(Label.create("//java/com/google:Test2")).iterator().next();
+      results.perTargetResults.get(Label.create("//java/com/google:Test2")).iterator().next();
     assertThat(result2.getTestStatus()).isEqualTo(TestStatus.INCOMPLETE);
     assertThat(getOutputXmlFiles(Label.create(label2), result2, context, getProject()))
-        .containsExactly(new File("/usr/local/tmp/_cache/second_result.xml"));
+      .containsExactly(new File("/usr/local/tmp/_cache/second_result.xml"));
   }
 
   private static ImmutableList<File> getOutputXmlFiles(Label label, BlazeTestResult result, BlazeContext context, Project project) {
-    return LocalFileArtifact.getLocalFiles(com.google.idea.blaze.common.Label.of(label.toString()), result.getOutputXmlFiles(), context, project);
+    return LocalFileArtifact.getLocalFiles(com.google.idea.blaze.common.Label.of(label.toString()), result.getOutputXmlFiles(), context,
+                                           project, RuntimeArtifactKind.JAR);
   }
 
   private static InputStream asInputStream(BuildEvent.Builder... events) throws Exception {
@@ -627,41 +647,41 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
 
   private static BuildEvent.Builder targetConfiguredEvent(String label, String targetKind) {
     return BuildEvent.newBuilder()
-        .setId(
-            BuildEventId.newBuilder()
-                .setTargetConfigured(TargetConfiguredId.newBuilder().setLabel(label)))
-        .setConfigured(TargetConfigured.newBuilder().setTargetKind(targetKind));
+      .setId(
+        BuildEventId.newBuilder()
+          .setTargetConfigured(TargetConfiguredId.newBuilder().setLabel(label)))
+      .setConfigured(TargetConfigured.newBuilder().setTargetKind(targetKind));
   }
 
   private BuildEvent.Builder targetCompletedEvent(String label, String targetKind) {
     return BuildEvent.newBuilder()
-        .setId(
-            BuildEventId.newBuilder()
-                .setTargetCompleted(TargetCompletedId.newBuilder().setLabel(label)))
-        .setCompleted(TargetComplete.newBuilder().setTargetKind(targetKind));
+      .setId(
+        BuildEventId.newBuilder()
+          .setTargetCompleted(TargetCompletedId.newBuilder().setLabel(label)))
+      .setCompleted(TargetComplete.newBuilder().setTargetKind(targetKind));
   }
 
   private BuildEvent.Builder testResultEvent(
-      String label, BuildEventStreamProtos.TestStatus status, List<String> filePaths) {
+    String label, BuildEventStreamProtos.TestStatus status, List<String> filePaths) {
     return BuildEvent.newBuilder()
-        .setId(BuildEventId.newBuilder().setTestResult(TestResultId.newBuilder().setLabel(label)))
-        .setTestResult(
-            TestResult.newBuilder()
-                .setStatus(status)
-                .addAllTestActionOutput(
-                    filePaths.stream().map(this::toFileEvent).collect(toImmutableList())));
+      .setId(BuildEventId.newBuilder().setTestResult(TestResultId.newBuilder().setLabel(label)))
+      .setTestResult(
+        TestResult.newBuilder()
+          .setStatus(status)
+          .addAllTestActionOutput(
+            filePaths.stream().map(this::toFileEvent).collect(toImmutableList())));
   }
 
   private BuildEvent.Builder targetComplete(
-      String label, String configId, List<OutputGroup> outputGroups) {
+    String label, String configId, List<OutputGroup> outputGroups) {
     return BuildEvent.newBuilder()
-        .setId(
-            BuildEventId.newBuilder()
-                .setTargetCompleted(
-                    TargetCompletedId.newBuilder()
-                        .setConfiguration(ConfigurationId.newBuilder().setId(configId).build())
-                        .setLabel(label)))
-        .setCompleted(TargetComplete.newBuilder().addAllOutputGroup(outputGroups));
+      .setId(
+        BuildEventId.newBuilder()
+          .setTargetCompleted(
+            TargetCompletedId.newBuilder()
+              .setConfiguration(ConfigurationId.newBuilder().setId(configId).build())
+              .setLabel(label)))
+      .setCompleted(TargetComplete.newBuilder().addAllOutputGroup(outputGroups));
   }
 
   private OutputGroup outputGroup(String name, List<String> fileSets) {
@@ -672,8 +692,8 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
 
   private BuildEvent.Builder configuration(String name, String mnemonic) {
     return BuildEvent.newBuilder()
-        .setId(BuildEventId.newBuilder().setConfiguration(ConfigurationId.newBuilder().setId(name)))
-        .setConfiguration(Configuration.newBuilder().setMnemonic(mnemonic));
+      .setId(BuildEventId.newBuilder().setConfiguration(ConfigurationId.newBuilder().setId(name)))
+      .setConfiguration(Configuration.newBuilder().setMnemonic(mnemonic));
   }
 
   private BuildEvent.Builder setOfFiles(List<String> filePaths, String id) {
@@ -681,28 +701,28 @@ public class BuildEventProtocolOutputReaderTest extends BlazeTestCase {
   }
 
   private BuildEvent.Builder setOfFiles(
-      List<String> filePaths, String id, List<String> fileSetDeps) {
+    List<String> filePaths, String id, List<String> fileSetDeps) {
     return BuildEvent.newBuilder()
-        .setId(BuildEventId.newBuilder().setNamedSet(NamedSetOfFilesId.newBuilder().setId(id)))
-        .setNamedSetOfFiles(
-            NamedSetOfFiles.newBuilder()
-                .addAllFiles(filePaths.stream().map(this::toFileEvent).collect(toImmutableList()))
-                .addAllFileSets(
-                    fileSetDeps.stream()
-                        .map(dep -> NamedSetOfFilesId.newBuilder().setId(dep).build())
-                        .collect(toImmutableList())));
+      .setId(BuildEventId.newBuilder().setNamedSet(NamedSetOfFilesId.newBuilder().setId(id)))
+      .setNamedSetOfFiles(
+        NamedSetOfFiles.newBuilder()
+          .addAllFiles(filePaths.stream().map(this::toFileEvent).collect(toImmutableList()))
+          .addAllFileSets(
+            fileSetDeps.stream()
+              .map(dep -> NamedSetOfFilesId.newBuilder().setId(dep).build())
+              .collect(toImmutableList())));
   }
 
   private BuildEventStreamProtos.File toFileEvent(String filePath) {
     return BuildEventStreamProtos.File.newBuilder()
-        .setUri(fileUri(filePath))
-        .setName(filePath)
-        .build();
+      .setUri(fileUri(filePath))
+      .setName(filePath)
+      .build();
   }
 
   private String fileUri(String filePath) {
     return useOldFormatFileUri
-        ? LocalFileSystem.PROTOCOL_PREFIX + filePath
-        : new File(filePath).toURI().toString();
+           ? LocalFileSystem.PROTOCOL_PREFIX + filePath
+           : new File(filePath).toURI().toString();
   }
 }


### PR DESCRIPTION
Cherry pick AOSP commit [84e8dd8997e32815e24ae4c4a3e845c8203c8b41](https://cs.android.com/android-studio/platform/tools/adt/idea/+/84e8dd8997e32815e24ae4c4a3e845c8203c8b41).

STAT (diff to AOSP): 0 insertions(+), 8 deletion(-)

Bug: 401298873
Test: Updated
Change-Id: I33ffdafb02a0cf95091be6253f770e4449a7d9b2

AOSP: 84e8dd8997e32815e24ae4c4a3e845c8203c8b41
