### PR TITLE
Fix release action running out of disk space

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false
+          large-packages: false
+
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.15.0
         with:


### PR DESCRIPTION
Release action runs are sometimes failing with:
```
ERROR: /home/runner/work/intellij/intellij/intellij_platform_sdk/BUILD:157:13: //intellij_platform_sdk:terminal depends on @@+intellij_platform+clion_2025_2//:terminal in repository @@+intellij_platform+clion_2025_2 which failed to fetch. no such package '@@+intellij_platform+clion_2025_2//': java.io.IOException: Error extracting /home/runner/.bazel/external/+intellij_platform+clion_2025_2/temp6603681512745390900/clion-2025.2.4.zip to /home/runner/.bazel/external/+intellij_platform+clion_2025_2/temp6603681512745390900: write (No space left on device)
```

I hope that this step can free enough disk space to avoid this issue.