### PR TITLE
Fix incompatible flags in `bazel info` commands

### DIFF
--- a/base/src/com/google/idea/blaze/base/command/ProjectViewFlagsProvider.java
+++ b/base/src/com/google/idea/blaze/base/command/ProjectViewFlagsProvider.java
@@ -64,20 +64,30 @@ public class ProjectViewFlagsProvider implements BuildFlagsProvider {
     final var syncFlags = BlazeFlags.expandBuildFlags(projectViewSet.listItems(SyncFlagsSection.KEY));
 
     if (BlazeCommandName.INFO.equals(command)) {
-      syncFlags.removeIf(ProjectViewFlagsProvider::isInfoIncompatibleFlag);
+      removeInfoIncompatibleFlags(syncFlags);
     }
 
     flags.addAll(syncFlags);
   }
 
-  /**
-   * Whether a flag references a build configuration that the bazel info command cannot resolve. The
-   * flag name is taken from the leading token, so both the {@code --flag=value} and {@code --flag
-   * value} forms are matched, while unrelated flags sharing a prefix (e.g. {@code --config_foo}) are
-   * kept.
-   */
-  private static boolean isInfoIncompatibleFlag(String flag) {
-    final var name = flag.split("[=\\s]", 2)[0];
-    return INFO_INCOMPATIBLE_FLAGS.contains(name);
+  private static void removeInfoIncompatibleFlags(List<String> flags) {
+    final var iter = flags.listIterator();
+
+    while (iter.hasNext()) {
+      final var flag = iter.next();
+
+      final var name = flag.split("[=\\s]", 2)[0];
+      if (!INFO_INCOMPATIBLE_FLAGS.contains(name)) {
+        continue;
+      }
+
+      iter.remove();
+
+      // a bare flag carries its value in the next argument; drop that too
+      if (flag.equals(name) && iter.hasNext()) {
+        iter.next();
+        iter.remove();
+      }
+    }
   }
 }

--- a/base/src/com/google/idea/blaze/base/command/ProjectViewFlagsProvider.java
+++ b/base/src/com/google/idea/blaze/base/command/ProjectViewFlagsProvider.java
@@ -37,15 +37,15 @@ public class ProjectViewFlagsProvider implements BuildFlagsProvider {
       return;
     }
 
+    // some build configuration flags can cause the bazel info command to fail
+    if (BlazeCommandName.INFO.equals(command)) {
+      return;
+    }
+
     flags.addAll(BlazeFlags.expandBuildFlags(projectViewSet.listItems(BuildFlagsSection.KEY)));
 
     if (BlazeCommandName.TEST.equals(command)) {
       flags.addAll(BlazeFlags.expandBuildFlags(projectViewSet.listItems(TestFlagsSection.KEY)));
-    }
-
-    // platforms can break bazel info commands when using Bazel 8 https://github.com/bazelbuild/bazel/issues/25145
-    if (BlazeCommandName.INFO.equals(command)) {
-      flags.removeIf((it) -> it.startsWith("--platforms"));
     }
   }
 
@@ -57,6 +57,13 @@ public class ProjectViewFlagsProvider implements BuildFlagsProvider {
       BlazeContext context,
       BlazeInvocationContext invocationContext,
       List<String> flags) {
-    flags.addAll(BlazeFlags.expandBuildFlags(projectViewSet.listItems(SyncFlagsSection.KEY)));
+    final var syncFlags = BlazeFlags.expandBuildFlags(projectViewSet.listItems(SyncFlagsSection.KEY));
+
+    // bazel info cannot resolve --platforms/--config that reference external repos
+    if (BlazeCommandName.INFO.equals(command)) {
+      syncFlags.removeIf((it) -> it.startsWith("--platforms") || it.startsWith("--config"));
+    }
+
+    flags.addAll(syncFlags);
   }
 }

--- a/base/src/com/google/idea/blaze/base/command/ProjectViewFlagsProvider.java
+++ b/base/src/com/google/idea/blaze/base/command/ProjectViewFlagsProvider.java
@@ -22,8 +22,12 @@ import com.google.idea.blaze.base.projectview.section.sections.TestFlagsSection;
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.intellij.openapi.project.Project;
 import java.util.List;
