### PR TITLE
clion: fix plugin verifier warning

### DIFF
--- a/cpp/src/META-INF/blaze-cpp.xml
+++ b/cpp/src/META-INF/blaze-cpp.xml
@@ -14,7 +14,7 @@
   ~ limitations under the License.
   -->
 <idea-plugin>
-  <depends>com.intellij.modules.cidr.debugger</depends>
+  <depends>com.intellij.nativeDebug</depends>
 
   <project-components>
     <component>


### PR DESCRIPTION
plugin verifier does not work correctly
with plugin aliases defined in plugin
modules, so starting with 2025.2 we have
this verification problem reported on
the marketplace. it should be safe to
replace this dependency with native
debug plugin dependency as originally
ndp was providing this alias


