### PR TITLE
Replace /Zi with /Z7 for MSVC

### DIFF
--- a/clwb/src/com/google/idea/blaze/clwb/run/BazelDebugFlagsBuilder.kt
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BazelDebugFlagsBuilder.kt
@@ -87,7 +87,12 @@ class BazelDebugFlagsBuilder(
       else -> GCCSwitchBuilder() // default to GCC, as usual
     }
 
-    switchBuilder.withDebugInfo(2) // ignored for msvc/clangcl
+    when (compilerKind) {
+      // we have to use the "old style" debug info, /Zi causes errors with MSVC and Bazel
+      MSVCCompilerKind -> switchBuilder.withSwitch("/Z7")
+      else -> switchBuilder.withDebugInfo(2)
+    }
+
     switchBuilder.withDisableOptimization()
 
     flags.addAll(switchBuilder.buildRaw().map { "--copt=$it" })


### PR DESCRIPTION
With /Zi concurrent writes to the .pdb file will cause the build to fail. As far as I understand we cannot use /Zi with Bazel builds and thus have to use the "old style" /Z7 flag. 
