### PR TITLE
Add EAP release option to workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,8 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: "*.zip"
-          tag_name: ${{ inputs.version }}
+          # if EAP is true -> "<version>-eap"; else -> "<version>"
+          tag_name: ${{ inputs.eap && format('{0}-eap', inputs.version) || inputs.version }}
           # if EAP is true -> "CLwB-EAP Release <version>"; else -> "CLwB Release <version>"
           name: ${{ inputs.eap && format('CLwB-EAP Release {0}', inputs.version) || format('CLwB Release {0}', inputs.version) }}
           draft: false


### PR DESCRIPTION
Adds an option to the Release workflow to only build and release `clion-oss-under-dev`. Creates a pre-release on GitHub but still uploads the to the stable channel on the market place. However, the EAP build is naturally only available in EAP versions of CLion.
