### PR TITLE
Remove generic Bazel flags field from run configs

### DIFF
--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -197,6 +197,7 @@
     <postStartupActivity implementation="com.google.idea.blaze.base.formatter.ExternalFormatterCodeStyleManager$Installer"/>
     <postStartupActivity implementation="com.google.idea.blaze.base.prefetch.PrefetchProjectInitializer" />
     <postStartupActivity implementation="com.google.idea.blaze.base.project.OpenProjectViewStartupActivity"/>
+    <postStartupActivity implementation="com.google.idea.blaze.base.run.state.LegacyBlazeFlagsMigrationNotifier"/>
     <moduleRendererFactory implementation="com.google.idea.blaze.base.ui.BlazeModuleRendererFactory" order="first"/>
 
     <toolWindow id="Blaze"

--- a/base/src/com/google/idea/blaze/base/buildview/RunConfigBuild.kt
+++ b/base/src/com/google/idea/blaze/base/buildview/RunConfigBuild.kt
@@ -24,12 +24,10 @@ import com.google.idea.blaze.base.command.buildresult.LocalFileArtifact
 import com.google.idea.blaze.base.model.primitives.Label
 import com.google.idea.blaze.base.projectview.ProjectViewManager
 import com.google.idea.blaze.base.run.BlazeCommandRunConfiguration
-import com.google.idea.blaze.base.run.state.BlazeCommandRunConfigurationCommonState
 import com.google.idea.blaze.base.scope.BlazeContext
 import com.google.idea.blaze.base.sync.aspects.BlazeBuildOutputs
 import com.intellij.openapi.project.Project
 import com.intellij.util.PathUtil
-import com.intellij.util.asSafely
 import java.io.File
 import java.nio.file.Path
 
@@ -47,7 +45,6 @@ class RunConfigBuild @JvmOverloads constructor(
 
   override fun run(ctx: BlazeContext): Output {
     val projectViewSet = ProjectViewManager.getInstance(project).getProjectViewSet()
-    val handlerState = configuration.handler.state.asSafely<BlazeCommandRunConfigurationCommonState>()
 
     val flags = BlazeFlags.blazeFlags(
       project,
@@ -57,16 +54,10 @@ class RunConfigBuild @JvmOverloads constructor(
       invocationContext,
     )
 
-    val externalFlags = handlerState
-      ?.blazeFlagsState
-      ?.flagsForExternalProcesses
-      ?: emptyList()
-
     val cmd = BlazeCommand.builder(BlazeCommandName.BUILD)
       .addTargets(target)
       .addBlazeFlags(additionalFlags)
       .addBlazeFlags(flags)
-      .addBlazeFlags(externalFlags)
 
     val result = BazelExecService.of(project).build(ctx, cmd)
 

--- a/base/src/com/google/idea/blaze/base/command/BlazeFlags.java
+++ b/base/src/com/google/idea/blaze/base/command/BlazeFlags.java
@@ -99,9 +99,6 @@ public final class BlazeFlags {
   public static final String ADB_PATH = "--adb_path";
   public static final String DEVICE = "--device";
 
-  // Pass-through arg for sending test arguments.
-  public static final String TEST_ARG = "--test_arg=";
-
   private static final String TOOL_TAG = "--tool_tag=ijwb:";
 
   // TODO: remove these when mobile-install V1 is obsolete

--- a/base/src/com/google/idea/blaze/base/command/BlazeFlags.java
+++ b/base/src/com/google/idea/blaze/base/command/BlazeFlags.java
@@ -49,6 +49,8 @@ public final class BlazeFlags {
   public static final String DISABLE_TEST_SHARDING = "--test_sharding_strategy=disabled";
   // Filters the unit tests that are run (used with regexp for Java/Robolectric tests).
   public static final String TEST_FILTER = "--test_filter";
+  // Arguments passed to the test binary.
+  public static final String TEST_ARG = "--test_arg";
   // Re-run the test even if the results are cached.
   public static final String NO_CACHE_TEST_RESULTS = "--nocache_test_results";
   // Environment variables for the test runner

--- a/base/src/com/google/idea/blaze/base/execution/BlazeParametersListUtil.java
+++ b/base/src/com/google/idea/blaze/base/execution/BlazeParametersListUtil.java
@@ -16,12 +16,16 @@
 package com.google.idea.blaze.base.execution;
 
 import com.google.common.collect.ImmutableList;
+import com.google.idea.blaze.base.command.BlazeFlags;
+import com.intellij.openapi.util.text.Strings;
 import com.intellij.util.execution.ParametersListUtil;
 import java.util.List;
 import javax.annotation.Nullable;
 
 /** Workaround issues in ParametersListUtil */
 public class BlazeParametersListUtil {
+
+  private final static String TEST_FILTER_FLAG_PREFIX = BlazeFlags.TEST_FILTER + "=";
 
   /**
    * Like ParametersListUtil.encode(String) but will quote a param if it contains a single quote.
@@ -43,6 +47,28 @@ public class BlazeParametersListUtil {
     if (params == null) {
       return ImmutableList.of();
     }
+
     return ParametersListUtil.parse(params, true, true);
   }
+
+  /**
+   * Encodes a test filter value e.g., FooTest.testBar into a test filter flag string, e.g.
+   * --test_filter=FooTest.testBar. Uses shall escapes such that the flag can be passed directly to
+   * the blaze command line.
+   */
+  public static String encodeTestFilterFlag(String filterValue) {
+    return TEST_FILTER_FLAG_PREFIX + encodeParam(filterValue);
+  }
+
+  /**
+   * Decodes a test filter flag string, e.g. --test_filter=FooTest.testBar into the raw filter value by
+   * undoing the shall escapes.
+   */
+  public static String decodeTestFilterFlag(String filterFlag) {
+    final var filter = Strings.trimStart(filterFlag, TEST_FILTER_FLAG_PREFIX);
+    final var tokens = ParametersListUtil.parse(filter, false, true);
+
+    return tokens.isEmpty() ? filter : tokens.getFirst();
+  }
+
 }

--- a/base/src/com/google/idea/blaze/base/run/confighandler/BlazeCommandGenericRunConfigurationRunner.java
+++ b/base/src/com/google/idea/blaze/base/run/confighandler/BlazeCommandGenericRunConfigurationRunner.java
@@ -91,7 +91,6 @@ public final class BlazeCommandGenericRunConfigurationRunner
   /** {@link RunProfileState} for generic blaze commands. */
   public static class BlazeCommandRunProfileState extends CommandLineState {
 
-    private static final int BLAZE_BUILD_INTERRUPTED = 8;
     private final BlazeCommandRunConfiguration configuration;
     private final BlazeCommandRunConfigurationCommonState handlerState;
     private final ImmutableList<Filter> consoleFilters;
@@ -244,19 +243,23 @@ public final class BlazeCommandGenericRunConfigurationRunner
         command = BlazeCommandName.COVERAGE;
       }
 
-      return BlazeCommand.builder(invoker, command)
+      final var builder = BlazeCommand.builder(invoker, command)
           .addTargets(configuration.getTargets())
-          .addBlazeFlags(
-              BlazeFlags.blazeFlags(
-                  project,
-                  projectViewSet,
-                  getCommand(),
-                  context,
-                  BlazeInvocationContext.runConfigContext(
-                      executorType, configuration.getType(), false)))
-          .addBlazeFlags(extraBlazeFlags)
-          .addBlazeFlags(handlerState.getBlazeFlagsState().getFlagsForExternalProcesses())
-          .addExeFlags(handlerState.getExeFlagsState().getFlagsForExternalProcesses());
+          .addBlazeFlags(BlazeFlags.blazeFlags(
+              project,
+              projectViewSet,
+              getCommand(),
+              context,
+              BlazeInvocationContext.runConfigContext(executorType, configuration.getType(), false)
+          ))
+          .addBlazeFlags(extraBlazeFlags);
+
+      final var testFilterFlag = handlerState.getTestFilterFlag();
+      if (testFilterFlag != null && BlazeCommandName.TEST.equals(handlerState.getCommandState().getCommand())) {
+        builder.addBlazeFlags(testFilterFlag, BlazeFlags.DISABLE_TEST_SHARDING);
+      }
+
+      return builder.addExeFlags(handlerState.getExeFlagsState().getFlagsForExternalProcesses());
     }
 
     private BlazeCommandName getCommand() {

--- a/base/src/com/google/idea/blaze/base/run/producers/BlazeBuildFileRunConfigurationProducer.java
+++ b/base/src/com/google/idea/blaze/base/run/producers/BlazeBuildFileRunConfigurationProducer.java
@@ -103,7 +103,7 @@ public class BlazeBuildFileRunConfigurationProducer
 
     // ignore filtered test configs, produced by other configuration producers.
     final var handlerState = configuration.getHandlerStateIfType(BlazeCommandRunConfigurationCommonState.class);
-    if (handlerState != null && handlerState.getTestFilterFlag() != null) {
+    if (handlerState != null && handlerState.getTestFilterState().getTestFilter() != null) {
       return false;
     }
 

--- a/base/src/com/google/idea/blaze/base/run/producers/BlazeFilterExistingRunConfigurationProducer.java
+++ b/base/src/com/google/idea/blaze/base/run/producers/BlazeFilterExistingRunConfigurationProducer.java
@@ -15,32 +15,25 @@
  */
 package com.google.idea.blaze.base.run.producers;
 
-import com.google.common.collect.ImmutableList;
 import com.google.idea.blaze.base.command.BlazeCommandName;
-import com.google.idea.blaze.base.command.BlazeFlags;
-import com.google.idea.blaze.base.model.primitives.TargetExpression;
+import com.google.idea.blaze.base.execution.BlazeParametersListUtil;
 import com.google.idea.blaze.base.run.BlazeCommandRunConfiguration;
 import com.google.idea.blaze.base.run.BlazeCommandRunConfigurationType;
 import com.google.idea.blaze.base.run.smrunner.BlazeTestEventsHandler;
 import com.google.idea.blaze.base.run.smrunner.SmRunnerUtils;
 import com.google.idea.blaze.base.run.state.BlazeCommandRunConfigurationCommonState;
-import com.intellij.execution.Location;
 import com.intellij.execution.actions.ConfigurationContext;
-import com.intellij.execution.configurations.RunConfiguration;
 import com.intellij.openapi.util.Ref;
 import com.intellij.psi.PsiElement;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
 /**
- * Handles the specific case where the user creates a run configuration by selecting test suites /
- * classes / methods from the test UI tree.
+ * Handles the specific case where the user creates a run configuration by selecting test suites / classes / methods
+ * from the test UI tree.
  *
  * <p>In this special case we already know the blaze target string, and only need to apply a filter
- * to the existing configuration. Delegates language-specific filter calculation to {@link
- * BlazeTestEventsHandler}.
+ * to the existing configuration. Delegates language-specific filter calculation to {@link BlazeTestEventsHandler}.
  */
 public class BlazeFilterExistingRunConfigurationProducer
     extends BlazeRunConfigurationProducer<BlazeCommandRunConfiguration> {
@@ -53,64 +46,57 @@ public class BlazeFilterExistingRunConfigurationProducer
   protected boolean doSetupConfigFromContext(
       BlazeCommandRunConfiguration configuration,
       ConfigurationContext context,
-      Ref<PsiElement> sourceElement) {
-    Optional<String> testFilter = getTestFilter(context);
-    if (!testFilter.isPresent()) {
+      Ref<PsiElement> sourceElement
+  ) {
+    final var testFilterFlag = getTestFilter(context);
+    if (testFilterFlag.isEmpty()) {
       return false;
     }
-    BlazeCommandRunConfigurationCommonState handlerState =
-        configuration.getHandlerStateIfType(BlazeCommandRunConfigurationCommonState.class);
-    if (handlerState == null
-        || !BlazeCommandName.TEST.equals(handlerState.getCommandState().getCommand())) {
-      return false;
-    }
-    // replace old test filter flag if present
-    List<String> flags = new ArrayList<>(handlerState.getBlazeFlagsState().getRawFlags());
-    flags.removeIf((flag) -> flag.startsWith(BlazeFlags.TEST_FILTER));
-    flags.add(testFilter.get());
 
-    if (SmRunnerUtils.countSelectedTestCases(context) == 1
-        && !flags.contains(BlazeFlags.DISABLE_TEST_SHARDING)) {
-      flags.add(BlazeFlags.DISABLE_TEST_SHARDING);
+    final var handlerState = configuration.getHandlerStateIfType(BlazeCommandRunConfigurationCommonState.class);
+    if (handlerState == null || !BlazeCommandName.TEST.equals(handlerState.getCommandState().getCommand())) {
+      return false;
     }
-    handlerState.getBlazeFlagsState().setRawFlags(flags);
+
+    handlerState.getTestFilterState().setTestFilter(testFilterFlag.get());
     configuration.setName(configuration.getName() + " (filtered)");
     configuration.setNameChangedByUser(true);
+
     return true;
   }
 
   @Override
-  protected boolean doIsConfigFromContext(
-      BlazeCommandRunConfiguration configuration, ConfigurationContext context) {
-    Optional<String> testFilter = getTestFilter(context);
-    if (!testFilter.isPresent()) {
+  protected boolean doIsConfigFromContext(BlazeCommandRunConfiguration configuration, ConfigurationContext context) {
+    final var testFilterFlag = getTestFilter(context);
+    if (testFilterFlag.isEmpty()) {
       return false;
     }
-    BlazeCommandRunConfigurationCommonState handlerState =
-        configuration.getHandlerStateIfType(BlazeCommandRunConfigurationCommonState.class);
+
+    final var handlerState = configuration.getHandlerStateIfType(BlazeCommandRunConfigurationCommonState.class);
 
     return handlerState != null
         && Objects.equals(handlerState.getCommandState().getCommand(), BlazeCommandName.TEST)
-        && Objects.equals(testFilter.get(), handlerState.getTestFilterFlag());
+        && Objects.equals(testFilterFlag.get(), handlerState.getTestFilterState().getTestFilter());
   }
 
   private static Optional<String> getTestFilter(ConfigurationContext context) {
-    RunConfiguration base = context.getOriginalConfiguration(null);
+    final var base = context.getOriginalConfiguration(null);
     if (!(base instanceof BlazeCommandRunConfiguration)) {
       return Optional.empty();
     }
-    ImmutableList<? extends TargetExpression> targets =
-        ((BlazeCommandRunConfiguration) base).getTargets();
+
+    final var targets = ((BlazeCommandRunConfiguration) base).getTargets();
     if (targets.isEmpty()) {
       return Optional.empty();
     }
-    List<Location<?>> selectedElements = SmRunnerUtils.getSelectedSmRunnerTreeElements(context);
+
+    final var selectedElements = SmRunnerUtils.getSelectedSmRunnerTreeElements(context);
     if (selectedElements.isEmpty()) {
       return Optional.empty();
     }
-    Optional<BlazeTestEventsHandler> testEventsHandler =
-        BlazeTestEventsHandler.getHandlerForTargets(context.getProject(), targets);
-    return testEventsHandler.map(
-        handler -> handler.getTestFilter(context.getProject(), selectedElements));
+
+    return BlazeTestEventsHandler.getHandlerForTargets(context.getProject(), targets)
+        .map(handler -> handler.getTestFilter(context.getProject(), selectedElements))
+        .map(BlazeParametersListUtil::decodeTestFilterFlag);
   }
 }

--- a/base/src/com/google/idea/blaze/base/run/producers/PendingAsyncTestContext.java
+++ b/base/src/com/google/idea/blaze/base/run/producers/PendingAsyncTestContext.java
@@ -15,7 +15,6 @@
  */
 package com.google.idea.blaze.base.run.producers;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -52,7 +51,7 @@ class PendingAsyncTestContext extends TestContext implements PendingRunConfigura
       ImmutableSet<ExecutorType> supportedExecutors,
       ListenableFuture<TargetInfo> target,
       PsiElement sourceElement,
-      ImmutableList<BlazeFlagsModification> blazeFlags,
+      @Nullable String testFilter,
       @Nullable String description) {
     Project project = sourceElement.getProject();
     String buildSystem = Blaze.buildSystemName(project);
@@ -67,14 +66,14 @@ class PendingAsyncTestContext extends TestContext implements PendingRunConfigura
               }
               RunConfigurationContext context =
                   PendingWebTestContext.findWebTestContext(
-                      project, supportedExecutors, t, sourceElement, blazeFlags, description);
+                      project, supportedExecutors, t, sourceElement, testFilter, description);
               return context != null
                   ? context
-                  : new KnownTargetTestContext(t, sourceElement, blazeFlags, description);
+                  : new KnownTargetTestContext(t, sourceElement, testFilter, description);
             },
             PooledThreadExecutor.INSTANCE);
     return new PendingAsyncTestContext(
-        supportedExecutors, future, progressMessage, sourceElement, blazeFlags, description);
+        supportedExecutors, future, progressMessage, sourceElement, testFilter, description);
   }
 
   private final ImmutableSet<ExecutorType> supportedExecutors;
@@ -86,9 +85,9 @@ class PendingAsyncTestContext extends TestContext implements PendingRunConfigura
       ListenableFuture<RunConfigurationContext> future,
       String progressMessage,
       PsiElement sourceElement,
-      ImmutableList<BlazeFlagsModification> blazeFlags,
+      @Nullable String testFilter,
       @Nullable String description) {
-    super(sourceElement, blazeFlags, description);
+    super(sourceElement, testFilter, description);
     this.supportedExecutors = supportedExecutors;
     this.future = recursivelyResolveContext(future);
     this.progressMessage = progressMessage;

--- a/base/src/com/google/idea/blaze/base/run/producers/PendingWebTestContext.java
+++ b/base/src/com/google/idea/blaze/base/run/producers/PendingWebTestContext.java
@@ -68,7 +68,7 @@ public class PendingWebTestContext extends TestContext implements PendingRunConf
       ImmutableSet<ExecutorType> supportedExecutors,
       TargetInfo target,
       PsiElement sourceElement,
-      ImmutableList<BlazeFlagsModification> blazeFlags,
+      @Nullable String testFilter,
       @Nullable String description) {
     if (!findWebTestContext.getValue()) {
       return null;
@@ -82,10 +82,10 @@ public class PendingWebTestContext extends TestContext implements PendingRunConf
       return null;
     } else if (wrapperTests.size() == 1) {
       return new KnownTargetTestContext(
-          wrapperTests.get(0), sourceElement, blazeFlags, description);
+          wrapperTests.get(0), sourceElement, testFilter, description);
     }
     return new PendingWebTestContext(
-        wrapperTests, supportedExecutors, sourceElement, blazeFlags, description);
+        wrapperTests, supportedExecutors, sourceElement, testFilter, description);
   }
 
   private final ImmutableList<TargetInfo> wrapperTests;
@@ -95,9 +95,9 @@ public class PendingWebTestContext extends TestContext implements PendingRunConf
       ImmutableList<TargetInfo> wrapperTests,
       ImmutableSet<ExecutorType> supportedExecutors,
       PsiElement sourceElement,
-      ImmutableList<BlazeFlagsModification> blazeFlags,
+      @Nullable String testFilter,
       @Nullable String description) {
-    super(sourceElement, blazeFlags, description);
+    super(sourceElement, testFilter, description);
     this.wrapperTests = wrapperTests;
     this.supportedExecutors = supportedExecutors;
   }
