### PR TITLE
chore(clean up): Remove support for query sync specific actions

### DIFF
--- a/base/src/com/google/idea/blaze/base/sync/status/BlazeSyncStatus.java
+++ b/base/src/com/google/idea/blaze/base/sync/status/BlazeSyncStatus.java
@@ -39,11 +39,6 @@ public interface BlazeSyncStatus {
 
   void syncEnded(SyncMode syncMode, SyncResult syncResult);
 
-  /**
-   * @deprecated For query sync, use {@link
-   *     com.google.idea.blaze.base.qsync.QuerySyncManager#operationInProgress}
-   */
-  @Deprecated
   boolean syncInProgress();
 
   void setDirty();

--- a/base/src/com/google/idea/blaze/base/sync/status/BlazeSyncStatusImpl.java
+++ b/base/src/com/google/idea/blaze/base/sync/status/BlazeSyncStatusImpl.java
@@ -52,9 +52,6 @@ public class BlazeSyncStatusImpl implements BlazeSyncStatus {
 
   @Override
   public boolean syncInProgress() {
-    if (Blaze.getProjectType(project).equals(ProjectType.QUERY_SYNC)) {
-      return QuerySyncManager.getInstance(project).operationInProgress();
-    }
     return syncInProgress.get();
   }
 


### PR DESCRIPTION
Since we deprecated query sync, explicit handling for query sync specific actions is no longer required.