### PR TITLE
Fix Bazel 9 aspect compatibility issues

### DIFF
--- a/aspect/java_info.bzl
+++ b/aspect/java_info.bzl
@@ -1,5 +1,7 @@
 # TEMPLATE-INCLUDE-BEGIN
-###if( $isJavaEnabled == "true" && $bazel8OrAbove == "true" )
+###if( $isJavaEnabled == "true" && $bazel9OrAbove == "true" )
+##load("@compatibility_proxy//:proxy.bzl", "JavaInfo", "java_common")
+###elseif( $isJavaEnabled == "true" && $bazel8OrAbove == "true" )
 ##load("@rules_java//java/common:java_info.bzl", "JavaInfo")
 ##load("@rules_java//java/common:java_common.bzl", "java_common")
 ###end

--- a/aspect/scala_info.bzl
+++ b/aspect/scala_info.bzl
@@ -12,8 +12,8 @@ def scala_info_in_target(target):
 
 # TEMPLATE-INCLUDE-BEGIN
 ###if( $isScalaEnabled == "true" )
-##  return ScalaInfo in target
+##    return ScalaInfo in target
 ###else
-##  return False
+##    return False
 ###end
 # TEMPLATE-INCLUDE-END


### PR DESCRIPTION
## Summary
- **java_info.bzl**: Add Bazel 9 support using `@compatibility_proxy`. In Bazel 9, `JavaInfo` moved from `@rules_java` to `@compatibility_proxy`.
- **scala_info.bzl**: Fix indentation in TEMPLATE-INCLUDE block. The docstring uses 4-space indent but the template used 2-space, causing syntax errors when Scala is disabled.

Fixes #7706