@@ -170,7 +170,7 @@ public class PendingWebTestContext extends TestContext implements PendingRunConf
     // Changing the description here prevents rerun,
     // due to RunnerAndConfigurationSettings being tied to description.
     RunConfigurationContext context =
-        new KnownTargetTestContext(wrapperTest, sourceElement, blazeFlags, description);
+        new KnownTargetTestContext(wrapperTest, sourceElement, testFilter, description);
     if (context.setupRunConfiguration(config)) {
       config.clearPendingContext();
       rerun.run();

--- a/base/src/com/google/idea/blaze/base/run/producers/RunConfigurationContext.java
+++ b/base/src/com/google/idea/blaze/base/run/producers/RunConfigurationContext.java
@@ -100,7 +100,7 @@ public interface RunConfigurationContext {
         }
         return Objects.equals(handlerState.getCommandState().getCommand(), command)
             && Objects.equals(config.getTargets(), ImmutableList.of(target))
-            && handlerState.getTestFilterFlag() == null;
+            && handlerState.getTestFilterState().getTestFilter() == null;
       }
     };
   }

--- a/base/src/com/google/idea/blaze/base/run/producers/TestContext.java
+++ b/base/src/com/google/idea/blaze/base/run/producers/TestContext.java
@@ -16,38 +16,34 @@
 package com.google.idea.blaze.base.run.producers;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.idea.blaze.base.command.BlazeCommandName;
-import com.google.idea.blaze.base.command.BlazeFlags;
 import com.google.idea.blaze.base.dependencies.TargetInfo;
-import com.google.idea.blaze.base.execution.BlazeParametersListUtil;
 import com.google.idea.blaze.base.run.BlazeCommandRunConfiguration;
 import com.google.idea.blaze.base.run.BlazeConfigurationNameBuilder;
 import com.google.idea.blaze.base.run.ExecutorType;
 import com.google.idea.blaze.base.run.state.BlazeCommandRunConfigurationCommonState;
