### PR TITLE
Transitions Support: ignore actions from tool configurations

### DIFF
--- a/clwb/src/com/google/idea/blaze/clwb/run/DiscoverTargetConfigurations.kt
+++ b/clwb/src/com/google/idea/blaze/clwb/run/DiscoverTargetConfigurations.kt
@@ -103,10 +103,12 @@ class DiscoverTargetConfigurations(
   )
 }
 
+// Actions in the exec/tool configuration (e.g. code generators like protoc) are never linked into the
+// debuggee, so their lack of debug info is expected and must not be flagged.
 private fun ActionGraph.Target.compileAction(): ActionGraph.Action? {
-  return actions.firstOrNull { it.mnemonic == CC_COMPILE_MNEMONIC }
+  return actions.firstOrNull { it.mnemonic == CC_COMPILE_MNEMONIC && !it.configuration.isTool }
 }
 
 private fun ActionGraph.Target.linkAction(): ActionGraph.Action? {
-  return actions.firstOrNull { it.mnemonic == CC_LINK_MNEMONIC }
+  return actions.firstOrNull { it.mnemonic == CC_LINK_MNEMONIC && !it.configuration.isTool }
 }

--- a/common/aquery/ActionGraph.kt
+++ b/common/aquery/ActionGraph.kt
@@ -111,6 +111,9 @@ class ActionGraph(
 
     val mnemonic: String get() = src.mnemonic
 
+    /** Whether this configuration is used for building tools (i.e. the exec/tool configuration). */
+    val isTool: Boolean get() = src.isTool
+
     override fun toString(): String = "$mnemonic - ${checksum.substring(0, 8)}"
   }
 }

--- a/common/aquery/ActionGraphTest.kt
+++ b/common/aquery/ActionGraphTest.kt
@@ -56,7 +56,7 @@ class ActionGraphTest {
   @Test
   fun action_configuration() {
     val action = graph.defaultTarget.actions.first()
-    assertThat(action.configuration).isEqualTo("91e24984663c795f7d9f904758d4b84ba1954389b2ab756f70a6f32db2a79020")
+    assertThat(action.configuration.checksum).isEqualTo("91e24984663c795f7d9f904758d4b84ba1954389b2ab756f70a6f32db2a79020")
   }
 
   @Test


### PR DESCRIPTION
When a target depends on a build tool written in C/CPP (e.g. protoc) we also receive compile commands for this in the aquery. This can lead to false positives when reporting not debuggable targets.
