### PR TITLE
Fix android build error in release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
         uses: jlumbroso/free-disk-space@v1.3.1
         with:
           tool-cache: false
+          android: false
           large-packages: false
 
       - name: Setup Bazel


### PR DESCRIPTION
After removing the android SDK from the runner our builds started to fail with
```
ERROR: /home/runner/.bazel/external/rules_android+/rules/android_sdk_repository/rule.bzl:114:13: An error occurred during the fetch of repository 'rules_android++android_sdk_repository_extension+androidsdk':
   Traceback (most recent call last):
	File "/home/runner/.bazel/external/rules_android+/rules/android_sdk_repository/rule.bzl", line 114, column 13, in _android_sdk_repository_impl
		fail("No Android SDK apis found in the Android SDK at %s. Please install APIs from the Android SDK Manager." % android_sdk_path)
```

Caused by the android dependency of `rules_kotlin`.