### PR TITLE
Transition Support: add configuration id to TargetKey

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -250,3 +250,10 @@ http_archive(
         "https://github.com/abseil/abseil-cpp/archive/refs/tags/20240722.0.tar.gz",
     ],
 )
+
+# import clwb test project for aspect tests
+bazel_dep(name = "clwb_transition_project")
+local_path_override(
+    module_name = "clwb_transition_project",
+    path = "clwb/tests/projects/transition",
+)

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -18,7 +18,8 @@
     "https://bcr.bazel.build/modules/abseil-py/2.1.0/source.json": "0e8fc4f088ce07099c1cd6594c20c7ddbb48b4b3c0849b7d94ba94be88ff042b",
     "https://bcr.bazel.build/modules/apple_support/1.11.1/MODULE.bazel": "1843d7cd8a58369a444fc6000e7304425fba600ff641592161d9f15b179fb896",
     "https://bcr.bazel.build/modules/apple_support/1.15.1/MODULE.bazel": "a0556fefca0b1bb2de8567b8827518f94db6a6e7e7d632b4c48dc5f865bc7c85",
-    "https://bcr.bazel.build/modules/apple_support/1.15.1/source.json": "517f2b77430084c541bc9be2db63fdcbb7102938c5f64c17ee60ffda2e5cf07b",
+    "https://bcr.bazel.build/modules/apple_support/1.23.1/MODULE.bazel": "53763fed456a968cf919b3240427cf3a9d5481ec5466abc9d5dc51bc70087442",
+    "https://bcr.bazel.build/modules/apple_support/1.23.1/source.json": "d888b44312eb0ad2c21a91d026753f330caa48a25c9b2102fae75eb2b0dcfdd2",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.13.0/MODULE.bazel": "af4a546cb88c618f2e241721d2d76b70b7ecfaa1d58fe27b9187d3edb9e418da",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.13.0/source.json": "5538ef77a1ecff41c119e040d4bc0148c83e9e79464a165ec86a1aa3171a5535",
     "https://bcr.bazel.build/modules/bazel_features/1.1.0/MODULE.bazel": "cfd42ff3b815a5f39554d97182657f8c4b9719568eb7fded2b9135f084bf760b",
@@ -32,6 +33,7 @@
     "https://bcr.bazel.build/modules/bazel_features/1.21.0/MODULE.bazel": "675642261665d8eea09989aa3b8afb5c37627f1be178382c320d1b46afba5e3b",
     "https://bcr.bazel.build/modules/bazel_features/1.23.0/MODULE.bazel": "fd1ac84bc4e97a5a0816b7fd7d4d4f6d837b0047cf4cbd81652d616af3a6591a",
     "https://bcr.bazel.build/modules/bazel_features/1.25.0/MODULE.bazel": "e2e60a10a6da64bbf533f15ca652bf61a033e41c2ed734d79a9a08ba87f68c1a",
+    "https://bcr.bazel.build/modules/bazel_features/1.27.0/MODULE.bazel": "621eeee06c4458a9121d1f104efb80f39d34deff4984e778359c60eaf1a8cb65",
     "https://bcr.bazel.build/modules/bazel_features/1.28.0/MODULE.bazel": "4b4200e6cbf8fa335b2c3f43e1d6ef3e240319c33d43d60cc0fbd4b87ece299d",
     "https://bcr.bazel.build/modules/bazel_features/1.3.0/MODULE.bazel": "cdcafe83ec318cda34e02948e81d790aab8df7a929cec6f6969f13a489ccecd9",
     "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
@@ -78,6 +80,8 @@
     "https://bcr.bazel.build/modules/googletest/1.15.2/MODULE.bazel": "6de1edc1d26cafb0ea1a6ab3f4d4192d91a312fd2d360b63adaa213cd00b2108",
     "https://bcr.bazel.build/modules/googletest/1.17.0/MODULE.bazel": "dbec758171594a705933a29fcf69293d2468c49ec1f2ebca65c36f504d72df46",
     "https://bcr.bazel.build/modules/googletest/1.17.0/source.json": "38e4454b25fc30f15439c0378e57909ab1fd0a443158aa35aec685da727cd713",
+    "https://bcr.bazel.build/modules/hermetic_cc_toolchain/3.1.0/MODULE.bazel": "ea4b3a25a9417a7db57a8a2f9ebdee91d679823c6274b482b817ed128d81c594",
+    "https://bcr.bazel.build/modules/hermetic_cc_toolchain/3.1.0/source.json": "9d1df0459caefdf41052d360469922a73e219f67c8ce4da0628cc604469822b9",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.5/MODULE.bazel": "31271aedc59e815656f5736f282bb7509a97c7ecb43e927ac1a37966e0578075",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.6/MODULE.bazel": "2f8d20d3b7d54143213c4dfc3d98225c42de7d666011528dc8fe91591e2e17b0",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.6/source.json": "a04756d367a2126c3541682864ecec52f92cdee80a35735a3cb249ce015ca000",
@@ -122,8 +126,8 @@
     "https://bcr.bazel.build/modules/rules_android/0.6.4/source.json": "95d3c233c81005ad95eadc9382fde7dc6bd2c61752361e463264ee8349c071fb",
     "https://bcr.bazel.build/modules/rules_apple/3.16.0/MODULE.bazel": "0d1caf0b8375942ce98ea944be754a18874041e4e0459401d925577624d3a54a",
     "https://bcr.bazel.build/modules/rules_apple/3.16.0/source.json": "d8b5fe461272018cc07cfafce11fe369c7525330804c37eec5a82f84cd475366",
