### PR TITLE
cpp: allow XcodeCompilerSettingsProvider override

### DIFF
--- a/cpp/src/META-INF/blaze-cpp.xml
+++ b/cpp/src/META-INF/blaze-cpp.xml
@@ -53,7 +53,8 @@
      Therefore, we register a service that returns nothing.
      We override this registration on macOS systems later. -->
     <projectService serviceInterface="com.google.idea.blaze.cpp.XcodeCompilerSettingsProvider"
-                    serviceImplementation="com.google.idea.blaze.cpp.XcodeCompilerSettingsProviderNoopImpl"/>
+                    serviceImplementation="com.google.idea.blaze.cpp.XcodeCompilerSettingsProviderNoopImpl"
+                    open="true"/>
     <projectService serviceInterface="com.google.idea.blaze.cpp.XcodeCompilerSettingsProvider"
                     serviceImplementation="com.google.idea.blaze.cpp.XcodeCompilerSettingsProviderImpl"
                     os="mac"


### PR DESCRIPTION
from 2026.1 non open services are not allowed to be override
