### PR TITLE
Add registry key bazel.cpp.lldb.launch.execroot to control lldb cwd

### DIFF
--- a/clwb/src/com/google/idea/blaze/clwb/run/BazelDebugFlagsBuilder.kt
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BazelDebugFlagsBuilder.kt
@@ -16,6 +16,7 @@
 package com.google.idea.blaze.clwb.run
 
 import com.google.common.collect.ImmutableList
+import com.google.idea.blaze.clwb.run.BlazeLLDBDriverConfiguration.LLDB_LAUNCH_EXECROOT_REGISTRY_KEY
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.util.registry.Registry
 import com.intellij.util.system.OS
@@ -36,11 +37,12 @@ private val VALID_LLDB_COMPILERS = listOf(ClangCompilerKind, ClangClCompilerKind
  * In theory we would like to have one builder that builds a BlazeCommand to
  * have full control over the environment in the builder.
  */
-class BazelDebugFlagsBuilder(
+class BazelDebugFlagsBuilder private constructor(
   private val debuggerKind: BlazeDebuggerKind,
   private val compilerKind: OCCompilerKind,
   private val targetOS: OS,
   private val withFissionFlag: Boolean = false,
+  private val withClangCustomDebugDir: Boolean = false,
 ) {
 
   companion object {
@@ -54,6 +56,7 @@ class BazelDebugFlagsBuilder(
       compilerKind,
       OS.CURRENT,
       withFissionFlag = !Registry.`is`("bazel.clwb.debug.fission.disabled"),
+      withClangCustomDebugDir = !Registry.`is`(LLDB_LAUNCH_EXECROOT_REGISTRY_KEY),
     )
   }
 
@@ -66,6 +69,8 @@ class BazelDebugFlagsBuilder(
       isLldb() -> LOG.assertTrue(compilerKind in VALID_LLDB_COMPILERS)
     }
   }
+
+  private fun isClang() = compilerKind == ClangCompilerKind || compilerKind == ClangClCompilerKind
 
   private fun isLldb() = debuggerKind == BlazeDebuggerKind.BUNDLED_LLDB
 
@@ -89,6 +94,10 @@ class BazelDebugFlagsBuilder(
 
     switchBuilder.withDebugInfo(2) // ignored for msvc/clangcl
     switchBuilder.withDisableOptimization()
+
+    if (isLldb() && isClang() && withClangCustomDebugDir && workspaceRoot != null) {
+      switchBuilder.withSwitch("-fdebug-compilation-dir=\"$workspaceRoot\"")
+    }
 
     flags.addAll(switchBuilder.buildRaw().map { "--copt=$it" })
 

--- a/cpp/src/META-INF/blaze-cpp.xml
+++ b/cpp/src/META-INF/blaze-cpp.xml
@@ -68,6 +68,9 @@
                     overrides="true"/>
 
     <registryKey defaultValue="true"
+                 description="Launch LLDB from execution root"
+                 key="bazel.cpp.lldb.launch.execroot"/>
+    <registryKey defaultValue="true"
                  description="Allow external targets from source directories be imported in"
                  key="bazel.cpp.sync.external.targets.from.directories"/>
     <registryKey defaultValue="false"


### PR DESCRIPTION
To allow disabling behavior implemented in #8046
