### PR TITLE
Do not relativize out-of-project paths for LLDB breakpoints

### DIFF
--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeLLDBDriverConfiguration.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeLLDBDriverConfiguration.java
@@ -40,16 +40,23 @@ public class BlazeLLDBDriverConfiguration extends CLionLLDBDriverConfiguration {
     }
 
     @Override
-    public String convertToProjectModelPath(@Nullable String absolutePath) {
-        if (absolutePath == null) {
+    public String convertToProjectModelPath(@Nullable String absolutePathString) {
+        if (absolutePathString == null) {
             return null;
+        }
+
+        // this might work for non-hermetic toolchain libraries if those have
+        // debug symbols available
+        Path absolutePath = Path.of(absolutePathString);
+        if (!absolutePath.startsWith(projectRoot)) {
+            return absolutePathString;
         }
 
         // we need to relativize the path to the project root for breakpoints.
         // LLDB started from execroot can set only relative breakpoints, and for
         // absolute it requires path mapping to be set, which is quite hard to
         // configure properly because the source location is dynamic inside the build sandbox
-        return projectRoot.relativize(Path.of(absolutePath)).toString();
+        return projectRoot.relativize(absolutePath).toString();
     }
 
     @NotNull


### PR DESCRIPTION
This was spotted in #8046 discussion, that there might be non-hermetic libraries used with debug information available, so reducing the scope for relativization
