### PR TITLE
Fix hanging gdbserver process in sandbox with network namespace

### DIFF
--- a/clwb/gdbserver
+++ b/clwb/gdbserver
@@ -54,6 +54,23 @@ gdbserver_wrapper::detect_version() {
   return 0
 }
 
+gdbserver_wrapper::check_network_access() {
+  # Bazel sandboxing can disable network access. If there is no network access,
+  # the gdbserver will not be able to communicate with the IDE outside the sandbox.
+  # We check this by verifying if the loopback interface 'lo' is the only interface
+  # present in /sys/class/net, which indicates an isolated network namespace.
+  local active_interfaces
+  if [[ -d /sys/class/net ]]; then
+    active_interfaces="$(ls /sys/class/net 2>/dev/null)"
+    if [[ "${active_interfaces}" == "lo" ]] || [[ -z "${active_interfaces}" ]]; then
+      echo >&2 "error: gdbserver_wrapper: No network access detected in sandbox."
+      echo >&2 "The IDE debugger cannot connect to a gdbserver inside a network-isolated sandbox."
+      echo >&2 "Please ensure network is allowed (e.g., by omitting --nosandbox_default_allow_network)."
+      exit 1
+    fi
+  fi
+}
+
 gdbserver_wrapper::setup() {
   # create work directory for all temporary files
   work_directory="$(mktemp --tmpdir --directory "gdbserver_wrapper.XXXXXXXX")"
@@ -189,6 +206,8 @@ gdbserver_wrapper::main() {
   verbose="${GDB_WRAPPER_VERBOSE}"
 
   original_args=("$@")
+
+  gdbserver_wrapper::check_network_access
 
   # detect version from the first arg (gdbserver binary)
   gdbserver_version="$(gdbserver_wrapper::detect_version "${original_args[0]}")"

--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrLauncher.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrLauncher.java
@@ -290,8 +290,6 @@ public final class BlazeCidrLauncher extends CidrLauncher {
 
     configProcessHandler(targetProcess, false, true, getProject());
 
-    targetProcess.startNotify();
-
     // CidrRemoteDebugParameters can't be constructed with a null sysroot, so pass in the default
     // value "target:". Causes paths/files to be resolved in the context of the target.
     CidrRemoteDebugParameters parameters =

--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrRemoteDebugProcess.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrRemoteDebugProcess.java
@@ -18,10 +18,12 @@ package com.google.idea.blaze.clwb.run;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.filters.TextConsoleBuilder;
+import com.intellij.execution.process.ProcessEvent;
 import com.intellij.execution.process.ProcessHandler;
-import com.intellij.execution.ui.ConsoleView;
-import com.intellij.execution.ui.ConsoleViewContentType;
+import com.intellij.execution.process.ProcessListener;
+import com.intellij.openapi.util.Key;
 import com.intellij.xdebugger.XDebugSession;
+import org.jetbrains.annotations.NotNull;
 import com.jetbrains.cidr.execution.TrivialInstaller;
 import com.jetbrains.cidr.execution.TrivialRunParameters;
 import com.jetbrains.cidr.execution.debugger.CidrDebugProcess;
@@ -38,6 +40,7 @@ import java.io.File;
  * <p>This should be extending CidrRemoteGDBDebugProcess, but that is 'final'
  */
 public class BlazeCidrRemoteDebugProcess extends CidrDebugProcess {
+
   private final ProcessHandler targetProcess;
   private final CidrRemoteDebugParameters remoteDebugParameters;
 
@@ -49,25 +52,54 @@ public class BlazeCidrRemoteDebugProcess extends CidrDebugProcess {
       TextConsoleBuilder textConsoleBuilder)
       throws ExecutionException {
     super(
-        new TrivialRunParameters(
-            debuggerDriverConfiguration, new TrivialInstaller(new GeneralCommandLine())),
+        new TrivialRunParameters(debuggerDriverConfiguration, new TrivialInstaller(new GeneralCommandLine())),
         xDebugSession,
-        textConsoleBuilder);
+        textConsoleBuilder
+    );
+
     this.remoteDebugParameters = remoteDebugParameters;
     this.targetProcess = targetProcess;
+
+    installServerProcess();
   }
 
-  private void writeLineToConsole(String s) {
-    myConsole.print(s + System.lineSeparator(), ConsoleViewContentType.SYSTEM_OUTPUT);
-  }
+  // mirrors GdbWithGdbServerProcess#installServerProcess
+  private void installServerProcess() {
+    targetProcess.addProcessListener(new ProcessListener() {
+      @Override
+      public void processTerminated(@NotNull ProcessEvent event) {
+        getSession().stop();
+      }
 
-  @Override
-  public ConsoleView createConsole() {
-    writeLineToConsole("Running debug binary");
-    writeLineToConsole("Command: " + targetProcess);
-    writeLineToConsole("");
-    myConsole.attachToProcess(targetProcess);
-    return myConsole;
+      @Override
+      public void onTextAvailable(@NotNull ProcessEvent event, @NotNull Key outputType) {
+        getProcessHandler().notifyTextAvailable(event.getText(), outputType);
+      }
+    });
+
+    getProcessHandler().addProcessListener(new ProcessListener() {
+      @Override
+      public void startNotified(@NotNull ProcessEvent event) {
+        printlnToConsole("Running debug binary");
+        printlnToConsole("Command: " + targetProcess);
+        printlnToConsole("");
+
+        targetProcess.startNotify();
+      }
+
+      @Override
+      public void processTerminated(@NotNull ProcessEvent event) {
+        if (!targetProcess.isStartNotified()) {
+          targetProcess.startNotify();
+        }
+
+        if (!targetProcess.isProcessTerminated()) {
+          targetProcess.destroyProcess();
+        }
+
+        event.getProcessHandler().removeProcessListener(this);
+      }
+    });
   }
 
   @Override
@@ -77,15 +109,23 @@ public class BlazeCidrRemoteDebugProcess extends CidrDebugProcess {
 
   @Override
   protected Inferior doLoadTarget(DebuggerDriver debuggerDriver) throws ExecutionException {
-    if (!(debuggerDriver instanceof GDBDriver)) {
+    if (targetProcess.isProcessTerminated()) {
+      throw new ExecutionException(
+          "Target process terminated before debugger could attach (exit code "
+              + targetProcess.getExitCode() + "). "
+              + "Please check the console output for errors.");
+    }
+
+    if (!(debuggerDriver instanceof GDBDriver gdbDriver)) {
       throw new ExecutionException("Invalid DebuggerDriver - wanted GDBDriver");
     }
-    GDBDriver gdbDriver = (GDBDriver) debuggerDriver;
+
     return gdbDriver.loadForRemote(
         remoteDebugParameters.getRemoteCommand(),
         new File(remoteDebugParameters.getSymbolFile()),
         new File(remoteDebugParameters.getSysroot()),
-        remoteDebugParameters.driverPathMapping());
+        remoteDebugParameters.driverPathMapping()
+    );
   }
 
   public ProcessHandler getTargetProcess() {

--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrRemoteDebugProcess.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrRemoteDebugProcess.java
@@ -93,6 +93,12 @@ public class BlazeCidrRemoteDebugProcess extends CidrDebugProcess {
           targetProcess.startNotify();
         }
 
+        // let targetProcess (bazel run + gdbserver --once) drain on its own when the inferior
+        // exits; only force-destroy if it is still alive after the grace period
+        if (!targetProcess.isProcessTerminated()) {
+          targetProcess.waitFor(5000);
+        }
+
         if (!targetProcess.isProcessTerminated()) {
           targetProcess.destroyProcess();
         }

--- a/clwb/tests/headlesstests/com/google/idea/blaze/clwb/ExecutionTest.kt
+++ b/clwb/tests/headlesstests/com/google/idea/blaze/clwb/ExecutionTest.kt
@@ -73,6 +73,8 @@ class ExecutionTest : ClwbHeadlessTestCase() {
       checkRun(DefaultDebugExecutor.EXECUTOR_ID)
       checkArgs(DefaultDebugExecutor.EXECUTOR_ID)
       checkTest(DefaultDebugExecutor.EXECUTOR_ID)
+
+      checkTestSandboxNoNetwork()
     }
   }
 
@@ -154,6 +156,19 @@ class ExecutionTest : ClwbHeadlessTestCase() {
     assertThat(catchFiltered.output).doesNotContain("Test0")
   }
 
+  fun checkTestSandboxNoNetwork() {
+    val result = execute(
+      Label.create("//main:gtest"), DefaultDebugExecutor.EXECUTOR_ID,
+      flags = listOf("--nosandbox_default_allow_network")
+    )
+
+    if (OS.CURRENT != OS.Linux) {
+      result.assertSuccess()
+    } else {
+      assertThat(result.exitCode).isEqualTo(3)
+    }
+  }
+
   private fun executeEcho(target: String, executorId: String, args: String): List<String> {
     val result = execute(Label.create("//main:$target"), executorId, args = listOf(args))
     result.assertSuccess()
@@ -173,6 +188,23 @@ class ExecutionTest : ClwbHeadlessTestCase() {
     flags: List<String> = emptyList(),
     args: List<String> = emptyList()
   ): ExecutionResult {
+    val future = CompletableFuture<Int>()
+    val outputBuilder = StringBuilder()
+
+    val listener = object : ProcessListener {
+      override fun onTextAvailable(event: ProcessEvent, outputType: Key<*>) {
+        if (outputType == ProcessOutputTypes.STDOUT) {
+          outputBuilder.append(event.text)
+        }
+      }
+    }
+
+    // register the listener first before starting the run config
+    project.messageBus.connect(testRootDisposable).subscribe(
+      ExecutionManager.EXECUTION_TOPIC,
+      ExecutionResultListener(myProject, listener, future)
+    )
+
     val element = findRule(label)
 
     val dataContextBuilder = SimpleDataContext.builder()
@@ -201,22 +233,6 @@ class ExecutionTest : ClwbHeadlessTestCase() {
     manager.forceCompilationInTests = true
     manager.restartRunProfile(environmentBuilder.build())
 
-    val future = CompletableFuture<Int>()
-    val outputBuilder = StringBuilder()
-
-    val listener = object : ProcessListener {
-      override fun onTextAvailable(event: ProcessEvent, outputType: Key<*>) {
-        if (outputType == ProcessOutputTypes.STDOUT) {
-          outputBuilder.append(event.text)
-        }
-      }
-    }
-
-    project.messageBus.connect(testRootDisposable).subscribe(
-      ExecutionManager.EXECUTION_TOPIC,
-      ExecutionResultListener(myProject, listener, future)
-    )
-
     val exitCode = pullFuture(future, 2, TimeUnit.MINUTES)
     return ExecutionResult(outputBuilder.toString(), exitCode ?: -1)
   }
@@ -235,11 +251,26 @@ private class ExecutionResultListener(
   private val future: CompletableFuture<Int>
 ) : ExecutionListener {
 
-  private var waitForRemoteDebugProcess = false
+  // For remote debug we need to wait for two terminations and prefer the target's exit code.
+  // thenCombine fires only after both have completed, picking the target code when present.
+  private val targetTermination = CompletableFuture<Int?>()
+  private val handlerTermination = CompletableFuture<Int>()
 
-  override fun processStarted(executor: String, env: ExecutionEnvironment, handler: ProcessHandler) {
+  init {
+    targetTermination
+      .thenCombine(handlerTermination) { target, handler -> target ?: handler }
+      .whenComplete { exit, throwable ->
+        if (throwable != null)
+          future.completeExceptionally(throwable)
+        else
+          future.complete(exit)
+      }
+  }
+
+  override fun processStarting(executor: String, env: ExecutionEnvironment, handler: ProcessHandler) {
     if (executor == DefaultRunExecutor.EXECUTOR_ID) {
       handler.addProcessListener(listener)
+      targetTermination.complete(null)
       return
     }
 
@@ -254,17 +285,16 @@ private class ExecutionResultListener(
     val debugProcess = session.debugProcess
     if (debugProcess is CidrLocalDebugProcess) {
       debugProcess.processHandler.addProcessListener(listener)
+      targetTermination.complete(null)
       return
     }
 
     if (debugProcess is BlazeCidrRemoteDebugProcess) {
-      waitForRemoteDebugProcess = true
-
-      // this is probably a race with startNotify
       debugProcess.targetProcess.addProcessListener(listener)
+
       debugProcess.targetProcess.addProcessListener(object : ProcessListener {
         override fun processTerminated(event: ProcessEvent) {
-          future.complete(event.exitCode)
+          targetTermination.complete(event.exitCode)
         }
       })
 
@@ -279,8 +309,6 @@ private class ExecutionResultListener(
   }
 
   override fun processTerminated(executor: String, env: ExecutionEnvironment, handler: ProcessHandler, exitCode: Int) {
-    if (!waitForRemoteDebugProcess) {
-      future.complete(exitCode)
-    }
+    handlerTermination.complete(exitCode)
   }
 }

--- a/clwb/tests/headlesstests/com/google/idea/blaze/clwb/ExecutionTest.kt
+++ b/clwb/tests/headlesstests/com/google/idea/blaze/clwb/ExecutionTest.kt
@@ -260,6 +260,7 @@ private class ExecutionResultListener(
     if (debugProcess is BlazeCidrRemoteDebugProcess) {
       waitForRemoteDebugProcess = true
 
+      // this is probably a race with startNotify
       debugProcess.targetProcess.addProcessListener(listener)
       debugProcess.targetProcess.addProcessListener(object : ProcessListener {
         override fun processTerminated(event: ProcessEvent) {


### PR DESCRIPTION
The `gdbserver` wrapper script detects if it is run in a network namespace and fails fast. Also fixes a race in `BlazeCidrRemoteDebugProcess` where calling `targetProcess.startNotify()` too eraly could drop gdbserver output.

Also extends the headless ExecutionTest to cover `--nosandbox_default_allow_network`, and rewrites `ExecutionResultListener` to wait for both the debug-driver handler and the gdbserver target to terminate while still reporting the target's exit code.