### PR TITLE
Use MSVCSwitchBuilder for clang-cl

### DIFF
--- a/clwb/src/com/google/idea/blaze/clwb/run/BazelDebugFlagsBuilder.kt
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BazelDebugFlagsBuilder.kt
@@ -81,8 +81,8 @@ class BazelDebugFlagsBuilder(
     }
 
     val switchBuilder = when (compilerKind) {
-      MSVCCompilerKind -> MSVCSwitchBuilder()
-      ClangClCompilerKind -> ClangClSwitchBuilder()
+      // we should use the MSVCSwitchBuilder for clang-cl as well
+      MSVCCompilerKind, ClangClCompilerKind -> MSVCSwitchBuilder()
       ClangCompilerKind -> ClangSwitchBuilder()
       else -> GCCSwitchBuilder() // default to GCC, as usual
     }


### PR DESCRIPTION
Follow up for: #8061

Since clang-cl is interface compatible with MSVC we can simply use the MSVC switch builder and avoid some build issues caused by the `/clang:` prefix. 