### PR TITLE
Add Bazel binary verification

### DIFF
--- a/base/src/com/google/idea/blaze/base/bazel/BazelBinaryUtil.kt
+++ b/base/src/com/google/idea/blaze/base/bazel/BazelBinaryUtil.kt
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2026 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.bazel
+
+import com.google.common.annotations.VisibleForTesting
+import com.google.idea.blaze.base.projectview.ProjectViewManager
+import com.google.idea.blaze.base.projectview.ProjectViewSet
+import com.google.idea.blaze.base.projectview.section.sections.BazelBinarySection
+import com.google.idea.blaze.base.settings.BlazeUserSettings
+import com.intellij.execution.configurations.PathEnvironmentVariableUtil
+import com.intellij.openapi.project.Project
+import com.intellij.util.system.OS
+import java.nio.file.Files
+import java.nio.file.InvalidPathException
+import java.nio.file.Path
+import kotlin.io.path.name
+
+/**
+ * Resolves the binary used to invoke Bazel and checks whether it can actually be executed.
+ * 
+ * This is the single source of truth for the binary path; both the exec service and the sync
+ * pre-flight check go through it.
+ */
+object BazelBinaryUtil {
+
+  @JvmStatic
+  fun resolvePath(project: Project): String {
+    return resolvePath(ProjectViewManager.getInstance(project).getProjectViewSet())
+  }
+
+  @JvmStatic
+  fun resolvePath(projectViewSet: ProjectViewSet?): String {
+    projectViewSet?.getScalarValue(BazelBinarySection.KEY)?.orElse(null)?.let {
+      return it.path
+    }
+
+    return BlazeUserSettings.getInstance().bazelBinaryPath
+  }
+
+  /** Conservatively checks whether the binary can be executed. */
+  @JvmStatic
+  fun validate(path: String, workspaceRoot: Path?): Problem? {
+    return validate(path, workspaceRoot, PathEnvironmentVariableUtil.getPathVariableValue())
+  }
+
+  @JvmStatic
+  @VisibleForTesting
+  fun validate(path: String, workspaceRoot: Path?, pathVariableValue: String?): Problem? {
+    if (path.isBlank()) {
+      return Problem.NOT_CONFIGURED
+    }
+
+    if (validateOnPath(path, pathVariableValue)) {
+      return null
+    }
+
+    return validateFile(path, workspaceRoot)
+  }
+
+  private fun validateFile(path: String, workspaceRoot: Path?): Problem? {
+    val path = try {
+      Path.of(path)
+    } catch (_: InvalidPathException) {
+      return Problem.INVALID_PATH
+    }
+
+    var candidates = when {
+      path.isAbsolute -> listOf(path)
+      workspaceRoot != null -> listOf(path.toAbsolutePath(), workspaceRoot.resolve(path))
+      else -> listOf(path.toAbsolutePath())
+    }
+
+    candidates = candidates.flatMap(::resolveWindowsExtension)
+
+    candidates = candidates.filter { Files.exists(it) }
+    if (candidates.isEmpty()) {
+      return Problem.DOES_NOT_EXIST
+    }
+
+    candidates = candidates.filter { !Files.isDirectory(it) }
+    if (candidates.isEmpty()) {
+      return Problem.IS_A_DIRECTORY
+    }
+
+    candidates = candidates.filter { Files.isExecutable(it) }
+    if (candidates.isEmpty()) {
+      return Problem.NOT_EXECUTABLE
+    }
+
+    return null
+  }
+
+  /**
+   * On Windows CreateProcess appends the executable extensions to a path without one, so
+   * C:\tools\bazel launches C:\tools\bazel.exe
+   */
+  private fun resolveWindowsExtension(path: Path): List<Path> {
+    if (OS.CURRENT != OS.Windows || path.name.indexOf('.') >= 0) {
+      return listOf(path)
+    }
+
+    val extensions = PathEnvironmentVariableUtil.getWindowsExecutableFileExtensions().map {
+      path.resolveSibling(path.name + it)
+    }
+
+    return listOf(path) + extensions
+  }
+
+  private fun validateOnPath(name: String, pathVariableValue: String?): Boolean {
+    if (pathVariableValue == null) {
+      return false
+    }
+
+    if (PathEnvironmentVariableUtil.findInPath(name, pathVariableValue, null) != null) {
+      return true
+    }
+
+    if (OS.CURRENT != OS.Windows) {
+      return false
+    }
+
+    for (extension in PathEnvironmentVariableUtil.getWindowsExecutableFileExtensions()) {
+      if (PathEnvironmentVariableUtil.findInPath(name + extension, pathVariableValue, null) != null) {
+        return true
+      }
+    }
+
+    return false
+  }
+
+  /** Reasons why the configured bazel binary cannot be executed.  */
+  enum class Problem {
+    NOT_CONFIGURED,
+    INVALID_PATH,
+    DOES_NOT_EXIST,
+    IS_A_DIRECTORY,
+    NOT_EXECUTABLE,
+  }
+}

