### PR TITLE
Fix nested Bazel execution deadlock

### DIFF
--- a/third_party/bazel/jars/extension.bzl
+++ b/third_party/bazel/jars/extension.bzl
@@ -25,7 +25,7 @@ def _bazel_build_jars_impl(rctx):
         build_cmd = [bazel, "build"]
     else:
         # prevent external RC files from overriding --output_user_root (like on GH CI)
-        build_cmd = [bazel, "--nohome_rc", "--nosystem_rc", "--output_user_root=%s" % rctx.path("output"), "build"]
+        build_cmd = [bazel, "--nohome_rc", "--output_user_root=%s" % rctx.path("output"), "build"]
 
     for target in rctx.attr.jars:
         rctx.report_progress("building: %s" % target)


### PR DESCRIPTION
The action to set up Bazel in GitHub CI provides a system or user RC file which overrides the output_user_root. This can cause the nested Bazel client to try to connect to the outer Bazel server, effectively creating a dead lock.

So apparently:
- the system rc is required in order for Build Kit to work correctly
- and the home rc needs to be ignored for GH to work correctly 🫠 