-    "https://bcr.bazel.build/modules/rules_bazel_integration_test/0.33.2/MODULE.bazel": "5468d45d3b41f1f2e86666808047ee5f757a499fdac27245125463044cd718f8",
-    "https://bcr.bazel.build/modules/rules_bazel_integration_test/0.33.2/source.json": "6aef2ef3df055c98869aad8503dc6c51ab8c51d4ebd401a2a6de3d077b9b8fff",
+    "https://bcr.bazel.build/modules/rules_bazel_integration_test/0.34.0/MODULE.bazel": "1a5b5145b5703f05a3ef87b41355a9999a485419ed75555eb9ed2dd93fb0059d",
+    "https://bcr.bazel.build/modules/rules_bazel_integration_test/0.34.0/source.json": "e307a032218f5e81524435d5502bc776a064aef49f650a331b2bf524bdfdb83b",
     "https://bcr.bazel.build/modules/rules_cc/0.0.1/MODULE.bazel": "cb2aa0747f84c6c3a78dad4e2049c154f08ab9d166b1273835a8174940365647",
     "https://bcr.bazel.build/modules/rules_cc/0.0.10/MODULE.bazel": "ec1705118f7eaedd6e118508d3d26deba2a4e76476ada7e0e3965211be012002",
     "https://bcr.bazel.build/modules/rules_cc/0.0.13/MODULE.bazel": "0e8529ed7b323dad0775ff924d2ae5af7640b23553dfcd4d34344c7e7a867191",
@@ -138,7 +142,8 @@
     "https://bcr.bazel.build/modules/rules_cc/0.1.1/MODULE.bazel": "2f0222a6f229f0bf44cd711dc13c858dad98c62d52bd51d8fc3a764a83125513",
     "https://bcr.bazel.build/modules/rules_cc/0.2.0/MODULE.bazel": "b5c17f90458caae90d2ccd114c81970062946f49f355610ed89bebf954f5783c",
     "https://bcr.bazel.build/modules/rules_cc/0.2.8/MODULE.bazel": "f1df20f0bf22c28192a794f29b501ee2018fa37a3862a1a2132ae2940a23a642",
-    "https://bcr.bazel.build/modules/rules_cc/0.2.8/source.json": "85087982aca15f31307bd52698316b28faa31bd2c3095a41f456afec0131344c",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.9/MODULE.bazel": "34263f1dca62ea664265438cef714d7db124c03e1ed55ebb4f1dc860164308d1",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.9/source.json": "4e49b40effcbd14fbfb233eb929de42dfff7b66538b4ffda310ad501638e7986",
     "https://bcr.bazel.build/modules/rules_foreign_cc/0.9.0/MODULE.bazel": "c9e8c682bf75b0e7c704166d79b599f93b72cfca5ad7477df596947891feeef6",
     "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/MODULE.bazel": "40c97d1144356f52905566c55811f13b299453a14ac7769dfba2ac38192337a8",
     "https://bcr.bazel.build/modules/rules_go/0.41.0/MODULE.bazel": "55861d8e8bb0e62cbd2896f60ff303f62ffcb0eddb74ecb0e5c0cbe36fc292c8",
@@ -247,37 +252,6 @@
   },
   "selectedYankedVersions": {},
   "moduleExtensions": {
-    "@@apple_support+//crosstool:setup.bzl%apple_cc_configure_extension": {
-      "general": {
-        "bzlTransitiveDigest": "p7Ghcq3+nnQxCrf+U3xnhdn7yOSTDbcFyGHK7Ja+rU4=",
-        "usagesDigest": "EJfdUgbJdIRboG70S9dz8HhGVkL2/s3qFQ9xht8y2Rs=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "local_config_apple_cc_toolchains": {
-            "repoRuleId": "@@apple_support+//crosstool:setup.bzl%_apple_cc_autoconf_toolchains",
-            "attributes": {}
-          },
-          "local_config_apple_cc": {
-            "repoRuleId": "@@apple_support+//crosstool:setup.bzl%_apple_cc_autoconf",
-            "attributes": {}
-          }
-        },
-        "recordedRepoMappingEntries": [
-          [
-            "apple_support+",
-            "bazel_tools",
-            "bazel_tools"
-          ],
-          [
-            "bazel_tools",
-            "rules_cc",
-            "rules_cc+"
-          ]
-        ]
-      }
-    },
     "@@buildifier_prebuilt+//:defs.bzl%buildifier_prebuilt_deps_extension": {
       "general": {
         "bzlTransitiveDigest": "izaEjT7NE6vV9H5axiYiPrvmFtCLNkfjhj+bpMolt1A=",
@@ -431,6 +405,54 @@
           }
         },
         "recordedRepoMappingEntries": []
