### PR TITLE
cleanup logs from NoSuchFileException errors

### DIFF
--- a/base/src/com/google/idea/blaze/base/sync/workspace/ArtifactLocationDecoderImpl.java
+++ b/base/src/com/google/idea/blaze/base/sync/workspace/ArtifactLocationDecoderImpl.java
@@ -25,6 +25,7 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.io.FileUtil;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
@@ -98,6 +99,8 @@ public final class ArtifactLocationDecoderImpl implements ArtifactLocationDecode
         if (pathResolver.getWorkspacePath(realFile) != null) {
           return realFile;
         }
+      } catch (NoSuchFileException ignore) {
+        // this is ok as it might not exist
       } catch (IOException ioException) {
         LOG.warn("Failed to resolve real path for " + artifactLocation.getExecutionRootRelativePath() +
                 "\n" + ioException.getClass().getSimpleName() + ": " + ioException.getMessage());

--- a/base/src/com/google/idea/blaze/base/sync/workspace/ExecutionRootPathResolverImpl.java
+++ b/base/src/com/google/idea/blaze/base/sync/workspace/ExecutionRootPathResolverImpl.java
@@ -24,6 +24,7 @@ import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
 import com.intellij.openapi.diagnostic.Logger;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.NoSuchFileException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.VisibleForTesting;
 
@@ -131,6 +132,8 @@ public class ExecutionRootPathResolverImpl implements ExecutionRootPathResolver 
       if (workspacePathResolver.getWorkspacePath(realPath) != null) {
         return ImmutableList.of(realPath);
       }
+    } catch (NoSuchFileException ignore) {
+      // this is ok as it might not exist
     } catch (IOException ioException) {
       LOG.warn("Failed to resolve real path for " + pathInExecutionRoot, ioException);
     }


### PR DESCRIPTION
this turned out to be ok to have these files
as nonexisting because rulesets might point to
additional locations which do not contain files
we're looking for

