### PR TITLE
Remove wrong comment for additional file refresh

### DIFF
--- a/base/src/com/google/idea/blaze/base/filecache/FileCaches.java
+++ b/base/src/com/google/idea/blaze/base/filecache/FileCaches.java
@@ -51,7 +51,6 @@ public class FileCaches {
           });
     }
 
-    // CLion does not use this extension point, this is just an unnecessary refresh there
     if (!FileCache.EP_NAME.getExtensionList().isEmpty()) {
       LocalFileSystem.getInstance().refresh(true);
     }


### PR DESCRIPTION
We might also need to consider if this refresh is actually need or not. But since we added the HeaderCache we actually do use this extension point in CLwB.