### PR TITLE
Add check for initialized workspaces in CLionNotificationProvider

### DIFF
--- a/clwb/src/com/google/idea/blaze/clwb/CLionNotificationProvider.kt
+++ b/clwb/src/com/google/idea/blaze/clwb/CLionNotificationProvider.kt
@@ -27,6 +27,7 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.util.concurrency.annotations.RequiresReadLock
 import com.jetbrains.cidr.lang.daemon.OCFileScopeProvider.Companion.getProjectSourceLocationKind
 import com.google.idea.sdkcompat.clion.projectStatus.*
+import com.jetbrains.cidr.project.workspace.CidrWorkspace
 import java.io.File
 
 /// This function is a little overloaded, ensures the project could be imported
@@ -58,14 +59,20 @@ private fun guessWorkspaceRoot(project: Project, file: VirtualFile?): String? {
 @RequiresReadLock
 private fun guessWidgetStatus(project: Project, currentFile: VirtualFile?): WidgetStatus? {
   if (Blaze.isBlazeProject(project)) {
-    return DefaultWidgetStatus(Status.OK, Scope.Project, "Project is configured")
+    return DefaultWidgetStatus(Status.OK, Scope.Project, "Bazel project is configured")
   }
 
   if (currentFile == null || guessWorkspaceRoot(project, currentFile) == null) {
     return null
   }
 
-  return DefaultWidgetStatus(Status.Warning, Scope.Project, "Project is not configured")
+  val status = if (CidrWorkspace.getInitializedWorkspaces(project).isEmpty()) {
+    Status.Warning
+  } else {
+    Status.Info
+  }
+
+  return DefaultWidgetStatus(status, Scope.Project, "Bazel project is not configured")
 }
 
 class BazelProjectFixesProvider : ProjectFixesProvider {


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/CPP-45761

Will look like this in configured CMake project, users can still dismiss the notification.
<img width="1650" height="333" alt="image" src="https://github.com/user-attachments/assets/8e1c2736-2ece-4233-a33e-e5e3b836ce8d" />
