### PR TITLE
Transition Support: automatically select resolve configurations based on the last run config

### DIFF
--- a/clwb/src/META-INF/clwb.xml
+++ b/clwb/src/META-INF/clwb.xml
@@ -40,12 +40,18 @@
   <extensions defaultExtensionNs="com.google.idea.blaze">
     <SyncPlugin implementation="com.google.idea.blaze.clwb.sync.BlazeCLionSyncPlugin"/>
     <BlazeCommandRunConfigurationHandlerProvider implementation="com.google.idea.blaze.clwb.run.BlazeCidrRunConfigurationHandlerProvider" order="first"/>
+    <SyncListener implementation="com.google.idea.blaze.clwb.run.LastBuildConfigurations$SyncCleaner"/>
   </extensions>
 
   <extensions defaultExtensionNs="com.google.idea.blaze.cpp">
     <CppEnvironmentProvider implementation="com.google.idea.blaze.clwb.environment.MSVCEnvironmentProvider" />
     <CppEnvironmentProvider implementation="com.google.idea.blaze.clwb.environment.ClangClEnvironmentProvider" />
   </extensions>
+
+  <projectListeners>
+    <listener class="com.google.idea.blaze.clwb.run.LastBuildConfigurations$OCResolveContextNotifier"
+              topic="com.google.idea.blaze.clwb.run.LastBuildConfigurations$Listener"/>
+  </projectListeners>
 
   <actions>
     <action id="Bazel.ShowResolveContext"

--- a/clwb/src/com/google/idea/blaze/clwb/radler/BazelResolveConfigurationToolbar.kt
+++ b/clwb/src/com/google/idea/blaze/clwb/radler/BazelResolveConfigurationToolbar.kt
@@ -24,6 +24,7 @@ import com.google.idea.blaze.base.sync.SyncListener
 import com.google.idea.blaze.base.sync.SyncMode
 import com.google.idea.blaze.base.sync.SyncResult
 import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager
+import com.google.idea.blaze.clwb.run.LastBuildConfigurations
 import com.google.idea.blaze.cpp.BlazeResolveConfigurationID
 import com.intellij.icons.AllIcons
 import com.intellij.openapi.Disposable
@@ -85,6 +86,13 @@ private class BazelConfigSwitchComboAction(
     // trigger update on project data changes
     bus.subscribe(SyncListener.TOPIC, object : SyncListener {
       override fun afterSync(project: Project, context: BlazeContext, syncMode: SyncMode, syncResult: SyncResult, buildIds: ImmutableSet<Int>) {
+        state.invalidate()
+      }
+    })
+
+    // trigger update when the preferred run configuration changes
+    bus.subscribe(LastBuildConfigurations.TOPIC, object : LastBuildConfigurations.Listener {
+      override fun preferredConfigurationChanged() {
         state.invalidate()
       }
     })
@@ -197,12 +205,13 @@ private class BazelConfigSwitchComboAction(
       .filterNotNullValues()
 
     if (configurations.isEmpty()) return null
-    val selected = OCResolveConfigurations.findPreselectedOrSuitableConfiguration(project, configurations.keys)
+    val current = OCResolveConfigurations.findPreselectedOrSuitableConfiguration(project, configurations.keys).first
+    val selected = OCResolveContextSettings.getInstance(project).findPriorityConfiguration(configurations.keys)
 
     return SwitcherState(
-      currentConfig = configurations.getValue(selected.first),
+      currentConfig = configurations.getValue(current),
       availableConfigs = configurations.values.toList(),
-      isAutoSelect = !selected.second,
+      isAutoSelect = selected == null,
     )
   }
 }

--- a/clwb/src/com/google/idea/blaze/clwb/radler/RadRunConfigurationChooser.kt
+++ b/clwb/src/com/google/idea/blaze/clwb/radler/RadRunConfigurationChooser.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.clwb.radler
+
+import com.google.idea.blaze.clwb.run.LastBuildConfigurations
+import com.google.idea.blaze.cpp.BlazeResolveConfigurationID
+import com.google.idea.sdkcompat.radler.OCResolveConfigurationChooserAdapter
+import com.intellij.openapi.project.Project
+import com.jetbrains.cidr.lang.workspace.OCResolveConfiguration
+
+/**
+ * Selects the OCResolveConfiguration matching the Bazel configuration from the last build.
+ *
+ * Registered after PriorityBasedChooser so that manual user selection (via the config widget)
+ * takes priority. When no manual selection exists, this chooser picks the configuration
+ * matching the last aquery result.
+ *
+ * CLion pre-filters the configurations list to those relevant to the current file,
+ * so matching against the full set of build checksums correctly resolves per-file.
+ */
+class RadRunConfigurationChooser : OCResolveConfigurationChooserAdapter() {
+
+  override fun doSelectResolveConfiguration(
+    project: Project,
+    configurations: List<OCResolveConfiguration>,
+  ): OCResolveConfiguration? {
+    val checksums = LastBuildConfigurations.getInstance(project).preferredConfigurations
+    if (checksums.isEmpty()) return null
+
+    return configurations.firstOrNull { config ->
+      val id = BlazeResolveConfigurationID.fromOCResolveConfiguration(config) ?: return@firstOrNull false
+      checksums.any { checksum -> checksum.startsWith(id.configurationId) }
+    }
+  }
+}