--- a/base/src/com/google/idea/blaze/base/bazel/LocalInvoker.java
+++ b/base/src/com/google/idea/blaze/base/bazel/LocalInvoker.java
@@ -34,9 +34,6 @@ import com.google.idea.blaze.base.console.BlazeConsoleLineProcessorProvider;
 import com.google.idea.blaze.base.execution.BazelGuard;
 import com.google.idea.blaze.base.execution.ExecutionDeniedException;
 import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
-import com.google.idea.blaze.base.projectview.ProjectViewManager;
-import com.google.idea.blaze.base.projectview.ProjectViewSet;
-import com.google.idea.blaze.base.projectview.section.sections.BazelBinarySection;
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.scope.output.IssueOutput;
 import com.google.idea.blaze.base.settings.Blaze;
@@ -58,7 +55,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.function.Function;
-import javax.annotation.Nullable;
 
 /** A local Blaze/Bazel invoker that issues commands via CLI. */
 public class LocalInvoker extends AbstractBuildInvoker {
@@ -244,15 +240,6 @@ public class LocalInvoker extends AbstractBuildInvoker {
         || binaryType.equals(BuildBinaryType.BLAZE_CUSTOM)) {
       return BlazeUserSettings.getInstance().getBlazeBinaryPath();
     }
-    File projectSpecificBinary = null;
-    ProjectViewSet projectView = ProjectViewManager.getInstance(project).getProjectViewSet();
-    if (projectView != null) {
-      projectSpecificBinary = projectView.getScalarValue(BazelBinarySection.KEY).orElse(null);
-    }
-
-    if (projectSpecificBinary != null) {
-      return projectSpecificBinary.getPath();
-    }
-    return BlazeUserSettings.getInstance().getBazelBinaryPath();
+    return BazelBinaryUtil.resolvePath(project);
   }
 }

--- a/base/src/com/google/idea/blaze/base/buildview/BazelExecServiceImpl.kt
+++ b/base/src/com/google/idea/blaze/base/buildview/BazelExecServiceImpl.kt
@@ -19,6 +19,7 @@ package com.google.idea.blaze.base.buildview
 import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.BuildEvent
 import com.google.errorprone.annotations.MustBeClosed
 import com.google.idea.blaze.base.async.process.LineProcessingOutputStream
+import com.google.idea.blaze.base.bazel.BazelBinaryUtil
 import com.google.idea.blaze.base.buildview.events.BuildEventParser
 import com.google.idea.blaze.base.command.BlazeCommand
 import com.google.idea.blaze.base.command.BlazeCommandName
@@ -28,11 +29,8 @@ import com.google.idea.blaze.base.command.buildresult.BuildResultParser
 import com.google.idea.blaze.base.execution.BazelGuard
 import com.google.idea.blaze.base.execution.ExecutionDeniedException
 import com.google.idea.blaze.base.model.primitives.WorkspaceRoot
