### PR TITLE
chore(deps): update kotlin api version to 2.1

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -268,8 +268,8 @@
     "https://bcr.bazel.build/modules/rules_python/1.6.0/MODULE.bazel": "7e04ad8f8d5bea40451cf80b1bd8262552aa73f841415d20db96b7241bd027d8",
     "https://bcr.bazel.build/modules/rules_python/1.6.3/MODULE.bazel": "a7b80c42cb3de5ee2a5fa1abc119684593704fcd2fec83165ebe615dec76574f",
     "https://bcr.bazel.build/modules/rules_python/1.7.0/MODULE.bazel": "d01f995ecd137abf30238ad9ce97f8fc3ac57289c8b24bd0bf53324d937a14f8",
-    "https://bcr.bazel.build/modules/rules_python/1.8.4/MODULE.bazel": "33e3971e66161a3e955f7a0d411a8d1f291c4ce4c561851512466f3c77ff8ece",
-    "https://bcr.bazel.build/modules/rules_python/1.8.4/source.json": "9fbc0e57bae52cddcc3831d668bce87a47e0c655104a85098d4459dd9a3b0a10",
+    "https://bcr.bazel.build/modules/rules_python/1.8.5/MODULE.bazel": "28b2d79ed8368d7d45b34bacc220e3c0b99cbcd9392641961b849e4c3f55dd30",
+    "https://bcr.bazel.build/modules/rules_python/1.8.5/source.json": "e261b03c8804f2582c9536013f987e1ea105a2b38c238aa2ac8f98fc34c8b18a",
     "https://bcr.bazel.build/modules/rules_robolectric/4.14.1.2/MODULE.bazel": "d44fec647d0aeb67b9f3b980cf68ba634976f3ae7ccd6c07d790b59b87a4f251",
     "https://bcr.bazel.build/modules/rules_robolectric/4.14.1.2/source.json": "37c10335f2361c337c5c1f34ed36d2da70534c23088062b33a8bdaab68aa9dea",
     "https://bcr.bazel.build/modules/rules_shell/0.1.2/MODULE.bazel": "66e4ca3ce084b04af0b9ff05ff14cab4e5df7503973818bb91cbc6cda08d32fc",
@@ -481,7 +481,7 @@
     "@@rules_python+//python/extensions:config.bzl%config": {
       "general": {
         "bzlTransitiveDigest": "wUM/eFwo5Zy7rn36nZ9ZxN9tXhmcWMVGXIExerGg6gM=",
-        "usagesDigest": "p2al+dDKI5UlCyNvheMVynbWSGbdiji/jMz53fMNfJA=",
+        "usagesDigest": "lDbpRfhoWmZCHSaNxwZv/8fF2y0wu2th0G0f/uqX7VM=",
         "recordedInputs": [
           "REPO_MAPPING:rules_python+,bazel_tools bazel_tools",
           "REPO_MAPPING:rules_python+,pypi__build rules_python++config+pypi__build",
@@ -649,7 +649,7 @@
     "@@rules_python+//python/uv:uv.bzl%uv": {
       "general": {
         "bzlTransitiveDigest": "ijW9KS7qsIY+yBVvJ+Nr1mzwQox09j13DnE3iIwaeTM=",
-        "usagesDigest": "/HRt5Hw/vpDr9CDrKEPjeDIjxo4307VLxMu8BNAEDWA=",
+        "usagesDigest": "c4BCoL7WnccEomzDYulDuOys9pd6N93KaNI4mTVbqi0=",
         "recordedInputs": [
           "REPO_MAPPING:rules_python+,bazel_tools bazel_tools",
           "REPO_MAPPING:rules_python+,platforms platforms"

--- a/base/src/com/google/idea/blaze/base/sync/aspects/storage/AspectTemplateWriter.kt
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/storage/AspectTemplateWriter.kt
@@ -64,7 +64,7 @@ class AspectTemplateWriter : AspectWriter {
       REALIZED_CODE_GENERATOR,
       ASPECT_TEMPLATE_DIRECTORY,
       TEMPLATE_CODE_GENERATOR,
-      ImmutableMap.of<String, List<LanguageClassRuleNames>?>("languageClassRuleNames", languageClassRuleNames)
+      ImmutableMap.of<String, List<LanguageClassRuleNames>>("languageClassRuleNames", languageClassRuleNames)
     )
   }
 

--- a/third_party/kotlin/BUILD
+++ b/third_party/kotlin/BUILD
@@ -10,8 +10,8 @@ kt_kotlinc_options(
 # https://plugins.jetbrains.com/docs/intellij/using-kotlin.html#kotlin-standard-library
 define_kt_toolchain(
     name = "toolchain",
-    api_version = "2.0",
+    api_version = "2.1",
     jvm_target = "17",
     kotlinc_options = ":kotlinc_options",
-    language_version = "2.0",
+    language_version = "2.1",
 )


### PR DESCRIPTION
According to this [table](https://plugins.jetbrains.com/docs/intellij/using-kotlin.html#kotlin-standard-library) we can update our kotlin api version.