### PR TITLE
Include Cache: BazelDumpCacheDirectoriesAction

### DIFF
--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -159,9 +159,12 @@
       class="com.google.idea.blaze.base.wizard2.BazelDisableImportNotification$Action"
       text="Dismiss import notification"/>
 
-    <action id="BazelDumpVFSAction"
+    <action id="Bazel.DumpVFSAction"
       class="com.google.idea.blaze.base.actions.BazelDumpVFSAction"
       text="Bazel dump execroot VFS"/>
+    <action id="Bazel.DumpCacheDirectories"
+      class="com.google.idea.blaze.base.actions.BazelDumpCacheDirectories"
+      text="Bazel dump cache directories"/>
 
     <group id="Blaze.MainMenuActionGroup" class="com.google.idea.blaze.base.actions.BlazeMenuGroup" popup="true">
       <add-to-group group-id="MainMenu" anchor="before" relative-to-action="HelpMenu"/>

--- a/base/src/com/google/idea/blaze/base/actions/BazelDumpCacheDirectories.kt
+++ b/base/src/com/google/idea/blaze/base/actions/BazelDumpCacheDirectories.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2025 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.actions
+
+import com.google.idea.blaze.base.logging.LoggedDirectoryProvider
+import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.DumbAwareAction
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.jvm.optionals.getOrNull
+
+private val LOG = Logger.getInstance(BazelDumpCacheDirectories::class.java)
+
+class BazelDumpCacheDirectories : DumbAwareAction() {
+
+  override fun getActionUpdateThread(): ActionUpdateThread {
+    return ActionUpdateThread.BGT
+  }
+
+  override fun actionPerformed(event: AnActionEvent) {
+    val project = event.project
+    if (project == null) {
+      LOG.warn("no open project found")
+      return
+    }
+
+    LOG.info("################################### CACHE DIRS #################################")
+    for (provider in LoggedDirectoryProvider.EP_NAME.extensionList) {
+      val directory = provider.getLoggedDirectory(project).getOrNull() ?: continue
+
+      val exists = Files.exists(directory.path())
+      val size = if (exists) collectDirectorySize(directory.path()) else null
+
+      LOG.info("Directory: ${directory.path().toAbsolutePath()}")
+      LOG.info("-> purpose: ${directory.purpose()}")
+      LOG.info("->  origin: ${directory.originatingIdePart()}")
+      LOG.info("->  exists: $exists")
+
+      if (size != null) {
+        LOG.info("->    size: ${size.size}B")
+        LOG.info("->   items: ${size.items}")
+      }
+    }
+    LOG.info("################################################################################")
+  }
+}
+
+private data class DirectorySize(val items: Long, val size: Long)
+
+private fun collectDirectorySize(path: Path): DirectorySize? {
+  var items = 0L
+  var size = 0L
+
+  try {
+    for (item in Files.walk(path)) {
+      items++
+      size += Files.size(item)
+    }
+  } catch (e: IOException) {
+    LOG.warn("failed to collect directory size $path", e)
+  }
+
+  return DirectorySize(items, size)
+}

--- a/base/src/com/google/idea/blaze/base/actions/BazelDumpVFSAction.kt
+++ b/base/src/com/google/idea/blaze/base/actions/BazelDumpVFSAction.kt
@@ -22,6 +22,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.vfs.VirtualFileManager
+import kotlin.io.path.extension
 
 private val LOG = Logger.getInstance(BazelDumpVFSAction::class.java)
 
@@ -56,8 +57,16 @@ class BazelDumpVFSAction : DumbAwareAction() {
       return
     }
 
+    val histogram = mutableMapOf<String, Long>()
     LOG.info("################################## EXECROOT VFS ################################")
-    VfsUtil.getVfsChildrenAsSequence(virtualRoot).forEach { LOG.info(it.toString()) }
+    for (child in VfsUtil.getVfsChildrenAsSequence(virtualRoot)) {
+      histogram[child.extension] = histogram.getOrDefault(child.extension, 0) + 1L
+      LOG.info(child.toString())
+    }
+    LOG.info("################################## EXECROOT MAP ################################")
+    for ((ext, size) in histogram.entries.sortedByDescending { it.value }) {
+      LOG.info(String.format("%6d - %s", size, ext))
+    }
     LOG.info("################################################################################")
   }
 }


### PR DESCRIPTION
This PR adds an action to dump information about all registered caches to the log.

Extracted from: #7834

