### PR TITLE
Add detect_scala_info_provider in .bazelproject

### DIFF
--- a/base/src/com/google/idea/blaze/base/projectview/section/sections/DetectScalaInfoProviderSection.java
+++ b/base/src/com/google/idea/blaze/base/projectview/section/sections/DetectScalaInfoProviderSection.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.projectview.section.sections;
+
+import com.google.idea.blaze.base.projectview.section.ScalarSection;
+import com.google.idea.blaze.base.projectview.section.SectionKey;
+import com.google.idea.blaze.base.projectview.section.SectionParser;
+
+/** 'detect_scala_info_provider' section. */
+public class DetectScalaInfoProviderSection {
+    public static final SectionKey<Boolean, ScalarSection<Boolean>> KEY =
+            SectionKey.of("detect_scala_info_provider");
+
+    public static final SectionParser PARSER = new BooleanSectionParser(
+            KEY,
+            """
+                    Set to false if using an older rules_scala version (e.g. @io_bazel_rules_scala) that \
+                    does not export ScalaInfo from scala/providers.bzl. When false, Scala targets are \
+                    detected using the rule-name prefix heuristic (ctx.rule.kind.startswith("scala")) \
+                    instead of the ScalaInfo provider. By default this is true.
+                    """);
+}

--- a/base/src/com/google/idea/blaze/base/projectview/section/sections/Sections.java
+++ b/base/src/com/google/idea/blaze/base/projectview/section/sections/Sections.java
@@ -48,6 +48,7 @@ public class Sections {
           BazelBinarySection.PARSER,
           BuildConfigSection.PARSER,
           UseExclusionPatternsSection.PARSER,
+          DetectScalaInfoProviderSection.PARSER,
           UseQuerySyncSection.PARSER,
           ViewProjectRootSection.PARSER);
 

--- a/base/src/com/google/idea/blaze/base/sync/aspects/storage/AspectTemplateWriter.kt
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/storage/AspectTemplateWriter.kt
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableMap
 import com.google.idea.blaze.base.model.primitives.LanguageClass
 import com.google.idea.blaze.base.projectview.ProjectViewManager
 import com.google.idea.blaze.base.projectview.ProjectViewSet
+import com.google.idea.blaze.base.projectview.section.sections.DetectScalaInfoProviderSection
 import com.google.idea.blaze.base.sync.SyncProjectState
 import com.google.idea.blaze.base.sync.SyncScope.SyncFailedException
 import com.google.idea.blaze.base.sync.aspects.storage.AspectRepositoryProvider.ASPECT_TEMPLATE_DIRECTORY
@@ -120,7 +121,12 @@ class AspectTemplateWriter : AspectWriter {
     val isPythonEnabled = activeLanguages.contains(LanguageClass.PYTHON) &&
         (externalWorkspaceData != null && (!isAtLeastBazel8 || isNotBzlmod || hasRepository("rules_python")))
 
-    val isScalaEnabled = activeLanguages.contains(LanguageClass.SCALA) &&
+    val detectScalaInfoProvider = state.projectViewSet
+        .getScalarValue(DetectScalaInfoProviderSection.KEY)
+        .orElse(true)
+
+    val isScalaEnabled = detectScalaInfoProvider &&
+        activeLanguages.contains(LanguageClass.SCALA) &&
         (externalWorkspaceData != null && (!isAtLeastBazel8 || isNotBzlmod || hasRepository("rules_scala")))
 
     return ImmutableMap.of(

--- a/base/tests/unittests/com/google/idea/blaze/base/projectview/ProjectViewSetTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/projectview/ProjectViewSetTest.java
@@ -54,6 +54,7 @@ import com.google.idea.blaze.base.projectview.section.sections.TestSourceSection
 import com.google.idea.blaze.base.projectview.section.sections.TextBlock;
 import com.google.idea.blaze.base.projectview.section.sections.TextBlockSection;
 import com.google.idea.blaze.base.projectview.section.sections.TryImportSection;
+import com.google.idea.blaze.base.projectview.section.sections.DetectScalaInfoProviderSection;
 import com.google.idea.blaze.base.projectview.section.sections.UseExclusionPatternsSection;
 import com.google.idea.blaze.base.projectview.section.sections.UseQuerySyncSection;
 import com.google.idea.blaze.base.projectview.section.sections.ViewProjectRootSection;
@@ -121,6 +122,7 @@ public class ProjectViewSetTest extends BlazeTestCase {
                         ScalarSection.builder(BuildConfigSection.KEY)
                             .set(new WorkspacePath("test")))
                     .add(ScalarSection.builder(UseExclusionPatternsSection.KEY).set(false))
+                    .add(ScalarSection.builder(DetectScalaInfoProviderSection.KEY).set(true))
                     .add(ScalarSection.builder(ViewProjectRootSection.KEY).set(false))
                     .build())
             .build();


### PR DESCRIPTION
# Checklist

- [X] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [x] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: https://github.com/bazelbuild/intellij/issues/8182

# Description of this change

Adds a new `.bazelproject` section `detect_scala_info_provider` to opt into the older heuristic-based scala rule detection