### PR TITLE
Prepartation for Bazel 9: add load statements to intellij_project_sdk BUILD files

### DIFF
--- a/intellij_platform_sdk/BUILD.clion251
+++ b/intellij_platform_sdk/BUILD.clion251
@@ -17,6 +17,7 @@
 # Plugin source jars for CLion, accessed remotely.
 
 load("@//intellij_platform_sdk:build_defs.bzl", "no_mockito_extensions")
+load("@rules_java//java:defs.bzl", "java_import")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/intellij_platform_sdk/BUILD.clion252
+++ b/intellij_platform_sdk/BUILD.clion252
@@ -17,6 +17,7 @@
 # Plugin source jars for CLion, accessed remotely.
 
 load("@//intellij_platform_sdk:build_defs.bzl", "no_mockito_extensions")
+load("@rules_java//java:defs.bzl", "java_import")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/intellij_platform_sdk/BUILD.clion253
+++ b/intellij_platform_sdk/BUILD.clion253
@@ -17,6 +17,7 @@
 # Plugin source jars for CLion, accessed remotely.
 
 load("@//intellij_platform_sdk:build_defs.bzl", "no_mockito_extensions")
+load("@rules_java//java:defs.bzl", "java_import")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/intellij_platform_sdk/BUILD.python
+++ b/intellij_platform_sdk/BUILD.python
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_import")
+
 java_import(
     name = "python",
     jars = glob(["python-ce/lib/*.jar", "python-ce/lib/modules/*.jar"]),


### PR DESCRIPTION
Since autoload is disabled in Bazel 9 we need load statements here.