-import com.google.idea.blaze.base.projectview.ProjectViewManager
-import com.google.idea.blaze.base.projectview.section.sections.BazelBinarySection
 import com.google.idea.blaze.base.scope.BlazeContext
 import com.google.idea.blaze.base.scope.output.IssueOutput
-import com.google.idea.blaze.base.settings.BlazeUserSettings
 import com.google.idea.blaze.base.sync.aspects.BlazeBuildOutputs
 import com.google.idea.blaze.common.Interners
 import com.google.idea.blaze.common.PrintOutput
@@ -67,13 +65,6 @@ class BazelExecServiceImpl(private val project: Project, private val scope: Coro
     } catch (e: ExecutionDeniedException) {
       throw ExecutionException("Bazel execution denied: project is not trusted", e)
     }
-  }
-
-  private fun resolveBinaryPath(): String {
-    return Optional.ofNullable(ProjectViewManager.getInstance(project).projectViewSet)
-      .flatMap { it.getScalarValue(BazelBinarySection.KEY) }
-      .map { it.path }
-      .orElseGet { BlazeUserSettings.getInstance().bazelBinaryPath }
   }
 
   private fun assertNonBlocking() {
@@ -129,7 +120,7 @@ class BazelExecServiceImpl(private val project: Project, private val scope: Coro
     }
 
     cmdLine
-      .withExePath(resolveBinaryPath())
+      .withExePath(BazelBinaryUtil.resolvePath(project))
       .withParameters(cmd.toArgumentList())
       .withEnvironment(cmd.environment())
       .withWorkDirectory(root.pathString)

--- a/base/src/com/google/idea/blaze/base/scope/output/IssueOutput.kt
+++ b/base/src/com/google/idea/blaze/base/scope/output/IssueOutput.kt
@@ -122,7 +122,7 @@ class IssueOutput(
       }
 
       for ((description, fix) in fixes) {
-        builder.append("$description (<a href=\"${fix.id}\">click here</a>)")
+        builder.append("$description (<a href=\"${fix.id}\">click here</a>)\n")
       }
 
       val issue = object : BuildIssue {

--- a/base/src/com/google/idea/blaze/base/settings/ui/BlazeUserSettingsConfigurable.java
+++ b/base/src/com/google/idea/blaze/base/settings/ui/BlazeUserSettingsConfigurable.java
@@ -147,7 +147,7 @@ public class BlazeUserSettingsConfigurable extends AutoConfigurable {
           .componentFactory(fileSelector(BLAZE_BINARY_PATH_KEY, "Specify the blaze binary path"));
 
   public static final String BAZEL_BINARY_PATH_KEY = "bazel.binary.path";
-  private static final ConfigurableSetting<?, ?> BAZEL_BINARY_PATH =
+  public static final ConfigurableSetting<?, ?> BAZEL_BINARY_PATH =
       setting("Bazel binary location")
           .getter(BlazeUserSettings::getBazelBinaryPath)
           .setter(BlazeUserSettings::setBazelBinaryPath)

--- a/base/src/com/google/idea/blaze/base/sync/ProjectStateSyncTask.java
+++ b/base/src/com/google/idea/blaze/base/sync/ProjectStateSyncTask.java
@@ -24,7 +24,6 @@ import com.google.idea.blaze.base.async.FutureUtil;
 import com.google.idea.blaze.base.async.FutureUtil.FutureResult;
 import com.google.idea.blaze.base.async.executor.BlazeExecutor;
 import com.google.idea.blaze.base.bazel.BazelBinaryUtil;
-import com.google.idea.blaze.base.buildview.BuildViewMigration;
 import com.google.idea.blaze.base.command.BlazeCommandName;
 import com.google.idea.blaze.base.command.BlazeFlags;
 import com.google.idea.blaze.base.command.BlazeInvocationContext;
@@ -67,6 +66,7 @@ import com.google.idea.blaze.common.PrintOutput;
 import com.google.idea.blaze.exception.BuildException;
 import com.intellij.build.issue.BuildIssueQuickFix;
 import com.intellij.ide.actions.ShowSettingsUtilImpl;
+import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
@@ -76,6 +76,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
@@ -84,18 +85,28 @@ import javax.annotation.Nullable;
  */
 final class ProjectStateSyncTask {
 
-  private static final BuildIssueQuickFix OPEN_SETTINGS_FIX = new BuildIssueQuickFix() {
+  /** Persisted property which permanently disables {@link #verifyBazelBinary}. */
+  private static final String SKIP_BINARY_VALIDATION_KEY = "bazel.sync.skip.binary.validation";
+
+  /** A {@link BuildIssueQuickFix} which simply runs an action on the project. */
+  private record QuickFix(String id, Consumer<Project> action) implements BuildIssueQuickFix {
     @Override
     public @NotNull String getId() {
-      return "bazel.settings.bazel.binary.path";
+      return id;
     }
 
     @Override
     public @NotNull CompletableFuture<?> runQuickFix(@NotNull Project project, @NotNull DataContext dataContext) {
-      showBazelBinarySetting(project);
+      action.accept(project);
       return CompletableFuture.completedFuture(null);
     }
-  };
+  }
+
+  private static final BuildIssueQuickFix OPEN_SETTINGS_FIX =
+      new QuickFix("bazel.settings.bazel.binary.path", ProjectStateSyncTask::showBazelBinarySetting);
+
+  private static final BuildIssueQuickFix SKIP_VALIDATION_FIX =
+      new QuickFix(SKIP_BINARY_VALIDATION_KEY, ProjectStateSyncTask::skipBinaryValidation);
 
   static SyncProjectState collectProjectState(Project project, BlazeContext context, BlazeSyncParams syncParams)
       throws SyncCanceledException, SyncFailedException {
@@ -231,8 +242,12 @@ final class ProjectStateSyncTask {
   /**
    * Checks that the configured bazel binary can actually be executed. Throws
    * a {@link SyncFailedException} if the binary is invalid.
+   *
+   * <p>The check is skipped once the user dismissed it via {@link #SKIP_BINARY_VALIDATION_KEY}.
    */
   private void verifyBazelBinary(BlazeContext context, ProjectViewSet projectViewSet) throws SyncFailedException {
+    if (PropertiesComponent.getInstance().getBoolean(SKIP_BINARY_VALIDATION_KEY, false)) return;
+
     final var binaryPath = BazelBinaryUtil.resolvePath(projectViewSet);
     final var problem = BazelBinaryUtil.validate(binaryPath, workspaceRoot.directory().toPath());
     if (problem == null) return;
@@ -253,9 +268,15 @@ final class ProjectStateSyncTask {
         )
         .withOnClick(ProjectStateSyncTask::showBazelBinarySetting)
         .withFix("Open the Bazel settings", OPEN_SETTINGS_FIX)
+        .withFix("Disable this check and retry the sync", SKIP_VALIDATION_FIX)
         .submit(context);
 
     throw new SyncFailedException();
+  }
+
+  private static void skipBinaryValidation(Project project) {
+    PropertiesComponent.getInstance().setValue(SKIP_BINARY_VALIDATION_KEY, true);
+    BlazeSyncManager.getInstance(project).incrementalProjectSync("BazelBinaryValidationSkipped");
   }
 
   private static void showBazelBinarySetting(Project project) {

--- a/base/src/com/google/idea/blaze/base/sync/ProjectStateSyncTask.java
+++ b/base/src/com/google/idea/blaze/base/sync/ProjectStateSyncTask.java
@@ -23,6 +23,8 @@ import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.idea.blaze.base.async.FutureUtil;
 import com.google.idea.blaze.base.async.FutureUtil.FutureResult;
 import com.google.idea.blaze.base.async.executor.BlazeExecutor;
+import com.google.idea.blaze.base.bazel.BazelBinaryUtil;
+import com.google.idea.blaze.base.buildview.BuildViewMigration;
 import com.google.idea.blaze.base.command.BlazeCommandName;
 import com.google.idea.blaze.base.command.BlazeFlags;
 import com.google.idea.blaze.base.command.BlazeInvocationContext;
@@ -48,7 +50,8 @@ import com.google.idea.blaze.base.scope.scopes.TimingScope.EventType;
 import com.google.idea.blaze.base.settings.Blaze;
 import com.google.idea.blaze.base.settings.BlazeImportSettings;
 import com.google.idea.blaze.base.settings.BlazeImportSettingsManager;
-import com.google.idea.blaze.base.settings.BlazeUserSettings;
+import com.google.idea.blaze.base.settings.ui.BlazeUserSettingsCompositeConfigurable;
+import com.google.idea.blaze.base.settings.ui.BlazeUserSettingsConfigurable;
 import com.google.idea.blaze.base.sync.SyncScope.SyncCanceledException;
 import com.google.idea.blaze.base.sync.SyncScope.SyncFailedException;
 import com.google.idea.blaze.base.sync.projectview.LanguageSupport;
@@ -58,18 +61,41 @@ import com.google.idea.blaze.base.sync.workspace.WorkspacePathResolver;
 import com.google.idea.blaze.base.sync.workspace.WorkspacePathResolverImpl;
 import com.google.idea.blaze.base.vcs.BlazeVcsHandlerProvider;
 import com.google.idea.blaze.base.vcs.BlazeVcsHandlerProvider.BlazeVcsHandler;
+import com.google.idea.blaze.base.vcs.BlazeVcsHandlerProvider.BlazeVcsSyncHandler;
+import com.google.idea.blaze.base.vcs.BlazeVcsHandlerProvider.BlazeVcsSyncHandler.ValidationResult;
 import com.google.idea.blaze.common.PrintOutput;
 import com.google.idea.blaze.exception.BuildException;
+import com.intellij.build.issue.BuildIssueQuickFix;
+import com.intellij.ide.actions.ShowSettingsUtilImpl;
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
-/** Collects information about the project state (VCS, blaze info, .blazeproject contents, etc.). */
+/**
+ * Collects information about the project state (VCS, blaze info, .blazeproject contents, etc.).
+ */
 final class ProjectStateSyncTask {
+
+  private static final BuildIssueQuickFix OPEN_SETTINGS_FIX = new BuildIssueQuickFix() {
+    @Override
+    public @NotNull String getId() {
+      return "bazel.settings.bazel.binary.path";
+    }
+
+    @Override
+    public @NotNull CompletableFuture<?> runQuickFix(@NotNull Project project, @NotNull DataContext dataContext) {
+      showBazelBinarySetting(project);
+      return CompletableFuture.completedFuture(null);
+    }
+  };
 
   static SyncProjectState collectProjectState(Project project, BlazeContext context, BlazeSyncParams syncParams)
       throws SyncCanceledException, SyncFailedException {
@@ -113,7 +139,9 @@ final class ProjectStateSyncTask {
           context);
       throw new SyncFailedException();
     }
-    ProjectViewSet projectViewSet = workspacePathResolverAndProjectView.projectViewSet;
+
+    final var projectViewSet = workspacePathResolverAndProjectView.projectViewSet;
+    verifyBazelBinary(context, projectViewSet);
 
     List<String> syncFlags =
         BlazeFlags.blazeFlags(
@@ -200,6 +228,46 @@ final class ProjectStateSyncTask {
                .build();
   }
 
+  /**
+   * Checks that the configured bazel binary can actually be executed. Throws
+   * a {@link SyncFailedException} if the binary is invalid.
+   */
+  private void verifyBazelBinary(BlazeContext context, ProjectViewSet projectViewSet) throws SyncFailedException {
+    final var binaryPath = BazelBinaryUtil.resolvePath(projectViewSet);
+    final var problem = BazelBinaryUtil.validate(binaryPath, workspaceRoot.directory().toPath());
+    if (problem == null) return;
+
+    final var msg = switch (problem) {
+      case NOT_CONFIGURED -> "no binary is configured";
+      case INVALID_PATH -> String.format("not a valid path: %s", binaryPath);
+      case DOES_NOT_EXIST -> String.format("binary not found: %s", binaryPath);
+      case IS_A_DIRECTORY -> String.format("binary is a directory: %s", binaryPath);
+      case NOT_EXECUTABLE -> String.format("binary is not executable: %s", binaryPath);
+    };
+
+    IssueOutput.error("Invalid Bazel binary")
+        .withDescription(
+            "The Bazel binary could not be executed, " + msg + "\n" +
+            "The location is configured in the Bazel Settings, " +
+            "and can be overridden per project by the 'bazel_binary' section of the project view file."
+        )
+        .withOnClick(ProjectStateSyncTask::showBazelBinarySetting)
+        .withFix("Open the Bazel settings", OPEN_SETTINGS_FIX)
+        .submit(context);
+
+    throw new SyncFailedException();
+  }
+
+  private static void showBazelBinarySetting(Project project) {
+    ApplicationManager.getApplication().invokeLater(() ->
+        ShowSettingsUtilImpl.showSettingsDialog(
+            project,
+            BlazeUserSettingsCompositeConfigurable.ID,
+            BlazeUserSettingsConfigurable.BAZEL_BINARY_PATH.label()
+        )
+    );
+  }
+
   private ListenableFuture<BlazeInfo> createBazelInfoFuture(
       BlazeContext context,
       List<String> syncFlags,
@@ -207,16 +275,16 @@ final class ProjectStateSyncTask {
     boolean useBazelInfoRunner = !BlazeInfoProvider.isEnabled() || syncMode == SyncMode.FULL;
     if (useBazelInfoRunner) {
       return BlazeInfoRunner.getInstance()
-                 .runBlazeInfo(
-                     project,
-                     context,
-                     importSettings.getBuildSystem(),
-                     syncFlags);
+          .runBlazeInfo(
+              project,
+              context,
+              importSettings.getBuildSystem(),
+              syncFlags);
     }
     return BlazeInfoProvider.getInstance(project)
-               .getBlazeInfo(
-                   context,
-                   syncFlags);
+        .getBlazeInfo(
+            context,
+            syncFlags);
   }
 
   private ExternalWorkspaceData getExternalWorkspaceData(
@@ -235,6 +303,7 @@ final class ProjectStateSyncTask {
   }
 
   private static class WorkspacePathResolverAndProjectView {
+
     final WorkspacePathResolver workspacePathResolver;
     final ProjectViewSet projectViewSet;
 
@@ -252,7 +321,7 @@ final class ProjectStateSyncTask {
 
     for (int i = 0; i < 3; ++i) {
       WorkspacePathResolver vcsWorkspacePathResolver = null;
-      BlazeVcsHandlerProvider.BlazeVcsSyncHandler vcsSyncHandler = vcsHandler.createSyncHandler();
+      BlazeVcsSyncHandler vcsSyncHandler = vcsHandler.createSyncHandler();
       if (vcsSyncHandler != null) {
         boolean ok =
             Scope.push(
@@ -283,7 +352,7 @@ final class ProjectStateSyncTask {
       }
 
       if (vcsSyncHandler != null) {
-        BlazeVcsHandlerProvider.BlazeVcsSyncHandler.ValidationResult validationResult =
+        ValidationResult validationResult =
             vcsSyncHandler.validateProjectView(context, projectViewSet);
         switch (validationResult) {
           case OK:

--- a/base/tests/unittests/com/google/idea/blaze/base/bazel/BazelBinaryUtilTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/bazel/BazelBinaryUtilTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2026 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.bazel;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
+
+import com.google.common.collect.ImmutableList;
+import com.google.idea.blaze.base.bazel.BazelBinaryUtil.Problem;
+import com.intellij.util.system.OS;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link BazelBinaryUtil}. */
+@RunWith(JUnit4.class)
+public class BazelBinaryUtilTest {
+
+  @Rule
+  public final TemporaryFolder folder = new TemporaryFolder();
+
+  private static final String NO_PATH = "";
+
+  private File createExecutable(File directory, String name) throws IOException {
+    final var file = new File(directory, name);
+    assertThat(file.createNewFile()).isTrue();
+    assumeTrue(file.setExecutable(true));
+    return file;
+  }
+
+  @Test
+  public void blankPathIsNotConfigured() {
+    assertThat(BazelBinaryUtil.validate("", null, NO_PATH)).isEqualTo(Problem.NOT_CONFIGURED);
+    assertThat(BazelBinaryUtil.validate("  ", null, NO_PATH)).isEqualTo(Problem.NOT_CONFIGURED);
+  }
+
+  @Test
+  public void missingAbsolutePathDoesNotExist() {
+    final var missing = new File(folder.getRoot(), "bazel").getAbsolutePath();
+    assertThat(BazelBinaryUtil.validate(missing, null, NO_PATH)).isEqualTo(Problem.DOES_NOT_EXIST);
+  }
+
+  @Test
+  public void directoryIsReported() throws IOException {
+    final var directory = folder.newFolder("bazel").getAbsolutePath();
+    assertThat(BazelBinaryUtil.validate(directory, null, NO_PATH)).isEqualTo(Problem.IS_A_DIRECTORY);
+  }
+
+  @Test
+  public void executableAbsolutePathIsValid() throws IOException {
+    final var binary = createExecutable(folder.getRoot(), "bazel");
+    assertThat(BazelBinaryUtil.validate(binary.getAbsolutePath(), null, NO_PATH)).isNull();
+  }
+
+  @Test
+  public void nonExecutableFileIsReported() throws IOException {
+    // windows has no executable bit, File#canExecute is effectively an existence check there
+    assumeFalse(OS.CURRENT == OS.Windows);
+
+    final var binary = folder.newFile("bazel");
+    assumeTrue(binary.setExecutable(false));
+
+    assertThat(BazelBinaryUtil.validate(binary.getAbsolutePath(), null, NO_PATH)).isEqualTo(Problem.NOT_EXECUTABLE);
+  }
+
+  @Test
+  public void danglingSymlinkDoesNotExist() throws IOException {
+    assumeFalse(OS.CURRENT == OS.Windows);
+
+    final var link = new File(folder.getRoot(), "bazel");
+    Files.createSymbolicLink(link.toPath(), folder.getRoot().toPath().resolve("missing"));
+
+    assertThat(BazelBinaryUtil.validate(link.getPath(), null, NO_PATH)).isEqualTo(Problem.DOES_NOT_EXIST);
+  }
+
+  @Test
+  public void relativePathIsResolvedAgainstWorkspaceRoot() throws IOException {
+    final var tools = folder.newFolder("tools");
+    createExecutable(tools, "bazel");
+
+    assertThat(BazelBinaryUtil.validate("tools/bazel", folder.getRoot().toPath(), NO_PATH)).isNull();
+    assertThat(BazelBinaryUtil.validate("tools/missing", folder.getRoot().toPath(), NO_PATH)).isEqualTo(Problem.DOES_NOT_EXIST);
+  }
+
+  @Test
+  public void bareNameIsLookedUpOnPath() throws IOException {
+    final var binDir = folder.newFolder("bin");
+    createExecutable(binDir, OS.CURRENT == OS.Windows ? "bazel.exe" : "bazel");
+
+    assertThat(BazelBinaryUtil.validate("bazel", null, binDir.getAbsolutePath())).isNull();
+  }
+
+  @Test
+  public void bareNameMissingFromPathIsReported() throws IOException {
+    final var emptyDir = folder.newFolder("empty");
+
+    assertThat(BazelBinaryUtil.validate("bazel", null, emptyDir.getAbsolutePath())).isEqualTo(Problem.DOES_NOT_EXIST);
+    assertThat(BazelBinaryUtil.validate("bazel", null, NO_PATH)).isEqualTo(Problem.DOES_NOT_EXIST);
+  }
+}


### PR DESCRIPTION
A sync fails with a not so clear "Could not run Bazel info" error when the specified binary cannot be executed. This PR adds a check that tries to verify if the binary can be executed or not. The check can be disabled to limit the impact of false positives. 