+      }
+    },
+    "@@hermetic_cc_toolchain+//toolchain:ext.bzl%toolchains": {
+      "general": {
+        "bzlTransitiveDigest": "5FjJ3O1ACzyDcgFEEKQfIIjjlsMupNi0K5iLqvAI8qc=",
+        "usagesDigest": "3HHXhodmHGNPy0Om5qIn141gGr1Cd8M1zvP9BCqUQMQ=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "zig_sdk": {
+            "repoRuleId": "@@hermetic_cc_toolchain+//toolchain:defs.bzl%zig_repository",
+            "attributes": {
+              "version": "0.12.0",
+              "url_formats": [
+                "https://mirror.bazel.build/ziglang.org/download/{version}/zig-{host_platform}-{version}.{_ext}",
+                "https://ziglang.org/download/{version}/zig-{host_platform}-{version}.{_ext}"
+              ],
+              "host_platform_sha256": {
+                "linux-aarch64": "754f1029484079b7e0ca3b913a0a2f2a6afd5a28990cb224fe8845e72f09de63",
+                "linux-x86_64": "c7ae866b8a76a568e2d5cfd31fe89cdb629bdd161fdd5018b29a4a0a17045cad",
+                "macos-aarch64": "294e224c14fd0822cfb15a35cf39aa14bd9967867999bf8bdfe3db7ddec2a27f",
+                "macos-x86_64": "4d411bf413e7667821324da248e8589278180dbc197f4f282b7dbb599a689311",
+                "windows-aarch64": "04c6b92689241ca7a8a59b5f12d2ca2820c09d5043c3c4808b7e93e41c7bf97b",
+                "windows-x86_64": "2199eb4c2000ddb1fba85ba78f1fcf9c1fb8b3e57658f6a627a8e513131893f5"
+              },
+              "host_platform_ext": {
+                "linux-aarch64": "tar.xz",
+                "linux-x86_64": "tar.xz",
+                "macos-aarch64": "tar.xz",
+                "macos-x86_64": "tar.xz",
+                "windows-x86_64": "zip"
+              }
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "hermetic_cc_toolchain+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "hermetic_cc_toolchain+",
+            "hermetic_cc_toolchain",
+            "hermetic_cc_toolchain+"
+          ]
+        ]
       }
     },
     "@@pybind11_bazel+//:internal_configure.bzl%internal_configure_extension": {
@@ -617,7 +639,7 @@
     "@@rules_bazel_integration_test+//:extensions.bzl%bazel_binaries": {
       "general": {
         "bzlTransitiveDigest": "XC9nqZ31LIbq8N7cEK+rYa2iXNQLcJ3cyGWw+zPZlc0=",
-        "usagesDigest": "WiV8cgjEX30yiB9QMWlzuUxvHXNcooNoqoO2J5EIxOk=",
+        "usagesDigest": "J53MWQfDPhGjiQiEsZDmoLqel3PkfMtkKkiVzgl1cAI=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -642,10 +664,10 @@
               "bazelisk": "@bazel_binaries_bazelisk//:bazelisk"
             }
           },
-          "build_bazel_bazel_8_4_0": {
+          "build_bazel_bazel_8_4_1": {
             "repoRuleId": "@@rules_bazel_integration_test+//bazel_integration_test/private:bazel_binaries.bzl%bazel_binary",
             "attributes": {
-              "version": "8.4.0",
+              "version": "8.4.1",
               "bazelisk": "@bazel_binaries_bazelisk//:bazelisk"
             }
           },
@@ -662,10 +684,10 @@
               "version_to_repo": {
                 "6.5.0": "build_bazel_bazel_6_5_0",
                 "7.5.0": "build_bazel_bazel_7_5_0",
-                "8.4.0": "build_bazel_bazel_8_4_0",
+                "8.4.1": "build_bazel_bazel_8_4_1",
                 "last_green": "build_bazel_bazel_last_green"
               },
-              "current_version": "8.4.0"
+              "current_version": "8.4.1"
             }
           }
         },
@@ -675,7 +697,7 @@
             "bazel_binaries_bazelisk",
             "build_bazel_bazel_6_5_0",
             "build_bazel_bazel_7_5_0",
-            "build_bazel_bazel_8_4_0",
+            "build_bazel_bazel_8_4_1",
             "build_bazel_bazel_last_green",
             "bazel_binaries"
           ],

--- a/aspect/intellij_info_impl.bzl
+++ b/aspect/intellij_info_impl.bzl
@@ -163,11 +163,12 @@ def stringify_label(label):
     # okay with the fixture setups.
     return s.lstrip("@") if s.startswith("@@//") or s.startswith("@//") else s
 
-def make_target_key(label, aspect_ids):
+def make_target_key(ctx, label, aspect_ids):
     """Returns a TargetKey proto struct from a target."""
     return struct_omit_none(
         aspect_ids = tuple(aspect_ids) if aspect_ids else None,
         label = stringify_label(label),
+        configuration_id = getattr(ctx.configuration, "short_id", ""),  # looks like, will be picked to 8.5 and 7.7
     )
 
 def make_dep(dep, dependency_type):
@@ -585,7 +586,7 @@ def intellij_info_aspect_impl(target, ctx, semantics):
     file_name = file_name + ".intellij-info.txt"
     ide_info_file = ctx.actions.declare_file(file_name)
 
