### PR TITLE
Disable GDB server debug flags when registry key is set

### DIFF
--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeGDBServerProvider.kt
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeGDBServerProvider.kt
@@ -23,10 +23,9 @@ import com.google.idea.blaze.clwb.ToolchainUtils
 import com.google.idea.common.util.Datafiles
 import com.google.idea.sdkcompat.clion.debug.CidrDebuggerPathManagerAdapter
 import com.intellij.openapi.diagnostic.logger
-import com.intellij.util.PathUtil
+import com.intellij.openapi.util.registry.Registry
 import com.jetbrains.cidr.cpp.toolchains.CPPDebugger
 import com.jetbrains.cidr.cpp.toolchains.CPPToolchains
-import com.jetbrains.cidr.lang.workspace.compiler.GCCCompilerKind
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.absolutePathString
@@ -56,7 +55,10 @@ object BlazeGDBServerProvider {
       BlazeDebuggerKind.GDB_SERVER,
       RunConfigurationUtils.getCompilerKind(configuration),
     )
-    builder.withBuildFlags()
+
+    if (!Registry.`is`("bazel.clwb.debug.extraflags.disabled")) {
+      builder.withBuildFlags()
+    }
 
     if (state.commandState.command == BlazeCommandName.TEST) {
       builder.withTestFlags()


### PR DESCRIPTION
The bazel.clwb.debug.extraflags.disabled registry key can be used to disable extra injected flags for debug configurations. Apparently this flag was ignored when using GDB server.

