### PR TITLE
Transition Support: update DebugInfoWarningDialog layout

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -380,7 +380,7 @@
   "moduleExtensions": {
     "//intellij_platform_sdk:extension.bzl%intellij_platform": {
       "general": {
-        "bzlTransitiveDigest": "8DceVB+QV/R/r0M+vnTqq0DjaYaqkZtkiEjefhdRzsE=",
+        "bzlTransitiveDigest": "ZZYkRaasfufnRnF1nw5qVOrvoQEmaqjbqmnR2pItjS8=",
         "usagesDigest": "QaVNrkGgQMgdd2ZAfOzeGTIOqCbuG4s9HemLc5GI4sg=",
         "recordedInputs": [
           "REPO_MAPPING:,bazel_tools bazel_tools"

--- a/clwb/src/com/google/idea/blaze/clwb/run/DebugInfoCheck.kt
+++ b/clwb/src/com/google/idea/blaze/clwb/run/DebugInfoCheck.kt
@@ -18,14 +18,13 @@ package com.google.idea.blaze.clwb.run
 import com.google.idea.blaze.base.buildview.BuildStep
 import com.google.idea.blaze.base.buildview.fail
 import com.google.idea.blaze.base.buildview.warn
-import com.google.idea.blaze.base.model.primitives.Label
 import com.google.idea.blaze.base.scope.BlazeContext
 import com.google.idea.blaze.clwb.sync.enableInjectDebugFlags
 import com.google.idea.blaze.cpp.BlazeResolveConfigurationID
-import com.google.idea.common.aquery.ActionGraph
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.openapi.ui.DialogWrapper.CANCEL_EXIT_CODE
+import com.intellij.openapi.ui.DialogWrapper.OK_EXIT_CODE
 import com.intellij.util.system.OS
 import com.jetbrains.cidr.lang.CLanguageKind
 import com.jetbrains.cidr.lang.workspace.OCWorkspace
@@ -66,9 +65,9 @@ class DebugInfoCheck(
     val exitCode = showDebugInfoWarning(project, target, configurations.mainConfiguration)
 
     when (exitCode) {
-      DialogWrapper.OK_EXIT_CODE -> {} // Continue — fall through to the warning below.
-      DialogWrapper.CANCEL_EXIT_CODE -> fail(warning.toString())
-      INJECT_EXIT_CODE -> {
+      CONTINUE_ANYWAY_EXIT_CODE -> Unit // fall through to the warning below
+      CANCEL_EXIT_CODE -> fail(warning.toString())
+      OK_EXIT_CODE -> {
         enableInjectDebugFlags(project)
         rerunRunConfiguration(env)
         fail("Debug flag injection enabled, re-running debug session.")

--- a/clwb/src/com/google/idea/blaze/clwb/run/DebugInfoCheck.kt
+++ b/clwb/src/com/google/idea/blaze/clwb/run/DebugInfoCheck.kt
@@ -18,9 +18,11 @@ package com.google.idea.blaze.clwb.run
 import com.google.idea.blaze.base.buildview.BuildStep
 import com.google.idea.blaze.base.buildview.fail
 import com.google.idea.blaze.base.buildview.warn
+import com.google.idea.blaze.base.model.primitives.Label
 import com.google.idea.blaze.base.scope.BlazeContext
 import com.google.idea.blaze.clwb.sync.enableInjectDebugFlags
 import com.google.idea.blaze.cpp.BlazeResolveConfigurationID
+import com.google.idea.common.aquery.ActionGraph
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogWrapper.CANCEL_EXIT_CODE
@@ -33,6 +35,10 @@ import com.jetbrains.cidr.lang.workspace.compiler.ClangCompilerKind
 import com.jetbrains.cidr.lang.workspace.compiler.GCCCompilerKind
 import com.jetbrains.cidr.lang.workspace.compiler.MSVCCompilerKind
 import com.jetbrains.cidr.lang.workspace.compiler.OCCompilerKind
+import kotlin.io.path.extension
+import kotlin.text.startsWith
+
+typealias FlaggedActions = Sequence<Pair<Label, ActionGraph.Action>>
 
 class DebugInfoCheck(
   private val env: ExecutionEnvironment,
@@ -45,16 +51,16 @@ class DebugInfoCheck(
     val project = env.project
     val target = configurations.mainTarget
 
-    val compilerKind = findCompilerKind(project, configurations.mainConfiguration.checksum)
+    val compilerKind = findCompilerKind(project, configurations.mainConfiguration.checksum) ?: run {
+      warn(ctx, "Could not find compiler kind for configuration: ${configurations.mainConfiguration.checksum}")
+      return
+    }
 
-    val flaggedCompileActions = configurations.compileActions.asSequence()
-      .filter { (_, action) -> !checkCompileAction(action.arguments, compilerKind) }
-      .map { (label, action) -> label to action }
-    val flaggedLinkActions = configurations.linkActions.asSequence()
-      .filter { (_, action) -> !checkLinkAction(action.arguments, compilerKind) }
-      .map { (label, action) -> label to action }
-
-    val flaggedActions = (flaggedCompileActions + flaggedLinkActions).toList()
+    val flaggedActions = if (compilerKind == MSVCCompilerKind) {
+      checkMsvcDebugInfo(ctx, configurations)
+    } else {
+      checkDebugInfo(compilerKind, configurations)
+    }.toList()
     if (flaggedActions.isEmpty()) return
 
     val warning = StringBuilder("Non-debuggable dependencies:\n")
@@ -79,6 +85,35 @@ class DebugInfoCheck(
 
     warn(ctx, warning.toString())
   }
+
+  fun checkDebugInfo(compilerKind: OCCompilerKind, configs: DiscoverTargetConfigurations.Output): FlaggedActions {
+    val compilationActions = configs.compileActions.asSequence()
+      .filter { (_, action) -> !action.checkCompileAction(compilerKind) }
+      .map { (label, action) -> label to action }
+    val linkActions = configs.linkActions.asSequence()
+      .filter { (_, action) -> !action.checkLinkAction(compilerKind) }
+      .map { (label, action) -> label to action }
+
+    return compilationActions + linkActions
+  }
+
+  /**
+   * Bazel uses response files on Windows for MSVC thus we cannot look at the
+   * arguments directly. However, the final link action should output the final
+   * pdb file.
+   */
+  fun checkMsvcDebugInfo(ctx: BlazeContext, configs: DiscoverTargetConfigurations.Output): FlaggedActions {
+    val linkAction = configs.linkActions[configs.mainTarget] ?: run {
+      warn(ctx, "Could find main link action.")
+      return emptySequence()
+    }
+
+    return sequence {
+      if (linkAction.outputs.none { it.path.extension == "pdb" }) {
+        yield(configs.mainTarget to linkAction)
+      }
+    }
+  }
 }
 
 /**
@@ -101,10 +136,10 @@ private fun findCompilerKind(project: Project, bazelConfigHash: String): OCCompi
  * Checks that the given compile action arguments contain debug info flags
  * appropriate for the given compiler kind.
  */
-fun checkCompileAction(arguments: List<String>, compilerKind: OCCompilerKind?): Boolean {
+fun ActionGraph.Action.checkCompileAction(compilerKind: OCCompilerKind?): Boolean {
   return when (compilerKind) {
     GCCCompilerKind, ClangCompilerKind -> hasGccDebugInfo(arguments)
-    MSVCCompilerKind -> hasMsvcDebugInfo(arguments)
+    MSVCCompilerKind -> true // the MSVC toolchain uses response files, so we cannot look at the arguments directly
     ClangClCompilerKind -> hasGccDebugInfo(arguments) || hasClangClDebugInfo(arguments) || hasMsvcDebugInfo(arguments)
     else -> hasGccDebugInfo(arguments) || hasMsvcDebugInfo(arguments)
   }
@@ -128,7 +163,7 @@ private fun hasMsvcDebugInfo(arguments: List<String>): Boolean {
  * Checks that the given link action arguments produce path-independent
  * debug information. Atm only checks for oso_prefix on macOS.
  */
-fun checkLinkAction(arguments: List<String>, compilerKind: OCCompilerKind?): Boolean {
+fun ActionGraph.Action.checkLinkAction(compilerKind: OCCompilerKind?): Boolean {
   if (compilerKind != ClangCompilerKind || OS.CURRENT != OS.macOS) return true
   return arguments.any { it.contains("-oso_prefix,.") }
 }

--- a/clwb/src/com/google/idea/blaze/clwb/run/DebugInfoWarningDialog.kt
+++ b/clwb/src/com/google/idea/blaze/clwb/run/DebugInfoWarningDialog.kt
@@ -25,15 +25,17 @@ import com.intellij.ide.BrowserUtil
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.openapi.ui.OptionAction
 import com.intellij.ui.dsl.builder.panel
+import java.awt.event.ActionEvent
+import javax.swing.AbstractAction
 import javax.swing.Action
 import javax.swing.JComponent
-import javax.swing.SwingConstants
 
 private const val NOTIFICATION_TITLE = "Debug Info Warning"
 private const val DOC_URL = "https://jb.gg/clwb-debug-docs"
 
-internal const val INJECT_EXIT_CODE = DialogWrapper.NEXT_USER_EXIT_CODE
+internal const val CONTINUE_ANYWAY_EXIT_CODE = DialogWrapper.NEXT_USER_EXIT_CODE
 internal const val DISMISS_TARGET_EXIT_CODE = DialogWrapper.NEXT_USER_EXIT_CODE + 1
 internal const val DISMISS_PROJECT_EXIT_CODE = DialogWrapper.NEXT_USER_EXIT_CODE + 2
 
@@ -77,8 +79,6 @@ private class DebugInfoWarningDialog(
 
   init {
     title = NOTIFICATION_TITLE
-    setOKButtonText("Continue")
-    setButtonsAlignment(SwingConstants.CENTER)
     init()
   }
 
@@ -90,10 +90,9 @@ private class DebugInfoWarningDialog(
     separator()
     row {
       text(
-        "The target was built without debug info. You can " +
-            "<a>inject debug flags</a> to have the plugin build " +
-            "C/C++ run configurations in debug mode."
-      ) { close(INJECT_EXIT_CODE, true) }
+        "The target was built without debug info. Enabling debug flag injection " +
+            "will make the plugin build C/C++ run configurations in debug mode."
+      )
     }
     row {
       comment(
@@ -110,9 +109,20 @@ private class DebugInfoWarningDialog(
   }
 
   override fun createActions(): Array<Action> = arrayOf(
-    okAction,
-    cancelAction,
-    DialogWrapperExitAction("Dismiss for Target", DISMISS_TARGET_EXIT_CODE),
-    DialogWrapperExitAction("Dismiss for Project", DISMISS_PROJECT_EXIT_CODE),
+    DismissAction(),
+    DialogWrapperExitAction("Continue Anyway", CONTINUE_ANYWAY_EXIT_CODE),
+    DialogWrapperExitAction("Abort", CANCEL_EXIT_CODE),
+    DialogWrapperExitAction("Inject Debug Flags and Retry", OK_EXIT_CODE).apply { putValue(DEFAULT_ACTION, true) },
   )
+
+  private inner class DismissAction : AbstractAction("Don't Show for Target"), OptionAction {
+
+    override fun actionPerformed(e: ActionEvent) {
+      close(DISMISS_TARGET_EXIT_CODE, false)
+    }
+
+    override fun getOptions(): Array<Action> = arrayOf(
+      DialogWrapperExitAction("Don't Show for Project", DISMISS_PROJECT_EXIT_CODE),
+    )
+  }
 }

--- a/clwb/src/com/google/idea/blaze/clwb/run/DebugInfoWarningDialog.kt
+++ b/clwb/src/com/google/idea/blaze/clwb/run/DebugInfoWarningDialog.kt
@@ -109,10 +109,10 @@ private class DebugInfoWarningDialog(
   }
 
   override fun createActions(): Array<Action> = arrayOf(
-    DismissAction(),
     DialogWrapperExitAction("Continue Anyway", CONTINUE_ANYWAY_EXIT_CODE),
-    DialogWrapperExitAction("Abort", CANCEL_EXIT_CODE),
-    DialogWrapperExitAction("Inject Debug Flags and Retry", OK_EXIT_CODE).apply { putValue(DEFAULT_ACTION, true) },
+    DialogWrapperExitAction("Abort", CANCEL_EXIT_CODE).apply { putValue(DEFAULT_ACTION, true) },
+    DialogWrapperExitAction("Inject Debug Flags and Retry", OK_EXIT_CODE),
+    DismissAction(),
   )
 
   private inner class DismissAction : AbstractAction("Don't Show for Target"), OptionAction {

--- a/clwb/tests/headlesstests/com/google/idea/blaze/clwb/ExecutionTest.kt
+++ b/clwb/tests/headlesstests/com/google/idea/blaze/clwb/ExecutionTest.kt
@@ -320,7 +320,7 @@ private class ExecutionResultListener(
     future.completeExceptionally(IllegalStateException("unexpected debug process type"))
   }
 
-  override fun processNotStarted(executor: String, env: ExecutionEnvironment, cause: Throwable) {
+  override fun processNotStarted(executor: String, env: ExecutionEnvironment, cause: Throwable?) {
     future.completeExceptionally(cause)
   }
 

--- a/intellij_platform_sdk/extension.bzl
+++ b/intellij_platform_sdk/extension.bzl
@@ -30,7 +30,9 @@ def _download_maven_libraries(rctx, product_version):
     content = rctx.read(rctx.attr.build_file)
 
     for line in content.split("\n"):
+        # required on Windows, probably because of some leaking line breaks
         line = line.strip()
+
         start = line.find(directive)
         if start < 0:
             continue


### PR DESCRIPTION
Converted the link to inject the debug flags into a proper button as suggested by user feedback.

YT: https://youtrack.jetbrains.com/issue/CPP-50566/Bazel-target-might-not-be-debuggable