-    target_key = make_target_key(target.label, aspect_ids)
+    target_key = make_target_key(ctx, target.label, aspect_ids)
     ide_info = dict(
         build_file_artifact_location = build_file_artifact_location(ctx),
         features = ctx.features,

--- a/aspect/testing/BUILD
+++ b/aspect/testing/BUILD
@@ -33,6 +33,7 @@ test_suite(
         "//aspect/testing/tests/src/com/google/idea/blaze/aspect/cpp/cctest:CcTestTest",
         "//aspect/testing/tests/src/com/google/idea/blaze/aspect/cpp/cctoolchain:CcToolchainTest",
         "//aspect/testing/tests/src/com/google/idea/blaze/aspect/cpp/coptsmakevars:CoptsMakeVarsTest",
+        "//aspect/testing/tests/src/com/google/idea/blaze/aspect/cpp/transition:TransitionTest",
         "//aspect/testing/tests/src/com/google/idea/blaze/aspect/general/alias:AliasTest",
         "//aspect/testing/tests/src/com/google/idea/blaze/aspect/general/analysistest:AnalysisTestTest",
         "//aspect/testing/tests/src/com/google/idea/blaze/aspect/general/artifacts:ArtifactTest",

--- a/aspect/testing/rules/src/com/google/idea/blaze/aspect/IntellijAspectTest.java
+++ b/aspect/testing/rules/src/com/google/idea/blaze/aspect/IntellijAspectTest.java
@@ -36,6 +36,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
 /** Abstract base class for Intellij aspect tests. */
 public abstract class IntellijAspectTest {
@@ -69,18 +70,18 @@ public abstract class IntellijAspectTest {
         .collect(toImmutableList());
   }
 
-  protected TargetIdeInfo findTarget(
-      IntellijAspectTestFixture testFixture, String maybeRelativeLabel) {
-    String label =
-        isAbsoluteTarget(maybeRelativeLabel)
-            ? maybeRelativeLabel
-            : testRelative(maybeRelativeLabel);
-    return testFixture
-        .getTargetsList()
+  protected Stream<TargetIdeInfo> findTargets(IntellijAspectTestFixture testFixture, String maybeRelativeLabel) {
+    final var label = isAbsoluteTarget(maybeRelativeLabel)
+        ? maybeRelativeLabel
+        : testRelative(maybeRelativeLabel);
+
+    return testFixture.getTargetsList()
         .stream()
-        .filter(target -> matchTarget(target, label))
-        .findAny()
-        .orElse(null);
+        .filter(target -> matchTarget(target, label));
+  }
+
+  protected TargetIdeInfo findTarget(IntellijAspectTestFixture testFixture, String maybeRelativeLabel) {
+      return findTargets(testFixture, maybeRelativeLabel).findAny().orElse(null);
   }
 
   protected TargetIdeInfo findAspectTarget(

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/cpp/transition/BUILD
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/cpp/transition/BUILD
@@ -1,0 +1,28 @@
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_java//java:defs.bzl", "java_test")
+load(
+    "//aspect/testing/rules:intellij_aspect_test_fixture.bzl",
+    "intellij_aspect_test_fixture",
+)
+
+intellij_aspect_test_fixture(
+    name = "aspect_fixture",
+    deps = [
+        "@clwb_transition_project//main:multi_arch_main",
+    ],
+)
+
+java_test(
+    name = "TransitionTest",
+    srcs = ["TransitionTest.java"],
+    data = [":aspect_fixture"],
+    deps = [
+        "//aspect/testing:BazelIntellijAspectTest",
+        "//aspect/testing:guava",
+        "//aspect/testing/rules:IntellijAspectTest",
+        "//aspect/testing/rules:intellij_aspect_test_fixture_java_proto",
+        "//intellij_platform_sdk:test_libs",
+        "//proto:intellij_ide_info_java_proto",
+        "//third_party/java/junit",
+    ],
+)

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/cpp/transition/TransitionTest.java
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/cpp/transition/TransitionTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.aspect.cpp.transition;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.devtools.intellij.ideinfo.IntellijIdeInfo.TargetIdeInfo;
+import com.google.idea.blaze.BazelIntellijAspectTest;
+import java.io.IOException;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TransitionTest extends BazelIntellijAspectTest {
+
+  private List<TargetIdeInfo> getIdeInfos(String targetName) throws IOException {
+    final var testFixture = loadTestFixture(":aspect_fixture");
+
+    return findTargets(testFixture, targetName)
+        .filter(TargetIdeInfo::hasCIdeInfo)
+        .toList();
+  }
+
+  @Test
+  public void testMultipleIdeInfos() throws IOException {
+    final var ideInfos = getIdeInfos("@@clwb_transition_project+//main:main");
+    assertThat(ideInfos).hasSize(2);
+
+    for (final var ideInfo : ideInfos) {
+      assertThat(ideInfo.getKindString()).isEqualTo("cc_binary");
+      assertThat(ideInfo.getKey().getLabel()).isEqualTo("@@clwb_transition_project+//main:main");
+      assertThat(ideInfo.getKey().getConfigurationId()).isNotEmpty();
+    }
+
+    assertThat(ideInfos.get(0).getKey().getConfigurationId())
+        .isNotEqualTo(ideInfos.get(1).getKey().getConfigurationId());
+  }
+}

--- a/base/src/com/google/idea/blaze/base/dependencies/AddSourceToProjectHelper.java
+++ b/base/src/com/google/idea/blaze/base/dependencies/AddSourceToProjectHelper.java
@@ -374,7 +374,7 @@ class AddSourceToProjectHelper {
       return true;
     }
     ImportRoots roots = context.getImportRoots();
-    return targetsBuildingSource.stream().anyMatch(t -> roots.targetInProject(t.getLabel()));
+    return targetsBuildingSource.stream().anyMatch(t -> roots.targetInProject(t.label()));
   }
 
   static boolean packageCoveredByProjectTargets(LocationContext context) {

--- a/base/src/com/google/idea/blaze/base/ideinfo/TargetIdeInfo.java
+++ b/base/src/com/google/idea/blaze/base/ideinfo/TargetIdeInfo.java
@@ -137,7 +137,7 @@ public final class TargetIdeInfo implements ProtoWrapper<IntellijIdeInfo.TargetI
     }
     GoIdeInfo goIdeInfo = null;
     if (proto.hasGoIdeInfo()) {
-      goIdeInfo = GoIdeInfo.fromProto(proto.getGoIdeInfo(), key.getLabel(), kind);
+      goIdeInfo = GoIdeInfo.fromProto(proto.getGoIdeInfo(), key.label(), kind);
       sourcesBuilder.addAll(goIdeInfo.getSources());
     }
     JsIdeInfo jsIdeInfo = null;
@@ -367,7 +367,7 @@ public final class TargetIdeInfo implements ProtoWrapper<IntellijIdeInfo.TargetI
   }
 
   public TargetInfo toTargetInfo() {
-    return TargetInfo.builder(getKey().getLabel(), getKind().getKindString())
+    return TargetInfo.builder(getKey().label(), getKind().getKindString())
         .setTestSize(getTestIdeInfo() != null ? getTestIdeInfo().getTestSize() : null)
         .setTestClass(getJavaIdeInfo() != null ? getJavaIdeInfo().getTestClass() : null)
         .setSyncTime(getSyncTime())

--- a/base/src/com/google/idea/blaze/base/ideinfo/TargetKey.java
+++ b/base/src/com/google/idea/blaze/base/ideinfo/TargetKey.java
@@ -33,11 +33,14 @@ public abstract class TargetKey implements ProtoWrapper<IntellijIdeInfo.TargetKe
 
   public abstract ImmutableList<String> aspectIds();
 
+  public abstract String configurationId();
+
   public static TargetKey fromProto(IntellijIdeInfo.TargetKey proto) {
     return ProjectDataInterner.intern(
         new AutoValue_TargetKey(
             Label.fromProto(proto.getLabel()),
-            ProtoWrapper.internStrings(proto.getAspectIdsList())
+            ProtoWrapper.internStrings(proto.getAspectIdsList()),
+            ProtoWrapper.internString(proto.getConfigurationId())
         )
     );
   }
@@ -47,6 +50,7 @@ public abstract class TargetKey implements ProtoWrapper<IntellijIdeInfo.TargetKe
     return IntellijIdeInfo.TargetKey.newBuilder()
         .setLabel(label().toProto())
         .addAllAspectIds(aspectIds())
+        .setConfigurationId(configurationId())
         .build();
   }
 
@@ -54,14 +58,18 @@ public abstract class TargetKey implements ProtoWrapper<IntellijIdeInfo.TargetKe
    * Returns a key identifying a plain target
    */
   public static TargetKey forPlainTarget(Label label) {
-    return forGeneralTarget(label, ImmutableList.of());
+    return forGeneralTarget(label, ImmutableList.of(), "");
   }
 
   /**
    * Returns a key identifying a general target
    */
-  public static TargetKey forGeneralTarget(Label label, List<String> aspectIds) {
-    return ProjectDataInterner.intern(new AutoValue_TargetKey(label, ProtoWrapper.internStrings(aspectIds)));
+  public static TargetKey forGeneralTarget(Label label, List<String> aspectIds, String configurationId) {
+    return ProjectDataInterner.intern(new AutoValue_TargetKey(
+        label,
+        ProtoWrapper.internStrings(aspectIds),
+        ProtoWrapper.internString(configurationId)
+    ));
   }
 
   public boolean isPlainTarget() {
@@ -73,6 +81,7 @@ public abstract class TargetKey implements ProtoWrapper<IntellijIdeInfo.TargetKe
     return ComparisonChain.start()
         .compare(label(), o.label())
         .compare(aspectIds(), o.aspectIds(), Ordering.natural().lexicographical())
+        .compare(configurationId(), o.configurationId())
         .result();
   }
 }

--- a/base/src/com/google/idea/blaze/base/ideinfo/TargetMap.java
+++ b/base/src/com/google/idea/blaze/base/ideinfo/TargetMap.java
@@ -56,7 +56,7 @@ public final class TargetMap implements ProtoWrapper<ProjectData.TargetMap> {
   public ImmutableList<TargetIdeInfo> get(Label label) {
     return targetMap.entrySet()
         .stream()
-        .filter(it -> it.getKey().getLabel().equals(label))
+        .filter(it -> it.getKey().label().equals(label))
         .map(Entry::getValue)
         .collect(ImmutableList.toImmutableList());
   }

--- a/base/src/com/google/idea/blaze/base/model/AspectSyncProjectData.java
+++ b/base/src/com/google/idea/blaze/base/model/AspectSyncProjectData.java
@@ -129,7 +129,7 @@ public final class AspectSyncProjectData implements BlazeProjectData {
     }
     // otherwise just return any matching target
     return map.targets().stream()
-        .filter(t -> Objects.equals(label, t.getKey().getLabel()))
+        .filter(t -> Objects.equals(label, t.getKey().label()))
         .findFirst()
         .map(TargetIdeInfo::toTargetInfo)
         .orElse(null);
@@ -149,7 +149,7 @@ public final class AspectSyncProjectData implements BlazeProjectData {
   @Override
   public ImmutableList<Label> targets() {
     return getTargetMap().targets().stream()
-        .map(it -> it.getKey().getLabel())
+        .map(it -> it.getKey().label())
         .collect(ImmutableList.toImmutableList());
   }
 

--- a/base/src/com/google/idea/blaze/base/run/smrunner/BlazeWebTestLocator.java
+++ b/base/src/com/google/idea/blaze/base/run/smrunner/BlazeWebTestLocator.java
@@ -76,7 +76,7 @@ class BlazeWebTestLocator implements SMTestLocator {
         continue;
       }
       Kind kind = target.getKind();
-      Label label = targetKey.getLabel();
+      Label label = targetKey.label();
       if (Stream.of("_wrapped_test", "_debug").noneMatch(label.targetName().toString()::endsWith)) {
         continue;
       }

--- a/base/src/com/google/idea/blaze/base/run/ui/TargetExpressionListUi.java
+++ b/base/src/com/google/idea/blaze/base/run/ui/TargetExpressionListUi.java
@@ -240,7 +240,7 @@ public class TargetExpressionListUi extends JPanel {
       return projectData.getTargetMap().targets().stream()
           .filter(TargetIdeInfo::isPlainTarget)
           .map(TargetIdeInfo::getKey)
-          .map(TargetKey::getLabel)
+          .map(TargetKey::label)
           .filter(importRoots::importAsSource)
           .map(TargetExpression::toString)
           .collect(toImmutableList());

--- a/base/src/com/google/idea/blaze/base/sync/actions/CleanProjectTargetsSyncAction.java
+++ b/base/src/com/google/idea/blaze/base/sync/actions/CleanProjectTargetsSyncAction.java
@@ -88,7 +88,7 @@ public class CleanProjectTargetsSyncAction extends BlazeProjectSyncAction {
                       }
                       BlazeSyncManager.getInstance(project)
                           .filterProjectTargets(
-                              targetKey -> !deleted.contains(targetKey.getLabel()),
+                              targetKey -> !deleted.contains(targetKey.label()),
                               /* reason= */ "CleanProjectTargetsSyncAction");
                       removeInvalidRunConfigurations(project, deleted);
                     }));
@@ -113,14 +113,14 @@ public class CleanProjectTargetsSyncAction extends BlazeProjectSyncAction {
       toKeep.forEach(t -> foundTargets.add(t.label));
     }
     return targets.stream()
-        .map(t -> t.getKey().getLabel())
+        .map(t -> t.getKey().label())
         .filter(l -> !foundTargets.contains(l))
         .collect(toImmutableSet());
   }
 
   private static String getQuery(List<TargetIdeInfo> targets) {
     return targets.stream()
-        .map(t -> String.format("'%s'", t.getKey().getLabel()))
+        .map(t -> String.format("'%s'", t.getKey().label()))
         .collect(joining("+"));
   }
 

--- a/base/src/com/google/idea/blaze/base/sync/aspects/BlazeIdeInterfaceAspectsImpl.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/BlazeIdeInterfaceAspectsImpl.java
@@ -495,7 +495,7 @@ public class BlazeIdeInterfaceAspectsImpl implements BlazeIdeInterface {
     if (null != target.getPyIdeInfo() && target.getPyIdeInfo().isCodeGenerator()) {
       return false;
     }
-    if (importRoots.importAsSource(target.getKey().getLabel())) {
+    if (importRoots.importAsSource(target.getKey().label())) {
       ignoredLanguages.addAll(kind.getLanguageClasses());
     }
     return true;
@@ -516,7 +516,7 @@ public class BlazeIdeInterfaceAspectsImpl implements BlazeIdeInterface {
       return TargetIdeInfo.fromProto(message, syncTime);
     }
     TargetKey key = message.hasKey() ? TargetKey.fromProto(message.getKey()) : null;
-    if (key != null && importRoots.importAsSource(key.getLabel())) {
+    if (key != null && importRoots.importAsSource(key.label())) {
       ignoredLanguages.addAll(kind.getLanguageClasses());
     }
     return null;

--- a/base/src/com/google/idea/blaze/base/sync/autosync/ProjectTargetManagerImpl.java
+++ b/base/src/com/google/idea/blaze/base/sync/autosync/ProjectTargetManagerImpl.java
@@ -76,7 +76,7 @@ class ProjectTargetManagerImpl implements ProjectTargetManager {
     ImmutableCollection<TargetKey> syncedTargets =
         SourceToTargetMap.getInstance(project).getRulesForSourceFile(source);
     if (!syncedTargets.isEmpty()) {
-      return syncedTargets.stream().anyMatch(t -> syncInProgress(t.getLabel()))
+      return syncedTargets.stream().anyMatch(t -> syncInProgress(t.label()))
           ? SyncStatus.RESYNCING
           : SyncStatus.SYNCED;
     }

--- a/base/src/com/google/idea/blaze/base/sync/autosync/ProtoAutoSyncProvider.java
+++ b/base/src/com/google/idea/blaze/base/sync/autosync/ProtoAutoSyncProvider.java
@@ -90,7 +90,7 @@ class ProtoAutoSyncProvider implements AutoSyncProvider {
    */
   private static List<Label> getPlainTargets(Project project, TargetKey target) {
     if (target.isPlainTarget()) {
-      return ImmutableList.of(target.getLabel());
+      return ImmutableList.of(target.label());
     }
     ImmutableList.Builder<Label> output = new ImmutableList.Builder<>();
     Queue<TargetKey> todo = Queues.newArrayDeque();
@@ -104,7 +104,7 @@ class ProtoAutoSyncProvider implements AutoSyncProvider {
         continue;
       }
       if (targetKey.isPlainTarget()) {
-        output.add(targetKey.getLabel());
+        output.add(targetKey.label());
       } else {
         todo.addAll(reverseDependencyMap.get(targetKey));
       }

--- a/base/src/com/google/idea/blaze/base/sync/projectview/ProjectViewTargetImportFilter.java
+++ b/base/src/com/google/idea/blaze/base/sync/projectview/ProjectViewTargetImportFilter.java
@@ -43,7 +43,7 @@ public class ProjectViewTargetImportFilter {
   }
 
   public boolean isSourceTarget(TargetIdeInfo target) {
-    return importRoots.importAsSource(target.getKey().getLabel()) && !importTargetOutput(target);
+    return importRoots.importAsSource(target.getKey().label()) && !importTargetOutput(target);
   }
 
   public boolean containsWorkspacePath(WorkspacePath workspacePath) {
@@ -53,11 +53,11 @@ public class ProjectViewTargetImportFilter {
   private boolean importTargetOutput(TargetIdeInfo target) {
     return target.getTags().contains(Tags.TARGET_TAG_IMPORT_TARGET_OUTPUT)
         || target.getTags().contains(Tags.TARGET_TAG_IMPORT_AS_LIBRARY_LEGACY)
-        || importTargetOutputs.contains(target.getKey().getLabel());
+        || importTargetOutputs.contains(target.getKey().label());
   }
 
   public boolean excludeTarget(TargetIdeInfo target) {
-    return excludedTargets.contains(target.getKey().getLabel())
+    return excludedTargets.contains(target.getKey().label())
         || target.getTags().contains(Tags.TARGET_TAG_PROVIDED_BY_SDK)
         || target.getTags().contains(Tags.TARGET_TAG_EXCLUDE_TARGET);
   }

--- a/base/src/com/google/idea/blaze/base/sync/workspace/VirtualIncludesHandler.java
+++ b/base/src/com/google/idea/blaze/base/sync/workspace/VirtualIncludesHandler.java
@@ -118,10 +118,10 @@ public class VirtualIncludesHandler {
     if (stripPrefix.startsWith("/")) {
       workspacePath = new WorkspacePath(stripPrefix.substring(1));
     } else {
-      workspacePath = new WorkspacePath(key.getLabel().blazePackage(), stripPrefix);
+      workspacePath = new WorkspacePath(key.label().blazePackage(), stripPrefix);
     }
 
-    final var externalWorkspace = key.getLabel().externalWorkspaceName();
+    final var externalWorkspace = key.label().externalWorkspaceName();
     if (externalWorkspace == null) {
       return workspacePathResolver.resolveToIncludeDirectories(workspacePath);
     }

--- a/base/src/com/google/idea/blaze/base/targetmaps/AspectSyncSourceToTargetMap.java
+++ b/base/src/com/google/idea/blaze/base/targetmaps/AspectSyncSourceToTargetMap.java
@@ -55,7 +55,7 @@ public class AspectSyncSourceToTargetMap implements SourceToTargetMap {
         // Without this, you won't be able to invoke "build" on (say) a proto_library
         .filter(TargetIdeInfo::isPlainTarget)
         .map(TargetIdeInfo::getKey)
-        .map(TargetKey::getLabel)
+        .map(TargetKey::label)
         .collect(toImmutableList());
   }
 

--- a/base/src/com/google/idea/blaze/base/targetmaps/TransitiveDependencyMap.java
+++ b/base/src/com/google/idea/blaze/base/targetmaps/TransitiveDependencyMap.java
@@ -153,7 +153,7 @@ public class TransitiveDependencyMap {
 
       return target.getDependencies().stream()
           .map(Dependency::getTargetKey)
-          .map(TargetKey::getLabel)
+          .map(TargetKey::label)
           .map(TargetKey::forPlainTarget);
     }
 

--- a/clwb/tests/projects/transition/MODULE.bazel
+++ b/clwb/tests/projects/transition/MODULE.bazel
@@ -1,0 +1,14 @@
+module(name = "clwb_transition_project")
+
+bazel_dep(name = "rules_cc", version = "0.2.9")
+bazel_dep(name = "platforms", version = "1.0.0")
+
+bazel_dep(name = "hermetic_cc_toolchain", version = "3.1.0")
+
+toolchains = use_extension("@hermetic_cc_toolchain//toolchain:ext.bzl", "toolchains")
+use_repo(toolchains, "zig_sdk")
+
+register_toolchains(
+    "@zig_sdk//toolchain/...",
+    "@zig_sdk//libc_aware/toolchain/...",
+)

--- a/clwb/tests/projects/transition/main/BUILD
+++ b/clwb/tests/projects/transition/main/BUILD
@@ -1,0 +1,16 @@
+load(":multi_arch_binary.bzl", "multi_arch_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_binary(
+    name = "main",
+    srcs = ["main.cc"],
+)
+
+multi_arch_binary(
+    name = "multi_arch_main",
+    deps = ":main",
+    out_amd64 = "main_linux_amd64",
+    out_arm64  = "main_linux_arm64",
+)
+

--- a/clwb/tests/projects/transition/main/main.cc
+++ b/clwb/tests/projects/transition/main/main.cc
@@ -1,0 +1,3 @@
+int main() {
+	return 0;
+}

--- a/clwb/tests/projects/transition/main/multi_arch_binary.bzl
+++ b/clwb/tests/projects/transition/main/multi_arch_binary.bzl
@@ -1,0 +1,51 @@
+def _arch_split_impl(settings, attr):
+    # Each key identifies a branch of the split. We set --platforms per-branch.
+    return {
+        "amd64": {"//command_line_option:platforms": ["@zig_sdk//platform:linux_amd64"]},
+        "arm64": {"//command_line_option:platforms": ["@zig_sdk//platform:linux_arm64"]},
+    }
+
+arch_split = transition(
+    implementation = _arch_split_impl,
+    inputs = [],
+    outputs = ["//command_line_option:platforms"],
+)
+
+def _multi_arch_binary_impl(ctx):
+    # Each split branch gives us the dep *as built for that platform*.
+    dep_by_arch = ctx.split_attr.deps
+    dep_amd = dep_by_arch["amd64"]
+    dep_arm = dep_by_arch["arm64"]
+
+    # Grab the actual executables (works with cc_binary and other executable rules).
+    exe_amd = dep_amd[DefaultInfo].files_to_run.executable
+    exe_arm = dep_arm[DefaultInfo].files_to_run.executable
+
+    # User-provided output filenames:
+    out_amd = ctx.outputs.out_amd64
+    out_arm = ctx.outputs.out_arm64
+
+    # Make stable, cacheable symlinks so the outputs live under bazel-bin with your names.
+    ctx.actions.symlink(output = out_amd, target_file = exe_amd)
+    ctx.actions.symlink(output = out_arm, target_file = exe_arm)
+
+    return [DefaultInfo(
+        files = depset([out_amd, out_arm]),
+        runfiles = ctx.runfiles(files = [out_amd, out_arm]),
+    )]
+
+multi_arch_binary = rule(
+    implementation = _multi_arch_binary_impl,
+    attrs = {
+        # This dep is built *twice* via the split transition.
+        "deps": attr.label(
+            cfg = arch_split,
+            providers = [DefaultInfo],
+            doc = "Executable target (e.g., a cc_binary) to build for multiple arches.",
+        ),
+        # Named outputs (caller picks the filenames).
+        "out_amd64": attr.output(mandatory = True),
+        "out_arm64": attr.output(mandatory = True),
+    },
+    doc = "Build the same executable for amd64 and arm64, and expose both outputs.",
+)

--- a/cpp/src/com/google/idea/blaze/cpp/BlazeCTargetInfoService.java
+++ b/cpp/src/com/google/idea/blaze/cpp/BlazeCTargetInfoService.java
@@ -80,7 +80,7 @@ final public class BlazeCTargetInfoService implements PersistentStateComponent<B
 
     service.infoMap.clear();
     targetInfoMap.forEach((key, info) -> {
-      service.infoMap.put(key.getLabel().toString(), info);
+      service.infoMap.put(key.label().toString(), info);
     });
   }
 

--- a/cpp/src/com/google/idea/blaze/cpp/BlazeConfigurationResolver.java
+++ b/cpp/src/com/google/idea/blaze/cpp/BlazeConfigurationResolver.java
@@ -139,7 +139,7 @@ final class BlazeConfigurationResolver {
       WorkspacePathResolver workspacePathResolver) {
     if (target.toTargetInfo().getLabel().isExternal()) {
       WorkspaceRoot externalWorkspace = WorkspaceHelper.getExternalWorkspace(project,
-          target.getKey().getLabel().externalWorkspaceName());
+          target.getKey().label().externalWorkspaceName());
 
       if (externalWorkspace != null) {
         try {

--- a/cpp/src/com/google/idea/blaze/cpp/BlazeConfigurationToolchainResolver.java
+++ b/cpp/src/com/google/idea/blaze/cpp/BlazeConfigurationToolchainResolver.java
@@ -187,7 +187,7 @@ public final class BlazeConfigurationToolchainResolver {
   private static boolean usesAppleCcToolchain(TargetIdeInfo target) {
     return target.getDependencies().stream()
         .map(Dependency::getTargetKey)
-        .map(TargetKey::getLabel)
+        .map(TargetKey::label)
         .map(TargetExpression::toString)
         .anyMatch(s -> s.startsWith("//tools/osx/crosstool"));
   }

--- a/cpp/tests/unittests/com/google/idea/blaze/cpp/BlazeConfigurationResolverTest.java
+++ b/cpp/tests/unittests/com/google/idea/blaze/cpp/BlazeConfigurationResolverTest.java
@@ -855,7 +855,7 @@ public class BlazeConfigurationResolverTest extends BlazeTestCase {
      assertThatResolving(projectView, targetMap).producesConfigurationsFor(
          "//test:target and 1 other target(s)");
      assertThat(resolverResult.getAllConfigurations().get(0).getTargets().stream()
-         .map(targetKey -> targetKey.getLabel().toString())
+         .map(targetKey -> targetKey.label().toString())
          .collect(Collectors.toList())).containsAtLeast("//test:target",
          "@external_dependency//foo:bar");
    }

--- a/javascript/src/com/google/idea/blaze/javascript/run/producers/BlazeJavaScriptTestRunLineMarkerContributor.java
+++ b/javascript/src/com/google/idea/blaze/javascript/run/producers/BlazeJavaScriptTestRunLineMarkerContributor.java
@@ -148,7 +148,7 @@ public class BlazeJavaScriptTestRunLineMarkerContributor extends RunLineMarkerCo
                         TargetIdeInfo target = targetMap.get(key);
                         return target != null && target.getKind().isWebTest();
                       })
-                  .map(TargetKey::getLabel)
+                  .map(TargetKey::label)
                   .collect(ImmutableList.toImmutableList()),
               BlazeSyncModificationTracker.getInstance(project));
         });

--- a/proto/intellij_ide_info.proto
+++ b/proto/intellij_ide_info.proto
@@ -218,6 +218,7 @@ message KotlinToolchainIdeInfo {
 message TargetKey {
   string label = 1;
   repeated string aspect_ids = 3;
+  string configuration_id = 4;
 }
 
 message Dependency {

--- a/python/src/com/google/idea/blaze/python/sync/AlwaysPresentPythonSyncPlugin.java
+++ b/python/src/com/google/idea/blaze/python/sync/AlwaysPresentPythonSyncPlugin.java
@@ -70,7 +70,7 @@ public class AlwaysPresentPythonSyncPlugin implements BlazeSyncPlugin {
     }
     boolean hasPythonTarget =
         blazeProjectData.getTargetMap().targets().stream()
-            .filter(target -> importRoots.importAsSource(target.getKey().getLabel()))
+            .filter(target -> importRoots.importAsSource(target.getKey().label()))
             .anyMatch(target -> target.getKind().hasLanguage(LanguageClass.PYTHON));
     if (!hasPythonTarget) {
       return true;


### PR DESCRIPTION
In order to support transitions we need to be able to differentiate targets with different configurations. This PR adds the configuration id to the TargetKey class which is different after every transition.
