### PR TITLE
Add switch project view action

### DIFF
--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -168,9 +168,9 @@
     <action id="Bazel.ShowTargetInfo"
       class="com.google.idea.blaze.base.actions.BazelShowTargetInfoAction"
       text="Bazel show target info"/>
-    <action id="Bazel.LoadProjectViewFile"
-      class="com.google.idea.blaze.base.actions.LoadProjectViewAction"
-      text="Load Project View"
+    <action id="Bazel.SwitchProjectViewFile"
+      class="com.google.idea.blaze.base.actions.SwitchProjectViewAction"
+      text="Switch Project View"
       icon="BlazeIcons.Logo"/>
 
     <group id="Blaze.MainMenuActionGroup" class="com.google.idea.blaze.base.actions.BlazeMenuGroup" popup="true">
@@ -232,7 +232,7 @@
       <reference ref="Blaze.AddToQuerySyncProjectView"/>
       <reference ref="Blaze.OpenCorrespondingBuildFile"/>
       <reference ref="Blaze.CopyBlazeTargetPathAction"/>
-      <reference ref="Bazel.LoadProjectViewFile"/>
+      <reference ref="Bazel.SwitchProjectViewFile"/>
     </group>
     <group id="Internal.Blaze" text="Blaze" popup="true" internal="true">
       <action internal="true" id="Blaze.QSync.CleanDependencies" class="com.google.idea.blaze.base.qsync.action.ClearDependencies" text="QSync - Clear Dependencies" />

--- a/base/src/com/google/idea/blaze/base/actions/SwitchProjectViewAction.kt
+++ b/base/src/com/google/idea/blaze/base/actions/SwitchProjectViewAction.kt
@@ -24,7 +24,7 @@ import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 
-class LoadProjectViewAction : BlazeProjectAction(), DumbAware {
+class SwitchProjectViewAction : BlazeProjectAction(), DumbAware {
 
   override fun actionPerformedInBlazeProject(project: Project, e: AnActionEvent) {
     val project = e.project ?: return
@@ -36,7 +36,7 @@ class LoadProjectViewAction : BlazeProjectAction(), DumbAware {
     settings.projectViewFile = file.path
 
     // this also reloads the project view
-    BlazeSyncManager.getInstance(project).fullProjectSync( /* reason= */ "LoadProjectViewAction")
+    BlazeSyncManager.getInstance(project).fullProjectSync( /* reason= */ "SwitchProjectViewAction")
   }
 
   override fun updateForBlazeProject(project: Project, e: AnActionEvent) {


### PR DESCRIPTION
This PR adds an action to load a different project view by right clicking it in the file explorer, similar to what the new plugin offers.
