### PR TITLE
Provide a deterministic fallback for RadRunConfigurationChooser

### DIFF
--- a/clwb/src/com/google/idea/blaze/clwb/radler/RadRunConfigurationChooser.kt
+++ b/clwb/src/com/google/idea/blaze/clwb/radler/RadRunConfigurationChooser.kt
@@ -36,6 +36,11 @@ class RadRunConfigurationChooser : OCResolveConfigurationChooserAdapter() {
   override fun doSelectResolveConfiguration(
     project: Project,
     configurations: List<OCResolveConfiguration>,
+  ): OCResolveConfiguration? = byLastBuild(project, configurations) ?: byConfigurationID(configurations)
+
+  private fun byLastBuild(
+    project: Project,
+    configurations: List<OCResolveConfiguration>,
   ): OCResolveConfiguration? {
     val checksums = LastBuildConfigurations.getInstance(project).preferredConfigurations
     if (checksums.isEmpty()) return null
@@ -44,5 +49,12 @@ class RadRunConfigurationChooser : OCResolveConfigurationChooserAdapter() {
       val id = BlazeResolveConfigurationID.fromOCResolveConfiguration(config) ?: return@firstOrNull false
       checksums.any { checksum -> checksum.startsWith(id.configurationId) }
     }
+  }
+
+  // deterministic fallback
+  private fun byConfigurationID(configurations: List<OCResolveConfiguration>): OCResolveConfiguration? {
+     return configurations.maxByOrNull {
+       BlazeResolveConfigurationID.fromOCResolveConfiguration(it)?.configurationId ?: ""
+     }
   }
 }

--- a/clwb/src/com/google/idea/blaze/clwb/radler/RadRunConfigurationChooser.kt
+++ b/clwb/src/com/google/idea/blaze/clwb/radler/RadRunConfigurationChooser.kt
@@ -36,7 +36,9 @@ class RadRunConfigurationChooser : OCResolveConfigurationChooserAdapter() {
   override fun doSelectResolveConfiguration(
     project: Project,
     configurations: List<OCResolveConfiguration>,
-  ): OCResolveConfiguration? = byLastBuild(project, configurations) ?: byConfigurationID(configurations)
+  ): OCResolveConfiguration? {
+    return byLastBuild(project, configurations) ?: byConfigurationID(configurations)
+  }
 
   private fun byLastBuild(
     project: Project,


### PR DESCRIPTION
When no run configuration was executed and auto is selected in the drop no `OCResolveContext` was selected. A deterministic in `RadRunConfigurationChooser` guarantees that if a Bazel specific resolve configuration is a available it will be selected. 