-import com.google.idea.blaze.base.run.state.RunConfigurationFlagsState;
 import com.intellij.psi.PsiElement;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 import javax.annotation.Nullable;
 
 /** A context related to a blaze test target, used to configure a run configuration. */
 public abstract class TestContext implements RunConfigurationContext {
-  final PsiElement sourceElement;
-  final ImmutableList<BlazeFlagsModification> blazeFlags;
-  @Nullable final String description;
 
-  TestContext(
-      PsiElement sourceElement,
-      ImmutableList<BlazeFlagsModification> blazeFlags,
-      @Nullable String description) {
+  final PsiElement sourceElement;
+
+  @Nullable
+  final String testFilter;
+
+  @Nullable
+  final String description;
+
+  TestContext(PsiElement sourceElement, @Nullable String testFilter, @Nullable String description) {
     this.sourceElement = sourceElement;
-    this.blazeFlags = blazeFlags;
+    this.testFilter = testFilter;
     this.description = description;
   }
 
@@ -69,10 +65,7 @@ public abstract class TestContext implements RunConfigurationContext {
       return false;
     }
     commonState.getCommandState().setCommand(BlazeCommandName.TEST);
-
-    List<String> flags = new ArrayList<>(commonState.getBlazeFlagsState().getRawFlags());
-    blazeFlags.forEach(m -> m.modifyFlags(flags));
-    commonState.getBlazeFlagsState().setRawFlags(flags);
+    commonState.getTestFilterState().setTestFilter(testFilter);
 
     if (description != null) {
       BlazeConfigurationNameBuilder nameBuilder = new BlazeConfigurationNameBuilder(config);
@@ -96,9 +89,7 @@ public abstract class TestContext implements RunConfigurationContext {
     if (!Objects.equals(commonState.getCommandState().getCommand(), BlazeCommandName.TEST)) {
       return false;
     }
-    RunConfigurationFlagsState flagsState = commonState.getBlazeFlagsState();
-    return matchesTarget(config)
-        && blazeFlags.stream().allMatch(m -> m.matchesConfigState(flagsState));
+    return matchesTarget(config) && Objects.equals(testFilter, commonState.getTestFilterState().getTestFilter());
   }
 
   /** Returns true if the target is successfully set up. */
@@ -108,14 +99,16 @@ public abstract class TestContext implements RunConfigurationContext {
   abstract boolean matchesTarget(BlazeCommandRunConfiguration config);
 
   static class KnownTargetTestContext extends TestContext {
+
     final TargetInfo target;
 
     KnownTargetTestContext(
         TargetInfo target,
         PsiElement sourceElement,
-        ImmutableList<BlazeFlagsModification> blazeFlags,
-        @Nullable String description) {
-      super(sourceElement, blazeFlags, description);
+        @Nullable String testFilter,
+        @Nullable String description
+    ) {
+      super(sourceElement, testFilter, description);
       this.target = target;
     }
 
@@ -131,70 +124,6 @@ public abstract class TestContext implements RunConfigurationContext {
     }
   }
 
-  /**
-   * A modification to the blaze flags list for a run configuration. For example, setting a test
-   * filter.
-   */
-  public interface BlazeFlagsModification {
-    void modifyFlags(List<String> flags);
-
-    boolean matchesConfigState(RunConfigurationFlagsState state);
-
-    static BlazeFlagsModification addFlagIfNotPresent(String flag) {
-      return new BlazeFlagsModification() {
-        @Override
-        public void modifyFlags(List<String> flags) {
-          if (!flags.contains(flag)) {
-            flags.add(flag);
-          }
-        }
-
-        @Override
-        public boolean matchesConfigState(RunConfigurationFlagsState state) {
-          return state.getRawFlags().contains(flag);
-        }
-      };
-    }
-
-    static BlazeFlagsModification testFilter(String filter) {
-      return new BlazeFlagsModification() {
-        @Override
-        public void modifyFlags(List<String> flags) {
-          // remove old test filter flag if present
-          flags.removeIf((flag) -> flag.startsWith(BlazeFlags.TEST_FILTER));
-          if (filter != null) {
-            flags.add(BlazeFlags.TEST_FILTER + "=" + BlazeParametersListUtil.encodeParam(filter));
-          }
-        }
-
-        @Override
-        public boolean matchesConfigState(RunConfigurationFlagsState state) {
-          return state
-              .getRawFlags()
-              .contains(BlazeFlags.TEST_FILTER + "=" + BlazeParametersListUtil.encodeParam(filter));
-        }
-      };
-    }
-
-    static BlazeFlagsModification testEnv(String testEnv) {
-      return new BlazeFlagsModification() {
-        @Override
-        public void modifyFlags(List<String> flags) {
-          if (testEnv != null) {
-            flags.add(BlazeFlags.TEST_ENV + "=" + BlazeParametersListUtil.encodeParam(testEnv));
-          }
-        }
-
-        @Override
-        public boolean matchesConfigState(RunConfigurationFlagsState state) {
-          return state
-              .getRawFlags()
-              .contains(BlazeFlags.TEST_ENV + "=" + BlazeParametersListUtil.encodeParam(testEnv));
-        }
-      };
-    }
-  }
-
   public static Builder builder(
       PsiElement sourceElement, ImmutableSet<ExecutorType> supportedExecutors) {
     return new Builder(sourceElement, supportedExecutors);
@@ -202,12 +131,16 @@ public abstract class TestContext implements RunConfigurationContext {
 
   /** Builder class for {@link TestContext}. */
   public static class Builder {
+
     private final PsiElement sourceElement;
     private final ImmutableSet<ExecutorType> supportedExecutors;
     private ListenableFuture<RunConfigurationContext> contextFuture = null;
     private ListenableFuture<TargetInfo> targetFuture = null;
-    private final ImmutableList.Builder<BlazeFlagsModification> blazeFlags =
-        ImmutableList.builder();
+
+    @Nullable
+    private String testFilter = null;
+
+    @Nullable
     private String description = null;
 
     private Builder(PsiElement sourceElement, ImmutableSet<ExecutorType> supportedExecutors) {
@@ -235,26 +168,13 @@ public abstract class TestContext implements RunConfigurationContext {
 
     @CanIgnoreReturnValue
     public Builder setTestFilter(@Nullable String filter) {
-      if (filter != null) {
-        blazeFlags.add(BlazeFlagsModification.testFilter(filter));
-      }
-      return this;
-    }
-
-    @CanIgnoreReturnValue
-    public Builder addBlazeFlagsModification(BlazeFlagsModification modification) {
-      this.blazeFlags.add(modification);
+      this.testFilter = filter;
       return this;
     }
 
     @CanIgnoreReturnValue
     public Builder setDescription(String description) {
       this.description = description;
-      return this;
-    }
-
-    public Builder addTestEnv(String env) {
-      this.blazeFlags.add(BlazeFlagsModification.testEnv(env));
       return this;
     }
 
@@ -266,12 +186,12 @@ public abstract class TestContext implements RunConfigurationContext {
             contextFuture,
             "Resolving test context",
             sourceElement,
-            blazeFlags.build(),
+            testFilter,
             description);
       }
       Preconditions.checkState(targetFuture != null);
       return PendingAsyncTestContext.fromTargetFuture(
-          supportedExecutors, targetFuture, sourceElement, blazeFlags.build(), description);
+          supportedExecutors, targetFuture, sourceElement, testFilter, description);
     }
   }
 }

--- a/base/src/com/google/idea/blaze/base/run/smrunner/BlazeRerunFailedTestsAction.java
+++ b/base/src/com/google/idea/blaze/base/run/smrunner/BlazeRerunFailedTestsAction.java
@@ -16,7 +16,7 @@
 package com.google.idea.blaze.base.run.smrunner;
 
 import com.google.idea.blaze.base.command.BlazeCommandName;
-import com.google.idea.blaze.base.command.BlazeFlags;
+import com.google.idea.blaze.base.execution.BlazeParametersListUtil;
 import com.google.idea.blaze.base.run.BlazeCommandRunConfiguration;
 import com.google.idea.blaze.base.run.state.BlazeCommandRunConfigurationCommonState;
 import com.intellij.execution.ExecutionException;
@@ -31,7 +31,6 @@ import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.ComponentContainer;
 import com.intellij.psi.search.GlobalSearchScope;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -76,49 +75,32 @@ public class BlazeRerunFailedTestsAction extends AbstractRerunFailedTestsAction 
 
     @Nullable
     @Override
-    public RunProfileState getState(Executor executor, ExecutionEnvironment environment)
-        throws ExecutionException {
-      BlazeCommandRunConfigurationCommonState handlerState =
-          configuration.getHandlerStateIfType(BlazeCommandRunConfigurationCommonState.class);
-      if (handlerState == null
-          || !BlazeCommandName.TEST.equals(handlerState.getCommandState().getCommand())) {
+    public RunProfileState getState(Executor executor, ExecutionEnvironment environment) throws ExecutionException {
+      final var handlerState = configuration.getHandlerStateIfType(BlazeCommandRunConfigurationCommonState.class);
+      if (handlerState == null || !BlazeCommandName.TEST.equals(handlerState.getCommandState().getCommand())) {
         return null;
       }
-      Project project = getProject();
-      List<Location<?>> locations =
-          getFailedTests(project)
-              .stream()
-              .filter(AbstractTestProxy::isLeaf)
-              .map((test) -> toLocation(project, test))
-              .filter(Objects::nonNull)
-              .collect(Collectors.toList());
-      String testFilter = eventsHandler.getTestFilter(getProject(), locations);
-      if (testFilter == null) {
+
+      final var project = getProject();
+
+      final List<Location<?>> locations = getFailedTests(project).stream()
+          .filter(AbstractTestProxy::isLeaf)
+          .map((test) -> toLocation(project, test))
+          .filter(Objects::nonNull)
+          .collect(Collectors.toList());
+
+      final var testFilterFlag = eventsHandler.getTestFilter(project, locations);
+      if (testFilterFlag == null) {
         return null;
       }
-      List<String> blazeFlags =
-          setTestFilter(handlerState.getBlazeFlagsState().getRawFlags(), testFilter);
-      handlerState.getBlazeFlagsState().setRawFlags(blazeFlags);
+
+      handlerState.getTestFilterState().setTestFilter(BlazeParametersListUtil.decodeTestFilterFlag(testFilterFlag));
       return configuration.getState(executor, environment);
     }
 
     @Nullable
     private Location<?> toLocation(Project project, AbstractTestProxy test) {
       return test.getLocation(project, GlobalSearchScope.allScope(project));
-    }
-
-    /** Replaces existing test_filter flag, or appends if none exists. */
-    private List<String> setTestFilter(List<String> flags, String testFilter) {
-      List<String> copy = new ArrayList<>(flags);
-      for (int i = 0; i < copy.size(); i++) {
-        String flag = copy.get(i);
-        if (flag.startsWith(BlazeFlags.TEST_FILTER)) {
-          copy.set(i, testFilter);
-          return copy;
-        }
-      }
-      copy.add(testFilter);
-      return copy;
     }
   }
 }

--- a/base/src/com/google/idea/blaze/base/run/state/BlazeCommandRunConfigurationCommonState.java
+++ b/base/src/com/google/idea/blaze/base/run/state/BlazeCommandRunConfigurationCommonState.java
@@ -15,49 +15,55 @@
  */
 package com.google.idea.blaze.base.run.state;
 
-import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.collect.ImmutableList.toImmutableList;
-
 import com.google.common.collect.ImmutableList;
 import com.google.idea.blaze.base.command.BlazeFlags;
+import com.google.idea.blaze.base.execution.BlazeParametersListUtil;
 import com.google.idea.blaze.base.settings.BuildSystemName;
 import com.intellij.execution.configurations.RuntimeConfigurationError;
 import com.intellij.execution.configurations.RuntimeConfigurationException;
 import com.intellij.openapi.actionSystem.DataKey;
 import com.intellij.openapi.project.Project;
-import java.io.File;
+import java.util.ArrayList;
 import javax.annotation.Nullable;
+import org.jdom.Element;
 
 /**
  * Shared state common to several {@link
  * com.google.idea.blaze.base.run.confighandler.BlazeCommandRunConfigurationHandler} types.
  */
 public class BlazeCommandRunConfigurationCommonState extends RunConfigurationCompositeState {
-  public static final DataKey<String[]> USER_BLAZE_FLAG = DataKey.create("blaze-user-flag");
   public static final DataKey<String[]> USER_EXE_FLAG = DataKey.create("blaze-user-exe-flag");
 
-  private static final String TEST_FILTER_FLAG_PREFIX = BlazeFlags.TEST_FILTER + '=';
+  private static final String LEGACY_USER_FLAG_TAG = "blaze-user-flag";
+  private static final String TEST_FILTER_FLAG_PREFIX = BlazeFlags.TEST_FILTER + "=";
+  private static final String TEST_ARG_FLAG_PREFIX = BlazeFlags.TEST_ARG + "=";
 
   protected final BlazeCommandState command;
-  protected final RunConfigurationFlagsState blazeFlags;
+  protected final TestFilterState testFilter;
   protected final RunConfigurationFlagsState exeFlags;
   protected final EnvironmentVariablesState envVars;
 
+  /**
+   * Flags found in legacy {@code <blaze-user-flag>} XML elements that didn't migrate into a known
+   * state (i.e. weren't {@code --test_filter=...}). Captured at read time so the migration notifier
+   * can surface them to the user.
+   */
+  private ImmutableList<String> legacyUserFlags = ImmutableList.of();
+
   public BlazeCommandRunConfigurationCommonState(BuildSystemName buildSystemName) {
     command = new BlazeCommandState();
-    blazeFlags = new RunConfigurationFlagsState(USER_BLAZE_FLAG, buildSystemName + " flags:");
+    testFilter = new TestFilterState();
     exeFlags = new RunConfigurationFlagsState(USER_EXE_FLAG, "Executable flags:");
     envVars = new EnvironmentVariablesState();
   }
 
   @Override
   protected ImmutableList<RunConfigurationState> initializeStates() {
-    return ImmutableList.of(command, blazeFlags, exeFlags, envVars);
+    return ImmutableList.of(command, testFilter, exeFlags, envVars);
   }
 
-  /** @return The list of blaze flags that the user specified manually. */
-  public RunConfigurationFlagsState getBlazeFlagsState() {
-    return blazeFlags;
+  public TestFilterState getTestFilterState() {
+    return testFilter;
   }
 
   /** @return The list of executable flags the user specified manually. */
@@ -74,44 +80,71 @@ public class BlazeCommandRunConfigurationCommonState extends RunConfigurationCom
     return command;
   }
 
-  /** Searches through all blaze flags for the first one beginning with '--test_filter' */
+  /** Returns the {@code --test_filter=<encoded>} flag for inclusion on a Bazel command line. */
   @Nullable
   public String getTestFilterFlag() {
-    for (String flag : getBlazeFlagsState().getRawFlags()) {
-      if (flag.startsWith(BlazeFlags.TEST_FILTER)) {
-        return flag;
-      }
-    }
-    return null;
+    return testFilter.getTestFilterFlag();
   }
 
   /**
    * The actual test filter value intended to be passed directly to external processes or
-   * environment variables.
-   *
-   * <p>Unlike {@link #getTestFilterFlag()}, this is not a flag intended to be used on the command
-   * line, so the shell-escaping/quoting has been removed.
+   * environment variables. Unlike {@link #getTestFilterFlag()}, this has no shell escaping or
+   * quoting.
    */
   @Nullable
   public String getTestFilterForExternalProcesses() {
-    String testFilterFlag =
-        getBlazeFlagsState().getFlagsForExternalProcesses().stream()
-            .filter(flag -> flag.startsWith(BlazeFlags.TEST_FILTER))
-            .findFirst()
-            .orElse(null);
-    if (testFilterFlag == null) {
-      return null;
-    }
-
-    checkState(testFilterFlag.startsWith(TEST_FILTER_FLAG_PREFIX));
-    return testFilterFlag.substring(TEST_FILTER_FLAG_PREFIX.length());
+    return testFilter.getTestFilter();
   }
 
-  public ImmutableList<String> getTestArgs() {
-    return getBlazeFlagsState().getRawFlags().stream()
-        .filter(f -> f.startsWith(BlazeFlags.TEST_ARG))
-        .map(f -> f.substring(BlazeFlags.TEST_ARG.length()))
-        .collect(toImmutableList());
+  /**
+   * Legacy {@code <blaze-user-flag>} entries that couldn't be migrated to a typed state. Cleared
+   * by the migration notifier after the user moves them to the project view file.
+   */
+  public ImmutableList<String> getLegacyUserFlags() {
+    return legacyUserFlags;
+  }
+
+  public void clearLegacyUserFlags() {
+    legacyUserFlags = ImmutableList.of();
+  }
+
+  @Override
+  protected void migrate(Element element) {
+    final var legacy = new ArrayList<>(element.getChildren(LEGACY_USER_FLAG_TAG));
+    if (legacy.isEmpty()) {
+      return;
+    }
+
+    final var leftovers = new ArrayList<String>();
+    final var testArgs = new ArrayList<String>();
+
+    String filter = null;
+    for (final var child : legacy) {
+      final var raw = child.getTextTrim();
+      if (raw == null || raw.isEmpty()) {
+        continue;
+      }
+
+      if (raw.startsWith(TEST_FILTER_FLAG_PREFIX)) {
+        // last-wins, matching Bazel's repeated-flag semantics
+        filter = BlazeParametersListUtil.decodeTestFilterFlag(raw);
+      } else if (raw.startsWith(TEST_ARG_FLAG_PREFIX)) {
+        // multiple uses are accumulated
+        testArgs.add(raw.substring(TEST_ARG_FLAG_PREFIX.length()));
+      } else {
+        leftovers.add(raw);
+      }
+    }
+
+    if (filter != null) {
+      testFilter.setTestFilter(filter);
+    }
+    if (!testArgs.isEmpty()) {
+      exeFlags.setRawFlags(testArgs);
+    }
+
+    legacyUserFlags = ImmutableList.copyOf(leftovers);
+    element.removeChildren(LEGACY_USER_FLAG_TAG);
   }
 
   public void validate(BuildSystemName buildSystemName) throws RuntimeConfigurationException {
@@ -122,6 +155,6 @@ public class BlazeCommandRunConfigurationCommonState extends RunConfigurationCom
 
   @Override
   public RunConfigurationStateEditor getEditor(Project project) {
-    return new RunConfigurationCompositeStateEditor(project, getStates());
+    return new BlazeCommandRunConfigurationCommonStateEditor(project, getStates());
   }
 }

--- a/base/src/com/google/idea/blaze/base/run/state/BlazeCommandRunConfigurationCommonState.java
+++ b/base/src/com/google/idea/blaze/base/run/state/BlazeCommandRunConfigurationCommonState.java
@@ -139,8 +139,8 @@ public class BlazeCommandRunConfigurationCommonState extends RunConfigurationCom
     if (filter != null) {
       testFilter.setTestFilter(filter);
     }
-    if (!testArgs.isEmpty()) {
-      exeFlags.setRawFlags(testArgs);
+    for (String testArg : testArgs) {
+      element.addContent(new Element(USER_EXE_FLAG.getName()).setText(testArg));
     }
 
     legacyUserFlags = ImmutableList.copyOf(leftovers);

--- a/base/src/com/google/idea/blaze/base/run/state/BlazeCommandRunConfigurationCommonStateEditor.kt
+++ b/base/src/com/google/idea/blaze/base/run/state/BlazeCommandRunConfigurationCommonStateEditor.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.run.state
+
+import com.google.idea.blaze.base.command.BlazeCommandName
+import com.google.idea.blaze.base.run.state.RunConfigurationCompositeState.RunConfigurationCompositeStateEditor
+import com.google.idea.blaze.base.run.state.TestFilterState.TestFilterStateEditor
+import com.intellij.openapi.project.Project
+
+/**
+ * Composite editor for [BlazeCommandRunConfigurationCommonState] that toggles the test
+ * filter field's visibility based on whether the currently selected Bazel command is `test`.
+ */
+internal class BlazeCommandRunConfigurationCommonStateEditor(
+  project: Project,
+  states: MutableList<RunConfigurationState>
+) : RunConfigurationCompositeStateEditor(project, states) {
+
+  private val testFilterEditor: TestFilterStateEditor?
+
+  init {
+    testFilterEditor = findEditor<TestFilterStateEditor>()
+    findEditor<BlazeCommandState.BlazeCommandStateEditor>()?.addCommandChangeListener(::updateTestFilterVisibility)
+  }
+
+  override fun resetEditorFrom(genericState: RunConfigurationState?) {
+    super.resetEditorFrom(genericState)
+
+    if (genericState is BlazeCommandRunConfigurationCommonState) {
+      updateTestFilterVisibility(genericState.commandState.command)
+    }
+  }
+
+  private fun updateTestFilterVisibility(command: BlazeCommandName?) {
+    testFilterEditor?.setComponentVisible(BlazeCommandName.TEST == command)
+  }
+
+  private inline fun <reified T : RunConfigurationStateEditor> findEditor(): T? {
+    return editors.filterIsInstance<T>().firstOrNull()
+  }
+}

--- a/base/src/com/google/idea/blaze/base/run/state/BlazeCommandState.java
+++ b/base/src/com/google/idea/blaze/base/run/state/BlazeCommandState.java
@@ -21,17 +21,24 @@ import com.google.idea.blaze.base.settings.Blaze;
 import com.google.idea.blaze.base.ui.UiUtil;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.ComboBox;
-import javax.annotation.Nullable;
+import java.awt.event.ItemEvent;
+import java.util.function.Consumer;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import javax.swing.text.JTextComponent;
 import org.jdom.Element;
+import org.jetbrains.annotations.Nullable;
 
 /** State for a {@link BlazeCommandName}. */
 public final class BlazeCommandState implements RunConfigurationState {
+
   private static final String COMMAND_ATTR = "blaze-command";
 
-  @Nullable private BlazeCommandName command;
+  @Nullable
+  private BlazeCommandName command;
 
   public BlazeCommandState() {}
 
@@ -65,7 +72,8 @@ public final class BlazeCommandState implements RunConfigurationState {
     return new BlazeCommandStateEditor(project);
   }
 
-  private static class BlazeCommandStateEditor implements RunConfigurationStateEditor {
+  static class BlazeCommandStateEditor implements RunConfigurationStateEditor {
+
     private final String buildSystemName;
 
     private final ComboBox<?> commandCombo;
@@ -76,6 +84,50 @@ public final class BlazeCommandState implements RunConfigurationState {
           new ComboBox<>(new DefaultComboBoxModel<>(BlazeCommandName.knownCommands().toArray()));
       // Allow the user to manually specify an unlisted command.
       commandCombo.setEditable(true);
+    }
+
+    /**
+     * Invokes {@code listener} whenever the selected command changes, either by
+     * selection or by free text edit.
+     */
+    public void addCommandChangeListener(Consumer<@Nullable BlazeCommandName> listener) {
+      commandCombo.addItemListener(event -> {
+        if (event.getStateChange() == ItemEvent.SELECTED) {
+          listener.accept(currentCommand());
+        }
+      });
+
+      final var editorComponent = commandCombo.getEditor().getEditorComponent();
+      if (editorComponent instanceof JTextComponent text) {
+        text.getDocument().addDocumentListener(
+            new DocumentListener() {
+              @Override
+              public void insertUpdate(DocumentEvent e) {
+                listener.accept(currentCommand());
+              }
+
+              @Override
+              public void removeUpdate(DocumentEvent e) {
+                listener.accept(currentCommand());
+              }
+
+              @Override
+              public void changedUpdate(DocumentEvent e) {
+                listener.accept(currentCommand());
+              }
+            });
+      }
+    }
+
+    @Nullable
+    private BlazeCommandName currentCommand() {
+      final var selected = commandCombo.getSelectedItem();
+      if (selected instanceof BlazeCommandName name) {
+        return name;
+      }
+
+      final var text = selected == null ? null : selected.toString();
+      return Strings.isNullOrEmpty(text) ? null : BlazeCommandName.fromString(text);
     }
 
     @Override

--- a/base/src/com/google/idea/blaze/base/run/state/LegacyBlazeFlagsMigrationDialog.kt
+++ b/base/src/com/google/idea/blaze/base/run/state/LegacyBlazeFlagsMigrationDialog.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.run.state
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.components.JBTextArea
+import com.intellij.ui.dsl.builder.Align
+import com.intellij.ui.dsl.builder.panel
+import java.awt.Font
+import javax.swing.JComponent
+import javax.swing.SwingConstants
+
+private const val DIALOG_TITLE = "Bazel run-config flags removed"
+private const val OK_BUTTON_TEXT = "Move to .bazelproject"
+private const val CANCEL_BUTTON_TEXT = "Dismiss"
+
+private const val OUTPUT_ROWS = 12
+private const val OUTPUT_COLUMNS = 60
+
+/** Shows the migration dialog on the EDT and returns the chosen exit code. */
+internal fun showLegacyBlazeFlagsMigrationDialog(
+  project: Project,
+  affected: Map<String, List<String>>,
+): Int {
+  var exitCode = DialogWrapper.CANCEL_EXIT_CODE
+  ApplicationManager.getApplication().invokeAndWait {
+    val dialog = LegacyBlazeFlagsMigrationDialog(project, affected)
+    dialog.show()
+    exitCode = dialog.exitCode
+  }
+
+  return exitCode
+}
+
+/** Pure rendering of the affected configurations into the terminal-style block shown to the user. */
+private fun renderAffected(affected: Map<String, List<String>>): String =
+  affected.entries.joinToString("\n\n") { (name, flags) ->
+    val body = flags.joinToString("\n") { "  -> $it" }
+    "$name:\n$body"
+  }
+
+private class LegacyBlazeFlagsMigrationDialog(
+  project: Project,
+  private val affected: Map<String, List<String>>,
+) : DialogWrapper(project) {
+
+  init {
+    title = DIALOG_TITLE
+    setOKButtonText(OK_BUTTON_TEXT)
+    setCancelButtonText(CANCEL_BUTTON_TEXT)
+    init()
+  }
+
+  override fun createCenterPanel(): JComponent = panel {
+    row {
+      text(
+        "The user-editable \"Bazel flags\" field on run configurations was removed. " +
+            "Each affected configuration's remaining flags are listed below:"
+      )
+    }
+    row {
+      val textArea = JBTextArea(renderAffected(affected), OUTPUT_ROWS, OUTPUT_COLUMNS).apply {
+        isEditable = false
+        font = Font(Font.MONOSPACED, Font.PLAIN, font.size)
+      }
+      cell(JBScrollPane(textArea)).align(Align.FILL)
+    }.resizableRow()
+  }
+}

--- a/base/src/com/google/idea/blaze/base/run/state/LegacyBlazeFlagsMigrationNotifier.kt
+++ b/base/src/com/google/idea/blaze/base/run/state/LegacyBlazeFlagsMigrationNotifier.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2026 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.run.state
+
+import com.google.idea.blaze.base.projectview.ProjectViewEdit
+import com.google.idea.blaze.base.projectview.section.ListSection
+import com.google.idea.blaze.base.projectview.section.sections.BuildFlagsSection
+import com.google.idea.blaze.base.run.BlazeCommandRunConfiguration
+import com.google.idea.blaze.base.settings.ui.OpenProjectViewAction
+import com.google.idea.blaze.base.sync.BlazeSyncManager
+import com.intellij.execution.RunManager
+import com.intellij.execution.impl.RunManagerImpl
+import com.intellij.ide.util.PropertiesComponent
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.StartupActivity
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.openapi.ui.Messages
+
+private const val SHOWN_KEY = "legacy_blaze_flags_migration_shown"
+private const val SYNC_REASON = "LegacyBlazeFlagsMigrationNotifier"
+
+/**
+ * Once per project, scans for run configurations carrying legacy `<blaze-user-flag>` entries that
+ * no longer have a typed home and offers to move them into the project view's `build_flags:`
+ * section via a modal dialog.
+ */
+class LegacyBlazeFlagsMigrationNotifier : StartupActivity.DumbAware {
+
+  override fun runActivity(project: Project) {
+    if (ApplicationManager.getApplication().isUnitTestMode) return
+    if (isLegacyMigrationShown(project)) return
+
+    val affected = collectLegacyConfigurations(project)
+    if (affected.isEmpty()) return
+
+    ApplicationManager.getApplication().invokeLater {
+      markLegacyMigrationShown(project)
+
+      val exitCode = showLegacyBlazeFlagsMigrationDialog(project, affected)
+      if (exitCode != DialogWrapper.OK_EXIT_CODE) return@invokeLater
+
+      migrateToProjectView(project, affected)
+    }
+  }
+}
+
+private fun collectLegacyConfigurations(project: Project): Map<String, List<String>> {
+  return RunManager.getInstance(project).allConfigurationsList
+    .filterIsInstance<BlazeCommandRunConfiguration>()
+    .mapNotNull { config ->
+      config.getHandlerStateIfType(BlazeCommandRunConfigurationCommonState::class.java)?.let { state ->
+        if (state.legacyUserFlags.isEmpty()) null else config.name to state.legacyUserFlags
+      }
+    }
+    .toMap()
+}
+
+private fun migrateToProjectView(project: Project, affected: Map<String, List<String>>) {
+  val deduped = affected.values.flatten().distinct()
+
+  val edit = ProjectViewEdit.editLocalProjectView(project) { builder ->
+    val existing = builder.getLast(BuildFlagsSection.KEY)
+    val updated = ListSection.update(BuildFlagsSection.KEY, existing).apply { deduped.forEach(::add) }
+    builder.replace(existing, updated)
+    true
+  }
+
+  if (edit == null) {
+    Messages.showErrorDialog(
+      project,
+      "Could not modify the project view. Check for errors and try again.",
+      "Migration Failed",
+    )
+  } else {
+    edit.apply()
+    clearLegacyFlagsFromConfigs(project)
+    OpenProjectViewAction.openLocalProjectViewFile(project)
+    BlazeSyncManager.getInstance(project).incrementalProjectSync(SYNC_REASON)
+  }
+
+}
+
+private fun clearLegacyFlagsFromConfigs(project: Project) {
+  val runManager = RunManagerImpl.getInstanceImpl(project)
+  runManager.allSettings.forEach { settings ->
+    val config = settings.configuration as? BlazeCommandRunConfiguration ?: return@forEach
+    val state = config.getHandlerStateIfType(BlazeCommandRunConfigurationCommonState::class.java)
+      ?: return@forEach
+    if (state.legacyUserFlags.isEmpty()) return@forEach
+
+    state.clearLegacyUserFlags()
+    runManager.fireRunConfigurationChanged(settings)
+  }
+}
+
+private fun isLegacyMigrationShown(project: Project): Boolean {
+  return PropertiesComponent.getInstance(project).getBoolean(SHOWN_KEY, false)
+}
+
+private fun markLegacyMigrationShown(project: Project) {
+  PropertiesComponent.getInstance(project).setValue(SHOWN_KEY, true)
+}

--- a/base/src/com/google/idea/blaze/base/run/state/LegacyBlazeFlagsMigrationNotifier.kt
+++ b/base/src/com/google/idea/blaze/base/run/state/LegacyBlazeFlagsMigrationNotifier.kt
@@ -74,7 +74,10 @@ private fun migrateToProjectView(project: Project, affected: Map<String, List<St
 
   val edit = ProjectViewEdit.editLocalProjectView(project) { builder ->
     val existing = builder.getLast(BuildFlagsSection.KEY)
-    val updated = ListSection.update(BuildFlagsSection.KEY, existing).apply { deduped.forEach(::add) }
+    val existingFlags = existing?.items()?.toSet() ?: emptySet()
+    val updated = ListSection.update(BuildFlagsSection.KEY, existing).apply {
+      deduped.filter { it !in existingFlags }.forEach(::add)
+    }
     builder.replace(existing, updated)
     true
   }

--- a/base/src/com/google/idea/blaze/base/run/state/LegacyBlazeFlagsMigrationNotifier.kt
+++ b/base/src/com/google/idea/blaze/base/run/state/LegacyBlazeFlagsMigrationNotifier.kt
@@ -25,10 +25,13 @@ import com.intellij.execution.RunManager
 import com.intellij.execution.impl.RunManagerImpl
 import com.intellij.ide.util.PropertiesComponent
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.EDT
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.startup.StartupActivity
+import com.intellij.openapi.startup.ProjectActivity
 import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.openapi.ui.Messages
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 private const val SHOWN_KEY = "legacy_blaze_flags_migration_shown"
 private const val SYNC_REASON = "LegacyBlazeFlagsMigrationNotifier"
@@ -38,20 +41,20 @@ private const val SYNC_REASON = "LegacyBlazeFlagsMigrationNotifier"
  * no longer have a typed home and offers to move them into the project view's `build_flags:`
  * section via a modal dialog.
  */
-class LegacyBlazeFlagsMigrationNotifier : StartupActivity.DumbAware {
+class LegacyBlazeFlagsMigrationNotifier : ProjectActivity {
 
-  override fun runActivity(project: Project) {
+  override suspend fun execute(project: Project) {
     if (ApplicationManager.getApplication().isUnitTestMode) return
     if (isLegacyMigrationShown(project)) return
 
     val affected = collectLegacyConfigurations(project)
     if (affected.isEmpty()) return
 
-    ApplicationManager.getApplication().invokeLater {
+    withContext(Dispatchers.EDT) {
       markLegacyMigrationShown(project)
 
       val exitCode = showLegacyBlazeFlagsMigrationDialog(project, affected)
-      if (exitCode != DialogWrapper.OK_EXIT_CODE) return@invokeLater
+      if (exitCode != DialogWrapper.OK_EXIT_CODE) return@withContext
 
       migrateToProjectView(project, affected)
     }

--- a/base/src/com/google/idea/blaze/base/run/state/LegacyBlazeFlagsMigrationNotifier.kt
+++ b/base/src/com/google/idea/blaze/base/run/state/LegacyBlazeFlagsMigrationNotifier.kt
@@ -23,8 +23,7 @@ import com.google.idea.blaze.base.settings.ui.OpenProjectViewAction
 import com.google.idea.blaze.base.sync.BlazeSyncManager
 import com.intellij.execution.RunManager
 import com.intellij.execution.impl.RunManagerImpl
-import com.intellij.ide.util.PropertiesComponent
-import com.intellij.openapi.application.ApplicationManager
+import com.intellij.ide.util.runOnceForProject
 import com.intellij.openapi.application.EDT
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.ProjectActivity
@@ -33,7 +32,7 @@ import com.intellij.openapi.ui.Messages
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-private const val SHOWN_KEY = "legacy_blaze_flags_migration_shown"
+private const val RUN_ONCE_ID = "legacy_blaze_flags_migration_shown"
 private const val SYNC_REASON = "LegacyBlazeFlagsMigrationNotifier"
 
 /**
@@ -44,19 +43,16 @@ private const val SYNC_REASON = "LegacyBlazeFlagsMigrationNotifier"
 class LegacyBlazeFlagsMigrationNotifier : ProjectActivity {
 
   override suspend fun execute(project: Project) {
-    if (ApplicationManager.getApplication().isUnitTestMode) return
-    if (isLegacyMigrationShown(project)) return
-
     val affected = collectLegacyConfigurations(project)
     if (affected.isEmpty()) return
 
-    withContext(Dispatchers.EDT) {
-      markLegacyMigrationShown(project)
+    runOnceForProject(project, RUN_ONCE_ID) {
+      withContext(Dispatchers.EDT) {
+        val exitCode = showLegacyBlazeFlagsMigrationDialog(project, affected)
+        if (exitCode != DialogWrapper.OK_EXIT_CODE) return@withContext
 
-      val exitCode = showLegacyBlazeFlagsMigrationDialog(project, affected)
-      if (exitCode != DialogWrapper.OK_EXIT_CODE) return@withContext
-
-      migrateToProjectView(project, affected)
+        migrateToProjectView(project, affected)
+      }
     }
   }
 }
@@ -111,12 +107,4 @@ private fun clearLegacyFlagsFromConfigs(project: Project) {
     state.clearLegacyUserFlags()
     runManager.fireRunConfigurationChanged(settings)
   }
-}
-
-private fun isLegacyMigrationShown(project: Project): Boolean {
-  return PropertiesComponent.getInstance(project).getBoolean(SHOWN_KEY, false)
-}
-
-private fun markLegacyMigrationShown(project: Project) {
-  PropertiesComponent.getInstance(project).setValue(SHOWN_KEY, true)
 }

--- a/base/src/com/google/idea/blaze/base/run/state/RunConfigurationCompositeState.java
+++ b/base/src/com/google/idea/blaze/base/run/state/RunConfigurationCompositeState.java
@@ -55,10 +55,14 @@ public abstract class RunConfigurationCompositeState implements RunConfiguration
 
   @Override
   public final void readExternal(Element element) throws InvalidDataException {
+    migrate(element);
     for (RunConfigurationState state : getStates()) {
       state.readExternal(element);
     }
   }
+
+  /** Hook for subclasses to migrate legacy XML representations before substates are read. */
+  protected void migrate(Element element) {}
 
   /** Updates the element with the handler's state. */
   @Override
@@ -78,8 +82,7 @@ public abstract class RunConfigurationCompositeState implements RunConfiguration
   static class RunConfigurationCompositeStateEditor implements RunConfigurationStateEditor {
     List<RunConfigurationStateEditor> editors;
 
-    public RunConfigurationCompositeStateEditor(
-        Project project, List<RunConfigurationState> states) {
+    public RunConfigurationCompositeStateEditor(Project project, List<RunConfigurationState> states) {
       editors = states.stream().map(state -> state.getEditor(project)).collect(Collectors.toList());
     }
 

--- a/base/src/com/google/idea/blaze/base/run/state/TestFilterState.kt
+++ b/base/src/com/google/idea/blaze/base/run/state/TestFilterState.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.run.state
+
+import com.google.idea.blaze.base.command.BlazeFlags
+import com.google.idea.blaze.base.execution.BlazeParametersListUtil
+import com.google.idea.blaze.base.ui.UiUtil
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.project.Project
+import com.intellij.ui.components.JBTextField
+import org.jdom.Element
+import javax.swing.JComponent
+import javax.swing.JLabel
+
+private const val TEST_FILTER_XML_TAG = "blaze-test-filter"
+
+/** State holding the Bazel `--test_filter` value for a test run configuration.  */
+class TestFilterState : RunConfigurationState {
+
+  /** The raw `--test_filter` value, or null when not set. */
+  var testFilter: String? = null
+    set (value) {
+      field = if (value.isNullOrEmpty()) null else value
+    }
+
+  /** The rendered `--test_filter=<encoded>` flag, or null when not set.  */
+  val testFilterFlag: String?
+    get() {
+      if (testFilter == null) {
+        return null
+      }
+
+      return BlazeParametersListUtil.encodeTestFilterFlag(testFilter)
+    }
+
+  override fun readContext(context: DataContext?) {}
+
+  override fun readExternal(element: Element) {
+    element.getChild(TEST_FILTER_XML_TAG)?.let { testFilter = it.textTrim }
+  }
+
+  override fun writeExternal(element: Element) {
+    element.removeChildren(TEST_FILTER_XML_TAG)
+    testFilter?.let { element.addContent(Element(TEST_FILTER_XML_TAG).setText(it)) }
+  }
+
+  override fun getEditor(project: Project): RunConfigurationStateEditor {
+    return TestFilterStateEditor()
+  }
+
+  /** Editor for [TestFilterState] — a single-line text field with a label. */
+  internal class TestFilterStateEditor : RunConfigurationStateEditor {
+
+    private val field = JBTextField()
+    private val component = UiUtil.createBox(JLabel("Bazel test filter:"), field)
+
+    override fun resetEditorFrom(genericState: RunConfigurationState) {
+      val state = genericState as TestFilterState
+      field.text = state.testFilter.orEmpty()
+    }
+
+    override fun applyEditorTo(genericState: RunConfigurationState?) {
+      val state = genericState as TestFilterState
+      state.testFilter =  field.text.trim()
+    }
+
+    override fun createComponent(): JComponent {
+      return component
+    }
+
+    override fun setComponentEnabled(enabled: Boolean) {
+      field.isEnabled = enabled
+    }
+
+    fun setComponentVisible(visible: Boolean) {
+      component.isVisible = visible
+    }
+  }
+}

--- a/base/tests/integrationtests/com/google/idea/blaze/base/run/BlazeCommandRunConfigurationGenericHandlerIntegrationTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/run/BlazeCommandRunConfigurationGenericHandlerIntegrationTest.java
@@ -86,7 +86,7 @@ public class BlazeCommandRunConfigurationGenericHandlerIntegrationTest
     BlazeCommandRunConfigurationCommonState state =
         (BlazeCommandRunConfigurationCommonState) configuration.getHandler().getState();
     state.getCommandState().setCommand(COMMAND);
-    state.getBlazeFlagsState().setRawFlags(ImmutableList.of("--flag1", "--flag2"));
+    state.getTestFilterState().setTestFilter("Foo#bar");
     state.getExeFlagsState().setRawFlags(ImmutableList.of("--exeFlag1"));
     state.getUserEnvVarsState().setEnvVars(ImmutableMap.of("HELLO", "world"));
 
@@ -103,9 +103,7 @@ public class BlazeCommandRunConfigurationGenericHandlerIntegrationTest
     BlazeCommandRunConfigurationCommonState readState =
         (BlazeCommandRunConfigurationCommonState) readConfiguration.getHandler().getState();
     assertThat(readState.getCommandState().getCommand()).isEqualTo(COMMAND);
-    assertThat(readState.getBlazeFlagsState().getRawFlags())
-        .containsExactly("--flag1", "--flag2")
-        .inOrder();
+    assertThat(readState.getTestFilterState().getTestFilter()).isEqualTo("Foo#bar");
     assertThat(readState.getExeFlagsState().getRawFlags()).containsExactly("--exeFlag1");
     assertThat(readState.getUserEnvVarsState().getData().getEnvs()).isEqualTo(ImmutableMap.of("HELLO", "world"));
   }
@@ -133,7 +131,7 @@ public class BlazeCommandRunConfigurationGenericHandlerIntegrationTest
     BlazeCommandRunConfigurationCommonState state =
         (BlazeCommandRunConfigurationCommonState) configuration.getHandler().getState();
     state.getCommandState().setCommand(COMMAND);
-    state.getBlazeFlagsState().setRawFlags(ImmutableList.of("--flag1", "--flag2"));
+    state.getTestFilterState().setTestFilter("Foo#bar");
     state.getExeFlagsState().setRawFlags(ImmutableList.of("--exeFlag1"));
     state.getUserEnvVarsState().setEnvVars(ImmutableMap.of("HELLO", "world"));
 
@@ -150,8 +148,8 @@ public class BlazeCommandRunConfigurationGenericHandlerIntegrationTest
         (BlazeCommandRunConfigurationCommonState) readConfiguration.getHandler().getState();
     assertThat(readState.getCommandState().getCommand())
         .isEqualTo(state.getCommandState().getCommand());
-    assertThat(readState.getBlazeFlagsState().getRawFlags())
-        .isEqualTo(state.getBlazeFlagsState().getRawFlags());
+    assertThat(readState.getTestFilterState().getTestFilter())
+        .isEqualTo(state.getTestFilterState().getTestFilter());
     assertThat(readState.getExeFlagsState().getRawFlags())
         .isEqualTo(state.getExeFlagsState().getRawFlags());
     assertThat(readState.getUserEnvVarsState().getData().getEnvs())
@@ -183,7 +181,7 @@ public class BlazeCommandRunConfigurationGenericHandlerIntegrationTest
     BlazeCommandRunConfigurationCommonState readState =
         (BlazeCommandRunConfigurationCommonState) readConfiguration.getHandler().getState();
     readState.getCommandState().setCommand(COMMAND);
-    readState.getBlazeFlagsState().setRawFlags(ImmutableList.of("--flag1", "--flag2"));
+    readState.getTestFilterState().setTestFilter("Foo#bar");
     readState.getExeFlagsState().setRawFlags(ImmutableList.of("--exeFlag1"));
     readState.getUserEnvVarsState().setEnvVars(ImmutableMap.of("HELLO", "world"));
 
@@ -196,8 +194,8 @@ public class BlazeCommandRunConfigurationGenericHandlerIntegrationTest
     readState = (BlazeCommandRunConfigurationCommonState) readConfiguration.getHandler().getState();
     assertThat(readState.getCommandState().getCommand())
         .isEqualTo(state.getCommandState().getCommand());
-    assertThat(readState.getBlazeFlagsState().getRawFlags())
-        .isEqualTo(state.getBlazeFlagsState().getRawFlags());
+    assertThat(readState.getTestFilterState().getTestFilter())
+        .isEqualTo(state.getTestFilterState().getTestFilter());
     assertThat(readState.getExeFlagsState().getRawFlags())
         .isEqualTo(state.getExeFlagsState().getRawFlags());
     assertThat(readState.getUserEnvVarsState().getData().getEnvs())

--- a/base/tests/integrationtests/com/google/idea/blaze/base/run/exporter/RunConfigurationSerializerTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/run/exporter/RunConfigurationSerializerTest.java
@@ -92,7 +92,7 @@ public class RunConfigurationSerializerTest extends BlazeIntegrationTestCase {
                 + "    factoryName=\"Bazel Command\">\n"
                 + "  <blaze-settings\n"
                 + "      handler-id=\"BlazeCommandGenericRunConfigurationHandlerProvider\">\n"
-                + "    <blaze-user-flag>--some_flag</blaze-user-flag>\n"
+                + "    <blaze-test-filter>Foo#bar</blaze-test-filter>\n"
                 + "  </blaze-settings>\n"
                 + "</configuration>");
 

--- a/base/tests/integrationtests/com/google/idea/blaze/base/run/producers/BlazeBuildFileRunConfigurationProducerTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/run/producers/BlazeBuildFileRunConfigurationProducerTest.java
@@ -17,9 +17,7 @@ package com.google.idea.blaze.base.run.producers;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.common.collect.ImmutableList;
 import com.google.idea.blaze.base.command.BlazeCommandName;
-import com.google.idea.blaze.base.command.BlazeFlags;
 import com.google.idea.blaze.base.lang.buildfile.psi.FuncallExpression;
 import com.google.idea.blaze.base.lang.buildfile.psi.StringLiteral;
 import com.google.idea.blaze.base.lang.buildfile.psi.util.PsiUtils;
@@ -198,10 +196,7 @@ public class BlazeBuildFileRunConfigurationProducerTest
 
     BlazeCommandRunConfigurationCommonState handlerState =
         config.getHandlerStateIfType(BlazeCommandRunConfigurationCommonState.class);
-    handlerState
-        .getBlazeFlagsState()
-        .setRawFlags(
-            ImmutableList.of(BlazeFlags.TEST_FILTER + "=com.google.test.SingleTestClass#"));
+    handlerState.getTestFilterState().setTestFilter("com.google.test.SingleTestClass#");
 
     assertThat(
             new BlazeBuildFileRunConfigurationProducer()

--- a/base/tests/integrationtests/com/google/idea/blaze/base/run/state/BlazeCommandRunConfigurationCommonStateTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/run/state/BlazeCommandRunConfigurationCommonStateTest.java
@@ -15,9 +15,10 @@
  */
 package com.google.idea.blaze.base.run.state;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
 import com.google.idea.blaze.base.BlazeIntegrationTestCase;
 import com.google.idea.blaze.base.command.BlazeCommandName;
 import com.google.idea.blaze.base.settings.Blaze;
@@ -33,8 +34,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import static com.google.common.truth.Truth.assertThat;
-
 /** Tests for {@link BlazeCommandRunConfigurationCommonState}. */
 @RunWith(JUnit4.class)
 public class BlazeCommandRunConfigurationCommonStateTest extends BlazeIntegrationTestCase {
@@ -46,8 +45,6 @@ public class BlazeCommandRunConfigurationCommonStateTest extends BlazeIntegratio
 
   @Before
   public void init() {
-    // Note: super.setUp() is called automatically by JUnit since BlazeIntegrationTestCase.setUp()
-    // is also annotated with @Before. Do not call super.setUp() here explicitly.
     registerProjectService(BlazeImportSettingsManager.class, new BlazeImportSettingsManager(getProject()));
     BlazeImportSettingsManager.getInstance(getProject()).setImportSettings(DUMMY_IMPORT_SETTINGS);
 
@@ -57,7 +54,7 @@ public class BlazeCommandRunConfigurationCommonStateTest extends BlazeIntegratio
   @Test
   public void readAndWriteShouldMatch() throws Exception {
     state.getCommandState().setCommand(COMMAND);
-    state.getBlazeFlagsState().setRawFlags(ImmutableList.of("--flag1", "--flag2"));
+    state.getTestFilterState().setTestFilter("Foo#bar");
     state.getExeFlagsState().setRawFlags(ImmutableList.of("--exeFlag1"));
     state.getUserEnvVarsState().setEnvVars(ImmutableMap.of("HELLO", "world"));
 
@@ -68,11 +65,10 @@ public class BlazeCommandRunConfigurationCommonStateTest extends BlazeIntegratio
     readState.readExternal(element);
 
     assertThat(readState.getCommandState().getCommand()).isEqualTo(COMMAND);
-    assertThat(readState.getBlazeFlagsState().getRawFlags())
-        .containsExactly("--flag1", "--flag2")
-        .inOrder();
+    assertThat(readState.getTestFilterState().getTestFilter()).isEqualTo("Foo#bar");
     assertThat(readState.getExeFlagsState().getRawFlags()).containsExactly("--exeFlag1");
-    assertThat(readState.getUserEnvVarsState().getData().getEnvs()).isEqualTo(ImmutableMap.of("HELLO", "world"));
+    assertThat(readState.getUserEnvVarsState().getData().getEnvs())
+        .isEqualTo(ImmutableMap.of("HELLO", "world"));
   }
 
   @Test
@@ -85,35 +81,12 @@ public class BlazeCommandRunConfigurationCommonStateTest extends BlazeIntegratio
 
     assertThat(readState.getCommandState().getCommand())
         .isEqualTo(state.getCommandState().getCommand());
-    assertThat(readState.getBlazeFlagsState().getRawFlags())
-        .isEqualTo(state.getBlazeFlagsState().getRawFlags());
+    assertThat(readState.getTestFilterState().getTestFilter())
+        .isEqualTo(state.getTestFilterState().getTestFilter());
     assertThat(readState.getExeFlagsState().getRawFlags())
         .isEqualTo(state.getExeFlagsState().getRawFlags());
     assertThat(readState.getUserEnvVarsState().getData().getEnvs())
-            .isEqualTo(state.getUserEnvVarsState().getData().getEnvs());
-  }
-
-  @Test
-  public void readShouldOmitEmptyFlags() throws Exception {
-    state
-        .getBlazeFlagsState()
-        .setRawFlags(Lists.newArrayList("hi ", "", "I'm", " ", "\t", "Josh\r\n", "\n"));
-    state
-        .getExeFlagsState()
-        .setRawFlags(Lists.newArrayList("hi ", "", "I'm", " ", "\t", "Josh\r\n", "\n"));
-
-    Element element = new Element("test");
-    state.writeExternal(element);
-    BlazeCommandRunConfigurationCommonState readState =
-        new BlazeCommandRunConfigurationCommonState(Blaze.getBuildSystemName(getProject()));
-    readState.readExternal(element);
-
-    assertThat(readState.getBlazeFlagsState().getRawFlags())
-        .containsExactly("hi", "I'm", "Josh")
-        .inOrder();
-    assertThat(readState.getExeFlagsState().getRawFlags())
-        .containsExactly("hi", "I'm", "Josh")
-        .inOrder();
+        .isEqualTo(state.getUserEnvVarsState().getData().getEnvs());
   }
 
   @Test
@@ -121,7 +94,7 @@ public class BlazeCommandRunConfigurationCommonStateTest extends BlazeIntegratio
     final XMLOutputter xmlOutputter = new XMLOutputter(Format.getCompactFormat());
 
     state.getCommandState().setCommand(COMMAND);
-    state.getBlazeFlagsState().setRawFlags(ImmutableList.of("--flag1", "--flag2"));
+    state.getTestFilterState().setTestFilter("Foo#bar");
     state.getExeFlagsState().setRawFlags(ImmutableList.of("--exeFlag1"));
 
     Element firstWrite = new Element("test");
@@ -138,7 +111,7 @@ public class BlazeCommandRunConfigurationCommonStateTest extends BlazeIntegratio
     RunConfigurationStateEditor editor = state.getEditor(getProject());
 
     state.getCommandState().setCommand(COMMAND);
-    state.getBlazeFlagsState().setRawFlags(ImmutableList.of("--flag1", "--flag2"));
+    state.getTestFilterState().setTestFilter("Foo#bar");
     state.getExeFlagsState().setRawFlags(ImmutableList.of("--exeFlag1", "--exeFlag2"));
 
     editor.resetEditorFrom(state);
@@ -148,12 +121,12 @@ public class BlazeCommandRunConfigurationCommonStateTest extends BlazeIntegratio
 
     assertThat(readState.getCommandState().getCommand())
         .isEqualTo(state.getCommandState().getCommand());
-    assertThat(readState.getBlazeFlagsState().getRawFlags())
-        .isEqualTo(state.getBlazeFlagsState().getRawFlags());
+    assertThat(readState.getTestFilterState().getTestFilter())
+        .isEqualTo(state.getTestFilterState().getTestFilter());
     assertThat(readState.getExeFlagsState().getRawFlags())
         .isEqualTo(state.getExeFlagsState().getRawFlags());
     assertThat(readState.getUserEnvVarsState().getData().getEnvs())
-            .isEqualTo(state.getUserEnvVarsState().getData().getEnvs());
+        .isEqualTo(state.getUserEnvVarsState().getData().getEnvs());
   }
 
   @Test
@@ -167,11 +140,109 @@ public class BlazeCommandRunConfigurationCommonStateTest extends BlazeIntegratio
 
     assertThat(readState.getCommandState().getCommand())
         .isEqualTo(state.getCommandState().getCommand());
-    assertThat(readState.getBlazeFlagsState().getRawFlags())
-        .isEqualTo(state.getBlazeFlagsState().getRawFlags());
+    assertThat(readState.getTestFilterState().getTestFilter())
+        .isEqualTo(state.getTestFilterState().getTestFilter());
     assertThat(readState.getExeFlagsState().getRawFlags())
         .isEqualTo(state.getExeFlagsState().getRawFlags());
     assertThat(readState.getUserEnvVarsState().getData().getEnvs())
-            .isEqualTo(state.getUserEnvVarsState().getData().getEnvs());
+        .isEqualTo(state.getUserEnvVarsState().getData().getEnvs());
+  }
+
+  @Test
+  public void legacyBlazeUserFlagXmlMigratesToTestFilter() throws Exception {
+    Element element = new Element("blaze-settings");
+    element.addContent(new Element("blaze-user-flag").setText("--test_filter=Foo#bar"));
+    element.addContent(new Element("blaze-user-flag").setText("--some_other_flag"));
+
+    state.readExternal(element);
+
+    assertThat(state.getTestFilterState().getTestFilter()).isEqualTo("Foo#bar");
+    assertThat(state.getLegacyUserFlags()).containsExactly("--some_other_flag");
+    assertThat(element.getChildren("blaze-user-flag")).isEmpty();
+  }
+
+  @Test
+  public void legacyBlazeUserFlagTestArgsMigrateToExeFlags() throws Exception {
+    Element element = new Element("blaze-settings");
+    element.addContent(new Element("blaze-user-flag").setText("--test_arg=foo"));
+    element.addContent(new Element("blaze-user-flag").setText("--test_arg=bar"));
+    element.addContent(new Element("blaze-user-flag").setText("--some_other_flag"));
+
+    state.readExternal(element);
+
+    assertThat(state.getExeFlagsState().getRawFlags()).containsExactly("foo", "bar").inOrder();
+    assertThat(state.getLegacyUserFlags()).containsExactly("--some_other_flag");
+    assertThat(element.getChildren("blaze-user-flag")).isEmpty();
+  }
+
+  @Test
+  public void legacyTestArgsAreMergedWithExistingExeFlags() throws Exception {
+    Element element = new Element("blaze-settings");
+    element.addContent(new Element("blaze-user-exe-flag").setText("--existing"));
+    element.addContent(new Element("blaze-user-flag").setText("--test_arg=migrated"));
+
+    state.readExternal(element);
+
+    assertThat(state.getExeFlagsState().getRawFlags())
+        .containsExactly("--existing", "migrated")
+        .inOrder();
+  }
+
+  @Test
+  public void legacyXmlWithMultipleTestFilterFlagsKeepsLastOne() throws Exception {
+    Element element = new Element("blaze-settings");
+    element.addContent(new Element("blaze-user-flag").setText("--test_filter=Foo"));
+    element.addContent(new Element("blaze-user-flag").setText("--test_filter=Bar"));
+
+    state.readExternal(element);
+
+    assertThat(state.getTestFilterState().getTestFilter()).isEqualTo("Bar");
+    assertThat(state.getLegacyUserFlags()).isEmpty();
+  }
+
+  @Test
+  public void legacyQuotedTestFilterIsShellDecoded() throws Exception {
+    Element element = new Element("blaze-settings");
+    element.addContent(new Element("blaze-user-flag").setText("--test_filter=\"Foo Bar\""));
+
+    state.readExternal(element);
+
+    assertThat(state.getTestFilterState().getTestFilter()).isEqualTo("Foo Bar");
+    assertThat(state.getLegacyUserFlags()).isEmpty();
+  }
+
+  @Test
+  public void legacyMigrationIgnoresBlankAndEmptyEntries() throws Exception {
+    Element element = new Element("blaze-settings");
+    element.addContent(new Element("blaze-user-flag").setText(""));
+    element.addContent(new Element("blaze-user-flag").setText("   "));
+    element.addContent(new Element("blaze-user-flag").setText("--real_flag"));
+
+    state.readExternal(element);
+
+    assertThat(state.getLegacyUserFlags()).containsExactly("--real_flag");
+  }
+
+  @Test
+  public void legacyMigrationIsNoOpWhenNoLegacyChildrenPresent() throws Exception {
+    Element element = new Element("blaze-settings");
+
+    state.readExternal(element);
+
+    assertThat(state.getTestFilterState().getTestFilter()).isNull();
+    assertThat(state.getExeFlagsState().getRawFlags()).isEmpty();
+    assertThat(state.getLegacyUserFlags()).isEmpty();
+  }
+
+  @Test
+  public void clearLegacyUserFlagsRemovesThem() throws Exception {
+    Element element = new Element("blaze-settings");
+    element.addContent(new Element("blaze-user-flag").setText("--some_flag"));
+
+    state.readExternal(element);
+    assertThat(state.getLegacyUserFlags()).containsExactly("--some_flag");
+
+    state.clearLegacyUserFlags();
+    assertThat(state.getLegacyUserFlags()).isEmpty();
   }
 }

--- a/base/tests/unittests/com/google/idea/blaze/base/run/state/TestFilterStateTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/run/state/TestFilterStateTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.run.state;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.jdom.Element;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link TestFilterState}. */
+@RunWith(JUnit4.class)
+public class TestFilterStateTest {
+
+  @Test
+  public void testFilterFlagIsNullWhenUnset() {
+    TestFilterState state = new TestFilterState();
+    assertThat(state.getTestFilter()).isNull();
+    assertThat(state.getTestFilterFlag()).isNull();
+  }
+
+  @Test
+  public void blankTestFilterIsNormalisedToNull() {
+    TestFilterState state = new TestFilterState();
+    state.setTestFilter("");
+    assertThat(state.getTestFilter()).isNull();
+    assertThat(state.getTestFilterFlag()).isNull();
+  }
+
+  @Test
+  public void simpleTestFilterRendersAsBareFlag() {
+    TestFilterState state = new TestFilterState();
+    state.setTestFilter("Foo#bar");
+    assertThat(state.getTestFilterFlag()).isEqualTo("--test_filter=Foo#bar");
+  }
+
+  @Test
+  public void testFilterWithWhitespaceIsShellQuoted() {
+    TestFilterState state = new TestFilterState();
+    state.setTestFilter("Foo Bar");
+    assertThat(state.getTestFilterFlag()).isEqualTo("--test_filter=\"Foo Bar\"");
+  }
+
+  @Test
+  public void readAndWriteRoundTripsThroughXml() {
+    TestFilterState source = new TestFilterState();
+    source.setTestFilter("ClassName#method");
+
+    Element element = new Element("test");
+    source.writeExternal(element);
+
+    TestFilterState target = new TestFilterState();
+    target.readExternal(element);
+    assertThat(target.getTestFilter()).isEqualTo("ClassName#method");
+  }
+
+  @Test
+  public void writeOfEmptyStateProducesNoXmlChildren() {
+    TestFilterState state = new TestFilterState();
+    Element element = new Element("test");
+    state.writeExternal(element);
+    assertThat(element.getChildren("blaze-test-filter")).isEmpty();
+  }
+
+  @Test
+  public void readExternalIsNoOpWhenElementHasNoTestFilter() {
+    TestFilterState state = new TestFilterState();
+    state.setTestFilter("preserved");
+
+    state.readExternal(new Element("test"));
+    assertThat(state.getTestFilter()).isEqualTo("preserved");
+  }
+
+  @Test
+  public void repeatedWriteReplacesPreviousElement() {
+    TestFilterState state = new TestFilterState();
+    state.setTestFilter("first");
+
+    Element element = new Element("test");
+    state.writeExternal(element);
+    state.setTestFilter("second");
+    state.writeExternal(element);
+
+    assertThat(element.getChildren("blaze-test-filter")).hasSize(1);
+    assertThat(element.getChildText("blaze-test-filter")).isEqualTo("second");
+  }
+}

--- a/base/tests/utils/integration/com/google/idea/blaze/base/run/producers/BlazeRunConfigurationProducerTestCase.java
+++ b/base/tests/utils/integration/com/google/idea/blaze/base/run/producers/BlazeRunConfigurationProducerTestCase.java
@@ -15,7 +15,6 @@
  */
 package com.google.idea.blaze.base.run.producers;
 
-import com.google.common.collect.ImmutableList;
 import com.google.idea.blaze.base.BlazeIntegrationTestCase;
 import com.google.idea.blaze.base.EditorTestHelper;
 import com.google.idea.blaze.base.command.BlazeCommandName;
@@ -93,13 +92,6 @@ public class BlazeRunConfigurationProducerTestCase extends BlazeIntegrationTestC
     BlazeCommandRunConfigurationCommonState handlerState =
         config.getHandlerStateIfType(BlazeCommandRunConfigurationCommonState.class);
     return handlerState != null ? handlerState.getTestFilterFlag() : null;
-  }
-
-  @Nullable
-  protected static ImmutableList<String> getTestArgsContents(BlazeCommandRunConfiguration config) {
-    BlazeCommandRunConfigurationCommonState handlerState =
-        config.getHandlerStateIfType(BlazeCommandRunConfigurationCommonState.class);
-    return handlerState != null ? handlerState.getTestArgs() : null;
   }
 
   @Nullable

--- a/clwb/src/com/google/idea/blaze/clwb/radler/RadTestEventsHandler.kt
+++ b/clwb/src/com/google/idea/blaze/clwb/radler/RadTestEventsHandler.kt
@@ -40,7 +40,7 @@ class RadTestEventsHandler: BlazeTestEventsHandler {
     project: Project?,
     testLocations: List<Location<*>?>?
   ): String? {
-    // not supported yet
+    // not supported yet, we need to support both catch and gtest here
     return null
   }
 }

--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrLauncher.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrLauncher.java
@@ -158,9 +158,14 @@ public final class BlazeCidrLauncher extends CidrLauncher {
                         ExecutorType.fromExecutor(env.getExecutor()),
                         configuration.getType(),
                         false)))
-            .addBlazeFlags(testHandlerFlags)
-            .addBlazeFlags(handlerState.getBlazeFlagsState().getFlagsForExternalProcesses())
-            .addExeFlags(handlerState.getExeFlagsState().getFlagsForExternalProcesses());
+            .addBlazeFlags(testHandlerFlags);
+
+    String testFilterFlag = handlerState.getTestFilterFlag();
+    if (testFilterFlag != null && BlazeCommandName.TEST.equals(handlerState.getCommandState().getCommand())) {
+      commandBuilder.addBlazeFlags(testFilterFlag, BlazeFlags.DISABLE_TEST_SHARDING);
+    }
+
+    commandBuilder.addExeFlags(handlerState.getExeFlagsState().getFlagsForExternalProcesses());
 
     state.setConsoleBuilder(createConsoleBuilder(testUiSession));
     state.addConsoleFilters(getConsoleFilters().toArray(new Filter[0]));
@@ -249,14 +254,13 @@ public final class BlazeCidrLauncher extends CidrLauncher {
 
       commandLine.addParameters(getTargetArguments(target));
       commandLine.addParameters(handlerState.getExeFlagsState().getFlagsForExternalProcesses());
-      commandLine.addParameters(handlerState.getTestArgs());
 
       // otherwise is handled in createProcess
       updateCommandlineWithEnvironmentData(commandLine);
 
       // the test filter needs to be passed manually since the binary is not run by bazel
-      final var testFilter = getTestFilter();
-      if (testFilter != null) {
+      final var testFilter = handlerState.getTestFilterForExternalProcesses();
+      if (testFilter != null && !testFilter.isBlank()) {
         commandLine.withEnvironment(TEST_FILTER_ENV_VARIABLE, testFilter);
       }
 
@@ -307,25 +311,6 @@ public final class BlazeCidrLauncher extends CidrLauncher {
 
     return CidrCoroutineHelper.runOnEDT(() -> new BlazeCidrRemoteDebugProcess(
         targetProcess, debuggerDriverConfiguration, parameters, session, state.getConsoleBuilder()));
-  }
-
-  /**
-   * Extracts the --test_filter value from the Blaze flags, if present.
-   */
-  private @Nullable String getTestFilter() {
-    final var flag = handlerState.getTestFilterFlag();
-
-    final var prefix = BlazeFlags.TEST_FILTER + "=";
-    if (flag == null || !flag.startsWith(prefix)) {
-      return null;
-    }
-
-    final var filter = flag.substring(prefix.length());
-    if (filter.isBlank()) {
-      return null;
-    }
-
-    return filter;
   }
 
   @Override

--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrRunConfigState.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrRunConfigState.java
@@ -35,7 +35,7 @@ final class BlazeCidrRunConfigState extends BlazeCommandRunConfigurationCommonSt
 
   @Override
   protected ImmutableList<RunConfigurationState> initializeStates() {
-    return ImmutableList.of(command, blazeFlags, exeFlags, envVars, debugPortState);
+    return ImmutableList.of(command, testFilter, exeFlags, envVars, debugPortState);
   }
 
   EnvironmentVariablesState getEnvVarsState() {

--- a/clwb/src/com/google/idea/blaze/clwb/run/DiscoverTargetConfigurations.kt
+++ b/clwb/src/com/google/idea/blaze/clwb/run/DiscoverTargetConfigurations.kt
@@ -25,11 +25,9 @@ import com.google.idea.blaze.base.command.BlazeInvocationContext
 import com.google.idea.blaze.base.model.primitives.Label
 import com.google.idea.blaze.base.projectview.ProjectViewManager
 import com.google.idea.blaze.base.run.BlazeCommandRunConfiguration
-import com.google.idea.blaze.base.run.state.BlazeCommandRunConfigurationCommonState
 import com.google.idea.blaze.base.scope.BlazeContext
 import com.google.idea.common.aquery.ActionGraph
 import com.intellij.openapi.project.Project
-import com.intellij.util.asSafely
 import java.io.IOException
 
 private const val CC_COMPILE_MNEMONIC = "CppCompile"
@@ -47,7 +45,6 @@ class DiscoverTargetConfigurations(
 
   override fun run(ctx: BlazeContext): Output {
     val projectViewSet = ProjectViewManager.getInstance(project).getProjectViewSet()
-    val handlerState = configuration.handler.state.asSafely<BlazeCommandRunConfigurationCommonState>()
 
     val flags = BlazeFlags.blazeFlags(
       project,
@@ -57,16 +54,10 @@ class DiscoverTargetConfigurations(
       invocationContext,
     )
 
-    val externalFlags = handlerState
-      ?.blazeFlagsState
-      ?.flagsForExternalProcesses
-      ?: emptyList()
-
     val cmd = BlazeCommand.builder(BlazeCommandName.AQUERY)
       .addBlazeFlags("deps($target)")
       .addBlazeFlags(additionalFlags)
       .addBlazeFlags(flags)
-      .addBlazeFlags(externalFlags)
       .addBlazeFlags("--output=streamed_proto")
 
     BazelExecService.of(project).exec(ctx, cmd).use { result ->

--- a/clwb/tests/headlesstests/com/google/idea/blaze/clwb/ExecutionTest.kt
+++ b/clwb/tests/headlesstests/com/google/idea/blaze/clwb/ExecutionTest.kt
@@ -19,12 +19,12 @@ package com.google.idea.blaze.clwb
 import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.Truth.assertWithMessage
 import com.google.idea.blaze.base.bazel.BazelVersion
+import com.google.idea.blaze.base.model.primitives.Label
+import com.google.idea.blaze.base.run.BlazeCommandRunConfiguration
 import com.google.idea.blaze.base.run.producers.BlazeBuildFileRunConfigurationProducer
 import com.google.idea.blaze.base.run.state.BlazeCommandRunConfigurationCommonState
 import com.google.idea.blaze.clwb.base.ClwbHeadlessTestCase
 import com.google.idea.blaze.clwb.run.BlazeCidrRemoteDebugProcess
-import com.google.idea.blaze.base.model.primitives.Label
-import com.google.idea.testing.headless.BazelVersionRule
 import com.google.idea.testing.headless.ProjectViewBuilder
 import com.intellij.execution.*
 import com.intellij.execution.actions.ConfigurationContext
@@ -32,7 +32,10 @@ import com.intellij.execution.actions.RunConfigurationProducer
 import com.intellij.execution.executors.DefaultDebugExecutor
 import com.intellij.execution.executors.DefaultRunExecutor
 import com.intellij.execution.impl.ExecutionManagerImpl
-import com.intellij.execution.process.*
+import com.intellij.execution.process.ProcessEvent
+import com.intellij.execution.process.ProcessHandler
+import com.intellij.execution.process.ProcessListener
+import com.intellij.execution.process.ProcessOutputTypes
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.runners.ExecutionUtil
 import com.intellij.openapi.actionSystem.ActionPlaces
@@ -42,10 +45,10 @@ import com.intellij.openapi.actionSystem.impl.SimpleDataContext
 import com.intellij.openapi.module.ModuleUtilCore
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Key
+import com.intellij.util.asSafely
 import com.intellij.util.system.OS
 import com.intellij.xdebugger.XDebuggerManager
 import com.jetbrains.cidr.execution.debugger.CidrLocalDebugProcess
-import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -86,6 +89,7 @@ class ExecutionTest : ClwbHeadlessTestCase() {
     }
 
     builder.addBuildFlag("--compilation_mode=dbg")
+    builder.addBuildFlag("--test_output=streamed")
 
     return builder
   }
@@ -126,7 +130,7 @@ class ExecutionTest : ClwbHeadlessTestCase() {
     // filter gtest by suite name
     val gtestFiltered = execute(
       Label.create("//main:gtest"), executorId,
-      flags = listOf("--test_output=streamed", "--test_filter=FilterSuite.*")
+      testFilter = "FilterSuite.*"
     )
     gtestFiltered.assertSuccess()
     assertThat(gtestFiltered.output).contains("FilterSuite.FilteredTest")
@@ -137,7 +141,7 @@ class ExecutionTest : ClwbHeadlessTestCase() {
     // filter gtest by specific test
     val gtestSingleTest = execute(
       Label.create("//main:gtest"), executorId,
-      flags = listOf("--test_output=streamed", "--test_filter=FilterSuite.FilteredTest")
+      testFilter = "FilterSuite.FilteredTest"
     )
     gtestSingleTest.assertSuccess()
     assertThat(gtestSingleTest.output).contains("FilterSuite.FilteredTest")
@@ -146,7 +150,7 @@ class ExecutionTest : ClwbHeadlessTestCase() {
     // filter catch2 tests
     val catchFiltered = execute(
       Label.create("//main:catch"), executorId,
-      flags = listOf("--test_output=streamed", "--test_filter=FilteredTest")
+      testFilter = "FilteredTest"
     )
     catchFiltered.assertSuccess()
     assertThat(catchFiltered.output).contains("FilteredTest")
@@ -170,7 +174,7 @@ class ExecutionTest : ClwbHeadlessTestCase() {
   private fun execute(
     label: Label,
     executorId: String,
-    flags: List<String> = emptyList(),
+    testFilter: String? = null,
     args: List<String> = emptyList()
   ): ExecutionResult {
     val element = findRule(label)
@@ -179,7 +183,6 @@ class ExecutionTest : ClwbHeadlessTestCase() {
       .add(CommonDataKeys.PROJECT, project)
       .add(PlatformCoreDataKeys.MODULE, ModuleUtilCore.findModuleForPsiElement(element))
       .add(Location.DATA_KEY, PsiLocation.fromPsiElement(element))
-      .add(BlazeCommandRunConfigurationCommonState.USER_BLAZE_FLAG, flags.toTypedArray())
       .add(BlazeCommandRunConfigurationCommonState.USER_EXE_FLAG, args.toTypedArray())
 
     val context = ConfigurationContext.getFromContext(
@@ -193,6 +196,16 @@ class ExecutionTest : ClwbHeadlessTestCase() {
     val producer = RunConfigurationProducer.getInstance(BlazeBuildFileRunConfigurationProducer::class.java)
     val configuration = producer.createConfigurationFromContext(context)
     requireNotNull(configuration)
+
+    if (testFilter != null) {
+      val blazeConfig = configuration.configuration.asSafely<BlazeCommandRunConfiguration>()
+      requireNotNull(blazeConfig)
+
+      val handlerState = blazeConfig.getHandlerStateIfType(BlazeCommandRunConfigurationCommonState::class.java)
+      requireNotNull(handlerState)
+
+      handlerState.testFilterState.testFilter = testFilter
+    }
 
     val environmentBuilder = ExecutionUtil.createEnvironment(executor, configuration.configurationSettings)
     requireNotNull(environmentBuilder)

--- a/python/src/com/google/idea/blaze/python/run/BlazePyRunConfigState.java
+++ b/python/src/com/google/idea/blaze/python/run/BlazePyRunConfigState.java
@@ -32,7 +32,7 @@ final class BlazePyRunConfigState extends BlazeCommandRunConfigurationCommonStat
 
   @Override
   protected ImmutableList<RunConfigurationState> initializeStates() {
-    return ImmutableList.of(command, blazeFlags, exeFlags, envVars);
+    return ImmutableList.of(command, testFilter, exeFlags, envVars);
   }
 
   EnvironmentVariablesState getEnvVarsState() {

--- a/python/src/com/google/idea/blaze/python/run/BlazePyRunConfigurationRunner.java
+++ b/python/src/com/google/idea/blaze/python/run/BlazePyRunConfigurationRunner.java
@@ -23,7 +23,6 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.idea.blaze.base.buildview.RunConfigBuild;
 import com.google.idea.blaze.base.command.BlazeCommandName;
-import com.google.idea.blaze.base.command.BlazeFlags;
 import com.google.idea.blaze.base.command.BlazeInvocationContext;
 import com.google.idea.blaze.base.ideinfo.PyIdeInfo;
 import com.google.idea.blaze.base.ideinfo.TargetIdeInfo;
@@ -178,17 +177,16 @@ public class BlazePyRunConfigurationRunner implements BlazeCommandRunConfigurati
       };
     }
 
-    private static ImmutableList<String> getScriptParams(
-        BlazeCommandRunConfigurationCommonState state) {
+    private static ImmutableList<String> getScriptParams(BlazeCommandRunConfigurationCommonState state) {
       ImmutableList.Builder<String> paramsBuilder = ImmutableList.builder();
       paramsBuilder.addAll(state.getExeFlagsState().getFlagsForExternalProcesses());
-      paramsBuilder.addAll(state.getTestArgs());
-      String filterFlag = state.getTestFilterFlag();
-      if (filterFlag != null) {
-        String testFilterArg = filterFlag.substring((BlazeFlags.TEST_FILTER + "=").length());
-        // testFilterArg is a space-delimited list of filters
-        paramsBuilder.addAll(Splitter.on(" ").splitToList(testFilterArg));
+
+      final var testFilter = state.getTestFilterForExternalProcesses();
+      if (testFilter != null) {
+        // testFilter is a space-delimited list of filters
+        paramsBuilder.addAll(Splitter.on(' ').splitToList(testFilter));
       }
+
       return paramsBuilder.build();
     }
   }


### PR DESCRIPTION
The free-form flags field is removed because per-config Bazel flags participate in Bazel's analysis cache key and cause sync/cache-invalidation issues; a dedicated single-line "Bazel test filter" field replaces its only remaining legitimate use case. Existing run-config XML is migrated on load: `--test_filter=...` flows into the new field, `--test_arg=...` flows into the executable-flags field, and any remaining flags are surfaced to the user via a one-time modal dialog that offers to copy them into the project view's `build_flags:` section.