### PR TITLE
Fix unexpected cancellations while selecting test targets

### DIFF
--- a/base/src/com/google/idea/blaze/base/run/producers/PendingAsyncTestContext.java
+++ b/base/src/com/google/idea/blaze/base/run/producers/PendingAsyncTestContext.java
@@ -36,6 +36,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiElement;
 import com.intellij.util.ui.UIUtil;
 import javax.annotation.Nullable;
+import org.jetbrains.ide.PooledThreadExecutor;
 
 /**
  * For situations where we appear to be in a recognized test context, but can't efficiently resolve
@@ -71,7 +72,7 @@ class PendingAsyncTestContext extends TestContext implements PendingRunConfigura
                   ? context
                   : new KnownTargetTestContext(t, sourceElement, blazeFlags, description);
             },
-            MoreExecutors.directExecutor());
+            PooledThreadExecutor.INSTANCE);
     return new PendingAsyncTestContext(
         supportedExecutors, future, progressMessage, sourceElement, blazeFlags, description);
   }


### PR DESCRIPTION
After #8029 run test gutters almost always display "Nothing here" Now SyncCache checks for cancellations and `ReverseDependencyMap.get` is considered as canceled, because `ProgressManager.checkCancelled` ensures that Job is active, but it's not because of the following:

`PendingAsyncTestContext.fromTargetFuture` used directExecutor, which might reuse / reuses future thread, but future is executed in coroutine scope converted to future, so scope's Job is completed when future is done. We should avoid using directExecutor as mentioned in Futures documentation