+import java.util.Set;
 
 public class ProjectViewFlagsProvider implements BuildFlagsProvider {
+
+  // bazel info cannot resolve these flags if they reference external repos
+  private static final Set<String> INFO_INCOMPATIBLE_FLAGS = Set.of("--platforms", "--config");
 
   @Override
   public void addBuildFlags(
@@ -59,11 +63,21 @@ public class ProjectViewFlagsProvider implements BuildFlagsProvider {
       List<String> flags) {
     final var syncFlags = BlazeFlags.expandBuildFlags(projectViewSet.listItems(SyncFlagsSection.KEY));
 
-    // bazel info cannot resolve --platforms/--config that reference external repos
     if (BlazeCommandName.INFO.equals(command)) {
-      syncFlags.removeIf((it) -> it.startsWith("--platforms") || it.startsWith("--config"));
+      syncFlags.removeIf(ProjectViewFlagsProvider::isInfoIncompatibleFlag);
     }
 
     flags.addAll(syncFlags);
+  }
+
+  /**
+   * Whether a flag references a build configuration that the bazel info command cannot resolve. The
+   * flag name is taken from the leading token, so both the {@code --flag=value} and {@code --flag
+   * value} forms are matched, while unrelated flags sharing a prefix (e.g. {@code --config_foo}) are
+   * kept.
+   */
+  private static boolean isInfoIncompatibleFlag(String flag) {
+    final var name = flag.split("[=\\s]", 2)[0];
+    return INFO_INCOMPATIBLE_FLAGS.contains(name);
   }
 }

--- a/base/src/com/google/idea/blaze/base/command/ProjectViewFlagsProvider.java
+++ b/base/src/com/google/idea/blaze/base/command/ProjectViewFlagsProvider.java
@@ -15,6 +15,7 @@
  */
 package com.google.idea.blaze.base.command;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.idea.blaze.base.projectview.ProjectViewSet;
 import com.google.idea.blaze.base.projectview.section.sections.BuildFlagsSection;
 import com.google.idea.blaze.base.projectview.section.sections.SyncFlagsSection;
@@ -70,7 +71,8 @@ public class ProjectViewFlagsProvider implements BuildFlagsProvider {
     flags.addAll(syncFlags);
   }
 
-  private static void removeInfoIncompatibleFlags(List<String> flags) {
+  @VisibleForTesting
+  static void removeInfoIncompatibleFlags(List<String> flags) {
     final var iter = flags.listIterator();
 
     while (iter.hasNext()) {

--- a/base/src/com/google/idea/blaze/base/command/info/BlazeInfo.java
+++ b/base/src/com/google/idea/blaze/base/command/info/BlazeInfo.java
@@ -33,7 +33,6 @@ public abstract class BlazeInfo implements ProtoWrapper<ProjectData.BlazeInfo> {
   public static final String BUILD_LANGUAGE = "build-language";
   public static final String OUTPUT_BASE_KEY = "output_base";
   public static final String OUTPUT_PATH_KEY = "output_path";
-  public static final String MASTER_LOG = "master-log";
   public static final String RELEASE = "release";
   public static final String JAVA_HOME = "java-home";
 
@@ -59,16 +58,6 @@ public abstract class BlazeInfo implements ProtoWrapper<ProjectData.BlazeInfo> {
     throw new IllegalArgumentException("Unrecognized build system: " + buildSystemName);
   }
 
-  public static String blazeTestlogsKey(BuildSystemName buildSystemName) {
-    switch (buildSystemName) {
-      case Blaze:
-        return "blaze-testlogs";
-      case Bazel:
-        return "bazel-testlogs";
-    }
-    throw new IllegalArgumentException("Unrecognized build system: " + buildSystemName);
-  }
-
   public static Builder builder() {
     return new AutoValue_BlazeInfo.Builder();
   }
@@ -82,9 +71,6 @@ public abstract class BlazeInfo implements ProtoWrapper<ProjectData.BlazeInfo> {
     ExecutionRootPath blazeGenfiles =
         ExecutionRootPath.createAncestorRelativePath(
             executionRoot, new File(getOrThrow(blazeInfoMap, blazeGenfilesKey(buildSystemName))));
-    ExecutionRootPath blazeTestlogs =
-        ExecutionRootPath.createAncestorRelativePath(
-            executionRoot, new File(getOrThrow(blazeInfoMap, blazeTestlogsKey(buildSystemName))));
     File outputBase = new File(getOrThrow(blazeInfoMap, OUTPUT_BASE_KEY).trim());
     File outputPath = new File(getOrThrow(blazeInfoMap, OUTPUT_PATH_KEY).trim());
     File javaHome = new File(getOrThrow(blazeInfoMap, JAVA_HOME).trim());
@@ -93,7 +79,6 @@ public abstract class BlazeInfo implements ProtoWrapper<ProjectData.BlazeInfo> {
         .setExecutionRoot(executionRoot)
         .setBlazeBin(blazeBin)
         .setBlazeGenfiles(blazeGenfiles)
-        .setBlazeTestlogs(blazeTestlogs)
         .setOutputBase(outputBase)
         .setOutputPath(outputPath)
         .setJavaHome(javaHome)
@@ -125,22 +110,24 @@ public abstract class BlazeInfo implements ProtoWrapper<ProjectData.BlazeInfo> {
 
   public abstract File getExecutionRoot();
 
+  // should not be used, might be wrong if sync/build flags deviate
+  @Deprecated
   public abstract ExecutionRootPath getBlazeBin();
 
+  // should not be used, might be wrong if sync/build flags deviate
+  @Deprecated
   public File getBlazeBinDirectory() {
     return getBlazeBin().getFileRootedAt(getExecutionRoot());
   }
 
+  // should not be used, might be wrong if sync/build flags deviate
+  @Deprecated
   public abstract ExecutionRootPath getBlazeGenfiles();
 
+  // should not be used, might be wrong if sync/build flags deviate
+  @Deprecated
   public File getGenfilesDirectory() {
     return getBlazeGenfiles().getFileRootedAt(getExecutionRoot());
-  }
-
-  public abstract ExecutionRootPath getBlazeTestlogs();
-
-  public File getBlazeTestlogsDirectory() {
-    return getBlazeTestlogs().getFileRootedAt(getExecutionRoot());
   }
 
   public abstract File getOutputBase();
@@ -163,8 +150,7 @@ public abstract class BlazeInfo implements ProtoWrapper<ProjectData.BlazeInfo> {
       String outputBase,
       String executionRoot,
       String blazeBin,
-      String blazeGenFiles,
-      String blazeTestlogs) {
+      String blazeGenFiles) {
     BuildSystemName buildSystemName = BuildSystemName.Bazel;
     ImmutableMap.Builder<String, String> blazeInfoMap =
         ImmutableMap.<String, String>builder()
@@ -173,7 +159,6 @@ public abstract class BlazeInfo implements ProtoWrapper<ProjectData.BlazeInfo> {
             .put(EXECUTION_ROOT_KEY, executionRoot)
             .put(blazeBinKey(buildSystemName), blazeBin)
             .put(blazeGenfilesKey(buildSystemName), blazeGenFiles)
-            .put(blazeTestlogsKey(buildSystemName), blazeTestlogs)
             .put(JAVA_HOME, "/tmp/java");
     return BlazeInfo.create(buildSystemName, blazeInfoMap.build());
   }
@@ -187,8 +172,6 @@ public abstract class BlazeInfo implements ProtoWrapper<ProjectData.BlazeInfo> {
     public abstract Builder setBlazeBin(ExecutionRootPath value);
 
     public abstract Builder setBlazeGenfiles(ExecutionRootPath value);
-
-    public abstract Builder setBlazeTestlogs(ExecutionRootPath value);
 
     public abstract Builder setOutputBase(File value);
 
@@ -214,10 +197,6 @@ public abstract class BlazeInfo implements ProtoWrapper<ProjectData.BlazeInfo> {
           .put(
               blazeGenfilesKey(buildSystemName),
               blazeInfo.getBlazeGenfiles().getFileRootedAt(execRoot).getAbsolutePath());
-      blazeInfoMapBuilder()
-          .put(
-              blazeTestlogsKey(buildSystemName),
-              blazeInfo.getBlazeTestlogs().getFileRootedAt(execRoot).getAbsolutePath());
       return autoBuild();
     }
 

--- a/base/src/com/google/idea/blaze/base/command/info/BlazeInfoRunnerImpl.java
+++ b/base/src/com/google/idea/blaze/base/command/info/BlazeInfoRunnerImpl.java
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.idea.blaze.base.async.executor.BlazeExecutor;
-import com.google.idea.blaze.base.bazel.BuildSystem.BuildInvoker;
 import com.google.idea.blaze.base.buildview.BazelExecService;
 import com.google.idea.blaze.base.command.BlazeCommand;
 import com.google.idea.blaze.base.command.BlazeCommandName;
@@ -66,7 +65,6 @@ class BlazeInfoRunnerImpl extends BlazeInfoRunner {
             blazeFlags,
             BlazeInfo.blazeBinKey(buildSystemName),
             BlazeInfo.blazeGenfilesKey(buildSystemName),
-            BlazeInfo.blazeTestlogsKey(buildSystemName),
             BlazeInfo.EXECUTION_ROOT_KEY,
             BlazeInfo.PACKAGE_PATH_KEY,
             BlazeInfo.OUTPUT_PATH_KEY,

--- a/base/src/com/google/idea/blaze/base/model/primitives/ExecutionRootPath.java
+++ b/base/src/com/google/idea/blaze/base/model/primitives/ExecutionRootPath.java
@@ -30,6 +30,9 @@ import javax.annotation.Nullable;
 @AutoValue
 public abstract class ExecutionRootPath implements ProtoWrapper<String> {
 
+  private static final Path BAZEL_OUT = Path.of("bazel-out");
+  private static final Path BIN = Path.of("bin");
+
   public abstract Path path();
 
   public static ExecutionRootPath create(Path path) {
@@ -149,5 +152,21 @@ public abstract class ExecutionRootPath implements ProtoWrapper<String> {
   @ToPrettyString
   public String toPrettyString() {
     return path().toString();
+  }
+
+  public boolean isBazelOut() {
+    return path().equals(BAZEL_OUT);
+  }
+
+  public boolean isInBazelOut() {
+    return path().startsWith(BAZEL_OUT);
+  }
+
+  public boolean isBazelBin() {
+    return isInBazelOut() && path().getNameCount() == 3 && path().getName(2).equals(BIN);
+  }
+
+  public boolean isInBazelBin() {
+    return isInBazelOut() && path().getNameCount() >= 3 && path().getName(2).equals(BIN);
   }
 }

--- a/base/tests/unittests/com/google/idea/blaze/base/command/ProjectViewFlagsProviderTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/command/ProjectViewFlagsProviderTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.command;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link ProjectViewFlagsProvider}. */
+@RunWith(JUnit4.class)
+public class ProjectViewFlagsProviderTest {
+
+  private static List<String> filter(String... flags) {
+    final var list = new ArrayList<String>(List.of(flags));
+    ProjectViewFlagsProvider.removeInfoIncompatibleFlags(list);
+    return list;
+  }
+
+  @Test
+  public void keepsUnrelatedFlags() {
+    assertThat(filter("--foo", "--bar=baz")).containsExactly("--foo", "--bar=baz").inOrder();
+  }
+
+  @Test
+  public void removesInlineValueForm() {
+    assertThat(filter("--config=release", "--platforms=//foo:bar")).isEmpty();
+  }
+
+  @Test
+  public void removesSpaceSeparatedFormWithinSingleElement() {
+    // a single project view line such as "--config release" arrives as one element
+    assertThat(filter("--config release", "--platforms //foo:bar")).isEmpty();
+  }
+
+  @Test
+  public void removesBareFlagAndFollowingValueArgument() {
+    assertThat(filter("--config", "release", "--foo")).containsExactly("--foo");
+    assertThat(filter("--platforms", "//foo:bar", "--foo")).containsExactly("--foo");
+  }
+
+  @Test
+  public void bareFlagConsumesFollowingArgumentEvenIfItLooksLikeAFlag() {
+    // --config/--platforms always take the next argument as their value, so it is dropped too
+    assertThat(filter("--config", "--foo", "--keep")).containsExactly("--keep");
+  }
+
+  @Test
+  public void removesBareFlagAtEndOfList() {
+    assertThat(filter("--foo", "--config")).containsExactly("--foo");
+  }
+
+  @Test
+  public void keepsFlagsThatOnlySharePrefix() {
+    assertThat(filter("--config_foo", "--platforms_bar"))
+        .containsExactly("--config_foo", "--platforms_bar")
+        .inOrder();
+  }
+
+  @Test
+  public void handlesMixOfFormsAndPreservesOrder() {
+    assertThat(
+            filter(
+                "--keep_one",
+                "--config=debug",
+                "--config",
+                "fastbuild",
+                "--platforms //foo:bar",
+                "--keep_two"))
+        .containsExactly("--keep_one", "--keep_two")
+        .inOrder();
+  }
+}

--- a/base/tests/unittests/com/google/idea/blaze/base/command/ProjectViewFlagsProviderTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/command/ProjectViewFlagsProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The Bazel Authors. All rights reserved.
+ * Copyright 2026 The Bazel Authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Tests for {@link ProjectViewFlagsProvider}. */
 @RunWith(JUnit4.class)
 public class ProjectViewFlagsProviderTest {
 
@@ -45,7 +44,6 @@ public class ProjectViewFlagsProviderTest {
 
   @Test
   public void removesSpaceSeparatedFormWithinSingleElement() {
-    // a single project view line such as "--config release" arrives as one element
     assertThat(filter("--config release", "--platforms //foo:bar")).isEmpty();
   }
 
@@ -57,7 +55,6 @@ public class ProjectViewFlagsProviderTest {
 
   @Test
   public void bareFlagConsumesFollowingArgumentEvenIfItLooksLikeAFlag() {
-    // --config/--platforms always take the next argument as their value, so it is dropped too
     assertThat(filter("--config", "--foo", "--keep")).containsExactly("--keep");
   }
 
@@ -68,22 +65,18 @@ public class ProjectViewFlagsProviderTest {
 
   @Test
   public void keepsFlagsThatOnlySharePrefix() {
-    assertThat(filter("--config_foo", "--platforms_bar"))
-        .containsExactly("--config_foo", "--platforms_bar")
-        .inOrder();
+    assertThat(filter("--config_foo", "--platforms_bar")).containsExactly("--config_foo", "--platforms_bar").inOrder();
   }
 
   @Test
   public void handlesMixOfFormsAndPreservesOrder() {
-    assertThat(
-            filter(
-                "--keep_one",
-                "--config=debug",
-                "--config",
-                "fastbuild",
-                "--platforms //foo:bar",
-                "--keep_two"))
-        .containsExactly("--keep_one", "--keep_two")
-        .inOrder();
+    assertThat(filter(
+        "--keep_one",
+        "--config=debug",
+        "--config",
+        "fastbuild",
+        "--platforms //foo:bar",
+        "--keep_two"
+    )).containsExactly("--keep_one", "--keep_two").inOrder();
   }
 }

--- a/base/tests/unittests/com/google/idea/blaze/base/sync/BlazeSyncManagerTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/sync/BlazeSyncManagerTest.java
@@ -31,7 +31,6 @@ import com.google.idea.blaze.base.model.BlazeProjectData;
 import com.google.idea.blaze.base.model.BlazeVersionData;
 import com.google.idea.blaze.base.model.ExternalWorkspaceData;
 import com.google.idea.blaze.base.model.MockBlazeProjectDataBuilder;
-import com.google.idea.blaze.base.model.RemoteOutputArtifacts;
 import com.google.idea.blaze.base.model.primitives.LanguageClass;
 import com.google.idea.blaze.base.model.primitives.TargetExpression;
 import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
@@ -41,7 +40,6 @@ import com.google.idea.blaze.base.projectview.ProjectViewSet;
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.settings.BlazeImportSettingsManager;
 import com.google.idea.blaze.base.settings.BlazeUserSettings;
-import com.google.idea.blaze.base.settings.BuildSystemName;
 import com.google.idea.blaze.base.sync.projectview.WorkspaceLanguageSettings;
 import com.google.idea.blaze.base.sync.workspace.WorkspacePathResolver;
 import com.google.idea.blaze.base.sync.workspace.WorkspacePathResolverImpl;
@@ -180,8 +178,7 @@ public class BlazeSyncManagerTest extends BlazeTestCase {
                 "/",
                 "/root",
                 "/root/out/bin",
-                "/root/out/gen",
-                "/root/out/testlogs"))
+                "/root/out/gen"))
         .setWorkspacePathResolver(
             new WorkspacePathResolverImpl(WorkspaceRoot.fromProjectSafe(project)))
         .setExternalWorkspaceData(ExternalWorkspaceData.EMPTY)

--- a/base/tests/unittests/com/google/idea/blaze/base/sync/workspace/ArtifactLocationDecoderTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/sync/workspace/ArtifactLocationDecoderTest.java
@@ -54,8 +54,7 @@ public class ArtifactLocationDecoderTest extends BlazeTestCase {
                 OUTPUT_BASE,
                 EXECUTION_ROOT,
                 EXECUTION_ROOT + "/blaze-out/crosstool/bin",
-                EXECUTION_ROOT + "/blaze-out/crosstool/genfiles",
-                EXECUTION_ROOT + "/blaze-out/crosstool/testlogs"),
+                EXECUTION_ROOT + "/blaze-out/crosstool/genfiles"),
             null,
             RemoteOutputArtifacts.EMPTY);
 
@@ -84,8 +83,7 @@ public class ArtifactLocationDecoderTest extends BlazeTestCase {
                 OUTPUT_BASE,
                 EXECUTION_ROOT,
                 EXECUTION_ROOT + "/blaze-out/crosstool/bin",
-                EXECUTION_ROOT + "/blaze-out/crosstool/genfiles",
-                EXECUTION_ROOT + "/blaze-out/crosstool/testlogs"),
+                EXECUTION_ROOT + "/blaze-out/crosstool/genfiles"),
             null,
             RemoteOutputArtifacts.EMPTY);
 
@@ -113,8 +111,7 @@ public class ArtifactLocationDecoderTest extends BlazeTestCase {
                 OUTPUT_BASE,
                 EXECUTION_ROOT,
                 EXECUTION_ROOT + "/blaze-out/crosstool/bin",
-                EXECUTION_ROOT + "/blaze-out/crosstool/genfiles",
-                EXECUTION_ROOT + "/blaze-out/crosstool/testlogs"),
+                EXECUTION_ROOT + "/blaze-out/crosstool/genfiles"),
             null,
             RemoteOutputArtifacts.EMPTY);
 

--- a/base/tests/utils/unit/com/google/idea/blaze/base/model/MockBlazeProjectDataBuilder.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/model/MockBlazeProjectDataBuilder.java
@@ -130,8 +130,7 @@ public class MockBlazeProjectDataBuilder {
               outputBase,
               outputBase + "/execroot/_main",
               outputBase + "/execroot/_main/bin",
-              outputBase + "/execroot/_main/gen",
-              outputBase + "/execroot/_main/testlogs");
+              outputBase + "/execroot/_main/gen");
     }
     BlazeVersionData blazeVersionData =
         this.blazeVersionData != null ? this.blazeVersionData : BlazeVersionData.builder().build();

--- a/cpp/src/com/google/idea/blaze/cpp/HeaderRootTrimmerImpl.kt
+++ b/cpp/src/com/google/idea/blaze/cpp/HeaderRootTrimmerImpl.kt
@@ -60,7 +60,7 @@ class HeaderRootTrimmerImpl(private val scope: CoroutineScope) : HeaderRootTrimm
         ctx.pushJob("HeaderRootTrimmer") {
           val results = paths.map { root ->
             async(Dispatchers.IO) {
-              collectHeaderRoots(executionRootPathResolver, root, projectData)
+              collectHeaderRoots(executionRootPathResolver, root)
             }
           }
 

--- a/cpp/src/com/google/idea/blaze/cpp/HeaderRootTrimmerImpl.kt
+++ b/cpp/src/com/google/idea/blaze/cpp/HeaderRootTrimmerImpl.kt
@@ -103,7 +103,6 @@ private fun collectExecutionRootPaths(
 private fun collectHeaderRoots(
   executionRootPathResolver: ExecutionRootPathResolver,
   path: ExecutionRootPath,
-  projectData: BlazeProjectData,
 ): List<Path> {
   val possibleDirectories = executionRootPathResolver.resolveToIncludeDirectories(path).map(File::toPath)
 
@@ -113,10 +112,10 @@ private fun collectHeaderRoots(
   for (directory in possibleDirectories) {
     val add = when {
       // only allow bazel-bin as a header search path when the registry key is set
-      path.isBazelBin(projectData.blazeInfo()) -> allowBazelBin
+      path.isBazelBin -> allowBazelBin
 
       // if it is not an output directory, there should be now big binary artifacts
-      !path.isOutputDirectory(projectData.blazeInfo()) -> true
+      !path.isInBazelOut -> true
 
       // if it is an output directory, but there are headers, we need to allow it
       genRootMayContainHeaders(directory) -> true
@@ -166,13 +165,4 @@ private fun logHeaderRootPaths(roots: ImmutableSet<Path>) {
   LOG.trace("############################## VALID HEADER ROOTS ##############################")
   roots.forEach { LOG.trace(it.toString()) }
   LOG.trace("################################################################################")
-}
-
-private fun ExecutionRootPath.isBazelBin(info: BlazeInfo): Boolean {
-  return ExecutionRootPath.pathsEqual(info.blazeBin, this)
-}
-
-private fun ExecutionRootPath.isOutputDirectory(info: BlazeInfo): Boolean {
-  return ExecutionRootPath.isAncestor(info.blazeGenfiles, this, false)
-      || ExecutionRootPath.isAncestor(info.blazeBin, this, false)
 }


### PR DESCRIPTION
Only forward sync flags to bazel info calls and also filter problematic flags: --config and --platform
