### PR TITLE
Fix CcInfo being None when C/C++ is disabled

### DIFF
--- a/aspect/cc_info.bzl
+++ b/aspect/cc_info.bzl
@@ -10,18 +10,17 @@
 load("@rules_cc//cc:defs.bzl", "CcInfo", "cc_common")
 
 CC_USE_GET_TOOL_FOR_ACTION = True
-# TEMPLATE-IGNORE-END
 
 CcInfoCompat = CcInfo
-
-# TEMPLATE-IGNORE-BEGIN
 cc_common_compat = cc_common
 # TEMPLATE-IGNORE-END
 
 # TEMPLATE-INCLUDE-BEGIN
 ## #if( $isCcEnabled == "true")
+##CcInfoCompat = CcInfo
 ##cc_common_compat = cc_common
 ## #else
+##CcInfoCompat = None
 ##cc_common_compat = None
 ##  #end
 # TEMPLATE-INCLUDE-END


### PR DESCRIPTION
When $isCcEnabled is false, the load statement for CcInfo is skipped, but `CcInfoCompat = CcInfo` was outside the template conditional. This causes CcInfo to be undefined, resulting in:

```
Error in aspect: at index 0 of required_aspect_providers,
got element of type NoneType, want Provider
```

Move CcInfoCompat and cc_common_compat assignments inside the template conditional with proper fallback to None when CC is disabled.