### PR TITLE
clion: fix split debugger warning in 2026.1

### DIFF
--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeCppRunner.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeCppRunner.java
@@ -16,15 +16,16 @@
 package com.google.idea.blaze.clwb.run;
 
 import com.google.idea.blaze.base.run.BlazeCommandRunConfiguration;
+import com.google.idea.sdkcompat.clion.XDebugSessionCompat;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.RunProfile;
 import com.intellij.execution.configurations.RunProfileState;
 import com.intellij.execution.executors.DefaultDebugExecutor;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.ui.RunContentDescriptor;
-import com.intellij.xdebugger.XDebugSession;
 import com.jetbrains.cidr.execution.CidrCommandLineState;
 import com.jetbrains.cidr.execution.CidrRunner;
+
 import javax.annotation.Nullable;
 
 /**
@@ -56,10 +57,8 @@ public class BlazeCppRunner extends CidrRunner {
   protected RunContentDescriptor doExecute(RunProfileState state, ExecutionEnvironment environment)
       throws ExecutionException {
     if (environment.getExecutor().getId().equals(DefaultDebugExecutor.EXECUTOR_ID)
-        && state instanceof CidrCommandLineState) {
-      CidrCommandLineState cidrState = (CidrCommandLineState) state;
-      XDebugSession debugSession = startDebugSession(cidrState, environment, false);
-      return debugSession.getRunContentDescriptor();
+        && state instanceof CidrCommandLineState cidrState) {
+        return XDebugSessionCompat.getRunContentDescriptor(this, environment, cidrState);
     }
     return super.doExecute(state, environment);
   }

--- a/sdkcompat/v253/com/google/idea/sdkcompat/clion/XDebugSessionCompat.kt
+++ b/sdkcompat/v253/com/google/idea/sdkcompat/clion/XDebugSessionCompat.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.idea.sdkcompat.clion
+
+import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.execution.ui.RunContentDescriptor
+import com.jetbrains.cidr.execution.CidrCommandLineState
+import com.jetbrains.cidr.execution.CidrRunner
+
+// #api253
+object XDebugSessionCompat {
+    @JvmStatic
+    fun getRunContentDescriptor(
+        runner: CidrRunner, environment: ExecutionEnvironment, cidrState: CidrCommandLineState
+    ): RunContentDescriptor? {
+        return runner.startDebugSession(cidrState, environment, false).getRunContentDescriptor()
+    }
+}

--- a/sdkcompat/v261/com/google/idea/sdkcompat/clion/XDebugSessionCompat.kt
+++ b/sdkcompat/v261/com/google/idea/sdkcompat/clion/XDebugSessionCompat.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.idea.sdkcompat.clion
+
+import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.execution.ui.RunContentDescriptor
+import com.jetbrains.cidr.execution.CidrCommandLineState
+import com.jetbrains.cidr.execution.CidrRunner
+
+// #api253
+object XDebugSessionCompat {
+    @JvmStatic
+    fun getRunContentDescriptor(
+        runner: CidrRunner, environment: ExecutionEnvironment, cidrState: CidrCommandLineState
+    ): RunContentDescriptor? {
+        return runner.startDebugDescriptor(cidrState, environment, false)
+    }
+}


### PR DESCRIPTION
2026.1 SDK deprecated usage of startDebugSession because of migration to split debugger mode
