### PR TITLE
Add test filter for parameterized google tests

### DIFF
--- a/clwb/src/com/google/idea/blaze/clwb/radler/RadGoogleTestContextProvider.kt
+++ b/clwb/src/com/google/idea/blaze/clwb/radler/RadGoogleTestContextProvider.kt
@@ -26,6 +26,10 @@ class RadGoogleTestContextProvider : RadTestContextProvider() {
     val suite = test.suites?.firstOrNull() ?: "*"
     val name = test.test ?: "*"
 
-    return "$suite.$name"
+    // derive 3 patterns from the suite and test name:
+    // 1. match regular test
+    // 2. match parameterized thest without installation prefix
+    // 3. match parameterized test with installation prefix
+    return "$suite.$name:$suite.$name/*:*/$suite.$name/*"
   }
 }


### PR DESCRIPTION
Generate additional test filters to cover parameterized tests. See #7995 for details.

Note on testing: we cannot write tests atm for this since the context provider are Radler specific and we cannot test with Radler yet.