### PR TITLE
chore(deps): update dependency rules_jvm_external to v6.10

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -41,6 +41,9 @@ single_version_override(
     patches = ["//third_party/kotlin/patches:strip_stdlib.patch"],
 )
 
+# override rules_android to use latest version (fixes compatibility issue)
+bazel_dep(name = "rules_android", version = "0.7.1")
+
 register_toolchains("//third_party/kotlin:toolchain")
 
 # configure python cor rules_python


### PR DESCRIPTION
Follow up for: #8137

Apparently requires us to fix rules android again, since older versions don't play nicely with Bazel 9.