### PR TITLE
Suppress JVM warnings when running Bazel jars

### DIFF
--- a/base/tests/integrationtests/com/google/idea/blaze/base/execlog/ExeclogParserTest.kt
+++ b/base/tests/integrationtests/com/google/idea/blaze/base/execlog/ExeclogParserTest.kt
@@ -37,6 +37,9 @@ class ExeclogParserTest : BasePlatformTestCase() {
   fun testRunParser() {
     val output = runBlocking { RunJarService.capture(PARSER_JAR_PATH, "--help") }
     assertThat(output.exitCode).isEqualTo(0)
+
+    // the parser must not emit anything on stderr, in particular no jvm warnings
+    assertThat(output.stderr).isEmpty()
   }
 
   @Test
@@ -51,5 +54,6 @@ class ExeclogParserTest : BasePlatformTestCase() {
     val output = runBlocking { RunJarService.capture(PARSER_JAR_PATH, "--log_path", fixturePath) }
     assertThat(output.exitCode).isEqualTo(0)
     assertThat(output.stdout).isNotEmpty()
+    assertThat(output.stderr).isEmpty()
   }
 }

--- a/common/util/src/com/google/idea/common/util/RunJarService.kt
+++ b/common/util/src/com/google/idea/common/util/RunJarService.kt
@@ -23,12 +23,25 @@ import com.intellij.execution.process.ProcessOutput
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.progress.coroutineToIndicator
+import com.intellij.util.EnvironmentUtil
 import com.intellij.util.system.OS
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Path
+
+private val STRIP_ENVIRONMENT_VARIABLES = listOf(
+  // suppress warnings about picked up local options
+  "JAVA_TOOL_OPTIONS", "_JAVA_OPTIONS", "JDK_JAVA_OPTIONS"
+)
+
+private val ADDITIONAL_ARGUMENTS = listOf(
+  // suppress the restricted-method warning on jdk 21+
+  "--enable-native-access=ALL-UNNAMED",
+  // suppress the terminally deprecated method in sun.misc.Unsafe has been called warning
+  "--sun-misc-unsafe-memory-access=allow",
+)
 
 @Service(Service.Level.APP)
 class RunJarService {
@@ -51,13 +64,10 @@ class RunJarService {
 
     val cmdLine = GeneralCommandLine()
       .withExePath(java.toString())
-      .withParameters(
-        // suppress the restricted-method warning on jdk 21+
-        "--enable-native-access=ALL-UNNAMED",
-        // suppress the terminally deprecated method in sun.misc.Unsafe has been called warning
-        "--sun-misc-unsafe-memory-access=allow",
-        "-jar", jar.toString(), *args,
-      )
+      .withParentEnvironmentType(GeneralCommandLine.ParentEnvironmentType.NONE)
+      .withEnvironment(EnvironmentUtil.getEnvironmentMap().filterKeys { !STRIP_ENVIRONMENT_VARIABLES.contains(it) })
+      .withParameters(ADDITIONAL_ARGUMENTS)
+      .withParameters("-jar", jar.toString(), *args)
 
     return withContext(Dispatchers.IO) {
       OSProcessHandler(cmdLine)

--- a/common/util/src/com/google/idea/common/util/RunJarService.kt
+++ b/common/util/src/com/google/idea/common/util/RunJarService.kt
@@ -51,7 +51,13 @@ class RunJarService {
 
     val cmdLine = GeneralCommandLine()
       .withExePath(java.toString())
-      .withParameters("-jar", jar.toString(), *args)
+      .withParameters(
+        // suppress the restricted-method warning on jdk 21+
+        "--enable-native-access=ALL-UNNAMED",
+        // suppress the terminally deprecated method in sun.misc.Unsafe has been called warning
+        "--sun-misc-unsafe-memory-access=allow",
+        "-jar", jar.toString(), *args,
+      )
 
     return withContext(Dispatchers.IO) {
       OSProcessHandler(cmdLine)

--- a/skylark/tests/integrationtests/com/google/idea/blaze/skylark/repl/SkylarkReplTest.kt
+++ b/skylark/tests/integrationtests/com/google/idea/blaze/skylark/repl/SkylarkReplTest.kt
@@ -37,5 +37,8 @@ class SkylarkReplTest : BasePlatformTestCase() {
     val output = runBlocking { RunJarService.capture(REPL_JAR_PATH, "-c", "print('hello world')") }
     assertThat(output.stdout).isEqualTo("hello world\n")
     assertThat(output.exitCode).isEqualTo(0)
+
+    // the parser must not emit anything on stderr, in particular no jvm warnings
+    assertThat(output.stderr).isEmpty()
   }
 }


### PR DESCRIPTION
When running the Starlark REPL it prints the following warnings:
```
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::loadLibrary has been called by net.starlark.java.eval.JNI in an unnamed module (file:/home/daniel_brauner/.local/share/JetBrains/CLion2026.2/clwb/bazel/starlark_repl.jar)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled
```