### PR TITLE
Fix show import Bazel project fix when project has invalid workspace root

### DIFF
--- a/clwb/src/com/google/idea/blaze/clwb/CLionNotificationProvider.kt
+++ b/clwb/src/com/google/idea/blaze/clwb/CLionNotificationProvider.kt
@@ -104,7 +104,8 @@ class BazelProjectFixesProvider : ProjectFixesProvider {
 
   override suspend fun collectFixes(project: Project, file: VirtualFile?, context: DataContext): List<AnAction> {
     val workspaceRoot = readAction { guessWorkspaceRoot(project, file) } ?: return emptyList()
-    return if (validateWorkspaceRoot(workspaceRoot)) listOf(BazelImportCurrentProjectAction(File(workspaceRoot))) else emptyList()
+    if (withContext(Dispatchers.IO) { !validateWorkspaceRoot(workspaceRoot) }) return emptyList()
+    return listOf(BazelImportCurrentProjectAction(File(workspaceRoot)))
   }
 }
 

--- a/clwb/src/com/google/idea/blaze/clwb/CLionNotificationProvider.kt
+++ b/clwb/src/com/google/idea/blaze/clwb/CLionNotificationProvider.kt
@@ -104,7 +104,7 @@ class BazelProjectFixesProvider : ProjectFixesProvider {
 
   override suspend fun collectFixes(project: Project, file: VirtualFile?, context: DataContext): List<AnAction> {
     val workspaceRoot = readAction { guessWorkspaceRoot(project, file) } ?: return emptyList()
-    return listOf(BazelImportCurrentProjectAction(File(workspaceRoot)))
+    return if (validateWorkspaceRoot(workspaceRoot)) listOf(BazelImportCurrentProjectAction(File(workspaceRoot))) else emptyList()
   }
 }
 


### PR DESCRIPTION
Reported on YT: https://youtrack.jetbrains.com/issue/CPP-49394/Do-not-show-the-Import-Bazel-project-in-the-Fix-link-for-the-CMake-based-project
