### PR TITLE
use clion-oss-latest-stable for default builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -25,4 +25,4 @@ common --repo_env=ANDROID_NDK_ROOT=""
 
 # Avoids frequent protoc rebuilds 
 build --@protobuf//bazel/toolchains:prefer_prebuilt_protoc
-
+build --define=ij_product=clion-oss-latest-stable


### PR DESCRIPTION
since this plugin is clion-only now
