### PR TITLE
chode(deps): ignore org.jetbrains.kotlin:kotlin-stdlib dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,6 @@
   "extends": [
     "config:recommended"
   ],
-  "ignorePaths": ["testing/test_deps/**"]
+  "ignorePaths": ["testing/test_deps/**"],
+  "ignoreDeps": ["org.jetbrains.kotlin:kotlin-stdlib"]
 }


### PR DESCRIPTION
For some reason the bot tries to push a lot of updates for this dependency and since we are not using the stdlib from maven anyway in production we can reduce the noise by ignoring the updates.
