### PR TITLE
drop fdebug-compilation-dir for macos debug

### DIFF
--- a/clwb/src/com/google/idea/blaze/clwb/run/BazelDebugFlagsBuilder.kt
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BazelDebugFlagsBuilder.kt
@@ -40,7 +40,6 @@ class BazelDebugFlagsBuilder(
   private val debuggerKind: BlazeDebuggerKind,
   private val compilerKind: OCCompilerKind,
   private val targetOS: OS,
-  private val withClangTrimPaths: Boolean = true,
   private val withFissionFlag: Boolean = false,
 ) {
 
@@ -54,7 +53,6 @@ class BazelDebugFlagsBuilder(
       debuggerKind,
       compilerKind,
       OS.CURRENT,
-      withClangTrimPaths = !Registry.`is`("bazel.trim.absolute.path.disabled"),
       withFissionFlag = !Registry.`is`("bazel.clwb.debug.fission.disabled"),
     )
   }
@@ -68,8 +66,6 @@ class BazelDebugFlagsBuilder(
       isLldb() -> LOG.assertTrue(compilerKind in VALID_LLDB_COMPILERS)
     }
   }
-
-  private fun isClang() = compilerKind == ClangCompilerKind || compilerKind == ClangClCompilerKind
 
   private fun isLldb() = debuggerKind == BlazeDebuggerKind.BUNDLED_LLDB
 
@@ -93,10 +89,6 @@ class BazelDebugFlagsBuilder(
 
     switchBuilder.withDebugInfo(2) // ignored for msvc/clangcl
     switchBuilder.withDisableOptimization()
-
-    if (isLldb() && isClang() && withClangTrimPaths && workspaceRoot != null) {
-      switchBuilder.withSwitch("-fdebug-compilation-dir=\"$workspaceRoot\"")
-    }
 
     flags.addAll(switchBuilder.buildRaw().map { "--copt=$it" })
 

--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrLauncher.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrLauncher.java
@@ -48,7 +48,6 @@ import com.google.idea.blaze.base.settings.Blaze;
 import com.google.idea.blaze.base.settings.BlazeUserSettings;
 import com.google.idea.blaze.base.settings.BuildSystemName;
 import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
-import com.google.idea.blaze.clwb.ToolchainUtils;
 import com.google.idea.blaze.cpp.CppBlazeRules;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configuration.EnvironmentVariablesData;
@@ -78,6 +77,7 @@ import com.jetbrains.cidr.execution.debugger.remote.CidrRemoteDebugParameters;
 import com.jetbrains.cidr.execution.debugger.remote.CidrRemotePathMapping;
 import com.jetbrains.cidr.execution.testing.google.CidrGoogleTestConsoleProperties;
 import java.io.File;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -289,7 +289,17 @@ public final class BlazeCidrLauncher extends CidrLauncher {
 
       final DebuggerDriverConfiguration debuggerDriver;
       if (debuggerKind == BlazeDebuggerKind.BUNDLED_LLDB) {
-        debuggerDriver = new BlazeLLDBDriverConfiguration(project, workspaceRoot.directory().toPath());
+        final var projectData = BlazeProjectDataManager.getInstance(project).getBlazeProjectData();
+        final Path executionRoot;
+        if (projectData == null) {
+          executionRoot = workspaceRoot.directory().toPath();
+        } else {
+          executionRoot = projectData.getBlazeInfo().getExecutionRoot().toPath();
+        }
+
+        // the working directory must be the execroot to make breakpoints work
+        debuggerDriver = new BlazeLLDBDriverConfiguration(project, executionRoot,
+                workspaceRoot.directory().toPath());
       } else {
         final var startupCommands = getGdbStartupCommands(workspaceRootDirectory);
         debuggerDriver = new BlazeGDBDriverConfiguration(project, startupCommands, workspaceRoot);

--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeLLDBDriverConfiguration.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeLLDBDriverConfiguration.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.idea.blaze.clwb.run;
 
 import com.google.idea.blaze.clwb.ToolchainUtils;
@@ -7,23 +23,41 @@ import com.intellij.openapi.project.Project;
 import com.jetbrains.cidr.ArchitectureType;
 import com.jetbrains.cidr.cpp.execution.debugger.backend.CLionLLDBDriverConfiguration;
 import com.jetbrains.cidr.execution.debugger.backend.DebuggerDriver;
-import org.jetbrains.annotations.NotNull;
-
 import java.nio.file.Path;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class BlazeLLDBDriverConfiguration extends CLionLLDBDriverConfiguration {
-    private final Path workingDirectory;
 
-    public BlazeLLDBDriverConfiguration(@NotNull Project project, Path workingDirectory) {
+    private final Path workingDirectory;
+    private final Path projectRoot;
+
+    public BlazeLLDBDriverConfiguration(@NotNull Project project, Path workingDirectory,
+            Path projectRoot) {
         super(project, ToolchainUtils.getToolchain());
         this.workingDirectory = workingDirectory;
+        this.projectRoot = projectRoot;
+    }
+
+    @Override
+    public String convertToProjectModelPath(@Nullable String absolutePath) {
+        if (absolutePath == null) {
+            return null;
+        }
+
+        // we need to relativize the path to the project root for breakpoints.
+        // LLDB started from execroot can set only relative breakpoints, and for
+        // absolute it requires path mapping to be set, which is quite hard to
+        // configure properly because the source location is dynamic inside the build sandbox
+        return projectRoot.relativize(Path.of(absolutePath)).toString();
     }
 
     @NotNull
     @Override
-    public GeneralCommandLine createDriverCommandLine(@NotNull DebuggerDriver driver, @NotNull ArchitectureType architectureType) throws ExecutionException {
+    public GeneralCommandLine createDriverCommandLine(@NotNull DebuggerDriver driver,
+            @NotNull ArchitectureType architectureType) throws ExecutionException {
         GeneralCommandLine commandLine = super.createDriverCommandLine(driver, architectureType);
-        commandLine.setWorkDirectory(this.workingDirectory.toFile());
+        commandLine.setWorkDirectory(workingDirectory.toFile());
         return commandLine;
     }
 }

--- a/cpp/src/META-INF/blaze-cpp.xml
+++ b/cpp/src/META-INF/blaze-cpp.xml
@@ -67,9 +67,6 @@
                     os="mac"
                     overrides="true"/>
 
-    <registryKey defaultValue="false"
-                 description="Disable absolute path trimming in debug clang builds"
-                 key="bazel.trim.absolute.path.disabled"/>
     <registryKey defaultValue="true"
                  description="Allow external targets from source directories be imported in"
                  key="bazel.cpp.sync.external.targets.from.directories"/>


### PR DESCRIPTION
Use of fdebug-compilation-dir in macos debug runs
leads to 100% remote cache miss because the path for
compilation dir is valid for the current user only.
The change reworks the original PR #4403 and provides a
more correct fix for #2101 by launching lldb in the
proper working directory and using relative paths to set
breakpoints