### PR TITLE
chore(cleanup): remove `SyncStrategy` and simplify sync logic

### DIFF
--- a/base/src/com/google/idea/blaze/base/bazel/BazelBuildSystem.java
+++ b/base/src/com/google/idea/blaze/base/bazel/BazelBuildSystem.java
@@ -37,11 +37,6 @@ class BazelBuildSystem implements BuildSystem {
   }
 
   @Override
-  public SyncStrategy getSyncStrategy(Project project) {
-    return SyncStrategy.SERIAL;
-  }
-
-  @Override
   public void populateBlazeVersionData(WorkspaceRoot workspaceRoot, BlazeInfo blazeInfo, BlazeVersionData.Builder builder) {
     builder.setBazelVersion(BazelVersion.parseVersion(blazeInfo));
   }

--- a/base/src/com/google/idea/blaze/base/bazel/BuildSystem.java
+++ b/base/src/com/google/idea/blaze/base/bazel/BuildSystem.java
@@ -46,24 +46,6 @@ import java.util.Set;
 public interface BuildSystem {
 
   /**
-   * Strategy to use for builds that are part of a project sync.
-   */
-  enum SyncStrategy {
-    /**
-     * Never parallelize sync builds.
-     */
-    SERIAL,
-    /**
-     * Parallelize sync builds if it's deemed likely that doing so will be faster.
-     */
-    DECIDE_AUTOMATICALLY,
-    /**
-     * Always parallelize sync builds.
-     */
-    PARALLEL,
-  }
-
-  /**
    * Encapsulates a means of executing build commands, often as a Bazel compatible binary.
    */
   interface BuildInvoker {
@@ -169,11 +151,6 @@ public interface BuildSystem {
   }
 
   /**
-   * Return the strategy for remote syncs to be used with this build system.
-   */
-  SyncStrategy getSyncStrategy(Project project);
-
-  /**
    * Populates the passed builder with version data.
    */
   void populateBlazeVersionData(
@@ -189,10 +166,6 @@ public interface BuildSystem {
    * otherwise returns the standard invoker.
    */
   default BuildInvoker getDefaultInvoker(Project project) {
-    if (Blaze.getProjectType(project) != ProjectType.QUERY_SYNC
-        && getSyncStrategy(project) == SyncStrategy.PARALLEL) {
-      return getBuildInvoker(project, ImmutableSet.of(BuildInvoker.Capability.BUILD_PARALLEL_SHARDS)).orElseThrow();
-    }
     return getBuildInvoker(project);
   }
 

--- a/base/src/com/google/idea/blaze/base/build/BlazeBuildService.java
+++ b/base/src/com/google/idea/blaze/base/build/BlazeBuildService.java
@@ -25,7 +25,6 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.idea.blaze.base.async.executor.ProgressiveTaskWithProgressIndicator;
 import com.google.idea.blaze.base.bazel.BuildSystem;
 import com.google.idea.blaze.base.bazel.BuildSystem.BuildInvoker;
-import com.google.idea.blaze.base.bazel.BuildSystem.SyncStrategy;
 import com.google.idea.blaze.base.command.BlazeInvocationContext;
 import com.google.idea.blaze.base.experiments.ExperimentScope;
 import com.google.idea.blaze.base.filecache.FileCaches;
@@ -245,8 +244,7 @@ public class BlazeBuildService {
                             projectView,
                             projectData.workspacePathResolver(),
                             targets,
-                            buildInvoker,
-                            SyncStrategy.SERIAL);
+                            buildInvoker);
                     if (shardedTargets.buildResult.status == BuildResult.Status.FATAL_ERROR) {
                       return null;
                     }

--- a/base/src/com/google/idea/blaze/base/sync/BuildPhaseSyncTask.java
+++ b/base/src/com/google/idea/blaze/base/sync/BuildPhaseSyncTask.java
@@ -202,8 +202,6 @@ public final class BuildPhaseSyncTask {
     }
     ShardedTargetList shardedTargets = shardedTargetsResult.shardedTargets;
 
-    boolean parallel = false;
-
     if (!shardedTargetsResult
         .shardedTargets
         .shardStats()
@@ -213,13 +211,10 @@ public final class BuildPhaseSyncTask {
           shardedTargets.shardStats().actualTargetSizePerShard().stream()
               .mapToInt(Integer::intValue)
               .sum();
-      printShardingSummary(context, targetCount, shardedTargets.shardCount(), parallel);
+      printShardingSummary(context, targetCount, shardedTargets.shardCount());
     }
 
-    BuildInvoker syncBuildInvoker =
-        parallel
-            ? buildSystem.getBuildInvoker(project, ImmutableSet.of(BuildInvoker.Capability.BUILD_PARALLEL_SHARDS)).orElseThrow()
-            : defaultInvoker;
+    BuildInvoker syncBuildInvoker = defaultInvoker;
     resultBuilder.setBlazeInfo(syncBuildInvoker.getBlazeInfo(context));
 
     buildStats
@@ -231,7 +226,7 @@ public final class BuildPhaseSyncTask {
                 .getCapabilities()
                 .contains(BuildInvoker.Capability.BUILD_PARALLEL_SHARDS));
 
-    final var blazeBuildResult = getBlazeBuildResult(context, viewSet, shardedTargets, syncBuildInvoker, parallel);
+    final var blazeBuildResult = getBlazeBuildResult(context, viewSet, shardedTargets, syncBuildInvoker, false);
     resultBuilder.setBuildResult(blazeBuildResult);
     buildStats
         .setBuildResult(blazeBuildResult.buildResult())
@@ -259,8 +254,7 @@ public final class BuildPhaseSyncTask {
     resultBuilder.setConfigurationData(getBlazeConfigData(context, defaultInvoker));
   }
 
-  private void printShardingSummary(
-      BlazeContext context, int targetCount, int shardCount, boolean parallel) {
+  private void printShardingSummary(BlazeContext context, int targetCount, int shardCount) {
     if (targetCount == 0 || shardCount == 0) {
       return;
     }
@@ -275,12 +269,7 @@ public final class BuildPhaseSyncTask {
                     StringUtil.pluralize("shard", shardCount)))
             .log());
     if (shardCount > 1) {
-      context.output(
-          SummaryOutput.output(
-                  Prefix.INFO,
-                  String.format(
-                      "Building multiple shards in %s...", parallel ? "parallel" : "serial"))
-              .log());
+      context.output(SummaryOutput.output(Prefix.INFO, "Building multiple shards in serial...").log());
     }
   }
 

--- a/base/src/com/google/idea/blaze/base/sync/BuildPhaseSyncTask.java
+++ b/base/src/com/google/idea/blaze/base/sync/BuildPhaseSyncTask.java
@@ -25,7 +25,6 @@ import com.google.common.collect.Sets;
 import com.google.idea.blaze.base.async.executor.ProgressiveTaskWithProgressIndicator;
 import com.google.idea.blaze.base.bazel.BuildSystem;
 import com.google.idea.blaze.base.bazel.BuildSystem.BuildInvoker;
-import com.google.idea.blaze.base.bazel.BuildSystem.SyncStrategy;
 import com.google.idea.blaze.base.command.config.BlazeConfigException;
 import com.google.idea.blaze.base.command.config.BlazeConfigRunner;
 import com.google.idea.blaze.base.buildview.BuildViewMigration;
@@ -197,28 +196,13 @@ public final class BuildPhaseSyncTask {
             viewSet,
             projectState.getWorkspacePathResolver(),
             targets,
-            defaultInvoker,
-            buildSystem.getSyncStrategy(project));
+            defaultInvoker);
     if (shardedTargetsResult.buildResult.status == BuildResult.Status.FATAL_ERROR) {
       throw new SyncFailedException();
     }
     ShardedTargetList shardedTargets = shardedTargetsResult.shardedTargets;
 
-    boolean parallel;
-    SyncStrategy strategy = buildSystem.getSyncStrategy(project);
-    switch (strategy) {
-      case PARALLEL:
-        parallel = true;
-        break;
-      case DECIDE_AUTOMATICALLY:
-        parallel = shardedTargets.shardCount() > 1;
-        break;
-      case SERIAL:
-        parallel = false;
-        break;
-      default:
-        throw new IllegalStateException("Invalid sync strategy: " + strategy);
-    }
+    boolean parallel = false;
 
     if (!shardedTargetsResult
         .shardedTargets

--- a/base/src/com/google/idea/blaze/base/sync/SyncPhaseCoordinator.java
+++ b/base/src/com/google/idea/blaze/base/sync/SyncPhaseCoordinator.java
@@ -88,7 +88,6 @@ import com.intellij.openapi.module.Module;
 import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.project.Project;
-import com.intellij.util.concurrency.AppExecutorUtil;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -188,14 +187,6 @@ public final class SyncPhaseCoordinator {
     }
   }
 
-  // an application-wide cap on the number of concurrent remote builds
-  private static final int MAX_BUILD_TASKS = 8;
-
-  // an application-wide executor to run concurrent blaze builds remotely
-  private static final ListeningExecutorService remoteBuildExecutor =
-      MoreExecutors.listeningDecorator(
-          AppExecutorUtil.createBoundedApplicationPoolExecutor("FetchExecutor", MAX_BUILD_TASKS));
-
   // a per-project executor to run single-threaded sync phases
   private final ListeningExecutorService singleThreadedExecutor;
   private final Project project;
@@ -223,7 +214,7 @@ public final class SyncPhaseCoordinator {
   ListenableFuture<Void> syncProject(BlazeSyncParams syncParams, BlazeContext parentContext) {
     boolean singleThreaded = true;
     return ProgressiveTaskWithProgressIndicator.builder(project, "Syncing Project")
-        .setExecutor(singleThreaded ? singleThreadedExecutor : remoteBuildExecutor)
+        .setExecutor(singleThreadedExecutor)
         .setModality(BuildViewMigration.progressModality())
         .submitTask(
             indicator ->

--- a/base/src/com/google/idea/blaze/base/sync/SyncPhaseCoordinator.java
+++ b/base/src/com/google/idea/blaze/base/sync/SyncPhaseCoordinator.java
@@ -28,7 +28,6 @@ import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.idea.blaze.base.async.executor.ProgressiveTaskWithProgressIndicator;
 import com.google.idea.blaze.base.bazel.BuildSystem;
-import com.google.idea.blaze.base.bazel.BuildSystem.SyncStrategy;
 import com.google.idea.blaze.base.buildview.BuildViewMigration;
 import com.google.idea.blaze.base.command.buildresult.BuildResult;
 import com.google.idea.blaze.base.command.buildresult.BuildResult.Status;
@@ -221,23 +220,8 @@ public final class SyncPhaseCoordinator {
     buildSystem = Blaze.getBuildSystemProvider(project).getBuildSystem();
   }
 
-  private boolean useRemoteExecutor(BlazeSyncParams syncParams) {
-    if (syncParams.syncMode() == SyncMode.NO_BUILD) {
-      return false;
-    }
-    SyncStrategy strategy = buildSystem.getSyncStrategy(project);
-    switch (strategy) {
-      case DECIDE_AUTOMATICALLY:
-      case PARALLEL:
-        return true;
-      case SERIAL:
-        return false;
-    }
-    throw new IllegalStateException("Invalid sync strategy: " + strategy);
-  }
-
   ListenableFuture<Void> syncProject(BlazeSyncParams syncParams, BlazeContext parentContext) {
-    boolean singleThreaded = !useRemoteExecutor(syncParams);
+    boolean singleThreaded = true;
     return ProgressiveTaskWithProgressIndicator.builder(project, "Syncing Project")
         .setExecutor(singleThreaded ? singleThreadedExecutor : remoteBuildExecutor)
         .setModality(BuildViewMigration.progressModality())

--- a/base/src/com/google/idea/blaze/base/sync/sharding/BlazeBuildTargetSharder.java
+++ b/base/src/com/google/idea/blaze/base/sync/sharding/BlazeBuildTargetSharder.java
@@ -23,7 +23,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.idea.blaze.base.bazel.BuildSystem.BuildInvoker;
-import com.google.idea.blaze.base.bazel.BuildSystem.SyncStrategy;
 import com.google.idea.blaze.base.logging.utils.ShardStats;
 import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.blaze.base.model.primitives.TargetExpression;
@@ -110,15 +109,11 @@ public class BlazeBuildTargetSharder {
     SHARD_WITHOUT_EXPANDING, // split unexpanded wildcard targets into batches
   }
 
-  private static ShardingApproach getShardingApproach(
-      SyncStrategy parallelStrategy, ProjectViewSet viewSet) {
+  private static ShardingApproach getShardingApproach(ProjectViewSet viewSet) {
     if (shardingRequested(viewSet)) {
       return ShardingApproach.EXPAND_AND_SHARD;
     }
-    if (parallelStrategy == SyncStrategy.SERIAL) {
-      return ShardingApproach.SHARD_WITHOUT_EXPANDING;
-    }
-    return ShardingApproach.EXPAND_AND_SHARD;
+    return ShardingApproach.SHARD_WITHOUT_EXPANDING;
   }
 
   /** Expand wildcard target patterns and partition the resulting target list. */
@@ -128,9 +123,8 @@ public class BlazeBuildTargetSharder {
       ProjectViewSet viewSet,
       WorkspacePathResolver pathResolver,
       List<TargetExpression> targets,
-      BuildInvoker queryInvoker,
-      SyncStrategy parallelStrategy) {
-    ShardingApproach approach = getShardingApproach(parallelStrategy, viewSet);
+      BuildInvoker queryInvoker) {
+    ShardingApproach approach = getShardingApproach(viewSet);
     switch (approach) {
       case SHARD_WITHOUT_EXPANDING:
         int suggestedSize = getTargetShardSize(viewSet);
@@ -150,8 +144,7 @@ public class BlazeBuildTargetSharder {
         }
 
         return new ShardedTargetsResult(
-            shardSingleTargets(
-                expandedTargets.singleTargets, parallelStrategy, getTargetShardSize(viewSet)),
+            shardSingleTargets(expandedTargets.singleTargets, getTargetShardSize(viewSet)),
             expandedTargets.buildResult);
       default:
         throw new IllegalStateException("Unhandled sharding approach: " + approach);
@@ -228,10 +221,8 @@ public class BlazeBuildTargetSharder {
    * target patterns).
    */
   @VisibleForTesting
-  static ShardedTargetList shardSingleTargets(
-      List<TargetExpression> targets, SyncStrategy syncStrategy, int shardSize) {
-    return BuildBatchingService.batchTargets(
-        canonicalizeSingleTargets(targets), syncStrategy, shardSize);
+  static ShardedTargetList shardSingleTargets(List<TargetExpression> targets, int shardSize) {
+    return BuildBatchingService.batchTargets(canonicalizeSingleTargets(targets), shardSize);
   }
 
   /**

--- a/base/src/com/google/idea/blaze/base/sync/sharding/BuildBatchingService.java
+++ b/base/src/com/google/idea/blaze/base/sync/sharding/BuildBatchingService.java
@@ -16,7 +16,6 @@
 package com.google.idea.blaze.base.sync.sharding;
 
 import com.google.common.collect.ImmutableList;
-import com.google.idea.blaze.base.bazel.BuildSystem.SyncStrategy;
 import com.google.idea.blaze.base.logging.utils.ShardStats.ShardingApproach;
 import com.google.idea.blaze.base.model.primitives.Label;
 import com.intellij.openapi.extensions.ExtensionPointName;
@@ -47,8 +46,7 @@ public interface BuildBatchingService {
    * @param suggestedShardSize a suggestion only; may be entirely ignored by the implementation
    */
   @Nullable
-  ImmutableList<ImmutableList<Label>> calculateTargetBatches(
-      Set<Label> targets, SyncStrategy syncStrategy, int suggestedShardSize);
+  ImmutableList<ImmutableList<Label>> calculateTargetBatches(Set<Label> targets, int suggestedShardSize);
 
   ShardingApproach getShardingApproach();
 
@@ -59,10 +57,9 @@ public interface BuildBatchingService {
    * <p>Iterates through all available implementations, returning the first successful result, or
    * else falling back to returning a single batch.
    */
-  static ShardedTargetList batchTargets(
-      Set<Label> targets, SyncStrategy syncStrategy, int suggestedShardSize) {
+  static ShardedTargetList batchTargets(Set<Label> targets, int suggestedShardSize) {
     return Arrays.stream(EP_NAME.getExtensions())
-        .map(s -> s.getShardedTargetList(targets, syncStrategy, suggestedShardSize))
+        .map(s -> s.getShardedTargetList(targets, suggestedShardSize))
         .filter(Objects::nonNull)
         .findFirst()
         .orElse(
@@ -79,10 +76,8 @@ public interface BuildBatchingService {
    * private when Java 11 language features are available.
    */
   @Nullable
-  default ShardedTargetList getShardedTargetList(
-      Set<Label> targets, SyncStrategy syncStrategy, int suggestedShardSize) {
-    ImmutableList<ImmutableList<Label>> targetBatches =
-        calculateTargetBatches(targets, syncStrategy, suggestedShardSize);
+  default ShardedTargetList getShardedTargetList(Set<Label> targets, int suggestedShardSize) {
+    ImmutableList<ImmutableList<Label>> targetBatches = calculateTargetBatches(targets, suggestedShardSize);
     return targetBatches == null
         ? null
         : new ShardedTargetList(targetBatches, getShardingApproach(), suggestedShardSize);

--- a/base/src/com/google/idea/blaze/base/sync/sharding/LexicographicTargetSharder.java
+++ b/base/src/com/google/idea/blaze/base/sync/sharding/LexicographicTargetSharder.java
@@ -23,7 +23,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.primitives.Ints;
-import com.google.idea.blaze.base.bazel.BuildSystem.SyncStrategy;
 import com.google.idea.blaze.base.logging.utils.ShardStats.ShardingApproach;
 import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.common.experiments.BoolExperiment;
@@ -67,8 +66,7 @@ public class LexicographicTargetSharder implements BuildBatchingService {
   private static final int LEGACY_CONCURRENT_SHARD_COUNT = 10;
 
   @Override
-  public ImmutableList<ImmutableList<Label>> calculateTargetBatches(
-      Set<Label> targets, SyncStrategy syncStrategy, int suggestedShardSize) {
+  public ImmutableList<ImmutableList<Label>> calculateTargetBatches(Set<Label> targets, int suggestedShardSize) {
     List<Label> sorted = ImmutableList.sortedCopyOf(Comparator.comparing(Label::toString), targets);
     // When LexicographicTargetSharder is used for remote build, we may decide optimized shard size
     // for users even they have provided shard_size in project view. The size is decided according
@@ -81,17 +79,6 @@ public class LexicographicTargetSharder implements BuildBatchingService {
     // will still be used. But use suggestedShardSize without further calculation since there's
     // only one worker in that case.
 
-    // TODO(b/218800878) Perhaps we should treat PARALLEL and DECIDE_AUTOMATICALLY differently here?
-    if (syncStrategy != SyncStrategy.SERIAL) {
-      suggestedShardSize =
-          computeParallelShardSize(
-              targets.size(),
-              parallelThreshold.getValue(),
-              remoteConcurrentSyncs.getValue(),
-              minimumRemoteShardSize.getValue(),
-              maximumRemoteShardSize.getValue(),
-              suggestedShardSize);
-    }
     return Lists.partition(sorted, suggestedShardSize).stream()
         .map(ImmutableList::copyOf)
         .collect(toImmutableList());

--- a/base/tests/unittests/com/google/idea/blaze/base/sync/sharding/BlazeBuildTargetSharderTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/sync/sharding/BlazeBuildTargetSharderTest.java
@@ -34,7 +34,6 @@ import com.google.idea.blaze.base.async.process.ExternalTask;
 import com.google.idea.blaze.base.async.process.ExternalTaskProvider;
 import com.google.idea.blaze.base.bazel.BazelBuildSystemProvider;
 import com.google.idea.blaze.base.bazel.BuildSystem;
-import com.google.idea.blaze.base.bazel.BuildSystem.SyncStrategy;
 import com.google.idea.blaze.base.bazel.BuildSystemProvider;
 import com.google.idea.blaze.base.bazel.FakeBlazeCommandRunner;
 import com.google.idea.blaze.base.bazel.FakeBuildInvoker;
@@ -158,9 +157,7 @@ public class BlazeBuildTargetSharderTest extends BlazeTestCase {
             target("-//java/com/google:one"),
             target("-//java/com/google:three"),
             target("-//java/com/google:six"));
-    ShardedTargetList shards =
-        BlazeBuildTargetSharder.shardSingleTargets(
-            targets, SyncStrategy.SERIAL, /* shardSize= */ 3);
+    ShardedTargetList shards = BlazeBuildTargetSharder.shardSingleTargets(targets, /* shardSize= */ 3);
 
     assertThat(shards.shardedTargets).hasSize(1);
     assertThat(shards.shardedTargets.get(0)).containsExactly(target("//java/com/google:two"));
@@ -175,9 +172,7 @@ public class BlazeBuildTargetSharderTest extends BlazeTestCase {
             target("//java/com/baz:target"),
             target("//java/com/foo:other"),
             target("-//java/com/foo/..."));
-    ShardedTargetList shards =
-        BlazeBuildTargetSharder.shardSingleTargets(
-            targets, SyncStrategy.SERIAL, /* shardSize= */ 2);
+    ShardedTargetList shards = BlazeBuildTargetSharder.shardSingleTargets(targets, /* shardSize= */ 2);
     assertThat(shards.shardedTargets).hasSize(1);
     assertThat(shards.shardedTargets.get(0))
         .containsExactly(target("//java/com/bar:target"), target("//java/com/baz:target"))
@@ -193,9 +188,7 @@ public class BlazeBuildTargetSharderTest extends BlazeTestCase {
             target("//java/com/google:one"),
             target("-//java/com/google:two"),
             target("//java/com/google:two"));
-    ShardedTargetList shards =
-        BlazeBuildTargetSharder.shardSingleTargets(
-            targets, SyncStrategy.SERIAL, /* shardSize= */ 3);
+    ShardedTargetList shards = BlazeBuildTargetSharder.shardSingleTargets(targets, /* shardSize= */ 3);
     assertThat(shards.shardedTargets).hasSize(1);
     assertThat(shards.shardedTargets.get(0))
         .containsExactly(target("//java/com/google:one"), target("//java/com/google:two"));
@@ -289,183 +282,15 @@ public class BlazeBuildTargetSharderTest extends BlazeTestCase {
   @Test
   public void expandAndShardTargets_shardingApproachPartitionWithoutExpanding() {
     List<TargetExpression> targets = ImmutableList.of(target("//java/com/google:foo"));
-    ShardedTargetsResult result =
-        expandAndShardTargets(SyncStrategy.SERIAL, ProjectView.builder().build(), targets);
+    ShardedTargetsResult result = expandAndShardTargets(ProjectView.builder().build(), targets);
 
     assertThat(result.buildResult.exitCode).isEqualTo(0);
     assertThat(result.shardedTargets.shardStats.shardingApproach())
         .isEqualTo(ShardingApproach.PARTITION_WITHOUT_EXPANDING);
   }
 
-  @Test
-  public void expandAndShardTargets_remoteBuild_buildBatchingServiceIsUsed() {
-    fakeBuildBatchingService
-        .setShardingApproach(ShardingApproach.BUILD_TARGET_BATCHING_SERVICE)
-        .setFailToBatchTarget(false);
-    List<TargetExpression> targets = ImmutableList.of(target("//java/com/google:foo"));
-    ShardedTargetsResult result =
-        expandAndShardTargets(SyncStrategy.PARALLEL, ProjectView.builder().build(), targets);
-
-    assertThat(result.buildResult.exitCode).isEqualTo(0);
-    assertThat(result.shardedTargets.shardStats.shardingApproach())
-        .isEqualTo(ShardingApproach.BUILD_TARGET_BATCHING_SERVICE);
-  }
-
-  @Test
-  public void expandAndShardTargets_localBuild_buildBatchingServiceIsUsed() {
-    fakeBuildBatchingService
-        .setShardingApproach(ShardingApproach.LEXICOGRAPHIC_TARGET_SHARDER)
-        .setFailToBatchTarget(false);
-    List<TargetExpression> targets = ImmutableList.of(target("//java/com/google:foo"));
-    ShardedTargetsResult result =
-        expandAndShardTargets(
-            SyncStrategy.PARALLEL,
-            ProjectView.builder()
-                .add(ScalarSection.builder(ShardBlazeBuildsSection.KEY).set(true))
-                .add(ScalarSection.builder(TargetShardSizeSection.KEY).set(500))
-                .build(),
-            targets);
-
-    assertThat(result.buildResult.exitCode).isEqualTo(0);
-    ShardStats shardStats = result.shardedTargets.shardStats;
-    assertThat(shardStats.shardingApproach())
-        .isEqualTo(ShardingApproach.LEXICOGRAPHIC_TARGET_SHARDER);
-  }
-
-  @Test
-  public void expandAndShardTargets_failToExpand_shardingApproachError() {
-    fakeWildCardTargetExpanderBlazeInvoker.setFailure(true);
-    fakeBuildBatchingService
-        .setShardingApproach(ShardingApproach.LEXICOGRAPHIC_TARGET_SHARDER)
-        .setFailToBatchTarget(false);
-    List<TargetExpression> targets = ImmutableList.of(target("//java/com/google/..."));
-    ShardedTargetsResult result =
-        expandAndShardTargets(
-            SyncStrategy.PARALLEL,
-            ProjectView.builder()
-                .add(ScalarSection.builder(ShardBlazeBuildsSection.KEY).set(true))
-                .add(ScalarSection.builder(TargetShardSizeSection.KEY).set(500))
-                .build(),
-            targets);
-
-    assertThat(result.buildResult.exitCode).isEqualTo(BuildResult.FATAL_ERROR.exitCode);
-    assertThat(result.shardedTargets.shardStats.shardingApproach())
-        .isEqualTo(ShardingApproach.ERROR);
-  }
-
-  @Test
-  public void expandAndShardTargets_failToBatchingTargets_shardingApproachError() {
-    fakeWildCardTargetExpanderExternalTaskProvider.setReturnVal(0);
-    fakeBuildBatchingService
-        .setShardingApproach(ShardingApproach.LEXICOGRAPHIC_TARGET_SHARDER)
-        .setFailToBatchTarget(true);
-    List<TargetExpression> targets = ImmutableList.of(target("//java/com/google:foo"));
-    ShardedTargetsResult result =
-        expandAndShardTargets(
-            SyncStrategy.PARALLEL,
-            ProjectView.builder()
-                .add(ScalarSection.builder(ShardBlazeBuildsSection.KEY).set(true))
-                .add(ScalarSection.builder(TargetShardSizeSection.KEY).set(500))
-                .build(),
-            targets);
-
-    assertThat(result.buildResult.exitCode).isEqualTo(0);
-    assertThat(result.shardedTargets.shardStats.shardingApproach())
-        .isEqualTo(ShardingApproach.ERROR);
-  }
-
-  @Test
-  public void expandAndShardTargets_expandWildcardTargets() {
-    String expectedLabel1 = "//java/com/google:one";
-    String expectedLabel2 = "//java/com/google:two";
-    fakeWildCardTargetExpanderExternalTaskProvider
-        .setReturnVal(0)
-        .setOutputMessage("sh_library rule " + expectedLabel1, "sh_library rule " + expectedLabel2);
-    fakeWildCardTargetExpanderBlazeInvoker.setOutputMessages(
-        ImmutableList.of("sh_library rule " + expectedLabel1, "sh_library rule " + expectedLabel2));
-    fakeBuildBatchingService
-        .setShardingApproach(ShardingApproach.LEXICOGRAPHIC_TARGET_SHARDER)
-        .setFailToBatchTarget(false);
-
-    List<TargetExpression> targets = ImmutableList.of(target("//java/com/google/..."));
-    ShardedTargetsResult result =
-        expandAndShardTargets(
-            SyncStrategy.PARALLEL,
-            ProjectView.builder()
-                .add(ScalarSection.builder(ShardBlazeBuildsSection.KEY).set(true))
-                .add(ScalarSection.builder(TargetShardSizeSection.KEY).set(500))
-                .build(),
-            targets);
-
-    ShardStats shardStats = result.shardedTargets.shardStats;
-    assertThat(shardStats.suggestedTargetSizePerShard()).isEqualTo(500);
-    assertThat(shardStats.actualTargetSizePerShard()).containsExactly(2);
-    assertThat(result.shardedTargets.shardedTargets)
-        .containsExactly(ImmutableList.of(target(expectedLabel1), target(expectedLabel2)));
-  }
-
-  @Test
-  public void expandAndShardTargets_expandWildcardTargetsNoExcludeManualTag() {
-    String expectedLabel1 = "//java/com/google:one";
-
-    fakeWildCardTargetExpanderExternalTaskProvider
-            .setReturnVal(0)
-            .setOutputMessage("sh_library rule " + expectedLabel1);
-    fakeWildCardTargetExpanderBlazeInvoker.setOutputMessages(
-            ImmutableList.of("sh_library rule " + expectedLabel1));
-    fakeBuildBatchingService
-            .setShardingApproach(ShardingApproach.LEXICOGRAPHIC_TARGET_SHARDER)
-            .setFailToBatchTarget(false);
-
-    List<TargetExpression> targets = ImmutableList.of(target("//java/com/google/..."));
-    ProjectView projectView = ProjectView.builder()
-            .add(ScalarSection.builder(SyncManualTargetsSection.KEY).set(true))
-            .add(ScalarSection.builder(ShardBlazeBuildsSection.KEY).set(true))
-            .add(ScalarSection.builder(TargetShardSizeSection.KEY).set(500))
-            .build();
-
-    ShardedTargetsResult result =
-            expandAndShardTargets(
-                    SyncStrategy.PARALLEL,
-                    projectView,
-                    targets);
-
-    assertThat(result.shardedTargets.shardedTargets)
-            .containsExactly(ImmutableList.of(target(expectedLabel1)));
-  }
-
-  @Test
-  public void expandAndShardTargets_expandWildcardTargetsIncludesManualTag() {
-    String expectedLabel1 = "//java/com/google:one";
-
-    fakeWildCardTargetExpanderExternalTaskProvider
-            .setReturnVal(0)
-            .setOutputMessage("sh_library rule " + expectedLabel1);
-    fakeWildCardTargetExpanderBlazeInvoker.setOutputMessages(
-            ImmutableList.of("sh_library rule " + expectedLabel1));
-    fakeBuildBatchingService
-            .setShardingApproach(ShardingApproach.LEXICOGRAPHIC_TARGET_SHARDER)
-            .setFailToBatchTarget(false);
-
-    List<TargetExpression> targets = ImmutableList.of(target("//java/com/google/..."));
-    ProjectView projectView = ProjectView.builder()
-            .add(ScalarSection.builder(SyncManualTargetsSection.KEY).set(false))
-            .add(ScalarSection.builder(ShardBlazeBuildsSection.KEY).set(true))
-            .add(ScalarSection.builder(TargetShardSizeSection.KEY).set(500))
-            .build();
-
-    ShardedTargetsResult result =
-            expandAndShardTargets(
-                    SyncStrategy.PARALLEL,
-                    projectView,
-                    targets);
-
-    assertThat(result.shardedTargets.shardedTargets)
-            .containsExactly(ImmutableList.of(target(expectedLabel1)));
-  }
-
   private ShardedTargetsResult expandAndShardTargets(
-      SyncStrategy syncStrategy, ProjectView projectView, List<TargetExpression> targets, BuildSystem.BuildInvoker invoker) {
+      ProjectView projectView, List<TargetExpression> targets, BuildSystem.BuildInvoker invoker) {
     WorkspaceRoot workspaceRoot = new WorkspaceRoot(new File("workspaceRoot"));
     return BlazeBuildTargetSharder.expandAndShardTargets(
         getProject(),
@@ -473,13 +298,11 @@ public class BlazeBuildTargetSharderTest extends BlazeTestCase {
         ProjectViewSet.builder().add(projectView).build(),
         new WorkspacePathResolverImpl(workspaceRoot),
         targets,
-        invoker,
-        syncStrategy);
+        invoker);
   }
 
-  private ShardedTargetsResult expandAndShardTargets(
-      SyncStrategy syncStrategy, ProjectView projectView, List<TargetExpression> targets) {
-    return expandAndShardTargets(syncStrategy, projectView, targets, fakeWildCardTargetExpanderBlazeInvoker);
+  private ShardedTargetsResult expandAndShardTargets(ProjectView projectView, List<TargetExpression> targets) {
+    return expandAndShardTargets(projectView, targets, fakeWildCardTargetExpanderBlazeInvoker);
   }
 
   private static TargetExpression target(String expression) {
@@ -635,8 +458,7 @@ public class BlazeBuildTargetSharderTest extends BlazeTestCase {
 
     @Nullable
     @Override
-    public ImmutableList<ImmutableList<Label>> calculateTargetBatches(
-        Set<Label> targets, SyncStrategy syncStrategy, int suggestedShardSize) {
+    public ImmutableList<ImmutableList<Label>> calculateTargetBatches(Set<Label> targets, int suggestedShardSize) {
       return failToBatchTargets
           ? null
           : ImmutableList.of(targets).stream()

--- a/base/tests/unittests/com/google/idea/blaze/base/sync/sharding/LexicographicTargetSharderTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/sync/sharding/LexicographicTargetSharderTest.java
@@ -26,7 +26,6 @@ import static com.google.idea.blaze.base.sync.sharding.ShardedTargetList.remoteC
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.idea.blaze.base.BlazeTestCase;
-import com.google.idea.blaze.base.bazel.BuildSystem.SyncStrategy;
 import com.google.idea.blaze.base.model.primitives.Label;
 import com.google.idea.common.experiments.ExperimentService;
 import com.google.idea.common.experiments.MockExperimentService;
@@ -86,63 +85,7 @@ public class LexicographicTargetSharderTest extends BlazeTestCase {
     setRemoteConcurrentSyncs(10);
     Set<Label> targets = ImmutableSet.of(LABEL_ONE, LABEL_TWO, LABEL_THREE, LABEL_FOUR);
     ImmutableList<ImmutableList<Label>> shardedTargets =
-        lexicographicTargetSharder.calculateTargetBatches(targets, SyncStrategy.SERIAL, 2);
-    assertThat(shardedTargets).hasSize(2);
-    assertThat(shardedTargets.get(0)).containsExactly(LABEL_FOUR, LABEL_ONE).inOrder();
-    assertThat(shardedTargets.get(1)).containsExactly(LABEL_THREE, LABEL_TWO).inOrder();
-  }
-
-  @Test
-  public void
-      calculateTargetBatches_testRemoteBuildTypeAndSuggestedSizeIsSmaller_suggestedSizeIsUsed() {
-    Set<Label> targets = ImmutableSet.of(LABEL_ONE, LABEL_TWO, LABEL_THREE, LABEL_FOUR);
-    setParallelThreshold(4);
-    setRemoteConcurrentSyncs(1);
-    ImmutableList<ImmutableList<Label>> shardedTargets =
-        lexicographicTargetSharder.calculateTargetBatches(targets, SyncStrategy.PARALLEL, 2);
-    assertThat(shardedTargets).hasSize(2);
-    assertThat(shardedTargets.get(0)).containsExactly(LABEL_FOUR, LABEL_ONE).inOrder();
-    assertThat(shardedTargets.get(1)).containsExactly(LABEL_THREE, LABEL_TWO).inOrder();
-  }
-
-  @Test
-  public void
-      calculateTargetBatches_testRemoteBuildTypeAndCalculatedSizeIsSmaller_calculatedSizeIsUsed() {
-    Set<Label> targets = ImmutableSet.of(LABEL_ONE, LABEL_TWO, LABEL_THREE, LABEL_FOUR);
-    setParallelThreshold(4);
-    setRemoteConcurrentSyncs(10);
-    ImmutableList<ImmutableList<Label>> shardedTargets =
-        lexicographicTargetSharder.calculateTargetBatches(targets, SyncStrategy.PARALLEL, 2);
-    assertThat(shardedTargets).hasSize(4);
-    assertThat(shardedTargets.get(0)).containsExactly(LABEL_FOUR);
-    assertThat(shardedTargets.get(1)).containsExactly(LABEL_ONE);
-    assertThat(shardedTargets.get(2)).containsExactly(LABEL_THREE);
-    assertThat(shardedTargets.get(3)).containsExactly(LABEL_TWO);
-  }
-
-  @Test
-  public void
-      calculateTargetBatches_testRemoteBuildTypeAndMaximumRemoteShardSizeIsSmaller_maximumRemoteShardSizeIsUsed() {
-    Set<Label> targets = ImmutableSet.of(LABEL_ONE, LABEL_TWO, LABEL_THREE, LABEL_FOUR);
-    setParallelThreshold(4);
-    setRemoteConcurrentSyncs(1);
-    setMaximumRemoteShardSize(3);
-    ImmutableList<ImmutableList<Label>> shardedTargets =
-        lexicographicTargetSharder.calculateTargetBatches(targets, SyncStrategy.PARALLEL, 100);
-    assertThat(shardedTargets).hasSize(2);
-    assertThat(shardedTargets.get(0)).containsExactly(LABEL_FOUR, LABEL_ONE, LABEL_THREE).inOrder();
-    assertThat(shardedTargets.get(1)).containsExactly(LABEL_TWO);
-  }
-
-  @Test
-  public void
-      calculateTargetBatches_testRemoteBuildTypeAndMinimumRemoteShardSizeIsLargerThanCalculated_minimumRemoteShardSizeIsUsed() {
-    ImmutableSet<Label> targets = ImmutableSet.of(LABEL_ONE, LABEL_TWO, LABEL_THREE, LABEL_FOUR);
-    setParallelThreshold(4);
-    setRemoteConcurrentSyncs(10);
-    setMinimumRemoteShardSize(2);
-    ImmutableList<ImmutableList<Label>> shardedTargets =
-        lexicographicTargetSharder.calculateTargetBatches(targets, SyncStrategy.PARALLEL, 100);
+        lexicographicTargetSharder.calculateTargetBatches(targets, 2);
     assertThat(shardedTargets).hasSize(2);
     assertThat(shardedTargets.get(0)).containsExactly(LABEL_FOUR, LABEL_ONE).inOrder();
     assertThat(shardedTargets.get(1)).containsExactly(LABEL_THREE, LABEL_TWO).inOrder();

--- a/base/tests/utils/unit/com/google/idea/blaze/base/bazel/BuildSystemProviderWrapper.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/bazel/BuildSystemProviderWrapper.java
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.MustBeClosed;
 import com.google.idea.blaze.base.bazel.BuildSystem.BuildInvoker;
-import com.google.idea.blaze.base.bazel.BuildSystem.SyncStrategy;
 import com.google.idea.blaze.base.command.BlazeCommand;
 import com.google.idea.blaze.base.command.BlazeCommandRunner;
 import com.google.idea.blaze.base.command.buildresult.BuildResultHelper;
@@ -53,7 +52,6 @@ public class BuildSystemProviderWrapper implements BuildSystemProvider {
   private BuildSystem buildSystem;
   private boolean throwExceptionOnGetBlazeInfo;
   private BuildBinaryType buildBinaryType;
-  private SyncStrategy syncStrategy;
 
   /**
    * Create a wrapper for the given {@link BuildSystemProvider}.
@@ -284,14 +282,6 @@ public class BuildSystemProviderWrapper implements BuildSystemProvider {
     @Override
     public BuildInvoker getBuildInvoker(Project project) {
       return new BuildInvokerWrapper(inner.getBuildInvoker(project));
-    }
-
-    @Override
-    public SyncStrategy getSyncStrategy(Project project) {
-      if (syncStrategy != null) {
-        return syncStrategy;
-      }
-      return inner.getSyncStrategy(project);
     }
 
     @Override

--- a/base/tests/utils/unit/com/google/idea/blaze/base/bazel/FakeBuildSystem.java
+++ b/base/tests/utils/unit/com/google/idea/blaze/base/bazel/FakeBuildSystem.java
@@ -38,7 +38,7 @@ import javax.annotation.Nullable;
 public abstract class FakeBuildSystem implements BuildSystem {
 
   public static Builder builder(BuildSystemName name) {
-    return new AutoValue_FakeBuildSystem.Builder().setName(name).setSyncStrategy(SyncStrategy.SERIAL);
+    return new AutoValue_FakeBuildSystem.Builder().setName(name);
   }
 
   @Override
@@ -51,12 +51,6 @@ public abstract class FakeBuildSystem implements BuildSystem {
   public Optional<BuildInvoker> getBuildInvoker(Project project, Set<BuildInvoker.Capability> requirements) {
     return getBuildInvoker();
   }
-  @Override
-  public SyncStrategy getSyncStrategy(Project project) {
-    return getSyncStrategy();
-  }
-
-  protected abstract SyncStrategy getSyncStrategy();
 
   @Override
   public void populateBlazeVersionData(WorkspaceRoot workspaceRoot, BlazeInfo blazeInfo, BlazeVersionData.Builder builder) { }
@@ -80,8 +74,6 @@ public abstract class FakeBuildSystem implements BuildSystem {
     public abstract Builder setName(BuildSystemName value);
 
     public abstract Builder setBuildInvoker(BuildInvoker value);
-
-    public abstract Builder setSyncStrategy(SyncStrategy value);
 
     public abstract Builder setBazelVersionString(Optional<String> value);
   }


### PR DESCRIPTION
Eliminated the `SyncStrategy` enum and updated relevant code paths to default to serial execution, since it was hardcoded to serial for the BazelBuildSystem anyway.