### PR TITLE
Only enable debug actions for Bazel projects

### DIFF
--- a/base/src/com/google/idea/blaze/base/actions/BazelDumpCacheDirectories.kt
+++ b/base/src/com/google/idea/blaze/base/actions/BazelDumpCacheDirectories.kt
@@ -16,6 +16,7 @@
 package com.google.idea.blaze.base.actions
 
 import com.google.idea.blaze.base.logging.LoggedDirectoryProvider
+import com.google.idea.blaze.base.settings.Blaze
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.diagnostic.Logger
@@ -31,6 +32,10 @@ class BazelDumpCacheDirectories : DumbAwareAction() {
 
   override fun getActionUpdateThread(): ActionUpdateThread {
     return ActionUpdateThread.BGT
+  }
+
+  override fun update(e: AnActionEvent) {
+    e.presentation.isEnabledAndVisible = Blaze.isBlazeProject(e.project)
   }
 
   override fun actionPerformed(event: AnActionEvent) {

--- a/base/src/com/google/idea/blaze/base/actions/BazelDumpVFSAction.kt
+++ b/base/src/com/google/idea/blaze/base/actions/BazelDumpVFSAction.kt
@@ -15,6 +15,7 @@
  */
 package com.google.idea.blaze.base.actions
 
+import com.google.idea.blaze.base.settings.Blaze
 import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager
 import com.google.idea.blaze.base.util.VfsUtil
 import com.intellij.openapi.actionSystem.ActionUpdateThread
@@ -30,6 +31,10 @@ class BazelDumpVFSAction : DumbAwareAction() {
 
   override fun getActionUpdateThread(): ActionUpdateThread {
     return ActionUpdateThread.BGT
+  }
+
+  override fun update(e: AnActionEvent) {
+    e.presentation.isEnabledAndVisible = Blaze.isBlazeProject(e.project)
   }
 
   override fun actionPerformed(event: AnActionEvent) {


### PR DESCRIPTION
Adds Action.update overrides to debug actions.