--- a/clwb/src/com/google/idea/blaze/clwb/radler/optional-plugin.xml
+++ b/clwb/src/com/google/idea/blaze/clwb/radler/optional-plugin.xml
@@ -27,6 +27,10 @@
     <iw.actionProvider implementation="com.google.idea.blaze.clwb.radler.BazelResolveConfigurationWidgetProvider"/>
   </extensions>
 
+  <extensions defaultExtensionNs="cidr.projectModel">
+    <resolveConfigurationChooser implementation="com.google.idea.blaze.clwb.radler.RadRunConfigurationChooser" order="after PriorityBasedChooser"/>
+  </extensions>
+
   <extensions defaultExtensionNs="com.intellij.rider.cpp.core.projectModel">
     <radProjectFallbackConfigDisabler implementation="com.google.idea.blaze.clwb.radler.RadBazelProjectFallbackConfigDisabler"/>
   </extensions>

--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrRunConfigurationRunner.kt
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrRunConfigurationRunner.kt
@@ -101,6 +101,9 @@ class BlazeCidrRunConfigurationRunner(private val configuration: BlazeCommandRun
       if (config != null) {
         ctx.println("Target configuration: ${config.mainTarget} (${config.mainConfiguration})")
 
+        // update the preferred configuration based on what is currently run
+        LastBuildConfigurations.getInstance(env.project).update(config.compileActions)
+
         if (isDebugging(env)) {
           DebugInfoCheck(env, config).execute(ctx)
         }

--- a/clwb/src/com/google/idea/blaze/clwb/run/LastBuildConfigurations.kt
+++ b/clwb/src/com/google/idea/blaze/clwb/run/LastBuildConfigurations.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.clwb.run
+
+import com.google.common.collect.ImmutableSet
+import com.google.idea.blaze.base.model.primitives.Label
+import com.google.idea.blaze.base.scope.BlazeContext
+import com.google.idea.blaze.base.sync.SyncListener
+import com.google.idea.blaze.base.sync.SyncMode
+import com.google.idea.blaze.base.sync.SyncResult
+import com.google.idea.common.aquery.ActionGraph
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import com.intellij.util.messages.Topic
+import com.jetbrains.cidr.lang.settings.OCResolveContextSettings
+
+/**
+ * Stores the per-target Bazel configuration checksums from the last aquery run.
+ *
+ * Different targets contributing to the same binary can have different Bazel configurations
+ * (due to transitions). This state allows the resolve configuration chooser to match
+ * OCResolveConfigurations to the configurations actually used in the last build.
+ *
+ * Session-only state (not persisted). Cleared on sync since configurations may change.
+ */
+@Service(Service.Level.PROJECT)
+class LastBuildConfigurations(private val project: Project) {
+
+  /** The set of unique configuration checksums from the last build. */
+  @Volatile
+  var preferredConfigurations: Set<String> = emptySet()
+    private set
+
+  fun update(compileActions: Map<Label, ActionGraph.Action>) {
+    preferredConfigurations = compileActions.values.map { it.configuration.checksum }.toSet()
+    project.messageBus.syncPublisher(TOPIC).preferredConfigurationChanged()
+  }
+
+  private fun clear() {
+    preferredConfigurations = emptySet()
+    project.messageBus.syncPublisher(TOPIC).preferredConfigurationChanged()
+  }
+
+  companion object {
+
+    @JvmField
+    val TOPIC: Topic<Listener> = Topic.create("LastBuildConfigurations", Listener::class.java)
+
+    @JvmStatic
+    fun getInstance(project: Project): LastBuildConfigurations =
+      project.service<LastBuildConfigurations>()
+  }
+
+  /** Clears stored build configurations on sync since configurations may change. */
+  class SyncCleaner : SyncListener {
+
+    override fun afterSync(
+      project: Project,
+      context: BlazeContext,
+      syncMode: SyncMode,
+      syncResult: SyncResult,
+      buildIds: ImmutableSet<Int>,
+    ) = getInstance(project).clear()
+  }
+
+  /** Notifies the OCResolveContext system when preferred configurations change. */
+  class OCResolveContextNotifier(private val project: Project) : Listener {
+
+    override fun preferredConfigurationChanged() {
+      OCResolveContextSettings.getInstance(project).notifyPrioritiesChange()
+    }
+  }
+
+  /** Callback for listening for configuration changes. */
+  interface Listener {
+
+    fun preferredConfigurationChanged()
+  }
+}


### PR DESCRIPTION
This PR adds support for automatically selecting the right resolve configuration based on the last run configuration. Thus, making sure code insight is reflects whatever the user is currently running.

However, this is as well affect by the `Bazel Flags` bug, e.g. if a `--test_filter` flag is and the aquery returns different configurations for the targets, the automatic selection does not work.