### PR TITLE
Revert "mark MacOS CI as soft failure (#7942)"

### DIFF
--- a/.bazelci/clion.yml
+++ b/.bazelci/clion.yml
@@ -65,7 +65,6 @@ tasks:
       - --test_output=errors
     test_targets:
       - //:clwb_tests
-    soft_fail: true
   CLion-MacOS-OSS-latest-stable:
     name: CLion MacOS OSS Latest Stable
     platform: macos_arm64
@@ -79,7 +78,6 @@ tasks:
       - --test_output=errors
     test_targets:
       - //:clwb_tests
-    soft_fail: true
   CLion-Linux-OSS-under-dev:
     name: CLion Linux OSS Under Development
     platform: ubuntu2204
@@ -121,7 +119,7 @@ tasks:
       - --test_output=errors
     test_targets:
       - //:clwb_tests
-    soft_fail: true
+    soft_fail: false
   CLion-last-green:
     name: CLion Headless Tests Last Green
     platform: ubuntu2204


### PR DESCRIPTION
The issue with MacOS agents (https://github.com/bazelbuild/continuous-integration/issues/2385) is resolved, MacOS CI can be enabled again.
