### PR TITLE
Include Cache: AspectModuleWriter

### DIFF
--- a/aspect/BUILD
+++ b/aspect/BUILD
@@ -7,19 +7,6 @@ load(":build_defs.bzl", "aspect_files", "aspect_library")
 
 licenses(["notice"])
 
-# Files needed at runtime for blaze-invoking integration tests
-filegroup(
-    name = "integration_test_files",
-    srcs = [
-        "artifacts.bzl",
-        "intellij_info_impl.bzl",
-        "make_variables.bzl",
-        "xcode_query.bzl",
-        ":BUILD.bazel",
-    ],
-    visibility = ["//visibility:public"],
-)
-
 # the aspect files that will be bundled with the final plugin zip
 aspect_library(
     name = "aspect_lib",
@@ -30,6 +17,13 @@ aspect_library(
         "xcode_query.bzl",  # maybe move this to a dedicated library, but let's keep this here for now
     ],
     namespace = "aspect/default",
+    visibility = ["//visibility:public"],
+)
+
+aspect_library(
+    name = "aspect_modules",
+    files = glob(["modules/*.bzl"]),
+    namespace = "aspect/modules",
     visibility = ["//visibility:public"],
 )
 

--- a/base/BUILD
+++ b/base/BUILD
@@ -31,6 +31,7 @@ kt_jvm_library(
     visibility = PLUGIN_PACKAGES_VISIBILITY,
     deps = [
         "//aspect:aspect_lib",
+        "//aspect:aspect_modules",
         "//aspect:aspect_template_lib",
         "//base/src/com/google/idea/blaze/base/command/buildresult/bepparser",
         "//common/actions",

--- a/base/src/com/google/idea/blaze/base/sync/aspects/storage/AspectModuleWriter.kt
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/storage/AspectModuleWriter.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2025 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.sync.aspects.storage
+
+import com.google.common.collect.ImmutableList
+import com.google.idea.blaze.base.sync.SyncProjectState
+import com.google.idea.blaze.base.sync.SyncScope.SyncFailedException
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.registry.Registry
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+
+private const val DEFAULT_FUNCTION_TEMPLATE = """
+def %s(ctx, target):
+    return %s
+"""
+
+private const val MODULES_DIRECTORY = "modules"
+
+abstract class AspectModuleWriter : AspectWriter {
+
+  protected fun interface Dependency {
+    fun isFulfilled(state: SyncProjectState): Boolean
+  }
+
+  protected fun ruleSetDependency(name: String) = Dependency { state ->
+    state.externalWorkspaceData?.getByRepoName(name) != null
+  }
+
+  protected fun registryKeyDependency(key: String) = Dependency {
+    Registry.`is`(key)
+  }
+
+  protected fun bazelDependency(minVersion: Int) = Dependency { state ->
+    state.blazeVersionData.bazelIsAtLeastVersion(minVersion, 0, 0)
+  }
+
+  protected abstract fun dependencies(): ImmutableList<Dependency>
+
+  protected data class Function(val name: String, val defaultValue: String)
+
+  protected abstract fun functions(): ImmutableList<Function>
+
+  @Throws(IOException::class)
+  private fun copyImplementation(dst: Path) {
+    Files.createDirectories(dst.resolve(MODULES_DIRECTORY))
+
+    val fileName = String.format("%s.bzl", name())
+
+    val srcResource = String.format("%s/%s", AspectRepositoryProvider.ASPECT_MODULE_DIRECTORY, fileName)
+    val srcStream = this.javaClass.classLoader.getResourceAsStream(srcResource)
+      ?: throw IOException("could not module resource file: $srcResource")
+
+    srcStream.use { srcStream ->
+      Files.newOutputStream(
+        dst.resolve(MODULES_DIRECTORY).resolve(fileName),
+        StandardOpenOption.CREATE,
+        StandardOpenOption.TRUNCATE_EXISTING,
+      ).use { dstStream -> srcStream.transferTo(dstStream) }
+    }
+  }
+
+  @Throws(IOException::class)
+  private fun generateDefault(dst: Path) {
+    Files.createDirectories(dst.resolve(MODULES_DIRECTORY))
+
+    val fileName = String.format("%s.bzl", name())
+
+    val writer = Files.newOutputStream(
+      dst.resolve(MODULES_DIRECTORY).resolve(fileName),
+      StandardOpenOption.CREATE,
+      StandardOpenOption.TRUNCATE_EXISTING,
+    ).bufferedWriter()
+
+    writer.use {
+      for (function in functions()) {
+        writer.write(String.format(DEFAULT_FUNCTION_TEMPLATE, function.name, function.defaultValue))
+      }
+    }
+  }
+
+  @Throws(SyncFailedException::class)
+  override fun writeDumb(dst: Path, project: Project) {
+    try {
+      generateDefault(dst)
+    } catch (e: IOException) {
+      throw SyncFailedException("Could not generate default implementation for module: ${name()}", e)
+    }
+  }
+
+  @Throws(SyncFailedException::class)
+  override fun write(dst: Path, project: Project, state: SyncProjectState) {
+    if (dependencies().any { !it.isFulfilled(state) }) {
+      writeDumb(dst, project)
+      return
+    }
+
+    try {
+      copyImplementation(dst)
+    } catch (e: IOException) {
+      throw SyncFailedException("Could not copy implementation for module: ${name()}", e)
+    }
+  }
+}

--- a/base/src/com/google/idea/blaze/base/sync/aspects/storage/AspectRepositoryProvider.kt
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/storage/AspectRepositoryProvider.kt
@@ -22,6 +22,7 @@ object AspectRepositoryProvider {
   const val ASPECT_DIRECTORY: String = "aspect/default"
   const val ASPECT_TEMPLATE_DIRECTORY: String = "aspect/template"
   const val ASPECT_QSYNC_DIRECTORY: String = "aspect/qsync"
+  const val ASPECT_MODULE_DIRECTORY: String = "aspect/modules"
 
   @JvmStatic
   fun aspectQSyncFile(file: String): ByteSource {


### PR DESCRIPTION
In preparation for modularization of the aspect. An aspect module is a collection of functions that can declare different dependencies. Only if all dependencies are fulfilled will the aspect module be written, otherwise only stubs will be generated.

Extracted from: #7834

