### PR TITLE
Revert "chore(CHANGELOG): update for v2026.01.19 release"

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,3 @@
-v2026.01.19
-===========
-* Updated plugin description #8099
-* Updated UI for the run before build step #8070
-* Fix none type issue in xcode cquery #8111
-
 v2025.12.16
 ===========
 * Support for cxxopts and conlyopts #8068


### PR DESCRIPTION
Du to a packaging issue of CLion the `kotlinx.coroutines.guava` library is not available atm and all `asListenableFuture` calls result in a class not found exceptions. Due to this issue the previous release `v2026.01.19` was broken. However, it was never released to the public, and thus it is safe to remove it from the change log again. 