### PR TITLE
Add check if current directory is a Bazel workspace root to CLionNotificationProvider

### DIFF
--- a/base/src/com/google/idea/blaze/base/project/AutoImportProjectOpenProcessor.java
+++ b/base/src/com/google/idea/blaze/base/project/AutoImportProjectOpenProcessor.java
@@ -37,6 +37,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Objects;
 import java.util.Optional;
 import javax.swing.Icon;
@@ -57,6 +58,8 @@ import org.jetbrains.annotations.Nullable;
  * Must be loaded after {@link BlazeProjectOpenProcessor} to only import new projects.
  */
 public class AutoImportProjectOpenProcessor extends ProjectOpenProcessor {
+
+  public static final String[] WORKSPACE_MARKER_FILES = {"WORKSPACE", "WORKSPACE.bazel", "MODULE.bazel"};
 
   public static final String MANAGED_PROJECT_RELATIVE_PATH = "tools/intellij/.managed.bazelproject";
   public static final String PROJECT_VIEW_FROM_ENV = "INTELLIJ_BAZEL_PROJECT_VIEW_TEMPLATE";
@@ -97,9 +100,7 @@ public class AutoImportProjectOpenProcessor extends ProjectOpenProcessor {
   }
 
   private boolean isBazelWorkspace(VirtualFile virtualFile) {
-    return virtualFile.findChild("WORKSPACE") != null
-        || virtualFile.findChild("WORKSPACE.bazel") != null
-        || virtualFile.findChild("MODULE.bazel") != null;
+    return Arrays.stream(WORKSPACE_MARKER_FILES).anyMatch((file) -> virtualFile.findChild(file) != null);
   }
 
   @Override


### PR DESCRIPTION
Apparently, I was to eager with #7994 and this requires a more proper fix. With this fix the Bazel import banner will be shown:
- for `com.intellij.clion.projectStatus.isProjectAwareFile` and files with `BuildFileType`
- if there is a `WORKSPACE(.bazel)?` or `MODULE.bazel` file in the project root

And if there is `CidrWorkspace.getInitializedWorkspaces(project)` the status will be an information rather then a warning. 

Furthermore, there seems to be some common logic that no banner is show for files which are already part of a project.
