### PR TITLE
Pass executable flags as `--test_args` for test commands

### DIFF
--- a/base/src/com/google/idea/blaze/base/run/confighandler/BlazeCommandGenericRunConfigurationRunner.java
+++ b/base/src/com/google/idea/blaze/base/run/confighandler/BlazeCommandGenericRunConfigurationRunner.java
@@ -255,11 +255,17 @@ public final class BlazeCommandGenericRunConfigurationRunner
           .addBlazeFlags(extraBlazeFlags);
 
       final var testFilterFlag = handlerState.getTestFilterFlag();
-      if (testFilterFlag != null && BlazeCommandName.TEST.equals(handlerState.getCommandState().getCommand())) {
+      if (testFilterFlag != null && handlerState.isTestCommand()) {
         builder.addBlazeFlags(testFilterFlag, BlazeFlags.DISABLE_TEST_SHARDING);
       }
 
-      return builder.addExeFlags(handlerState.getExeFlagsState().getFlagsForExternalProcesses());
+      if (handlerState.isTestCommand()) {
+        builder.addBlazeFlags(handlerState.getExeFlagsState().getFlagsForTestArgs());
+      } else {
+        builder.addExeFlags(handlerState.getExeFlagsState().getFlagsForExternalProcesses());
+      }
+
+      return builder;
     }
 
     private BlazeCommandName getCommand() {

--- a/base/src/com/google/idea/blaze/base/run/state/BlazeCommandRunConfigurationCommonState.java
+++ b/base/src/com/google/idea/blaze/base/run/state/BlazeCommandRunConfigurationCommonState.java
@@ -16,6 +16,7 @@
 package com.google.idea.blaze.base.run.state;
 
 import com.google.common.collect.ImmutableList;
+import com.google.idea.blaze.base.command.BlazeCommandName;
 import com.google.idea.blaze.base.command.BlazeFlags;
 import com.google.idea.blaze.base.execution.BlazeParametersListUtil;
 import com.google.idea.blaze.base.settings.BuildSystemName;
@@ -78,6 +79,11 @@ public class BlazeCommandRunConfigurationCommonState extends RunConfigurationCom
 
   public BlazeCommandState getCommandState() {
     return command;
+  }
+
+  /** Whether the selected command runs tests. */
+  public boolean isTestCommand() {
+    return BlazeCommandName.TEST.equals(command.getCommand());
   }
 
   /** Returns the {@code --test_filter=<encoded>} flag for inclusion on a Bazel command line. */

--- a/base/src/com/google/idea/blaze/base/run/state/RunConfigurationFlagsState.java
+++ b/base/src/com/google/idea/blaze/base/run/state/RunConfigurationFlagsState.java
@@ -61,6 +61,13 @@ public final class RunConfigurationFlagsState implements RunConfigurationState {
     return BlazeFlags.expandBuildFlags(processedFlags);
   }
 
+  /** Flags ready to be passed as Bazel command line arguments to a test. */
+  public ImmutableList<String> getFlagsForTestArgs() {
+    return flags.stream()
+        .map(flag -> BlazeFlags.TEST_ARG + "=" + flag)
+        .collect(ImmutableList.toImmutableList());
+  }
+
   /** Unprocessed flags that haven't been macro expanded or processed for escaping/quotes. */
   public List<String> getRawFlags() {
     return flags;

--- a/base/tests/integrationtests/com/google/idea/blaze/base/run/state/BlazeCommandRunConfigurationCommonStateTest.java
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/run/state/BlazeCommandRunConfigurationCommonStateTest.java
@@ -149,6 +149,39 @@ public class BlazeCommandRunConfigurationCommonStateTest extends BlazeIntegratio
   }
 
   @Test
+  public void isTestCommandOnlyHoldsForTheTestCommand() {
+    assertThat(state.isTestCommand()).isFalse();
+
+    state.getCommandState().setCommand(BlazeCommandName.RUN);
+    assertThat(state.isTestCommand()).isFalse();
+
+    state.getCommandState().setCommand(BlazeCommandName.TEST);
+    assertThat(state.isTestCommand()).isTrue();
+  }
+
+  @Test
+  public void exeFlagsAreEncodedAsTestArgs() {
+    state.getExeFlagsState().setRawFlags(ImmutableList.of("--first", "--second"));
+
+    assertThat(state.getExeFlagsState().getFlagsForTestArgs())
+        .containsExactly("--test_arg=--first", "--test_arg=--second")
+        .inOrder();
+  }
+
+  @Test
+  public void testArgWithWhitespaceIsNotShellQuoted() {
+    state.getExeFlagsState().setRawFlags(ImmutableList.of("\"one two\""));
+
+    assertThat(state.getExeFlagsState().getFlagsForTestArgs())
+        .containsExactly("--test_arg=\"one two\"");
+  }
+
+  @Test
+  public void testArgsAreEmptyWhenNoExeFlagsAreSet() {
+    assertThat(state.getExeFlagsState().getFlagsForTestArgs()).isEmpty();
+  }
+
+  @Test
   public void legacyBlazeUserFlagXmlMigratesToTestFilter() throws Exception {
     Element element = new Element("blaze-settings");
     element.addContent(new Element("blaze-user-flag").setText("--test_filter=Foo#bar"));

--- a/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrLauncher.java
+++ b/clwb/src/com/google/idea/blaze/clwb/run/BlazeCidrLauncher.java
@@ -162,11 +162,15 @@ public final class BlazeCidrLauncher extends CidrLauncher {
             .addBlazeFlags(testHandlerFlags);
 
     String testFilterFlag = handlerState.getTestFilterFlag();
-    if (testFilterFlag != null && BlazeCommandName.TEST.equals(handlerState.getCommandState().getCommand())) {
+    if (testFilterFlag != null && handlerState.isTestCommand()) {
       commandBuilder.addBlazeFlags(testFilterFlag, BlazeFlags.DISABLE_TEST_SHARDING);
     }
 
-    commandBuilder.addExeFlags(handlerState.getExeFlagsState().getFlagsForExternalProcesses());
+    if (handlerState.isTestCommand()) {
+      commandBuilder.addBlazeFlags(handlerState.getExeFlagsState().getFlagsForTestArgs());
+    } else {
+      commandBuilder.addExeFlags(handlerState.getExeFlagsState().getFlagsForExternalProcesses());
+    }
 
     state.setConsoleBuilder(createConsoleBuilder(testUiSession));
     state.addConsoleFilters(getConsoleFilters().toArray(new Filter[0]));

--- a/clwb/tests/headlesstests/com/google/idea/blaze/clwb/ExecutionTest.kt
+++ b/clwb/tests/headlesstests/com/google/idea/blaze/clwb/ExecutionTest.kt
@@ -171,6 +171,15 @@ class ExecutionTest : ClwbHeadlessTestCase() {
     assertThat(catchFiltered.output).contains("FilteredTest")
     assertThat(catchFiltered.output).doesNotContain("SkippedTest")
     assertThat(catchFiltered.output).doesNotContain("Test0")
+
+    // arguments for the test binary must be passed as --test_arg
+    val gtestArgs = execute(
+      Label.create("//main:gtest"), executorId,
+      args = listOf("--gtest_filter=FilterSuite.*")
+    )
+    gtestArgs.assertSuccess()
+    assertThat(gtestArgs.output).contains("FilterSuite.FilteredTest")
+    assertThat(gtestArgs.output).doesNotContain("SampleSuite.SampleTest")
   }
 
   fun checkTestSandboxNoNetwork() {


### PR DESCRIPTION
When running tests command line arguments cannot be passed directly but have to passed using the `--test_args` flag.